### PR TITLE
fix(chat): compact the Model · Agent trigger button (0.1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.3]
+
+### Changed
+- Compacted the Model · Agent trigger button by hiding the "MODEL" / "AGENT" prefix labels. The button now reads as just `<model> · <agent>` (e.g. `Sonnet 4.7 · Default`), which takes less horizontal space and leaves more room for the "New chat" and "Chat history" icons on narrow side panels. The full information is still available via the trigger's hover tooltip.
+
 ## [0.1.2]
 
 ### Fixed
@@ -61,7 +66,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Tests
 - 360+ tests across four phases: unit (Vitest + node/jsdom), integration (`@vscode/test-electron`), component (Vitest + React Testing Library), and E2E against a mock opencode HTTP/SSE server.
 
-[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/arthurzengg/opencui/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/arthurzengg/opencui/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/arthurzengg/opencui/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/arthurzengg/opencui/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -89,13 +89,11 @@ button {
   background: var(--vscode-button-secondaryHoverBackground);
 }
 .selector-prefix {
-  flex: 0 0 auto;
-  color: var(--vscode-descriptionForeground);
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  opacity: 0.75;
+  /* "MODEL" / "AGENT" labels are hidden globally so the trigger stays
+     compact and leaves more room for the New chat and Chat history icons
+     on narrow side panels. The labels are still rendered in the DOM and
+     covered by the trigger's `title` tooltip. */
+  display: none;
 }
 /* Primary (model) keeps its natural size up to where it can fit; */
 .selector-primary {
@@ -171,12 +169,6 @@ button {
   .statusbar {
     gap: 6px;
     padding-inline: 8px;
-  }
-  /* On narrow panels, drop the small prefix labels so the model and agent
-     values themselves keep room. Both values stay visible (ellipsis-truncated
-     if needed). */
-  .selector-prefix {
-    display: none;
   }
 }
 


### PR DESCRIPTION
Closes #10.

## Summary
Compact the Model · Agent trigger button in the statusbar by hiding its "MODEL" / "AGENT" prefix labels. The button now reads as just `<model> · <agent>` (e.g. `Sonnet 4.7 · Default`), so it takes less horizontal space and leaves more room for the "New chat" and "Chat history" icons on narrow side panels. The full information is still discoverable via the trigger's hover tooltip.

## What's NOT in this PR
The earlier attempts on this branch — replacing the in-webview Model · Agent popover with a VS Code QuickPick, pinning the icon buttons at 22px, re-anchoring the history popover — have been discarded via `git push --force-with-lease`. We're shipping just the trigger compaction for now.

## Release
- `package.json` 0.1.2 → 0.1.3
- CHANGELOG entry under [0.1.3]

## Test plan
- [x] `bun run test` — 373/373
- [x] `bun run check-types` — clean
- [ ] Visual smoke (dev host): the Model · Agent trigger now shows just `<model> · <agent>` without the "MODEL" / "AGENT" labels; the New chat and Chat history icons remain visible at narrower side panel widths.
- [ ] After merge: tag `v0.1.3` + create a GitHub Release; workflow auto-publishes.