### PR TITLE
chore(release): bump to 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.2]
+
+### Fixed
+- Release workflow: now installs webview deps before running tests, so the auto-publish workflow can reach the `vsce publish` step. No user-visible change vs 0.1.1; v0.1.1 was tagged but never reached the Marketplace because the workflow failed earlier.
+
 ## [0.1.1]
 
 ### Fixed
@@ -56,6 +61,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Tests
 - 360+ tests across four phases: unit (Vitest + node/jsdom), integration (`@vscode/test-electron`), component (Vitest + React Testing Library), and E2E against a mock opencode HTTP/SSE server.
 
-[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/arthurzengg/opencui/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/arthurzengg/opencui/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/arthurzengg/opencui/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
Closes #8.

## Summary
Bumps `package.json` 0.1.1 → 0.1.2 and adds the 0.1.2 CHANGELOG entry. v0.1.1 was tagged but never reached the Marketplace because the release workflow failed at the test step (see #6, fixed in #7). 0.1.2 is functionally identical to 0.1.1 from a user perspective — it exists to re-exercise the release workflow now that the fix is in.

## Test plan
- [x] CHANGELOG references updated (`[Unreleased]` compare link points at v0.1.2; new `[0.1.2]` row added).
- [ ] After merge, tag `v0.1.2` + create a GitHub Release. The workflow should now run green and land `haoyangzeng.opencui@0.1.2` on the Marketplace.