### PR TITLE
fix(chat): align history popover row + move New chat (0.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.1]
+
+### Fixed
+- Chat history popover: title, time, Rename and Delete now sit on the same horizontal line. Replaced baseline alignment with center alignment on the row's "open" button and normalized font-sizes / line-heights across the four elements.
+
+### Changed
+- Moved the "New chat" action from below the popover title to the right side of the title row, so the popover header now reads "Chat history … + New chat" on a single line.
+
 ## [0.1.0] — Initial release
 
 ### Chat
@@ -48,5 +56,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Tests
 - 360+ tests across four phases: unit (Vitest + node/jsdom), integration (`@vscode/test-electron`), component (Vitest + React Testing Library), and E2E against a mock opencode HTTP/SSE server.
 
-[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/arthurzengg/opencui/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/arthurzengg/opencui/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",

--- a/webview/src/components/StatusBar.tsx
+++ b/webview/src/components/StatusBar.tsx
@@ -165,18 +165,20 @@ function ChatHistoryMenu({
       </button>
       {open && (
         <div className="history-popover">
-          <div className="history-popover-title">Chat history</div>
-          <button
-            type="button"
-            className="history-new"
-            onClick={() => {
-              setOpen(false)
-              onCreate()
-            }}
-          >
-            <span className="history-new-icon" aria-hidden="true" />
-            <span className="history-new-text">New chat</span>
-          </button>
+          <div className="history-popover-header">
+            <div className="history-popover-title">Chat history</div>
+            <button
+              type="button"
+              className="history-new"
+              onClick={() => {
+                setOpen(false)
+                onCreate()
+              }}
+            >
+              <span className="history-new-icon" aria-hidden="true" />
+              <span className="history-new-text">New chat</span>
+            </button>
+          </div>
           {showSearch && (
             <input
               className="history-search"

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -276,8 +276,14 @@ button {
   background: var(--vscode-dropdown-background, var(--vscode-sideBar-background));
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.32);
 }
+.history-popover-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 2px 4px 6px;
+}
 .history-popover-title {
-  padding: 2px 4px 7px;
   color: var(--vscode-descriptionForeground);
   font-size: 11px;
   font-weight: 600;
@@ -288,9 +294,7 @@ button {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  align-self: flex-start;
   padding: 3px 6px;
-  margin: 2px 0 4px;
   border: 0;
   border-radius: 3px;
   background: transparent;
@@ -385,10 +389,10 @@ button {
 }
 .history-open {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 8px;
   min-width: 0;
-  padding: 4px 0;
+  padding: 3px 0;
   border: 0;
   background: transparent;
   color: inherit;
@@ -402,11 +406,13 @@ button {
   white-space: nowrap;
   text-overflow: ellipsis;
   font-size: 12px;
+  line-height: 1.2;
 }
 .history-date {
   flex: 0 0 auto;
   color: var(--vscode-descriptionForeground);
-  font-size: 10px;
+  font-size: 11px;
+  line-height: 1.2;
 }
 .history-action {
   padding: 3px 5px;
@@ -414,7 +420,8 @@ button {
   border-radius: 4px;
   background: transparent;
   color: var(--vscode-descriptionForeground);
-  font-size: 10px;
+  font-size: 11px;
+  line-height: 1.2;
   opacity: 0;
   transition: opacity 0.12s ease;
 }


### PR DESCRIPTION
Closes #5.

## Summary
Two small fixes in the chat history popover, plus the version bump to 0.1.1 to exercise the new release workflow.

### Row alignment
Title, time, Rename, and Delete now visually share the same horizontal line.
- `.history-open` switched from `align-items: baseline` to `center`.
- `.history-title`, `.history-date`, and `.history-action` now all use `line-height: 1.2`.
- `.history-date` and `.history-action` bumped from 10px to 11px so the difference vs. the 12px title is one step instead of two.

### "New chat" button placement
Wrapped the popover title and the "New chat" button in a new `.history-popover-header` flex row with `justify-content: space-between`, so the header reads "Chat history … + New chat" on one line instead of stacking.

### Release
- `package.json` 0.1.0 → 0.1.1
- CHANGELOG entry added under [0.1.1]

## Test plan
- [x] `bun run test` — 373/373
- [x] `bun run check-types` — clean
- [x] Webview `tsc --noEmit` — only the 3 pre-existing errors flagged in CLAUDE.md
- [ ] Visual smoke once merged: open the chat history popover, confirm the four elements line up and "New chat" sits at the right of the title row
- [ ] After merge, tag `v0.1.1` and create a GitHub Release — the new `release.yml` workflow should auto-publish 0.1.1 to the Marketplace