### PR TITLE
feat(chat): accept code and text files as paperclip attachments (0.1.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.1.7]
+
+### Added
+- **Attach code and text files.** The paperclip Attach button now accepts a curated set of ~50 common code / plain-text extensions in addition to images and PDFs — `.txt`, `.md`, `.json`, `.js` / `.ts`, `.py`, `.go`, `.rs`, `.yml`, `.html`, `.sh`, and so on. The file dialog adds a "Code & text" filter group and an "All supported" default. Each attached file is forwarded to opencode via its `file://` source path; the LLM sees both the filename and the content. In the message bubble, non-image attachments now render with a small extension badge (`MD`, `JSON`, `PDF`, …) instead of always saying "PDF".
+
 ## [0.1.6]
 
 ### Changed
@@ -81,7 +86,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Tests
 - 360+ tests across four phases: unit (Vitest + node/jsdom), integration (`@vscode/test-electron`), component (Vitest + React Testing Library), and E2E against a mock opencode HTTP/SSE server.
 
-[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.1.6...HEAD
+[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.1.7...HEAD
+[0.1.7]: https://github.com/arthurzengg/opencui/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/arthurzengg/opencui/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/arthurzengg/opencui/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/arthurzengg/opencui/compare/v0.1.3...v0.1.4

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",

--- a/src/attachments.ts
+++ b/src/attachments.ts
@@ -7,8 +7,33 @@ export const MAX_TOTAL_ATTACHMENT_BYTES = 25 * 1024 * 1024 // 25 MB across one p
 
 export const IMAGE_EXTS = ["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg"]
 export const DOC_EXTS = ["pdf"]
+/**
+ * Curated list of code / plain-text extensions the paperclip accepts. The
+ * LLM sees the filename when it receives the attachment, so language
+ * inference works even when we ship `text/plain` as the mime.
+ */
+export const TEXT_EXTS = [
+  // Plain text / markup
+  "txt", "md", "markdown", "mdx", "rst", "log", "csv", "tsv",
+  // Web / styles
+  "html", "htm", "css", "scss", "sass", "less",
+  // JS / TS
+  "js", "jsx", "ts", "tsx", "mjs", "cjs",
+  // Structured data
+  "json", "json5", "jsonc", "xml", "yml", "yaml", "toml", "ini", "conf", "env",
+  // General languages
+  "py", "pyw", "pyi", "rb", "go", "rs", "java", "kt", "kts", "swift", "cs",
+  "php", "pl", "lua", "dart", "scala", "r",
+  // C-family
+  "c", "cc", "cpp", "cxx", "h", "hpp", "hxx",
+  // Shells / scripts
+  "sh", "bash", "zsh", "fish", "ps1", "bat", "cmd",
+  // Misc text-bearing
+  "sql", "vue", "svelte", "astro", "tex", "graphql", "gql",
+]
 
 const MIME_BY_EXT: Record<string, string> = {
+  // Images / PDFs (binary)
   png: "image/png",
   jpg: "image/jpeg",
   jpeg: "image/jpeg",
@@ -17,16 +42,40 @@ const MIME_BY_EXT: Record<string, string> = {
   bmp: "image/bmp",
   svg: "image/svg+xml",
   pdf: "application/pdf",
+  // Text / code — known mimes for common kinds; everything else in TEXT_EXTS
+  // falls through to `text/plain` via the default in `guessMime`.
+  js: "text/javascript",
+  mjs: "text/javascript",
+  cjs: "text/javascript",
+  jsx: "text/javascript",
+  ts: "text/typescript",
+  tsx: "text/typescript",
+  json: "application/json",
+  json5: "application/json",
+  jsonc: "application/json",
+  html: "text/html",
+  htm: "text/html",
+  css: "text/css",
+  xml: "application/xml",
+  yml: "application/x-yaml",
+  yaml: "application/x-yaml",
+  csv: "text/csv",
+  tsv: "text/tab-separated-values",
+  md: "text/markdown",
+  markdown: "text/markdown",
+  mdx: "text/markdown",
 }
 
 export function guessMime(filename: string): string {
   const ext = path.extname(filename).slice(1).toLowerCase()
-  return MIME_BY_EXT[ext] ?? "application/octet-stream"
+  if (MIME_BY_EXT[ext]) return MIME_BY_EXT[ext]
+  if (TEXT_EXTS.includes(ext)) return "text/plain"
+  return "application/octet-stream"
 }
 
 export function isAcceptedExt(filename: string): boolean {
   const ext = path.extname(filename).slice(1).toLowerCase()
-  return IMAGE_EXTS.includes(ext) || DOC_EXTS.includes(ext)
+  return IMAGE_EXTS.includes(ext) || DOC_EXTS.includes(ext) || TEXT_EXTS.includes(ext)
 }
 
 /** Encode `bytes` as a `data:<mime>;base64,...` URL using Node's Buffer. */
@@ -65,12 +114,14 @@ export async function readAttachment(uri: vscode.Uri): Promise<ReadResult> {
   return { ok: true, attachment }
 }
 
-/** Open VS Code's native file dialog filtered to images/PDFs and return the chosen attachments. */
+/** Open VS Code's native file dialog filtered to the accepted extensions and return the chosen attachments. */
 export async function pickAttachments(): Promise<{ attachments: Attachment[]; error?: string }> {
   const uris = await vscode.window.showOpenDialog({
     canSelectMany: true,
     openLabel: "Attach",
     filters: {
+      "All supported": [...IMAGE_EXTS, ...DOC_EXTS, ...TEXT_EXTS],
+      "Code & text": TEXT_EXTS,
       "Images & PDFs": [...IMAGE_EXTS, ...DOC_EXTS],
       Images: IMAGE_EXTS,
       PDFs: DOC_EXTS,

--- a/test/host/attachments.test.ts
+++ b/test/host/attachments.test.ts
@@ -34,9 +34,20 @@ describe("isAcceptedExt", () => {
     expect(isAcceptedExt("foo.PDF")).toBe(true)
   })
 
-  it("rejects other types", () => {
+  it("accepts code and text files", () => {
+    expect(isAcceptedExt("foo.js")).toBe(true)
+    expect(isAcceptedExt("foo.TS")).toBe(true)
+    expect(isAcceptedExt("foo.py")).toBe(true)
+    expect(isAcceptedExt("foo.md")).toBe(true)
+    expect(isAcceptedExt("foo.json")).toBe(true)
+    expect(isAcceptedExt("foo.txt")).toBe(true)
+    expect(isAcceptedExt("foo.yml")).toBe(true)
+  })
+
+  it("rejects binary office docs and extensionless files", () => {
     expect(isAcceptedExt("foo.docx")).toBe(false)
-    expect(isAcceptedExt("foo.js")).toBe(false)
+    expect(isAcceptedExt("foo.xlsx")).toBe(false)
+    expect(isAcceptedExt("foo.exe")).toBe(false)
     expect(isAcceptedExt("foo")).toBe(false)
   })
 })

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -204,7 +204,7 @@ function UserMessageView({
                   {a.mime.startsWith("image/") ? (
                     <img className="attachment-thumb" src={a.dataUrl} alt={a.filename} />
                   ) : (
-                    <span className="attachment-icon" aria-hidden>PDF</span>
+                    <span className="attachment-icon" aria-hidden>{badgeForFilename(a.filename)}</span>
                   )}
                   <span className="attachment-name">{a.filename}</span>
                 </li>
@@ -226,6 +226,29 @@ function UserMessageView({
       )}
     </div>
   )
+}
+
+/**
+ * Choose a short badge label for a non-image attachment. PDF stays "PDF";
+ * everything else falls back to the file's uppercase extension, capped at
+ * 4 chars so the badge stays compact in the message bubble. Some longer
+ * canonical extensions are abbreviated by hand.
+ */
+function badgeForFilename(filename: string): string {
+  const dot = filename.lastIndexOf(".")
+  if (dot < 0) return "FILE"
+  const ext = filename.slice(dot + 1).toLowerCase()
+  if (!ext) return "FILE"
+  const aliases: Record<string, string> = {
+    markdown: "MD",
+    javascript: "JS",
+    typescript: "TS",
+    yaml: "YML",
+    python: "PY",
+  }
+  if (aliases[ext]) return aliases[ext]
+  if (ext === "pdf") return "PDF"
+  return ext.length <= 4 ? ext.toUpperCase() : ext.slice(0, 4).toUpperCase()
 }
 
 /**

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -359,8 +359,8 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
           <button
             type="button"
             className="icon-btn attach-btn"
-            aria-label="Attach image or PDF"
-            title="Attach image or PDF"
+            aria-label="Attach image, PDF, or code/text file"
+            title="Attach image, PDF, or code/text file"
             disabled={attaching || busy}
             onClick={handleAttachClick}
           >


### PR DESCRIPTION
Closes #18.

## Summary
The paperclip "Attach" button now accepts a curated set of ~50 common code and plain-text extensions in addition to images and PDFs. The full list lives in `TEXT_EXTS` in `src/attachments.ts` and covers:

- Plain text / markup: `txt`, `md`, `markdown`, `mdx`, `rst`, `log`, `csv`, `tsv`
- Web: `html`, `htm`, `css`, `scss`, `sass`, `less`
- JS / TS: `js`, `jsx`, `ts`, `tsx`, `mjs`, `cjs`
- Structured data: `json`, `json5`, `jsonc`, `xml`, `yml`, `yaml`, `toml`, `ini`, `conf`, `env`
- Languages: `py`, `pyw`, `pyi`, `rb`, `go`, `rs`, `java`, `kt`, `kts`, `swift`, `cs`, `php`, `pl`, `lua`, `dart`, `scala`, `r`
- C-family: `c`, `cc`, `cpp`, `cxx`, `h`, `hpp`, `hxx`
- Shells: `sh`, `bash`, `zsh`, `fish`, `ps1`, `bat`, `cmd`
- Misc: `sql`, `vue`, `svelte`, `astro`, `tex`, `graphql`, `gql`

### Implementation notes
- `src/attachments.ts`: `isAcceptedExt` ORs in `TEXT_EXTS`. `guessMime` maps common ones (`text/javascript`, `text/markdown`, `application/json`, etc.) and falls back to `text/plain` for everything else in the list.
- VS Code file dialog: new "All supported" group is the default, plus a dedicated "Code & text" filter for users who want to narrow down. Existing "Images & PDFs" / "Images" / "PDFs" groups still work.
- `MessageView` no longer hard-codes the non-image badge to "PDF". A new `badgeForFilename` helper picks PDF for `.pdf`, otherwise renders the uppercase extension capped at 4 chars, with a few hand-aliased long names (`markdown` → MD, `javascript` → JS, …).
- Send flow uses the existing `sourcePath` → `file://` URL path; no opencode SDK changes needed.

### Release
- `package.json` 0.1.6 → 0.1.7
- CHANGELOG entry under [0.1.7]

## Test plan
- [x] `bun run test` — 374/374 (was 373; added new positive cases for text extensions, split out a rejection-case test)
- [x] `bun run check-types` — clean
- [x] Visual smoke (dev host):
  - Click paperclip → "All supported" filter shows code/text/image/pdf files; "Code & text" narrows down.
  - Attach a `.md` and a `.py` file → chips appear in the prompt and the message bubble shows MD / PY badges (not "PDF").
  - LLM responds with content from the file (validates opencode reads `text/plain` via `file://` correctly).
- [x] After merge: ready to release alongside 0.1.5 / 0.1.6 when you decide.