### PR TITLE
feat(chat): handle question.asked events so the chat doesn't hang (0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.0]
+
+### Added
+- **Question dialog for agents that ask for input.** opencode 1.14.41+ (and agents like Hephaestus that depend on it) emits `question.asked` SSE events when the assistant wants the user to choose between options or supply a free-text answer mid-stream. The webview now renders a sticky dialog with the question text, suggested options (single- or multi-select via `multiple`), an optional free-text input (when `custom !== false`), a "Send" button, and a "Skip" button. Replies POST to opencode's `/question/:id/reply` endpoint; rejects POST to `/question/:id/reject`. Companion `question.replied` / `question.rejected` events from other clients clear our local dialog. Without this, sessions that hit a question silently hung "Working…" forever until the user aborted.
+
+### Fixed
+- Retry button's reconstructed attachments now include a synthetic `id` field. Previously TypeScript flagged this as an error; the runtime behavior is unchanged (the host only consumes mime/filename/dataUrl/sourcePath when forwarding the attachment).
+
 ## [0.2.0]
 
 ### Added
@@ -80,7 +88,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Tests
 - 360+ tests across four phases: unit (Vitest + node/jsdom), integration (`@vscode/test-electron`), component (Vitest + React Testing Library), and E2E against a mock opencode HTTP/SSE server.
 
-[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/arthurzengg/opencui/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/arthurzengg/opencui/compare/v0.1.4...v0.2.0
 [0.1.4]: https://github.com/arthurzengg/opencui/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/arthurzengg/opencui/compare/v0.1.2...v0.1.3

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",

--- a/src/chat/stream.ts
+++ b/src/chat/stream.ts
@@ -19,6 +19,27 @@ export type PermissionRequest = {
   type?: string
 }
 
+export type QuestionOption = {
+  label: string
+  description: string
+}
+
+export type QuestionInfo = {
+  question: string
+  header: string
+  options: QuestionOption[]
+  /** Allow selecting multiple options (default false). */
+  multiple?: boolean
+  /** Allow typing a custom free-text answer (default true). */
+  custom?: boolean
+}
+
+export type QuestionRequest = {
+  id: string
+  sessionID: string
+  questions: QuestionInfo[]
+}
+
 export type MessageUsage = {
   model?: string
   cost?: number
@@ -42,6 +63,9 @@ export type StreamHandlers = {
   onPatch?: (messageID: string, files: string[], diff?: string) => void
   onFileRead?: (messageID: string, filename: string) => void
   onPermissionNeeded?: (permission: PermissionRequest) => void
+  onQuestionAsked?: (question: QuestionRequest) => void
+  /** Fired when a question is answered (by us or another client) or rejected. */
+  onQuestionResolved?: (requestID: string) => void
   onSessionError?: (message: string) => void
   onSessionIdle?: () => void
   onSessionBusy?: () => void
@@ -110,6 +134,11 @@ export function subscribeSession(
       case "permission.asked":
       case "permission.updated":
         return onPermissionUpdated(props)
+      case "question.asked":
+        return onQuestionAsked(props)
+      case "question.replied":
+      case "question.rejected":
+        return onQuestionResolved(props)
       case "session.error":
         return onSessionError(props?.error)
       case "session.idle":
@@ -242,6 +271,22 @@ export function subscribeSession(
       pattern: p.pattern ?? p.patterns,
       type: p.permission ?? p.type,
     })
+  }
+
+  function onQuestionAsked(p: any) {
+    if (!p || p.sessionID !== sessionID) return
+    handlers.onQuestionAsked?.({
+      id: p.id,
+      sessionID: p.sessionID,
+      questions: Array.isArray(p.questions) ? p.questions : [],
+    })
+  }
+
+  function onQuestionResolved(p: any) {
+    if (!p || p.sessionID !== sessionID) return
+    const id = p.requestID ?? p.id
+    if (!id) return
+    handlers.onQuestionResolved?.(id)
   }
 
   function onSessionError(err: any) {

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -5,6 +5,7 @@ import type { Preferences } from "../preferences"
 import {
   subscribeSession,
   type PermissionRequest,
+  type QuestionRequest,
   type Subscription,
 } from "./stream"
 import { getEditorContext, formatContextHeader } from "../context"
@@ -50,6 +51,7 @@ export class ChatView implements vscode.WebviewViewProvider {
   private sessionID?: string
   private subscription?: Subscription
   private activePermissions = new Map<string, PermissionRequest>()
+  private activeQuestions = new Map<string, QuestionRequest>()
   /** opencode messageID → webview-side id used in UI */
   private messageMap = new Map<string, string>()
   private conversations: SavedConversation[]
@@ -127,7 +129,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.subscription = undefined
     this.sessionID = undefined
     this.messageMap.clear()
-    this.activePermissions.clear()
+    this.activePermissions.clear(); this.activeQuestions.clear()
     const conversation = this.addConversation("New conversation")
     this.activeConversationID = conversation.id
     this.messages = []
@@ -212,7 +214,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.subscription?.abort()
     this.subscription = undefined
     this.messageMap.clear()
-    this.activePermissions.clear()
+    this.activePermissions.clear(); this.activeQuestions.clear()
     this.activeConversationID = id
     this.restoreActiveState()
     await this.persistConversations()
@@ -240,7 +242,7 @@ export class ChatView implements vscode.WebviewViewProvider {
       this.subscription?.abort()
       this.subscription = undefined
       this.messageMap.clear()
-      this.activePermissions.clear()
+      this.activePermissions.clear(); this.activeQuestions.clear()
       this.activeConversationID = this.conversationSummaries()[0]!.id
       this.restoreActiveState()
       await this.persistConversations()
@@ -543,6 +545,47 @@ export class ChatView implements vscode.WebviewViewProvider {
         }
         return
       }
+      case "questionReply": {
+        this.activeQuestions.delete(msg.id)
+        await this.replyQuestion(msg.id, msg.answers)
+        return
+      }
+      case "questionReject": {
+        this.activeQuestions.delete(msg.id)
+        await this.rejectQuestion(msg.id)
+        return
+      }
+    }
+  }
+
+  /**
+   * POST the user's answers to opencode's question API. The installed SDK
+   * (1.14.33) doesn't yet expose typed question methods — those landed in
+   * the binary at 1.14.41 — so we use raw fetch against the backend URL.
+   */
+  private async replyQuestion(requestID: string, answers: string[][]) {
+    try {
+      const backend = await this.servers.ensure()
+      const res = await fetch(`${backend.url}/question/${encodeURIComponent(requestID)}/reply`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ answers }),
+      })
+      if (!res.ok) log("question reply failed", res.status, await res.text().catch(() => ""))
+    } catch (e) {
+      log("question reply threw", e)
+    }
+  }
+
+  private async rejectQuestion(requestID: string) {
+    try {
+      const backend = await this.servers.ensure()
+      const res = await fetch(`${backend.url}/question/${encodeURIComponent(requestID)}/reject`, {
+        method: "POST",
+      })
+      if (!res.ok) log("question reject failed", res.status, await res.text().catch(() => ""))
+    } catch (e) {
+      log("question reject threw", e)
     }
   }
 
@@ -741,6 +784,18 @@ export class ChatView implements vscode.WebviewViewProvider {
           title: perm.title,
           pattern: perm.pattern,
         })
+      },
+      onQuestionAsked: (q) => {
+        this.activeQuestions.set(q.id, q)
+        this.post({
+          type: "question",
+          id: q.id,
+          questions: q.questions,
+        })
+      },
+      onQuestionResolved: (id) => {
+        this.activeQuestions.delete(id)
+        this.post({ type: "questionResolved", id })
       },
       onSessionError: (message) => {
         log("session error", message)

--- a/test/webview/question-flow.test.ts
+++ b/test/webview/question-flow.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest"
+import { reducer, initialChatState } from "../../webview/src/hooks/useChatState"
+import type { QuestionInfo } from "../../webview/src/protocol"
+
+const question: QuestionInfo = {
+  question: "Pick one",
+  header: "Pick",
+  options: [
+    { label: "A", description: "first" },
+    { label: "B", description: "second" },
+  ],
+}
+
+describe("reducer — question flow", () => {
+  it("question action stores pendingQuestion with id + questions", () => {
+    const state = reducer(initialChatState, {
+      type: "question",
+      id: "que_1",
+      questions: [question],
+    })
+    expect(state.pendingQuestion?.id).toBe("que_1")
+    expect(state.pendingQuestion?.questions).toHaveLength(1)
+  })
+
+  it("questionResolved clears the matching pendingQuestion", () => {
+    const opened = reducer(initialChatState, {
+      type: "question",
+      id: "que_1",
+      questions: [question],
+    })
+    const closed = reducer(opened, { type: "questionResolved", id: "que_1" })
+    expect(closed.pendingQuestion).toBeUndefined()
+  })
+
+  it("questionResolved with a non-matching id is a no-op", () => {
+    const opened = reducer(initialChatState, {
+      type: "question",
+      id: "que_active",
+      questions: [question],
+    })
+    const stale = reducer(opened, { type: "questionResolved", id: "que_other" })
+    expect(stale.pendingQuestion?.id).toBe("que_active")
+  })
+
+  it("clearQuestion action also clears the matching pendingQuestion", () => {
+    const opened = reducer(initialChatState, {
+      type: "question",
+      id: "que_1",
+      questions: [question],
+    })
+    const closed = reducer(opened, { type: "clearQuestion", id: "que_1" })
+    expect(closed.pendingQuestion).toBeUndefined()
+  })
+})

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -6,6 +6,7 @@ import { MessageView } from "./components/MessageView"
 import { PromptBox } from "./components/PromptBox"
 import { StatusBar } from "./components/StatusBar"
 import { PermissionDialog } from "./components/PermissionDialog"
+import { QuestionDialog } from "./components/QuestionDialog"
 import { ReviewPanel } from "./components/ReviewPanel"
 
 export default function App() {
@@ -20,6 +21,8 @@ export default function App() {
     selectAgent,
     selectModel,
     replyPermission,
+    replyQuestion,
+    rejectQuestion,
     openReviewChange,
     editMessage,
     reviewAllInChange,
@@ -58,9 +61,18 @@ export default function App() {
       const text = textBlock && textBlock.type === "text" ? textBlock.text : ""
       if (!text) return
       const attachments: Attachment[] = []
-      for (const b of m.blocks) {
+      for (const [i, b] of m.blocks.entries()) {
         if (b.type === "attachment") {
-          attachments.push({ mime: b.mime, filename: b.filename, dataUrl: b.dataUrl, bytes: b.bytes })
+          // Synthesize an id from the message + position — the original
+          // upload-time id is lost after persistence, but handleSend only
+          // uses (mime/filename/dataUrl/sourcePath) so any stable id works.
+          attachments.push({
+            id: `att_retry_${m.id}_${i}`,
+            mime: b.mime,
+            filename: b.filename,
+            dataUrl: b.dataUrl,
+            bytes: b.bytes,
+          })
         }
       }
       editMessage(m.id, text, m.mentions, attachments)
@@ -161,6 +173,14 @@ export default function App() {
           title={state.pendingPermission.title}
           pattern={state.pendingPermission.pattern}
           onReply={replyPermission}
+        />
+      )}
+      {state.pendingQuestion && (
+        <QuestionDialog
+          id={state.pendingQuestion.id}
+          questions={state.pendingQuestion.questions}
+          onReply={replyQuestion}
+          onReject={rejectQuestion}
         />
       )}
       <ReviewPanel

--- a/webview/src/components/QuestionDialog.tsx
+++ b/webview/src/components/QuestionDialog.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useState } from "react"
+import type { QuestionInfo } from "../protocol"
+
+type Props = {
+  id: string
+  questions: QuestionInfo[]
+  onReply: (id: string, answers: string[][]) => void
+  onReject: (id: string) => void
+}
+
+/**
+ * Per-question answer state. `selected` is the labels chosen from the option
+ * list; `custom` is the optional free-text answer (used when the question
+ * allows `custom !== false`). When the user submits we serialize each per-
+ * question state into a `string[]` (selected labels, plus the custom string
+ * appended if non-empty).
+ */
+type AnswerState = { selected: Set<string>; custom: string }
+
+export function QuestionDialog({ id, questions, onReply, onReject }: Props) {
+  // One AnswerState per question, indexed by position.
+  const [answers, setAnswers] = useState<AnswerState[]>(() =>
+    questions.map(() => ({ selected: new Set<string>(), custom: "" })),
+  )
+
+  // If the parent swaps in a different question request (rare), reset.
+  useEffect(() => {
+    setAnswers(questions.map(() => ({ selected: new Set<string>(), custom: "" })))
+  }, [id, questions])
+
+  const updateAnswer = (idx: number, patch: (prev: AnswerState) => AnswerState) => {
+    setAnswers((prev) => prev.map((a, i) => (i === idx ? patch(a) : a)))
+  }
+
+  const toggleOption = (idx: number, label: string, multiple: boolean) => {
+    updateAnswer(idx, (prev) => {
+      const next = new Set(prev.selected)
+      if (multiple) {
+        if (next.has(label)) next.delete(label)
+        else next.add(label)
+      } else {
+        next.clear()
+        next.add(label)
+      }
+      return { ...prev, selected: next }
+    })
+  }
+
+  const setCustom = (idx: number, value: string) => {
+    updateAnswer(idx, (prev) => ({ ...prev, custom: value }))
+  }
+
+  // Every question needs at least one selected option OR a non-empty custom
+  // answer (when custom is enabled) before Send is allowed.
+  const canSubmit = questions.every((q, i) => {
+    const a = answers[i]!
+    if (a.selected.size > 0) return true
+    if (q.custom !== false && a.custom.trim().length > 0) return true
+    return false
+  })
+
+  const submit = () => {
+    if (!canSubmit) return
+    const payload: string[][] = answers.map((a) => {
+      const out = Array.from(a.selected)
+      const c = a.custom.trim()
+      if (c) out.push(c)
+      return out
+    })
+    onReply(id, payload)
+  }
+
+  return (
+    <div className="question">
+      <div className="question-title">❓ Question{questions.length > 1 ? "s" : ""} from the assistant</div>
+      <div className="question-body">
+        {questions.map((q, i) => (
+          <QuestionItem
+            key={i}
+            question={q}
+            answer={answers[i]!}
+            onToggle={(label) => toggleOption(i, label, q.multiple ?? false)}
+            onCustomChange={(value) => setCustom(i, value)}
+          />
+        ))}
+      </div>
+      <div className="question-actions">
+        <button className="btn" onClick={() => onReject(id)}>
+          Skip
+        </button>
+        <button className="btn primary" onClick={submit} disabled={!canSubmit}>
+          Send
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function QuestionItem({
+  question,
+  answer,
+  onToggle,
+  onCustomChange,
+}: {
+  question: QuestionInfo
+  answer: AnswerState
+  onToggle: (label: string) => void
+  onCustomChange: (value: string) => void
+}) {
+  const allowCustom = question.custom !== false
+  const multiple = question.multiple ?? false
+  return (
+    <div className="question-item">
+      {question.header && <div className="question-header">{question.header}</div>}
+      <div className="question-text">{question.question}</div>
+      {question.options.length > 0 && (
+        <ul className="question-options" role={multiple ? "group" : "radiogroup"}>
+          {question.options.map((opt) => {
+            const checked = answer.selected.has(opt.label)
+            return (
+              <li key={opt.label}>
+                <button
+                  type="button"
+                  className={`question-option ${checked ? "is-checked" : ""}`}
+                  role={multiple ? "checkbox" : "radio"}
+                  aria-checked={checked}
+                  onClick={() => onToggle(opt.label)}
+                >
+                  <span className={`question-option-marker ${multiple ? "square" : "circle"}`} aria-hidden="true">
+                    {checked && (multiple ? "✓" : "●")}
+                  </span>
+                  <span className="question-option-text">
+                    <span className="question-option-label">{opt.label}</span>
+                    {opt.description && <span className="question-option-desc">{opt.description}</span>}
+                  </span>
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+      {allowCustom && (
+        <textarea
+          className="question-custom"
+          placeholder={question.options.length > 0 ? "Or type a custom answer…" : "Type your answer…"}
+          rows={2}
+          value={answer.custom}
+          onChange={(e) => onCustomChange(e.target.value)}
+          // IME-aware Enter handler: in chat composers Enter sends; here we
+          // keep Enter as newline so users can write multi-line answers.
+          // Submission is via the Send button only.
+        />
+      )}
+    </div>
+  )
+}

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -8,6 +8,7 @@ import type {
   EditorContextRef,
   FileSearchHit,
   Outbound,
+  QuestionInfo,
   ReviewChange,
   ReviewHunkState,
   Selection,
@@ -37,9 +38,14 @@ export type ChatState = {
   messages: Message[]
   reviewHunks: Record<string, ReviewHunkState>
   pendingPermission?: { id: string; title: string; pattern?: string | string[] }
+  pendingQuestion?: { id: string; questions: QuestionInfo[] }
 }
 
-type Action = Outbound | { type: "reset" } | { type: "clearPermission" }
+type Action =
+  | Outbound
+  | { type: "reset" }
+  | { type: "clearPermission" }
+  | { type: "clearQuestion"; id: string }
 
 const initial: ChatState = {
   connected: false,
@@ -257,6 +263,18 @@ export function reducer(state: ChatState, action: Action): ChatState {
       }
     case "clearPermission":
       return { ...state, pendingPermission: undefined }
+    case "question":
+      return {
+        ...state,
+        pendingQuestion: { id: action.id, questions: action.questions },
+      }
+    case "questionResolved":
+    case "clearQuestion":
+      // Clear only if the resolved request matches the one we're showing —
+      // a different one could have come in between (rare, but cheap to be safe).
+      return state.pendingQuestion?.id === action.id
+        ? { ...state, pendingQuestion: undefined }
+        : state
     case "clear":
       return { ...initial, selection: state.selection, context: state.context, connected: state.connected }
     default:
@@ -367,6 +385,14 @@ export function useChatState() {
     replyPermission(id: string, response: "once" | "always" | "reject") {
       vscode.post({ type: "permissionReply", id, response })
       dispatch({ type: "clearPermission" })
+    },
+    replyQuestion(id: string, answers: string[][]) {
+      vscode.post({ type: "questionReply", id, answers })
+      dispatch({ type: "clearQuestion", id })
+    },
+    rejectQuestion(id: string) {
+      vscode.post({ type: "questionReject", id })
+      dispatch({ type: "clearQuestion", id })
     },
   }
 }

--- a/webview/src/protocol.ts
+++ b/webview/src/protocol.ts
@@ -25,6 +25,17 @@ export type ToolUpdate = {
   error?: string
 }
 
+export type QuestionOption = { label: string; description: string }
+export type QuestionInfo = {
+  question: string
+  header: string
+  options: QuestionOption[]
+  /** Allow selecting multiple options (default false). */
+  multiple?: boolean
+  /** Allow typing a custom free-text answer (default true). */
+  custom?: boolean
+}
+
 export type ChatBlock =
   | { type: "text"; text: string }
   | { type: "reasoning"; text: string }
@@ -130,6 +141,8 @@ export type Outbound =
   | { type: "sessionBusy" }
   | { type: "sessionIdle" }
   | { type: "permission"; id: string; title: string; pattern?: string | string[] }
+  | { type: "question"; id: string; questions: QuestionInfo[] }
+  | { type: "questionResolved"; id: string }
   | { type: "fileSearchResult"; requestID: number; hits: FileSearchHit[] }
   | { type: "attachmentResult"; requestID: number; attachments: Attachment[]; error?: string }
   | { type: "clear" }
@@ -156,3 +169,5 @@ export type Inbound =
   | { type: "fileSearch"; requestID: number; query: string }
   | { type: "attachFile"; requestID: number }
   | { type: "permissionReply"; id: string; response: "once" | "always" | "reject" }
+  | { type: "questionReply"; id: string; answers: string[][] }
+  | { type: "questionReject"; id: string }

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -1230,6 +1230,98 @@ button {
   flex-wrap: wrap;
 }
 
+/* ===== Question dialog ===== */
+.question {
+  position: sticky;
+  bottom: 0;
+  z-index: 4;
+  margin: 0 10px 8px;
+  padding: 10px;
+  border: 1px solid var(--vscode-focusBorder);
+  border-left: 3px solid var(--vscode-focusBorder);
+  background: var(--vscode-editorWidget-background);
+  border-radius: var(--radius);
+  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.22);
+  max-height: 60vh;
+  overflow-y: auto;
+}
+.question-title { font-weight: 600; margin-bottom: 8px; }
+.question-body { display: flex; flex-direction: column; gap: 12px; margin-bottom: 10px; }
+.question-item { display: flex; flex-direction: column; gap: 6px; }
+.question-header {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--vscode-descriptionForeground);
+}
+.question-text { font-size: 12px; line-height: 1.4; }
+.question-options { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 3px; }
+.question-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 8px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.question-option:hover { background: var(--vscode-list-hoverBackground); }
+.question-option.is-checked {
+  background: var(--vscode-list-activeSelectionBackground, var(--vscode-list-hoverBackground));
+}
+.question-option-marker {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  margin-top: 1px;
+  border: 1px solid var(--vscode-descriptionForeground);
+  color: var(--vscode-foreground);
+  font-size: 10px;
+  line-height: 1;
+}
+.question-option-marker.circle { border-radius: 50%; }
+.question-option-marker.square { border-radius: 3px; }
+.question-option.is-checked .question-option-marker {
+  border-color: var(--vscode-focusBorder);
+  color: var(--vscode-focusBorder);
+}
+.question-option-text { display: flex; flex-direction: column; min-width: 0; }
+.question-option-label { font-size: 12px; font-weight: 600; }
+.question-option-desc {
+  font-size: 11px;
+  color: var(--vscode-descriptionForeground);
+  line-height: 1.35;
+}
+.question-custom {
+  width: 100%;
+  min-height: 36px;
+  margin-top: 2px;
+  padding: 6px 8px;
+  border: 1px solid var(--vscode-input-border, transparent);
+  border-radius: 4px;
+  background: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  font-family: inherit;
+  font-size: 12px;
+  resize: vertical;
+  outline: none;
+}
+.question-custom:focus { border-color: var(--vscode-focusBorder); }
+.question-actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+
 /* ===== Review changes ===== */
 .review-panel {
   border-top: 1px solid var(--vscode-panel-border);


### PR DESCRIPTION
Closes #24.

## Summary
Fixes the chat-hang you observed with Hephaestus on opencode 1.14.41+. The agent emits `question.asked` SSE events when it wants the user to pick from suggested options or supply a free-text answer mid-stream. Our stream router only handled `permission.asked` / `permission.updated`, so `question.asked` fell through silently and the chat sat "Working…" forever.

## Flow
1. **`src/chat/stream.ts`** — routes `question.asked` → `onQuestionAsked`, and `question.replied` / `question.rejected` → `onQuestionResolved` (clears the dialog if another client like the opencode TUI answered).
2. **Protocol** — Outbound `question` / `questionResolved`; Inbound `questionReply` / `questionReject`. New `QuestionOption` / `QuestionInfo` types match the opencode schema (`packages/opencode/src/question/index.ts`).
3. **`useChatState`** — new `pendingQuestion` field, reducer cases for `question` / `questionResolved` / `clearQuestion`, plus `replyQuestion(id, answers)` and `rejectQuestion(id)` actions.
4. **`QuestionDialog` component** — renders the questions as a stack, supports single- / multi-select (`multiple`), optional free-text input (`custom !== false`), and Send / Skip buttons.
5. **`src/chat/view.ts`** — forwards events to the webview and posts replies via raw `fetch` to `/question/:id/reply` (body `{ answers: string[][] }`) or `/question/:id/reject`. Raw fetch avoids needing to bump the installed SDK from 1.14.33 — the typed methods only ship in 1.14.41+, but the running binary serves the endpoints anyway.

## Reference
Upstream source (sst/opencode @ dev):
- `packages/opencode/src/question/index.ts` — schema + service + Bus.publish for the three events
- `packages/opencode/src/server/routes/instance/httpapi/groups/question.ts` — `POST /question/:requestID/reply` and `POST /question/:requestID/reject`

## Incidental
Also fixes a small TypeScript error introduced earlier with the Retry button — the reconstructed `Attachment` objects now include a synthetic `id` field (required by the type; runtime unchanged because the host only reads mime/filename/dataUrl/sourcePath).

## Release
- `package.json` 0.2.0 → 0.3.0 (minor — new user-visible feature)
- CHANGELOG entry under [0.3.0]

## Test plan
- [x] `bun run test` — 378/378 (4 new reducer tests for the question flow)
- [x] `bun run check-types` — clean
- [x] Webview `tsc --noEmit` — back to the 3 pre-existing errors flagged in CLAUDE.md (the 4th from the Retry attachment is fixed)
- [ ] Visual smoke (dev host):
  - Reproduce the original Hephaestus stuck state. When `question.asked` fires, the dialog appears below the chat with the question, header, options, and (by default) a free-text textarea.
  - Pick an option, click Send → dialog disappears, opencode proceeds. Verify the agent continues past the question.
  - Try a multi-select question (one where `multiple: true` in the payload) — checkbox-style markers, both selections sent.
  - Try a free-text answer alone (no option selected) — Send is enabled, payload arrives as `[["typed text"]]`.
  - Click Skip → POSTs reject; opencode marks the request rejected and the dialog clears.
- [ ] After merge: tag `v0.3.0` + create GitHub Release; workflow auto-publishes.