### PR TITLE
fix(chat): pass directory query to /question endpoints so the chat doesn't stay stuck after Send (0.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.3]
+
+### Fixed
+- Question reply / reject now sends a `directory=<workspace>` query parameter so the request lands in the correct workspace's pending-questions map. Without it, opencode's `WorkspaceRoutingMiddleware` routed the reply to a default workspace where the pending request didn't exist; opencode logged "reply for unknown request" and the original `Question.ask` Effect stayed blocked, leaving the chat stuck "Working…" after Send. Also tightened logging — both reply and reject now log the request URL and the response status / body so failures aren't silent anymore.
+
 ## [0.3.2]
 
 ### Fixed
@@ -106,7 +111,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Tests
 - 360+ tests across four phases: unit (Vitest + node/jsdom), integration (`@vscode/test-electron`), component (Vitest + React Testing Library), and E2E against a mock opencode HTTP/SSE server.
 
-[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.3.3...HEAD
+[0.3.3]: https://github.com/arthurzengg/opencui/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/arthurzengg/opencui/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/arthurzengg/opencui/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/arthurzengg/opencui/compare/v0.2.0...v0.3.0

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -571,30 +571,45 @@ export class ChatView implements vscode.WebviewViewProvider {
    * POST the user's answers to opencode's question API. The installed SDK
    * (1.14.33) doesn't yet expose typed question methods — those landed in
    * the binary at 1.14.41 — so we use raw fetch against the backend URL.
+   *
+   * The reply / reject endpoints apply `WorkspaceRoutingMiddleware`, which
+   * reads an optional `directory` query parameter to pick the right
+   * workspace's pending-questions map. Without it, opencode falls back to
+   * a different workspace, fails to find the pending request, logs
+   * "reply for unknown request", and the original `Question.ask` Effect
+   * stays blocked forever — exactly the "stuck after submit" symptom.
    */
   private async replyQuestion(requestID: string, answers: string[][]) {
-    try {
-      const backend = await this.servers.ensure()
-      const res = await fetch(`${backend.url}/question/${encodeURIComponent(requestID)}/reply`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ answers }),
-      })
-      if (!res.ok) log("question reply failed", res.status, await res.text().catch(() => ""))
-    } catch (e) {
-      log("question reply threw", e)
-    }
+    await this.postQuestionEndpoint(requestID, "reply", { answers })
   }
 
   private async rejectQuestion(requestID: string) {
+    await this.postQuestionEndpoint(requestID, "reject")
+  }
+
+  private async postQuestionEndpoint(
+    requestID: string,
+    action: "reply" | "reject",
+    body?: Record<string, unknown>,
+  ) {
     try {
       const backend = await this.servers.ensure()
-      const res = await fetch(`${backend.url}/question/${encodeURIComponent(requestID)}/reject`, {
+      const url = new URL(`${backend.url}/question/${encodeURIComponent(requestID)}/${action}`)
+      if (backend.directory) url.searchParams.set("directory", backend.directory)
+      log(`question ${action} POST`, url.toString(), body ?? {})
+      const res = await fetch(url.toString(), {
         method: "POST",
+        headers: body ? { "Content-Type": "application/json" } : {},
+        body: body ? JSON.stringify(body) : undefined,
       })
-      if (!res.ok) log("question reject failed", res.status, await res.text().catch(() => ""))
+      const text = await res.text().catch(() => "")
+      if (!res.ok) {
+        log(`question ${action} failed`, res.status, text)
+      } else {
+        log(`question ${action} ok`, res.status, text || "(no body)")
+      }
     } catch (e) {
-      log("question reject threw", e)
+      log(`question ${action} threw`, e)
     }
   }
 


### PR DESCRIPTION
Closes #32.

## Summary
Hephaestus session reproducer: question dialog appears, user clicks Send, dialog dismisses, chat sits "Working…" forever. opencode's `Question.ask` Effect is waiting on a Deferred that we never resolve.

## Root cause
The reply / reject endpoints (`POST /question/:id/reply`, `POST /question/:id/reject`) sit behind `WorkspaceRoutingMiddleware` (sst/opencode @ dev), which reads an optional `directory` query parameter to pick which workspace's `pending` map to consult. Our raw \`fetch\` — used because the installed SDK 1.14.33 doesn't yet expose typed question methods — didn't pass any query. opencode routed to a default workspace, failed to find the pending request, logged "reply for unknown request", and the deferred stayed unresolved.

## Fix
- Pass `backend.directory` as `?directory=…` on both reply and reject.
- Collapse the two near-identical methods into a shared `postQuestionEndpoint(requestID, action, body?)` helper.
- Beef up logging — both success and failure paths now record URL + status + body, so a future regression is visible in `OpenCode Panel: Show Logs` instead of silent.

## Release
- `package.json` 0.3.2 → 0.3.3 (patch)
- CHANGELOG entry under [0.3.3]

## Test plan
- [x] `bun run test` — 399 / 399
- [x] `bun run check-types` — clean
- [ ] Visual smoke (dev host): reproduce the Hephaestus question, click Send → opencode emits follow-up events and the chat continues; output log shows `question reply POST <url>` and `question reply ok 200`.
- [ ] Skip path: open a question and click Skip → opencode receives the rejection and the chat unblocks (no longer hangs on reject either).
- [ ] After merge: bundle into the next release tag alongside the unreleased 0.3.1 / 0.3.2 work.