### PR TITLE
fix(chat): anchor Model · Agent popover to statusbar so it fits at narrow widths (0.1.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.4]
+
+### Fixed
+- Model · Agent popover no longer overflows the sidebar's left edge at narrow widths. Both popovers now anchor to `.statusbar` itself instead of their individual menu wrappers, with `right: 10px` matching the statusbar's right padding. Identical width-and-right math now lands both popovers in the same place. The history popover is visually unchanged (it was already at the bar's right edge).
+
 ## [0.1.3]
 
 ### Changed
@@ -66,7 +71,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Tests
 - 360+ tests across four phases: unit (Vitest + node/jsdom), integration (`@vscode/test-electron`), component (Vitest + React Testing Library), and E2E against a mock opencode HTTP/SSE server.
 
-[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.1.3...HEAD
+[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.1.4...HEAD
+[0.1.4]: https://github.com/arthurzengg/opencui/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/arthurzengg/opencui/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/arthurzengg/opencui/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/arthurzengg/opencui/compare/v0.1.0...v0.1.1

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -29,6 +29,12 @@ button {
 
 /* ===== Status bar ===== */
 .statusbar {
+  /* `position: relative` makes the statusbar the positioning context for
+     both popovers. Without this, each popover anchors to its own menu
+     wrapper — the History popover lands correctly (its wrapper is at the
+     bar's right edge) but the Selector popover overflows left (its
+     wrapper is in the middle of the bar). */
+  position: relative;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -60,7 +66,6 @@ button {
 .statusbar .spacer { flex: 1; }
 
 .selector-menu {
-  position: relative;
   flex: 0 1 auto;
   min-width: 0;
   /* Ensure the selector never claims more than its share of the bar so the
@@ -118,8 +123,12 @@ button {
 }
 .selector-popover {
   position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
+  /* `top: 100%` is the bottom of .statusbar; the +2px is a small visual
+     gap. `right: 10px` matches .statusbar's right padding so the popover's
+     right edge lands inside the sidebar, the same place the History
+     popover lands. */
+  top: calc(100% + 2px);
+  right: 10px;
   z-index: 20;
   width: min(300px, calc(100vw - 20px));
   display: flex;
@@ -173,7 +182,6 @@ button {
 }
 
 .history-menu {
-  position: relative;
   flex: 0 0 auto;
 }
 .history-trigger,
@@ -255,8 +263,8 @@ button {
 }
 .history-popover {
   position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
+  top: calc(100% + 2px);
+  right: 10px;
   z-index: 20;
   width: min(360px, calc(100vw - 20px));
   max-height: min(420px, calc(100vh - 70px));


### PR DESCRIPTION
Closes #12.

## Summary
Single-purpose follow-up to the trigger compaction in #11 — fixes the root cause that the Model · Agent popover overflowed off the sidebar's left edge at narrow widths.

### Root cause (per #12)
Both popovers use `width: min(N, calc(100vw - 20px))` and `right: 0`. The History popover landed correctly because `.history-menu` is the last child in the statusbar (its right edge ≈ sidebar right edge - 10 px). The Selector popover landed badly because `.selector-menu` is in the middle of the statusbar (~60 – 70 px from the right edge), so `right: 0` lined the popover's right edge up with the middle of the bar and the left edge spilled off-screen.

### Fix
Promote `.statusbar` to the positioning context for both popovers:
- Drop `position: relative` from `.selector-menu` and `.history-menu`.
- Add `position: relative` on `.statusbar`.
- Both popovers now use `right: 10px` (matching the statusbar's right padding) so their right edges land in exactly the same place inside the sidebar.
- Pull `top` from `calc(100% + 6px)` to `calc(100% + 2px)` to compensate for the new (taller) positioning context — the statusbar wraps the menus with 6 px of vertical padding.

### What's NOT in this PR
None of the broader changes that were force-pushed away from #11 — no QuickPick replacement, no icon-button pinning, no body min-width, no JSX/protocol changes.

### Release
- `package.json` 0.1.3 → 0.1.4
- CHANGELOG entry under [0.1.4]

## Test plan
- [x] `bun run test` — 373/373
- [x] `bun run check-types` — clean
- [ ] Visual smoke (dev host): at narrow side panel widths, the Model · Agent popover sits inside the sidebar (right edge aligned with sidebar right, left edge inside the sidebar); the History popover renders in the same visual place as before.
- [ ] After merge: tag `v0.1.4` + create a GitHub Release; workflow auto-publishes.