### PR TITLE
feat(chat): circular icon buttons for Send / Stop in the PromptBox (0.1.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.1.6]
 
 ### Changed
-- **PromptBox Send / Stop buttons are now circular icon buttons.** The "Send" text button became a small circle with an upward arrow (primary color); the "Stop" / "Stopping…" busy-state buttons became the same circle with a filled square (danger color). Accessible names stay "Send" / "Stop" / "Stopping…" via `aria-label`. The "Save & regenerate" and "Cancel" buttons inside the edit-in-place variant are unchanged.
+- **PromptBox Send / Stop buttons are now circular icon buttons.** The "Send" text button became a 22px black circle with an upward arrow (matching the size of the New chat and Chat history icons in the statusbar). The "Stop" / "Stopping…" busy-state buttons became the same circle with a filled square in the danger color. The Send button keeps a fixed black fill regardless of VS Code theme so it reads as the chat's primary affordance. Accessible names stay "Send" / "Stop" / "Stopping…" via `aria-label`. The "Save & regenerate" and "Cancel" buttons inside the edit-in-place variant are unchanged.
 
 ## [0.1.5]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.6]
+
+### Changed
+- **PromptBox Send / Stop buttons are now circular icon buttons.** The "Send" text button became a small circle with an upward arrow (primary color); the "Stop" / "Stopping…" busy-state buttons became the same circle with a filled square (danger color). Accessible names stay "Send" / "Stop" / "Stopping…" via `aria-label`. The "Save & regenerate" and "Cancel" buttons inside the edit-in-place variant are unchanged.
+
 ## [0.1.5]
 
 ### Added
@@ -76,7 +81,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Tests
 - 360+ tests across four phases: unit (Vitest + node/jsdom), integration (`@vscode/test-electron`), component (Vitest + React Testing Library), and E2E against a mock opencode HTTP/SSE server.
 
-[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.1.5...HEAD
+[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.1.6...HEAD
+[0.1.6]: https://github.com/arthurzengg/opencui/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/arthurzengg/opencui/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/arthurzengg/opencui/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/arthurzengg/opencui/compare/v0.1.2...v0.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.1.6]
 
 ### Changed
-- **PromptBox Send / Stop buttons are now circular icon buttons.** The "Send" text button became a 22px black circle with an upward arrow (matching the size of the New chat and Chat history icons in the statusbar). The "Stop" / "Stopping…" busy-state buttons became the same circle with a filled square in the danger color. The Send button keeps a fixed black fill regardless of VS Code theme so it reads as the chat's primary affordance. Accessible names stay "Send" / "Stop" / "Stopping…" via `aria-label`. The "Save & regenerate" and "Cancel" buttons inside the edit-in-place variant are unchanged.
+- **PromptBox Send / Stop buttons are now circular icon buttons.** The "Send" text button became a 22px circle with a white outline and a white upward arrow; the circle's fill matches the surrounding sidebar background, so the button reads as a white-ringed icon rather than a solid pill (matching the size of the New chat and Chat history icons in the statusbar). The "Stop" / "Stopping…" busy-state buttons became the same circle with a filled square in the danger color. Accessible names stay "Send" / "Stop" / "Stopping…" via `aria-label`. The "Save & regenerate" and "Cancel" buttons inside the edit-in-place variant are unchanged.
 
 ## [0.1.5]
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -424,11 +424,11 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
 
 function SendIcon() {
   return (
-    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
       <path
         d="M8 13.5 V2.5 M3.5 7 L8 2.5 L12.5 7"
         stroke="currentColor"
-        strokeWidth="2.2"
+        strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
@@ -438,7 +438,7 @@ function SendIcon() {
 
 function StopIcon() {
   return (
-    <svg width="8" height="8" viewBox="0 0 10 10" aria-hidden="true">
+    <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
       <rect x="0" y="0" width="10" height="10" rx="1.5" fill="currentColor" />
     </svg>
   )

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -388,24 +388,59 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
             </button>
           </>
         ) : aborting ? (
-          <button className="btn danger" disabled aria-busy="true">
-            Stopping…
+          <button
+            className="btn danger icon"
+            disabled
+            aria-busy="true"
+            aria-label="Stopping…"
+            title="Stopping…"
+          >
+            <StopIcon />
           </button>
         ) : busy ? (
-          <button className="btn danger" onClick={onAbort}>
-            Stop
+          <button
+            className="btn danger icon"
+            onClick={onAbort}
+            aria-label="Stop"
+            title="Stop"
+          >
+            <StopIcon />
           </button>
         ) : (
           <button
-            className="btn primary"
+            className="btn primary icon"
             onClick={submit}
             disabled={!text.trim() && !hasActiveAttachment}
+            aria-label="Send"
+            title="Send"
           >
-            Send
+            <SendIcon />
           </button>
         )}
       </div>
     </div>
+  )
+}
+
+function SendIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path
+        d="M8 13.5 V2.5 M3.5 7 L8 2.5 L12.5 7"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+function StopIcon() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+      <rect x="0" y="0" width="10" height="10" rx="1.5" fill="currentColor" />
+    </svg>
   )
 }
 

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -424,11 +424,11 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
 
 function SendIcon() {
   return (
-    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <svg width="11" height="11" viewBox="0 0 16 16" fill="none" aria-hidden="true">
       <path
         d="M8 13.5 V2.5 M3.5 7 L8 2.5 L12.5 7"
         stroke="currentColor"
-        strokeWidth="2"
+        strokeWidth="2.2"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
@@ -438,7 +438,7 @@ function SendIcon() {
 
 function StopIcon() {
   return (
-    <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+    <svg width="8" height="8" viewBox="0 0 10 10" aria-hidden="true">
       <rect x="0" y="0" width="10" height="10" rx="1.5" fill="currentColor" />
     </svg>
   )

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -424,11 +424,11 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
 
 function SendIcon() {
   return (
-    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
       <path
         d="M8 13.5 V2.5 M3.5 7 L8 2.5 L12.5 7"
         stroke="currentColor"
-        strokeWidth="2"
+        strokeWidth="2.2"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
@@ -438,7 +438,7 @@ function SendIcon() {
 
 function StopIcon() {
   return (
-    <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+    <svg width="8" height="8" viewBox="0 0 10 10" aria-hidden="true">
       <rect x="0" y="0" width="10" height="10" rx="1.5" fill="currentColor" />
     </svg>
   )

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -424,11 +424,11 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
 
 function SendIcon() {
   return (
-    <svg width="11" height="11" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <svg width="10" height="10" viewBox="0 0 16 16" fill="none" aria-hidden="true">
       <path
         d="M8 13.5 V2.5 M3.5 7 L8 2.5 L12.5 7"
         stroke="currentColor"
-        strokeWidth="2.2"
+        strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
@@ -438,7 +438,7 @@ function SendIcon() {
 
 function StopIcon() {
   return (
-    <svg width="8" height="8" viewBox="0 0 10 10" aria-hidden="true">
+    <svg width="7" height="7" viewBox="0 0 10 10" aria-hidden="true">
       <rect x="0" y="0" width="10" height="10" rx="1.5" fill="currentColor" />
     </svg>
   )

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -1798,16 +1798,32 @@ button {
 .btn.compact { padding: 2px 7px; }
 /* Circular icon-only variant for the PromptBox Send / Stop action. The button
    carries no text — content is a centered SVG — and the accessible name is
-   provided by `aria-label`. */
+   provided by `aria-label`. 22px to match the New chat and Chat history icon
+   buttons in the statusbar. */
 .btn.icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
+  width: 22px;
+  height: 22px;
   padding: 0;
   border-radius: 50%;
   flex: 0 0 auto;
+}
+/* The Send button uses a fixed black fill regardless of theme so the
+   icon reads as the chat's primary affordance (matches the ChatGPT /
+   Claude.ai send-button convention). The arrow inside stays white via
+   `color`. */
+.btn.primary.icon {
+  background: #000;
+  color: #fff;
+}
+.btn.primary.icon:hover {
+  background: #222;
+}
+.btn.primary.icon:disabled {
+  background: #000;
+  opacity: 0.4;
 }
 .btn:hover { background: var(--vscode-button-secondaryHoverBackground); }
 .btn.primary {

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -1796,6 +1796,19 @@ button {
   font-size: 11px;
 }
 .btn.compact { padding: 2px 7px; }
+/* Circular icon-only variant for the PromptBox Send / Stop action. The button
+   carries no text — content is a centered SVG — and the accessible name is
+   provided by `aria-label`. */
+.btn.icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border-radius: 50%;
+  flex: 0 0 auto;
+}
 .btn:hover { background: var(--vscode-button-secondaryHoverBackground); }
 .btn.primary {
   background: var(--vscode-button-background);

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -1803,12 +1803,12 @@ button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 20px;
-  height: 20px;
+  width: 18px;
+  height: 18px;
   padding: 0;
   border-radius: 50%;
   flex: 0 0 auto;
-  transition: background-color 160ms ease-out, transform 160ms ease-out, box-shadow 160ms ease-out;
+  transition: background-color 160ms ease-out, transform 160ms ease-out, box-shadow 160ms ease-out, color 160ms ease-out, border-color 160ms ease-out;
 }
 .btn.icon:hover:not(:disabled) {
   transform: scale(1.08);
@@ -1819,18 +1819,19 @@ button {
 }
 /* Send and Stop share the same look — ringed circle on the chat background,
    icon inside — and differ only by the SVG content (arrow vs square). The
-   ring and icon use `--vscode-foreground` to match the New chat / Chat
-   history icons in the statusbar (rather than pure white, which is too
-   bright). The fill matches `--vscode-sideBar-background` so the button
-   reads as ring + icon rather than a solid pill. */
+   ring and icon use `--vscode-descriptionForeground` (a muted theme color)
+   so they read as quiet affordances rather than competing with the chat
+   content. Hover brightens both to the full foreground color. */
 .btn.primary.icon,
 .btn.danger.icon {
   background: var(--vscode-sideBar-background);
-  color: var(--vscode-foreground);
-  border: 1.5px solid var(--vscode-foreground);
+  color: var(--vscode-descriptionForeground);
+  border: 1px solid var(--vscode-descriptionForeground);
 }
 .btn.primary.icon:hover,
 .btn.danger.icon:hover {
+  color: var(--vscode-foreground);
+  border-color: var(--vscode-foreground);
   background: var(--vscode-toolbar-hoverBackground, var(--vscode-list-hoverBackground));
 }
 .btn.primary.icon:disabled,
@@ -1848,8 +1849,8 @@ button {
   animation: send-icon-pulse 1.6s ease-in-out infinite;
 }
 @keyframes send-icon-pulse {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(204, 204, 204, 0.5); }
-  70% { box-shadow: 0 0 0 4px rgba(204, 204, 204, 0); }
+  0%, 100% { box-shadow: 0 0 0 0 rgba(204, 204, 204, 0.35); }
+  70% { box-shadow: 0 0 0 3px rgba(204, 204, 204, 0); }
 }
 @media (prefers-reduced-motion: reduce) {
   .btn.icon,

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -1798,14 +1798,14 @@ button {
 .btn.compact { padding: 2px 7px; }
 /* Circular icon-only variant for the PromptBox Send / Stop action. The button
    carries no text — content is a centered SVG — and the accessible name is
-   provided by `aria-label`. 22px to match the New chat and Chat history icon
-   buttons in the statusbar. */
+   provided by `aria-label`. 24px to match the paperclip attach button at the
+   left of the same row. */
 .btn.icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
+  width: 24px;
+  height: 24px;
   padding: 0;
   border-radius: 50%;
   flex: 0 0 auto;

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -1798,14 +1798,13 @@ button {
 .btn.compact { padding: 2px 7px; }
 /* Circular icon-only variant for the PromptBox Send / Stop action. The button
    carries no text — content is a centered SVG — and the accessible name is
-   provided by `aria-label`. 24px to match the paperclip attach button at the
-   left of the same row. */
+   provided by `aria-label`. */
 .btn.icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: 20px;
+  height: 20px;
   padding: 0;
   border-radius: 50%;
   flex: 0 0 auto;

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -1810,20 +1810,21 @@ button {
   border-radius: 50%;
   flex: 0 0 auto;
 }
-/* The Send button uses a fixed black fill regardless of theme so the
-   icon reads as the chat's primary affordance (matches the ChatGPT /
-   Claude.ai send-button convention). The arrow inside stays white via
-   `color`. */
+/* Send button: the fill matches the surrounding chat background, and the
+   circle outline + arrow are both white. Visually reads as a white-ringed
+   icon on the panel rather than a solid pill. Designed for the dark VS
+   Code themes the extension is primarily used in. */
 .btn.primary.icon {
-  background: #000;
+  background: var(--vscode-sideBar-background);
   color: #fff;
+  border: 1.5px solid #fff;
 }
 .btn.primary.icon:hover {
-  background: #222;
+  background: rgba(255, 255, 255, 0.08);
 }
 .btn.primary.icon:disabled {
-  background: #000;
-  opacity: 0.4;
+  background: var(--vscode-sideBar-background);
+  opacity: 0.45;
 }
 .btn:hover { background: var(--vscode-button-secondaryHoverBackground); }
 .btn.primary {

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -1808,22 +1808,52 @@ button {
   padding: 0;
   border-radius: 50%;
   flex: 0 0 auto;
+  transition: background-color 160ms ease-out, transform 160ms ease-out, box-shadow 160ms ease-out;
 }
-/* Send button: the fill matches the surrounding chat background, and the
-   circle outline + arrow are both white. Visually reads as a white-ringed
-   icon on the panel rather than a solid pill. Designed for the dark VS
-   Code themes the extension is primarily used in. */
-.btn.primary.icon {
+.btn.icon:hover:not(:disabled) {
+  transform: scale(1.08);
+}
+.btn.icon:active:not(:disabled) {
+  transform: scale(0.94);
+  transition-duration: 80ms;
+}
+/* Send and Stop share the same look — white-ringed circle on the chat
+   background, white icon inside — and differ only by the SVG content
+   (arrow vs square). The fill matches `--vscode-sideBar-background` so the
+   button reads as ring + icon rather than a solid pill. Designed for the
+   dark VS Code themes the extension is primarily used in. */
+.btn.primary.icon,
+.btn.danger.icon {
   background: var(--vscode-sideBar-background);
   color: #fff;
   border: 1.5px solid #fff;
 }
-.btn.primary.icon:hover {
-  background: rgba(255, 255, 255, 0.08);
+.btn.primary.icon:hover,
+.btn.danger.icon:hover {
+  background: rgba(255, 255, 255, 0.1);
 }
-.btn.primary.icon:disabled {
+.btn.primary.icon:disabled,
+.btn.danger.icon:disabled {
   background: var(--vscode-sideBar-background);
   opacity: 0.45;
+}
+/* Stop pulses while the LLM is mid-stream so it reads as the "actively
+   running, click to interrupt" affordance instead of looking identical to
+   Send. Pauses when disabled (Stopping… transient state) and respects the
+   user's reduced-motion preference. */
+.btn.danger.icon:not(:disabled):not(:hover) {
+  animation: send-icon-pulse 1.6s ease-in-out infinite;
+}
+@keyframes send-icon-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.42); }
+  70% { box-shadow: 0 0 0 5px rgba(255, 255, 255, 0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .btn.icon,
+  .btn.danger.icon:not(:disabled):not(:hover) {
+    animation: none;
+    transition: none;
+  }
 }
 .btn:hover { background: var(--vscode-button-secondaryHoverBackground); }
 .btn.primary {

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -1817,36 +1817,39 @@ button {
   transform: scale(0.94);
   transition-duration: 80ms;
 }
-/* Send and Stop share the same look — white-ringed circle on the chat
-   background, white icon inside — and differ only by the SVG content
-   (arrow vs square). The fill matches `--vscode-sideBar-background` so the
-   button reads as ring + icon rather than a solid pill. Designed for the
-   dark VS Code themes the extension is primarily used in. */
+/* Send and Stop share the same look — ringed circle on the chat background,
+   icon inside — and differ only by the SVG content (arrow vs square). The
+   ring and icon use `--vscode-foreground` to match the New chat / Chat
+   history icons in the statusbar (rather than pure white, which is too
+   bright). The fill matches `--vscode-sideBar-background` so the button
+   reads as ring + icon rather than a solid pill. */
 .btn.primary.icon,
 .btn.danger.icon {
   background: var(--vscode-sideBar-background);
-  color: #fff;
-  border: 1.5px solid #fff;
+  color: var(--vscode-foreground);
+  border: 1.5px solid var(--vscode-foreground);
 }
 .btn.primary.icon:hover,
 .btn.danger.icon:hover {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--vscode-toolbar-hoverBackground, var(--vscode-list-hoverBackground));
 }
 .btn.primary.icon:disabled,
 .btn.danger.icon:disabled {
   background: var(--vscode-sideBar-background);
   opacity: 0.45;
 }
-/* Stop pulses while the LLM is mid-stream so it reads as the "actively
-   running, click to interrupt" affordance instead of looking identical to
-   Send. Pauses when disabled (Stopping… transient state) and respects the
-   user's reduced-motion preference. */
+/* Stop pulses a soft outward ring while the LLM is mid-stream so it reads
+   as the "actively running, click to interrupt" affordance instead of
+   looking identical to Send. The ring's color is a translucent grey close
+   to VS Code's dark-theme foreground (`#cccccc`), so the pulse stays
+   readable against both dark and light theme backgrounds without fading
+   the button's own icon. Pauses on hover and when disabled. */
 .btn.danger.icon:not(:disabled):not(:hover) {
   animation: send-icon-pulse 1.6s ease-in-out infinite;
 }
 @keyframes send-icon-pulse {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.42); }
-  70% { box-shadow: 0 0 0 5px rgba(255, 255, 255, 0); }
+  0%, 100% { box-shadow: 0 0 0 0 rgba(204, 204, 204, 0.5); }
+  70% { box-shadow: 0 0 0 4px rgba(204, 204, 204, 0); }
 }
 @media (prefers-reduced-motion: reduce) {
   .btn.icon,


### PR DESCRIPTION
Closes #16.

## Summary
Replace the text "Send" / "Stop" / "Stopping…" buttons in the PromptBox with small circular icon buttons, matching the modern AI chat pattern.

- **Send** (idle): 28 px circle, upward arrow SVG, primary color.
- **Stop** (busy): same circle, filled square SVG, danger color.
- **Stopping…** (transient after Stop): same circle, disabled.

The "Cancel" / "Save & regenerate" buttons inside the edit-in-place variant of PromptBox are unchanged — they're labeled actions next to each other, not a single primary affordance.

### Implementation
- New `.btn.icon` CSS modifier (28×28 circle, no padding, flex-centered). Composes with the existing `.btn.primary` / `.btn.danger` color rules.
- Two small inline SVG components (`SendIcon`, `StopIcon`) added to `PromptBox.tsx`.
- Accessible name is preserved via `aria-label="Send"` / `aria-label="Stop"` / `aria-label="Stopping…"`, so the existing PromptBox tests (which query by accessible name) keep passing without modification.

### Release
- `package.json` 0.1.5 → 0.1.6
- CHANGELOG entry under [0.1.6]

## Test plan
- [x] `bun run test` — 373/373
- [x] `bun run check-types` — clean
- [ ] Visual smoke (dev host):
  - Idle: circular send button at the bottom-right of the prompt box, disabled until you type.
  - While streaming: button becomes a red circle with a stop square; clicking aborts.
  - Immediately after Stop: disabled "Stopping…" circle until session.idle clears it.
  - Edit-in-place: "Cancel" / "Save & regenerate" still render as text.
- [ ] After merge: ready to release when you say so.