### PR TITLE
feat(chat): show system-reminder body in chat by default (0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.1]
+
+### Changed
+- `<system-reminder>` callouts in assistant messages now render expanded by default, with the title "System reminder" above the body. Previously the body was collapsed and required clicking the chevron. The fold/unfold affordance is still there — click the title to collapse if the reminder is noisy. The redundant first-line preview next to the title was dropped since the body is now visible.
+
 ## [0.3.0]
 
 ### Added
@@ -88,7 +93,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Tests
 - 360+ tests across four phases: unit (Vitest + node/jsdom), integration (`@vscode/test-electron`), component (Vitest + React Testing Library), and E2E against a mock opencode HTTP/SSE server.
 
-[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/arthurzengg/opencui/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/arthurzengg/opencui/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/arthurzengg/opencui/compare/v0.1.4...v0.2.0
 [0.1.4]: https://github.com/arthurzengg/opencui/compare/v0.1.3...v0.1.4

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -596,20 +596,16 @@ export function splitWithReminders(text: string): RenderSegment[] {
   return segments
 }
 
-function reminderPreview(content: string): string {
-  const firstLine = content.split("\n", 1)[0]!.trim()
-  if (!firstLine) return ""
-  return firstLine.length > 80 ? firstLine.slice(0, 77).trimEnd() + "…" : firstLine
-}
-
 function SystemReminderCallout({ text }: { text: string }) {
-  const preview = reminderPreview(text)
+  // `open` so the body shows by default — users still get to fold it via
+  // the chevron if they don't want the noise. The first-line preview that
+  // sat next to the label is dropped now that the body is always visible
+  // (it duplicated the first line of the markdown below).
   return (
-    <details className="system-reminder">
+    <details className="system-reminder" open>
       <summary className="system-reminder-summary">
         <span className="system-reminder-chevron" aria-hidden>▸</span>
         <span className="system-reminder-label">System reminder</span>
-        {preview && <span className="system-reminder-preview"> · {preview}</span>}
       </summary>
       <div className="system-reminder-body">
         <Markdown text={text} />

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -1736,14 +1736,6 @@ button {
   font-weight: 600;
   flex: 0 0 auto;
 }
-.system-reminder-preview {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  min-width: 0;
-  flex: 1;
-  opacity: 0.75;
-}
 .system-reminder-body {
   padding: 4px 12px 10px;
   border-top: 1px solid var(--vscode-panel-border);


### PR DESCRIPTION
Closes #28.

## Summary
`<system-reminder>` callouts in assistant messages render expanded by default now. Previously they were collapsed `<details>` blocks and required clicking the chevron to see the content. Title stays "System reminder".

### Changes
- `SystemReminderCallout`: add `open` to the `<details>`. Drop the duplicate first-line preview that used to sit next to the title.
- Remove the now-unused `reminderPreview` helper and `.system-reminder-preview` CSS rule.

The fold/unfold affordance is intact — clicking the title still collapses the body for users who find a particular reminder noisy.

### Release
- `package.json` 0.3.0 → 0.3.1
- CHANGELOG entry under [0.3.1]

## Test plan
- [x] `bun run test` — 378/378
- [x] `bun run check-types` — clean
- [ ] Visual smoke (dev host): assistant emits a `<system-reminder>` block → body shows below the "System reminder" title without a click. Clicking the title still folds.
- [ ] After merge: tag `v0.3.1` + create GitHub Release; workflow auto-publishes.