### PR TITLE
fix(ci): install webview deps in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,12 @@ jobs:
         with:
           bun-version: 1.3.13
 
-      - name: Install deps
+      - name: Install deps (root)
         run: bun install --frozen-lockfile
+
+      - name: Install deps (webview)
+        run: bun install --frozen-lockfile
+        working-directory: webview
 
       - name: Verify tag matches package.json version
         run: |


### PR DESCRIPTION
Closes #6.

## Summary
The release workflow installed deps only at the repo root, missing the separately-installed `webview/node_modules`. Tests then failed to resolve `shiki/bundle/web` (a webview-only dep). Add an explicit `bun install --frozen-lockfile` step with `working-directory: webview` between the root install and the verify step.

## Why ci.yml works without this
`ci.yml` runs `bun run compile` before tests, and `compile` internally does `cd webview && bun install` as a side effect. The release workflow runs tests directly, so it needs the install spelled out.

## Test plan
- [x] YAML diff inspected by eye.
- [ ] After merge, delete the failed v0.1.1 tag + release and re-create v0.1.1 — the workflow should now reach the publish step and land 0.1.1 on the Marketplace.