### PR TITLE
fix(chat): persistent Working… indicator while message is pending (0.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.2.1]
+
+### Fixed
+- The pending assistant message now shows a persistent **Working…** indicator below its content the entire time it's mid-stream, not just before the first block arrives. Previously the "thinking" dots disappeared the moment any block (tool / reasoning / patch) rendered, making the chat look frozen during long tool calls. The indicator now stays animating until the message finalizes (text complete, errored, or stopped).
+
 ## [0.2.0]
 
 ### Added
@@ -80,7 +85,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Tests
 - 360+ tests across four phases: unit (Vitest + node/jsdom), integration (`@vscode/test-electron`), component (Vitest + React Testing Library), and E2E against a mock opencode HTTP/SSE server.
 
-[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/arthurzengg/opencui/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/arthurzengg/opencui/compare/v0.1.4...v0.2.0
 [0.1.4]: https://github.com/arthurzengg/opencui/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/arthurzengg/opencui/compare/v0.1.2...v0.1.3

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",

--- a/test/webview/message-view.test.tsx
+++ b/test/webview/message-view.test.tsx
@@ -200,15 +200,36 @@ describe("MessageView (user role)", () => {
 })
 
 describe("MessageView (assistant role)", () => {
-  it("renders thinking indicator when message is pending and has no blocks", () => {
-    render(
+  it("renders Working indicator while the message is pending (including after blocks arrive)", () => {
+    const { rerender } = render(
       <MessageView
         message={assistantMessage("", { pending: true })}
         processOpen={false}
         processOnly={false}
       />,
     )
-    expect(screen.getByText("thinking")).toBeInTheDocument()
+    expect(screen.getByText("Working…")).toBeInTheDocument()
+
+    // Once tool / text blocks render, the indicator must still be visible so
+    // the user knows the assistant is still working through them.
+    rerender(
+      <MessageView
+        message={assistantMessage("partial reply", { pending: true })}
+        processOpen={false}
+        processOnly={false}
+      />,
+    )
+    expect(screen.getByText("Working…")).toBeInTheDocument()
+
+    // When the message finalizes (pending=false), the indicator goes away.
+    rerender(
+      <MessageView
+        message={assistantMessage("final reply", { pending: false })}
+        processOpen={false}
+        processOnly={false}
+      />,
+    )
+    expect(screen.queryByText("Working…")).toBeNull()
   })
 
   it("renders error text when message has error", () => {

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -42,8 +42,8 @@ export function MessageView({
     <div className={`msg role-${message.role}`}>
       {message.ref?.label && <div className="msg-ref">{message.ref.label}</div>}
       {renderMessageBlocks(message, processOpen, processOnly, onReviewFile)}
-      {message.pending && message.blocks.length === 0 && (
-        <div className="thinking-dots" role="status" aria-label="Thinking">thinking</div>
+      {message.pending && (
+        <div className="thinking-dots" role="status" aria-label="Working">Working…</div>
       )}
       {(() => {
         // Stopped state overrides error: a message can carry both


### PR DESCRIPTION
Closes #22.

## Summary
Fix the "is it stuck or still running?" UX problem you saw — during long tool calls the chat looked frozen because the "thinking" dots disappeared the moment any block (tool / reasoning / patch) rendered. Only the subtle Stop-button pulse remained, which is too quiet to communicate "actively working".

## Fix
Drop the `message.blocks.length === 0` guard on the pending indicator so it stays visible the whole time a message is `pending`. Also rename the displayed text from "thinking" to "Working…" since the same indicator now covers tool-call and reasoning windows, not just the initial pre-stream thinking phase.

`webview/src/components/MessageView.tsx`:
```diff
-{message.pending && message.blocks.length === 0 && (
-  <div className="thinking-dots" role="status" aria-label="Thinking">thinking</div>
-)}
+{message.pending && (
+  <div className="thinking-dots" role="status" aria-label="Working">Working…</div>
+)}
```

CSS for `.thinking-dots` (breathing italic foreground text) is unchanged.

### Test plan
- [x] `bun run test` — 374/374. The existing "thinking when no blocks" test is replaced with a richer re-render test that asserts the indicator stays during 0-block, stays mid-stream, and disappears on finalize.
- [x] `bun run check-types` — clean
- [ ] Visual smoke (dev host):
  - Send a prompt that triggers tool calls. "Working…" stays animating below the tool trace until the response completes.
  - Press Stop → indicator goes away when the message is marked stopped.
- [ ] After merge: tag `v0.2.1`, create GitHub Release; workflow auto-publishes.

## Release
- `package.json` 0.2.0 → 0.2.1
- CHANGELOG entry under [0.2.1]