### PR TITLE
feat(chat): add Retry button beside the Stopped badge (0.1.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.5]
+
+### Added
+- **Retry button on stopped messages.** When you press Stop, the assistant message gets a small "Retry" button inline with the "● Stopped" badge. Clicking it reverts the session to before the stopped response and re-sends the preceding user prompt verbatim — same text, same mentions, same attachments. The partial response is discarded and the LLM starts fresh. The button is hidden while another message is in flight.
+
 ## [0.1.4]
 
 ### Fixed
@@ -71,7 +76,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Tests
 - 360+ tests across four phases: unit (Vitest + node/jsdom), integration (`@vscode/test-electron`), component (Vitest + React Testing Library), and E2E against a mock opencode HTTP/SSE server.
 
-[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.1.4...HEAD
+[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.1.5...HEAD
+[0.1.5]: https://github.com/arthurzengg/opencui/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/arthurzengg/opencui/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/arthurzengg/opencui/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/arthurzengg/opencui/compare/v0.1.1...v0.1.2

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react"
 import { useChatState } from "./hooks/useChatState"
 import type { Message } from "./hooks/useChatState"
+import type { Attachment } from "./protocol"
 import { MessageView } from "./components/MessageView"
 import { PromptBox } from "./components/PromptBox"
 import { StatusBar } from "./components/StatusBar"
@@ -42,6 +43,30 @@ export default function App() {
   useEffect(() => () => {
     if (openReviewChangeTimer.current) clearTimeout(openReviewChangeTimer.current)
   }, [])
+
+  // Retry a stopped assistant response: walk back to the user message that
+  // preceded it and re-run the edit flow with the same text / mentions /
+  // attachments. The host's editMessage handler does session.revert + send,
+  // so the partial assistant response is discarded and the LLM starts over.
+  const handleRetry = (assistantID: string) => {
+    const idx = state.messages.findIndex((m) => m.id === assistantID)
+    if (idx <= 0) return
+    for (let i = idx - 1; i >= 0; i--) {
+      const m = state.messages[i]
+      if (m.role !== "user") continue
+      const textBlock = m.blocks.find((b) => b.type === "text")
+      const text = textBlock && textBlock.type === "text" ? textBlock.text : ""
+      if (!text) return
+      const attachments: Attachment[] = []
+      for (const b of m.blocks) {
+        if (b.type === "attachment") {
+          attachments.push({ mime: b.mime, filename: b.filename, dataUrl: b.dataUrl, bytes: b.bytes })
+        }
+      }
+      editMessage(m.id, text, m.mentions, attachments)
+      return
+    }
+  }
 
   const busy = state.busy || state.messages.some((m) => m.pending)
   const activeProcessID = state.messages.findLast((m) => m.role === "assistant" && m.pending)?.id
@@ -124,6 +149,7 @@ export default function App() {
                 busy={busy}
                 onReviewFile={openReviewFile}
                 onEditMessage={editMessage}
+                onRetry={handleRetry}
               />
             ))}
           </div>

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -13,6 +13,7 @@ export function MessageView({
   busy,
   onReviewFile,
   onEditMessage,
+  onRetry,
   searchFiles,
   attachFile,
 }: {
@@ -22,6 +23,7 @@ export function MessageView({
   busy?: boolean
   onReviewFile?: (path: string) => void
   onEditMessage?: (id: string, text: string, mentions?: string[], attachments?: Attachment[]) => void
+  onRetry?: (assistantID: string) => void
   searchFiles?: (query: string) => Promise<FileSearchHit[]>
   attachFile?: () => Promise<{ attachments: Attachment[]; error?: string }>
 }) {
@@ -51,7 +53,23 @@ export function MessageView({
         // In either case render ONE neutral grey "Stopped" badge, not the red
         // error block. Real failures (network, etc.) still render in red.
         const stopped = message.stopped || /^aborted$/i.test((message.error ?? "").trim())
-        if (stopped) return <div className="msg-stopped">Stopped</div>
+        if (stopped) {
+          return (
+            <div className="msg-stopped">
+              <span>Stopped</span>
+              {onRetry && !busy && (
+                <button
+                  type="button"
+                  className="msg-retry"
+                  onClick={() => onRetry(message.id)}
+                  title="Resend the same prompt"
+                >
+                  Retry
+                </button>
+              )}
+            </div>
+          )
+        }
         if (message.error) return <div className="msg-error">{message.error}</div>
         return null
       })()}

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -823,6 +823,24 @@ button {
   background: currentColor;
   opacity: 0.7;
 }
+/* "Retry" sits inline with the Stopped badge — non-italic and a touch more
+   opaque than the badge label to read as an actionable affordance. */
+.msg-retry {
+  margin-left: 4px;
+  padding: 1px 6px;
+  border: 0;
+  border-radius: 4px;
+  background: var(--vscode-button-secondaryBackground);
+  color: var(--vscode-button-secondaryForeground);
+  font-size: 11px;
+  font-style: normal;
+  font-weight: 600;
+  opacity: 1;
+  cursor: pointer;
+}
+.msg-retry:hover {
+  background: var(--vscode-button-secondaryHoverBackground);
+}
 
 .msg-usage {
   font-size: 10px;


### PR DESCRIPTION
Closes #14.

## Summary
When the user pressed Stop and the input was already cleared, there was no one-click way to re-run the same prompt — the only workaround was clicking the preceding user bubble to enter edit-in-place mode and re-Send without changing anything. This PR surfaces that as an inline action.

### What it does
A small **Retry** button sits inline with the existing "● Stopped" badge on any stopped assistant message. Clicking it:
1. Walks back from the stopped assistant message to the user prompt that preceded it.
2. Reconstructs the user prompt's text / mentions / attachments from its blocks.
3. Re-runs the existing `editMessage` flow — which `session.revert`s past the stopped response and then re-sends the same prompt.

The partial assistant response is discarded; the LLM starts fresh from the same prompt.

### Where it appears
- Beside the "● Stopped" badge on stopped assistant messages.
- Hidden when the chat is `busy` with another message, so it can't fire mid-flight.

### Implementation notes
- `MessageView` gains an `onRetry(assistantID)` callback prop.
- `App.tsx` wires `onRetry` for assistant messages: finds the preceding user message, extracts text + attachments from its blocks, calls the existing `editMessage` action.
- No host / protocol / SDK changes — reuses the existing edit-and-regenerate machinery.
- `.msg-retry` styled as a small secondary button so it reads as actionable next to the quiet italic Stopped label.

### Release
- `package.json` 0.1.4 → 0.1.5
- CHANGELOG entry under [0.1.5]

## Test plan
- [x] `bun run test` — 373/373
- [x] `bun run check-types` — clean
- [ ] Visual smoke (dev host):
  - Send a prompt, press Stop while it's streaming → stopped assistant message shows "● Stopped  Retry".
  - Click Retry → the stopped message disappears, the same prompt is re-sent, the LLM responds.
  - Send another prompt; while it's streaming, the Retry button on the previous stopped message should be hidden (busy state).
  - Edit-in-place on user messages still works (no regression in `editMessage`).
- [ ] After merge: tag `v0.1.5` + create a GitHub Release; workflow auto-publishes.