### PR TITLE
chore: rebrand to OpenCode Panel + add community files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,48 @@
+---
+name: Bug report
+about: Something is broken or not behaving as expected
+title: "[bug] "
+labels: bug
+---
+
+## Describe the bug
+
+<!-- One or two sentences describing what's wrong. -->
+
+## Steps to reproduce
+
+1. ...
+2. ...
+3. ...
+
+## Expected behavior
+
+<!-- What you expected to happen. -->
+
+## Actual behavior
+
+<!-- What actually happened. Include error messages / screenshots / a short clip if relevant. -->
+
+## Environment
+
+- **OpenCode Panel version**: <!-- e.g. 0.1.0, check Extensions sidebar -->
+- **VS Code version**: <!-- Help → About -->
+- **opencode version**: <!-- run `opencode --version` -->
+- **OS**: <!-- macOS 14 / Ubuntu 22.04 / Windows 11 / etc. -->
+
+## Logs
+
+<!--
+Open the OpenCode Panel logs:
+- Command Palette → "OpenCode Panel: Show Logs"
+- Or check the Output panel → select "OpenCode Panel" from the dropdown
+Paste the last 20-30 lines (redact anything sensitive).
+-->
+
+```
+<!-- paste logs here -->
+```
+
+## Additional context
+
+<!-- Optional: anything else that might help (workspace setup, recent changes, ...). -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question / Discussion
+    url: https://github.com/arthurzengg/opencui/discussions
+    about: For open-ended questions, design discussions, or "how do I" — please use Discussions instead of an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest an idea or improvement
+title: "[feature] "
+labels: enhancement
+---
+
+## What problem does this solve?
+
+<!--
+Describe the use case or pain point. "I want to do X but the extension doesn't let me / makes it hard."
+-->
+
+## Proposed solution
+
+<!-- What you'd like to see. UI sketches / mockups welcome but not required. -->
+
+## Alternatives considered
+
+<!-- Other ways this could work. Why is your proposed solution better? -->
+
+## Additional context
+
+<!-- Optional: similar features in other tools, related issues, references, etc. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+<!--
+Thanks for the PR! A few quick checks before you submit:
+- Read CONTRIBUTING.md if this is your first PR
+- Run `bun run test` and `bun run check-types` locally — CI runs them too
+- Keep this PR focused; split refactors from fixes
+-->
+
+## Summary
+
+<!-- 1-3 bullet points: what changed and why. -->
+
+## Test plan
+
+<!--
+Concrete steps a reviewer can follow to validate.
+For UI changes, include screenshots / a short clip if possible.
+For backend / wire-format changes, point at the test files exercising them.
+-->
+
+- [ ] `bun run test` passes locally
+- [ ] `bun run check-types` passes
+- [ ] Tested manually in an Extension Development Host (F5)
+
+## Related issues
+
+<!-- Closes #123 / Refs #456 — or "n/a" -->

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Run OpenCode CUI Extension",
+      "name": "Run OpenCode Panel Extension",
       "type": "extensionHost",
       "request": "launch",
       "args": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to OpenCode CUI are documented here. The format follows
+All notable changes to OpenCode Panel are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
@@ -42,7 +42,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Stop button transitions to a disabled "Stopping…" state until opencode emits `session.idle`. While aborting, in-flight `textDelta` / `reasoningDelta` events are dropped so the stopped message does not keep growing.
 
 ### Backend management
-- Single `opencode serve` subprocess per workspace, owned by the extension. Auto-restart via `OpenCode CUI: Restart Backend`.
+- Single `opencode serve` subprocess per workspace, owned by the extension. Auto-restart via `OpenCode Panel: Restart Backend`.
 - Configurable `opencui.binaryPath` (defaults to `opencode` on PATH) and `opencui.serverPort` (`0` for auto).
 
 ### Tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project overview
 
-OpenCode CUI is a VS Code extension that wraps [opencode](https://github.com/sst/opencode) into a React chat sidebar. The extension is **decoupled** from opencode internals at runtime — it only talks to opencode's HTTP/SSE server through `@opencode-ai/sdk`. Never `import` anything from `opencode` directly; everything goes through the SDK client.
+OpenCode Panel is a VS Code extension that wraps [opencode](https://github.com/sst/opencode) into a React chat sidebar. The extension is **decoupled** from opencode internals at runtime — it only talks to opencode's HTTP/SSE server through `@opencode-ai/sdk`. Never `import` anything from `opencode` directly; everything goes through the SDK client.
 
 ## Build, test, dev
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+# Contributing to OpenCode Panel
+
+Thanks for considering a contribution! This doc covers the practical bits: how to set up, where things live, how to test, and what a good PR looks like.
+
+## Prerequisites
+
+- **[Bun](https://bun.sh) `1.3.13`** (project pinned via `packageManager` in `package.json`).
+- **[opencode](https://opencode.ai)** installed on `PATH` if you want to test end-to-end against a real backend. See the [README's Prerequisites section](./README.md#prerequisites) for install commands per platform.
+- **VS Code 1.95+** (matches the `engines.vscode` constraint).
+
+## Setup
+
+```bash
+git clone https://github.com/arthurzengg/opencui
+cd opencui
+bun install
+bun run compile         # host esbuild + webview vite
+```
+
+Open the folder in VS Code and press `F5` to launch an Extension Development Host with your local build loaded.
+
+## Project layout
+
+`CLAUDE.md` at the repo root has the architectural overview — protocol shape, where chat-host helpers live, the per-turn sticky bubble trick, the abort state machine, the IME guard, etc. **Skim it before making non-trivial changes**; it'll save you 30 minutes of reading source.
+
+Quick map:
+
+```
+src/                  extension host (Node) — opencode subprocess, message router, persistence
+src/chat/             chat logic split by concern (paths / diff / review / prompt / etc.)
+webview/src/          React webview (browser) — components, hooks, the protocol re-export
+test/host/            Vitest tests for host helpers (uses a vscode-module mock)
+test/webview/         Vitest + RTL component tests
+test/integration/     real-VS-Code tests via @vscode/test-electron
+```
+
+## Tests
+
+```bash
+bun run test              # unit + component + mock-opencode E2E (~5s)
+bun run test:watch        # rerun on file change
+bun run test:coverage     # writes coverage/index.html
+bun run test:integration  # boots a real VS Code (~30s first run)
+bun run check-types       # tsc --noEmit on the host side
+```
+
+CI runs all four phases on every push and PR (see `.github/workflows/ci.yml`). Your PR will be blocked from merging until CI is green.
+
+To run a single test file:
+
+```bash
+bun run test path/to/file.test.ts
+bun run test -t "name pattern"
+```
+
+## Pull request workflow
+
+1. **Branch from `main`**. Branch names: `feat/<short-desc>`, `fix/<short-desc>`, `docs/<short-desc>`, `refactor/<short-desc>`.
+2. **Commit style**: short imperative subject (≤72 chars), optional body explaining *why*. Conventional-commits-ish (`feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, `test:`) is welcome but not required.
+3. **Keep PRs focused**. One logical change per PR. Refactor-while-fixing PRs get held up; split them.
+4. **Add tests** for new behavior or bug fixes. The reducer + pure helpers are already pattern-friendly (`test/host/`, `test/webview/`). UI tweaks → component tests in `test/webview/*.test.tsx`.
+5. **Open the PR**. Use the template; fill in the test plan with concrete steps.
+6. **CI must pass** (`Test on ubuntu-latest` status check). Don't force-push to dismiss reviews — push new commits and let stale-approval dismissal handle it.
+
+## Code style
+
+- **No emojis in code or comments** unless the user-facing UX needs one.
+- **Don't write comments that just restate what the code does.** Comment WHY when non-obvious — hidden invariants, surprising decisions, references to a past bug.
+- **No backward-compatibility shims for code we just wrote.** If a signature changes and all callers are in this repo, change them all; don't keep stale aliases.
+- **Match existing test patterns**: pure helpers get their own `*.test.ts`; component tests are `*.test.tsx` using `@testing-library/react`.
+
+## Reporting bugs / requesting features
+
+Use the GitHub issue templates (Bug report / Feature request). For bugs, **include VS Code version, opencode version, and steps to reproduce**. Without these we can't help.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant](./CODE_OF_CONDUCT.md). By participating you agree to abide by it.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenCode CUI
+# OpenCode Panel
 
 > A modern React chat sidebar for AI coding in VS Code — powered by
 > [opencode](https://github.com/sst/opencode). Bring your own model
@@ -25,7 +25,7 @@
 
 ## Prerequisites
 
-OpenCode CUI talks to a locally-running [opencode](https://opencode.ai) server. You need opencode installed and signed in to a provider **once**:
+OpenCode Panel talks to a locally-running [opencode](https://opencode.ai) server. You need opencode installed and signed in to a provider **once**:
 
 ### Install opencode
 
@@ -52,15 +52,15 @@ opencode --version
 
 If `opencode` isn't on your PATH after install, set `opencui.binaryPath` in VS Code settings to its absolute path.
 
-## Install OpenCode CUI
+## Install OpenCode Panel
 
-Search for **"OpenCode CUI"** in the VS Code Extensions sidebar, or install from the command line:
+Search for **"OpenCode Panel"** in the VS Code Extensions sidebar, or install from the command line:
 
 ```bash
-code --install-extension arthurzeng.opencui
+code --install-extension haoyangzeng.opencui
 ```
 
-Open the OpenCode CUI sidebar (click the activity-bar icon or press `Cmd+L` / `Ctrl+L`).
+Open the OpenCode Panel sidebar (click the activity-bar icon or press `Cmd+L` / `Ctrl+L`).
 
 ## Settings
 
@@ -115,7 +115,7 @@ Open the OpenCode CUI sidebar (click the activity-bar icon or press `Cmd+L` / `C
 - **Edit-in-place review flow** — review actions live in the Review Changes card; the editor stays clean (no codelens or decorations).
 
 ### Backend management
-- The extension owns and manages a single `opencode serve` subprocess per workspace. It auto-spawns on activation, exposes the HTTP/SSE endpoint to the SDK, and shuts down cleanly on deactivation or `OpenCode CUI: Restart Backend`.
+- The extension owns and manages a single `opencode serve` subprocess per workspace. It auto-spawns on activation, exposes the HTTP/SSE endpoint to the SDK, and shuts down cleanly on deactivation or `OpenCode Panel: Restart Backend`.
 - The extension is **decoupled** from opencode at runtime: it only talks to opencode's HTTP server through `@opencode-ai/sdk`. opencode internals are never imported.
 
 ## Develop

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "opencui",
-  "displayName": "OpenCode CUI",
-  "description": "OpenCode CUI: opencode-powered AI assistant with a modern React chat UI",
+  "displayName": "OpenCode Panel",
+  "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
   "version": "0.1.0",
   "private": true,
-  "publisher": "arthurzeng",
+  "publisher": "haoyangzeng",
   "license": "MIT",
   "engines": {
     "vscode": "^1.95.0"
@@ -41,7 +41,7 @@
       "activitybar": [
         {
           "id": "opencui",
-          "title": "OpenCode CUI",
+          "title": "OpenCode Panel",
           "icon": "media/icon.svg"
         }
       ]
@@ -58,35 +58,35 @@
     "commands": [
       {
         "command": "opencui.chat.focus",
-        "title": "OpenCode CUI: Focus Chat"
+        "title": "OpenCode Panel: Focus Chat"
       },
       {
         "command": "opencui.chat.new",
-        "title": "OpenCode CUI: New Chat"
+        "title": "OpenCode Panel: New Chat"
       },
       {
         "command": "opencui.conversation.select",
-        "title": "OpenCode CUI: Select Conversation"
+        "title": "OpenCode Panel: Select Conversation"
       },
       {
         "command": "opencui.inlineEdit",
-        "title": "OpenCode CUI: Inline Edit"
+        "title": "OpenCode Panel: Inline Edit"
       },
       {
         "command": "opencui.selectAgent",
-        "title": "OpenCode CUI: Select Agent"
+        "title": "OpenCode Panel: Select Agent"
       },
       {
         "command": "opencui.selectModel",
-        "title": "OpenCode CUI: Select Model"
+        "title": "OpenCode Panel: Select Model"
       },
       {
         "command": "opencui.server.restart",
-        "title": "OpenCode CUI: Restart Backend"
+        "title": "OpenCode Panel: Restart Backend"
       },
       {
         "command": "opencui.showLogs",
-        "title": "OpenCode CUI: Show Logs"
+        "title": "OpenCode Panel: Show Logs"
       }
     ],
     "keybindings": [
@@ -107,7 +107,7 @@
       }
     ],
     "configuration": {
-      "title": "OpenCode CUI",
+      "title": "OpenCode Panel",
       "properties": {
         "opencui.binaryPath": {
           "type": "string",

--- a/src/chat/fs-ops.ts
+++ b/src/chat/fs-ops.ts
@@ -17,14 +17,14 @@ const SHELL_LANGS = new Set([
  */
 export async function applyCode(code: string, language?: string) {
   if (language && SHELL_LANGS.has(language.toLowerCase())) {
-    const terminal = vscode.window.activeTerminal ?? vscode.window.createTerminal({ name: "OpenCode CUI" })
+    const terminal = vscode.window.activeTerminal ?? vscode.window.createTerminal({ name: "OpenCode Panel" })
     terminal.show(true)
     terminal.sendText(code.replace(/\n+$/, ""), true)
     return
   }
   const editor = vscode.window.activeTextEditor
   if (!editor) {
-    vscode.window.showWarningMessage("OpenCode CUI: open a file first to apply this snippet")
+    vscode.window.showWarningMessage("OpenCode Panel: open a file first to apply this snippet")
     return
   }
   const doc = editor.document
@@ -118,7 +118,7 @@ export async function reviewHunk(
   const match = findHunkText(current, newText)
   if (!match) {
     if (!silent) {
-      vscode.window.showWarningMessage(`OpenCode CUI: could not undo hunk in ${relPath}; the file changed since the diff was generated.`)
+      vscode.window.showWarningMessage(`OpenCode Panel: could not undo hunk in ${relPath}; the file changed since the diff was generated.`)
       await vscode.window.showTextDocument(doc)
     }
     return false
@@ -127,7 +127,7 @@ export async function reviewHunk(
   edit.replace(uri, new vscode.Range(doc.positionAt(match.start), doc.positionAt(match.end)), oldText)
   const ok = await vscode.workspace.applyEdit(edit)
   if (!ok) {
-    if (!silent) vscode.window.showWarningMessage(`OpenCode CUI: could not undo hunk in ${relPath}`)
+    if (!silent) vscode.window.showWarningMessage(`OpenCode Panel: could not undo hunk in ${relPath}`)
     return false
   }
   await vscode.window.showTextDocument(doc)

--- a/src/chat/review-render.ts
+++ b/src/chat/review-render.ts
@@ -179,5 +179,5 @@ export function hasPendingReviewHunks(change: ReviewChange, reviewed: Record<str
 
 export function fallbackHtml(message: string): string {
   return `<!doctype html><html><body style="padding:20px;font-family:sans-serif;">
-    <h2>OpenCode CUI</h2><p>${message}</p></body></html>`
+    <h2>OpenCode Panel</h2><p>${message}</p></body></html>`
 }

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -146,7 +146,7 @@ export class ChatView implements vscode.WebviewViewProvider {
           id: c.id,
         })),
       ],
-      { title: "Select OpenCode CUI conversation" },
+      { title: "Select OpenCode Panel conversation" },
     )
     if (!picked) return
     if ("create" in picked) {
@@ -771,7 +771,7 @@ export class ChatView implements vscode.WebviewViewProvider {
 
   private async openReviewChange(change: ReviewChange) {
     if (!isTextReviewPath(change.path)) {
-      vscode.window.showWarningMessage(`OpenCode CUI: ${change.path} cannot be reviewed as text.`)
+      vscode.window.showWarningMessage(`OpenCode Panel: ${change.path} cannot be reviewed as text.`)
       return
     }
     try {
@@ -790,7 +790,7 @@ export class ChatView implements vscode.WebviewViewProvider {
       void this.syncReviewDecorations()
     } catch (e) {
       log(`could not open review file ${change.path}`, e)
-      vscode.window.showWarningMessage(`OpenCode CUI: could not open ${change.path} as text.`)
+      vscode.window.showWarningMessage(`OpenCode Panel: could not open ${change.path} as text.`)
     }
   }
 
@@ -847,7 +847,7 @@ export class ChatView implements vscode.WebviewViewProvider {
         }
       }
       vscode.window.showInformationMessage(
-        `OpenCode CUI: ${requestedPath} is no longer present; removed ${purged} pending hunk${purged === 1 ? "" : "s"} from review.`,
+        `OpenCode Panel: ${requestedPath} is no longer present; removed ${purged} pending hunk${purged === 1 ? "" : "s"} from review.`,
       )
       await this.syncReviewDecorations()
       return

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,7 @@ import { getOutputChannel, log } from "./output"
 let servers: ServerManager | undefined
 
 export async function activate(context: vscode.ExtensionContext) {
-  log("activating OpenCode CUI")
+  log("activating OpenCode Panel")
   servers = new ServerManager(context)
   const prefs = new Preferences(context.globalState)
   const status = new StatusBar(context, prefs)
@@ -47,7 +47,7 @@ export async function activate(context: vscode.ExtensionContext) {
     .catch((e) => {
       log("failed to start backend", e)
       status.set("error", String(e))
-      vscode.window.showErrorMessage(`OpenCode CUI: failed to start opencode backend: ${e.message}`)
+      vscode.window.showErrorMessage(`OpenCode Panel: failed to start opencode backend: ${e.message}`)
     })
 }
 

--- a/src/inline/edit.ts
+++ b/src/inline/edit.ts
@@ -14,11 +14,11 @@ export class InlineEdit {
   async run() {
     const editor = vscode.window.activeTextEditor
     if (!editor) {
-      vscode.window.showWarningMessage("OpenCode CUI: open a file first")
+      vscode.window.showWarningMessage("OpenCode Panel: open a file first")
       return
     }
     if (editor.selection.isEmpty) {
-      vscode.window.showWarningMessage("OpenCode CUI: select code to edit first")
+      vscode.window.showWarningMessage("OpenCode Panel: select code to edit first")
       return
     }
     const instruction = await vscode.window.showInputBox({
@@ -33,7 +33,7 @@ export class InlineEdit {
     const proceed = await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,
-        title: "OpenCode CUI is editing...",
+        title: "OpenCode Panel is editing...",
         cancellable: false,
       },
       async () => {
@@ -47,7 +47,7 @@ export class InlineEdit {
           return replacement
         } catch (e) {
           log("inline edit failed", e)
-          vscode.window.showErrorMessage(`OpenCode CUI: ${(e as Error).message}`)
+          vscode.window.showErrorMessage(`OpenCode Panel: ${(e as Error).message}`)
           return undefined
         }
       },
@@ -86,8 +86,8 @@ async function previewAndApply(
   language: string,
 ) {
   const doc = editor.document
-  const leftUri = vscode.Uri.parse(`untitled:OpenCode CUI-original.${ext(language)}`)
-  const rightUri = vscode.Uri.parse(`untitled:OpenCode CUI-proposed.${ext(language)}`)
+  const leftUri = vscode.Uri.parse(`untitled:OpenCode Panel-original.${ext(language)}`)
+  const rightUri = vscode.Uri.parse(`untitled:OpenCode Panel-proposed.${ext(language)}`)
 
   const left = await vscode.workspace.openTextDocument(leftUri)
   const right = await vscode.workspace.openTextDocument(rightUri)
@@ -98,10 +98,10 @@ async function previewAndApply(
   rightEdit.insert(rightUri, new vscode.Position(0, 0), replacement)
   await vscode.workspace.applyEdit(rightEdit)
 
-  await vscode.commands.executeCommand("vscode.diff", leftUri, rightUri, "OpenCode CUI: Proposed change")
+  await vscode.commands.executeCommand("vscode.diff", leftUri, rightUri, "OpenCode Panel: Proposed change")
 
   const choice = await vscode.window.showInformationMessage(
-    "Apply OpenCode CUI's edit?",
+    "Apply OpenCode Panel's edit?",
     { modal: false },
     "Apply",
     "Discard",

--- a/src/output.ts
+++ b/src/output.ts
@@ -4,7 +4,7 @@ let channel: vscode.OutputChannel | undefined
 
 export function getOutputChannel() {
   if (!channel) {
-    channel = vscode.window.createOutputChannel("OpenCode CUI")
+    channel = vscode.window.createOutputChannel("OpenCode Panel")
   }
   return channel
 }

--- a/src/picker.ts
+++ b/src/picker.ts
@@ -29,7 +29,7 @@ export class Picker {
       const backend = await this.servers.ensure()
       const res = await backend.client.app.agents()
       if (res.error || !res.data) {
-        vscode.window.showErrorMessage(`OpenCode CUI: failed to load agents`)
+        vscode.window.showErrorMessage(`OpenCode Panel: failed to load agents`)
         return
       }
       const usable = res.data.filter(isUserSelectableAgent)
@@ -41,19 +41,19 @@ export class Picker {
           detail: a.model ? `${a.model.providerID}/${a.model.modelID}` : undefined,
         })),
       ]
-      const picked = await vscode.window.showQuickPick(items, { title: "Select OpenCode CUI agent" })
+      const picked = await vscode.window.showQuickPick(items, { title: "Select OpenCode Panel agent" })
       if (!picked) return
       const name = picked.label.replace(/^\$\([^)]+\)\s*/, "")
       if (name === "(default)") {
         await this.prefs.setAgent(undefined)
-        vscode.window.showInformationMessage("OpenCode CUI: agent reset to default")
+        vscode.window.showInformationMessage("OpenCode Panel: agent reset to default")
       } else {
         await this.prefs.setAgent(name)
-        vscode.window.showInformationMessage(`OpenCode CUI: agent → ${name}`)
+        vscode.window.showInformationMessage(`OpenCode Panel: agent → ${name}`)
       }
     } catch (e) {
       log("pickAgent failed", e)
-      vscode.window.showErrorMessage(`OpenCode CUI: ${(e as Error).message}`)
+      vscode.window.showErrorMessage(`OpenCode Panel: ${(e as Error).message}`)
     }
   }
 
@@ -62,7 +62,7 @@ export class Picker {
       const backend = await this.servers.ensure()
       const res = await backend.client.config.providers()
       if (res.error || !res.data) {
-        vscode.window.showErrorMessage(`OpenCode CUI: failed to load providers`)
+        vscode.window.showErrorMessage(`OpenCode Panel: failed to load providers`)
         return
       }
       const providers = res.data.providers ?? []
@@ -79,23 +79,23 @@ export class Picker {
         }
       }
       const picked = await vscode.window.showQuickPick(items, {
-        title: "Select OpenCode CUI model",
+        title: "Select OpenCode Panel model",
         matchOnDescription: true,
       })
       if (!picked) return
       const cleaned = picked.label.replace(/^\$\([^)]+\)\s*/, "")
       if (cleaned === "(default)") {
         await this.prefs.setModel(undefined, undefined)
-        vscode.window.showInformationMessage("OpenCode CUI: model reset to default")
+        vscode.window.showInformationMessage("OpenCode Panel: model reset to default")
         return
       }
       const [providerID, ...rest] = cleaned.split("/")
       const modelID = rest.join("/")
       await this.prefs.setModel(providerID, modelID)
-      vscode.window.showInformationMessage(`OpenCode CUI: model → ${providerID}/${modelID}`)
+      vscode.window.showInformationMessage(`OpenCode Panel: model → ${providerID}/${modelID}`)
     } catch (e) {
       log("pickModel failed", e)
-      vscode.window.showErrorMessage(`OpenCode CUI: ${(e as Error).message}`)
+      vscode.window.showErrorMessage(`OpenCode Panel: ${(e as Error).message}`)
     }
   }
 }

--- a/src/status.ts
+++ b/src/status.ts
@@ -29,8 +29,8 @@ export class StatusBar {
       error: "$(error)",
       stopped: "$(circle-slash)",
     }
-    this.health.text = `${icons[status]} OpenCode CUI`
-    this.health.tooltip = detail ?? `OpenCode CUI: ${status}`
+    this.health.text = `${icons[status]} OpenCode Panel`
+    this.health.tooltip = detail ?? `OpenCode Panel: ${status}`
   }
 
   private renderAgent(sel: Selection) {
@@ -38,6 +38,6 @@ export class StatusBar {
     const model =
       sel.modelProviderID && sel.modelID ? `${sel.modelProviderID}/${sel.modelID}` : "default"
     this.agent.text = `$(person) ${agent}`
-    this.agent.tooltip = `Agent: ${agent}\nModel: ${model}\nClick to change agent (or run "OpenCode CUI: Select Model")`
+    this.agent.tooltip = `Agent: ${agent}\nModel: ${model}\nClick to change agent (or run "OpenCode Panel: Select Model")`
   }
 }

--- a/test/integration/extension.test.ts
+++ b/test/integration/extension.test.ts
@@ -1,7 +1,7 @@
 import * as assert from "node:assert"
 import * as vscode from "vscode"
 
-const EXTENSION_ID = "arthurzeng.opencui"
+const EXTENSION_ID = "haoyangzeng.opencui"
 
 suite("Extension activation", () => {
   test("extension is registered", () => {
@@ -54,12 +54,12 @@ suite("Settings", () => {
 })
 
 suite("Webview view registration", () => {
-  test("OpenCode CUI chat view is registered", async () => {
+  test("OpenCode Panel chat view is registered", async () => {
     // The chat view is registered via registerWebviewViewProvider during
     // activation. We verify by checking that the activity bar can show it.
     const ext = vscode.extensions.getExtension(EXTENSION_ID)!
     if (!ext.isActive) await ext.activate()
-    // Show the OpenCode CUI sidebar — this will fail if the view container
+    // Show the OpenCode Panel sidebar — this will fail if the view container
     // wasn't contributed properly in package.json.
     await vscode.commands.executeCommand("workbench.view.extension.opencui")
     // No throw means the view container exists and was opened.

--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -8,7 +8,7 @@ afterEach(cleanup)
 describe("PromptBox", () => {
   it("renders a textarea with placeholder", () => {
     render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} />)
-    expect(screen.getByPlaceholderText(/Ask OpenCode CUI/i)).toBeInTheDocument()
+    expect(screen.getByPlaceholderText(/Ask OpenCode Panel/i)).toBeInTheDocument()
   })
 
   it("Send button is disabled when textarea is empty", () => {

--- a/webview/index.html
+++ b/webview/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>OpenCode CUI</title>
+    <title>OpenCode Panel</title>
     <style>
       body { margin: 0; font-family: sans-serif; color: var(--vscode-foreground, #ccc); background: var(--vscode-sideBar-background, #1e1e1e); }
       .boot { padding: 20px; opacity: 0.7; font-size: 13px; }
@@ -11,7 +11,7 @@
   </head>
   <body>
     <div id="root">
-      <div class="boot">OpenCode CUI loading…</div>
+      <div class="boot">OpenCode Panel loading…</div>
     </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -89,7 +89,7 @@ export default function App() {
       >
         {state.messages.length === 0 && (
           <div className="welcome">
-            <div className="welcome-title">OpenCode CUI</div>
+            <div className="welcome-title">OpenCode Panel</div>
             <div className="welcome-sub">Ask about the current file, refactor code, or run a task.</div>
             <div className="welcome-suggestions">
               {WELCOME_PROMPTS.map((prompt) => (

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -316,7 +316,7 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
           ref={ref}
           value={text}
           rows={2}
-          placeholder="Ask OpenCode CUI…  (Enter to send, Shift+Enter for newline, @ to attach a file)"
+          placeholder="Ask OpenCode Panel…  (Enter to send, Shift+Enter for newline, @ to attach a file)"
           onChange={(e) => updateText(e.target.value, e.target.selectionStart ?? e.target.value.length)}
           onKeyDown={onKeyDown}
           onSelect={onSelect}


### PR DESCRIPTION
Closes #2.

## Summary
- Rename display name from OpenCode CUI to OpenCode Panel across `package.json`, README, CHANGELOG, CLAUDE.md, source strings, and tests.
- Change publisher from `arthurzeng` to `haoyangzeng`.
- Add GitHub community files for the Marketplace listing: bug report + feature request issue templates, issue config, PR template, and top-level `CONTRIBUTING.md`.

## Test plan
- [x] `bun run test` — 373/373 passing
- [x] `bun run check-types` — clean
- [x] Webview `tsc --noEmit` — only the 3 pre-existing errors flagged in CLAUDE.md
- [ ] Confirm command titles render as "OpenCode Panel: ..." in the VS Code command palette
- [ ] Confirm activity-bar title shows "OpenCode Panel"