### PR TITLE
ci: add release workflow for Marketplace auto-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish to VS Code Marketplace
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
+
+      - name: Install deps
+        run: bun install --frozen-lockfile
+
+      - name: Verify tag matches package.json version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG=$(node -p "require('./package.json').version")
+          if [ "$TAG" != "$PKG" ]; then
+            echo "Tag $GITHUB_REF_NAME (=$TAG) does not match package.json version $PKG" >&2
+            exit 1
+          fi
+
+      - name: Type-check
+        run: bun run check-types
+
+      - name: Tests
+        run: bun run test
+
+      - name: Production build
+        run: bun run package
+
+      - name: Publish to Marketplace
+        run: bunx @vscode/vsce publish --no-dependencies --pat "$VSCE_PAT"
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yml` that runs on `release: published`.
- The workflow installs deps, type-checks, runs tests, builds the production bundle, and publishes via `vsce` using the `VSCE_PAT` repo secret.
- A guard step fails the run early if the release tag (e.g. `v0.1.1`) does not match `package.json`'s `version`, so a mismatched release can never publish.

## Release flow this enables
1. Bump version in a feature PR (e.g. 0.1.0 → 0.1.1).
2. Merge the PR.
3. From `main`, tag `v0.1.1` and push the tag.
4. On GitHub: Releases → Draft new release → pick `v0.1.1` → Publish.
5. Workflow fires and publishes `haoyangzeng.opencui@0.1.1` to the Marketplace.

## Test plan
- [x] `VSCE_PAT` secret already configured on the repo.
- [ ] First real release (next version bump) verifies the workflow end to end.