### PR TITLE
feat(chat): opaque edit bubble, regenerate hint, icon Save button (0.3.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.4]
+
+### Fixed
+- Edit-in-place user bubble no longer goes transparent when the mouse leaves it. The `.is-editing` rule previously only had `background: transparent` and relied on the `.is-editable:hover` rule to layer in an opaque fill — once the mouse moved off, the bubble's fill vanished and chat content scrolling behind the sticky bubble showed through. Now the editing bubble carries an explicit `--vscode-input-background` fill at rest.
+
+### Changed
+- Edit-in-place's "Save & regenerate" button is now the same circular Send icon used in the regular prompt box, for visual consistency. The accessible name stays `"Save & regenerate"` so existing tests and screen readers keep working. Cancel remains a labelled text button.
+- The edit-in-place row now shows a subdued italic line — "Replies after this message will be discarded and regenerated." — between the textarea actions and the Cancel / Save buttons, so the destructive side-effect of saving an edit is no longer silent.
+
 ## [0.3.3]
 
 ### Fixed
@@ -19,7 +28,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `ProcessPanel` titles no longer leak `<system-reminder>` (or other raw scaffold tags) as the headline. `processTitle` now strips internal markers from the source text before deriving a title; `textTitle` defensively rejects strings that look like literal HTML tags. `hasProcessBlocks` also treats reminder-only / scaffold-only text and reasoning blocks as empty so a message containing nothing but a reminder doesn't render as an empty collapsible panel.
 - Toast dedup no longer breaks on spinner-frame animations or countdown timers. Some agents animate spinners (`·`, `•`, `●`, `○`, `◌`, `◦`, …) and emit countdown updates (`Resuming in 2s…`, `Resuming in 1s…`) as repeated toasts. The dedup key now strips leading punctuation/symbols, replaces digit runs with `N`, and lowercases before comparing — all spinner/countdown variants now collapse into a single popup.
 - Per-message `model · cost · tokens` usage line is now hidden while the chat is overall busy. Hephaestus-style agents emit multi-step turns where every finished sub-task carries its own usage; rendering those mid-flight made completed sub-tasks sit next to the still-running ProcessPanel and the chat looked both finished and working at the same time. Usage appears once everything settles. (Intermediate `processOnly` messages still suppress usage even when the chat is idle, since their compact panel header is meant as a summary.)
-)" 
 
 ### Added
 - Surface opencode `tui.toast.show` events as VS Code notifications. **Warnings** route to `showWarningMessage`, **errors** route to `showErrorMessage`. **Info / success** toasts go to the OpenCode Panel output channel only (typically "MCP server connected" / "added N tools" chatter). All toasts are logged. Consecutive identical toasts within 3 seconds are coalesced — Hephaestus and similar deep agents fire bursts and we drop the repeats.
@@ -111,7 +119,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Tests
 - 360+ tests across four phases: unit (Vitest + node/jsdom), integration (`@vscode/test-electron`), component (Vitest + React Testing Library), and E2E against a mock opencode HTTP/SSE server.
 
-[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.3.3...HEAD
+[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.3.4...HEAD
+[0.3.4]: https://github.com/arthurzengg/opencui/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/arthurzengg/opencui/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/arthurzengg/opencui/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/arthurzengg/opencui/compare/v0.3.0...v0.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Edit-in-place user bubble no longer goes transparent when the mouse leaves it. The `.is-editing` rule previously only had `background: transparent` and relied on the `.is-editable:hover` rule to layer in an opaque fill — once the mouse moved off, the bubble's fill vanished and chat content scrolling behind the sticky bubble showed through. Now the editing bubble carries an explicit `--vscode-input-background` fill at rest.
 
 ### Changed
-- Edit-in-place's "Save & regenerate" button is now the same circular Send icon used in the regular prompt box, for visual consistency. The accessible name stays `"Save & regenerate"` so existing tests and screen readers keep working. Cancel remains a labelled text button.
-- The edit-in-place row now shows a subdued italic line — "Replies after this message will be discarded and regenerated." — between the textarea actions and the Cancel / Save buttons, so the destructive side-effect of saving an edit is no longer silent.
+- Edit-in-place is now compact and self-dismissing. The "Save & regenerate" button is now the same circular Send icon used in the regular prompt box (accessible name `"Save & regenerate"` preserved). The Cancel button is gone — clicking anywhere outside the edit container cancels and returns to view mode, matching the existing Escape behavior. Outer bubble padding tightened from 8 px → 4 px so the textarea + Save button feel like a single in-place editor.
 
 ## [0.3.3]
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",

--- a/test/webview/message-view.test.tsx
+++ b/test/webview/message-view.test.tsx
@@ -133,20 +133,25 @@ describe("MessageView (user role)", () => {
     expect(container.querySelector("textarea")).toBeNull()
   })
 
-  it("Cancel returns to view mode without firing onEditMessage", async () => {
+  it("clicking outside the edit area cancels without firing onEditMessage", async () => {
     const user = userEvent.setup()
     const onEditMessage = vi.fn()
     const { container } = render(
-      <MessageView
-        message={userMessage("hi", { backendID: "b1" })}
-        processOpen={false}
-        processOnly={false}
-        onEditMessage={onEditMessage}
-      />,
+      <div>
+        <div data-testid="outside">outside the bubble</div>
+        <MessageView
+          message={userMessage("hi", { backendID: "b1" })}
+          processOpen={false}
+          processOnly={false}
+          onEditMessage={onEditMessage}
+        />
+      </div>,
     )
     await user.click(container.querySelector(".msg.role-user") as HTMLElement)
     expect(container.querySelector("textarea")).not.toBeNull()
-    await user.click(screen.getByText("Cancel"))
+    // A click anywhere outside the editing container should cancel edit
+    // mode — there is no Cancel button anymore.
+    await user.click(screen.getByTestId("outside"))
     expect(container.querySelector("textarea")).toBeNull()
     expect(onEditMessage).not.toHaveBeenCalled()
   })

--- a/test/webview/message-view.test.tsx
+++ b/test/webview/message-view.test.tsx
@@ -62,7 +62,7 @@ describe("MessageView (user role)", () => {
     await user.click(bubble)
     // Now in edit mode — textarea should appear
     expect(container.querySelector("textarea")).not.toBeNull()
-    expect(screen.getByText("Save & regenerate")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /save .{0,3}regenerate/i })).toBeInTheDocument()
   })
 
   it("does NOT enter edit mode while busy", async () => {
@@ -111,7 +111,7 @@ describe("MessageView (user role)", () => {
     const textarea = container.querySelector("textarea") as HTMLTextAreaElement
     await user.clear(textarea)
     await user.type(textarea, "updated text")
-    await user.click(screen.getByText("Save & regenerate"))
+    await user.click(screen.getByRole("button", { name: /save .{0,3}regenerate/i }))
     expect(onEditMessage).toHaveBeenCalledWith("u-edit", "updated text", undefined, undefined)
   })
 
@@ -127,7 +127,7 @@ describe("MessageView (user role)", () => {
       />,
     )
     await user.click(container.querySelector(".msg.role-user") as HTMLElement)
-    await user.click(screen.getByText("Save & regenerate"))
+    await user.click(screen.getByRole("button", { name: /save .{0,3}regenerate/i }))
     // No regenerate triggered, edit mode closed.
     expect(onEditMessage).not.toHaveBeenCalled()
     expect(container.querySelector("textarea")).toBeNull()
@@ -272,7 +272,7 @@ describe("MessageView edit preserves mentions + attachments", () => {
     const textarea = container.querySelector("textarea") as HTMLTextAreaElement
     await user.clear(textarea)
     await user.type(textarea, "@src/foo.ts rewrite it")
-    await user.click(screen.getByText("Save & regenerate"))
+    await user.click(screen.getByRole("button", { name: /save .{0,3}regenerate/i }))
     expect(onEditMessage).toHaveBeenCalledWith("u-mention", "@src/foo.ts rewrite it", ["src/foo.ts"], undefined)
   })
 
@@ -292,7 +292,7 @@ describe("MessageView edit preserves mentions + attachments", () => {
     const textarea = container.querySelector("textarea") as HTMLTextAreaElement
     await user.clear(textarea)
     await user.type(textarea, "no mentions here")
-    await user.click(screen.getByText("Save & regenerate"))
+    await user.click(screen.getByRole("button", { name: /save .{0,3}regenerate/i }))
     expect(onEditMessage).toHaveBeenCalledWith("u-mention", "no mentions here", undefined, undefined)
   })
 
@@ -318,7 +318,7 @@ describe("MessageView edit preserves mentions + attachments", () => {
     const textarea = container.querySelector("textarea") as HTMLTextAreaElement
     await user.clear(textarea)
     await user.type(textarea, "@screen.png what is this")
-    await user.click(screen.getByText("Save & regenerate"))
+    await user.click(screen.getByRole("button", { name: /save .{0,3}regenerate/i }))
     expect(onEditMessage).toHaveBeenCalledTimes(1)
     const call = onEditMessage.mock.calls[0]
     expect(call?.[0]).toBe("u-att")
@@ -451,7 +451,7 @@ describe("MessageView edit preserves mentions + attachments", () => {
     const textarea = container.querySelector("textarea") as HTMLTextAreaElement
     await user.clear(textarea)
     await user.type(textarea, "no attachments now")
-    await user.click(screen.getByText("Save & regenerate"))
+    await user.click(screen.getByRole("button", { name: /save .{0,3}regenerate/i }))
     expect(onEditMessage).toHaveBeenCalledWith("u-att", "no attachments now", undefined, undefined)
   })
 })

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -120,6 +120,20 @@ function UserMessageView({
     (b): b is Extract<Block, { type: "attachment" }> => b.type === "attachment",
   )
   const [editing, setEditing] = useState(false)
+  const editAreaRef = useRef<HTMLDivElement>(null)
+
+  // Click-outside cancels the edit. We listen on the document so any click
+  // outside the editing container — anywhere in the chat panel — drops us
+  // back to view mode. Cheap and matches the "no Cancel button" UX.
+  useEffect(() => {
+    if (!editing) return
+    const onPointerDown = (event: PointerEvent) => {
+      if (editAreaRef.current?.contains(event.target as Node)) return
+      setEditing(false)
+    }
+    document.addEventListener("pointerdown", onPointerDown)
+    return () => document.removeEventListener("pointerdown", onPointerDown)
+  }, [editing])
 
   // Re-derive attachment labels (same algorithm PromptBox originally used) and
   // wrap each attachment block into the Attachment shape, including a synthetic
@@ -191,7 +205,7 @@ function UserMessageView({
     >
       {message.ref?.label && <div className="msg-ref">{message.ref.label}</div>}
       {editing ? (
-        <div onClick={(event) => event.stopPropagation()}>
+        <div ref={editAreaRef} onClick={(event) => event.stopPropagation()}>
           <PromptBox
             busy={false}
             onSend={handleSubmit}

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -349,11 +349,6 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
           </ul>
         )}
       </div>
-      {variant === "edit" && (
-        <div className="user-edit-warning">
-          Replies after this point will be discarded and regenerated.
-        </div>
-      )}
       <div className="promptbox-row">
         {attachFile && (
           <button

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -378,13 +378,19 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
         <div className="spacer" />
         {variant === "edit" ? (
           <>
+            <span className="edit-regenerate-hint">
+              Replies after this message will be discarded and regenerated.
+            </span>
+            <div className="spacer" />
             <button className="btn subtle" onClick={onAbort}>Cancel</button>
             <button
-              className="btn primary"
+              className="btn primary icon"
               onClick={submit}
               disabled={busy || (!text.trim() && !hasActiveAttachment)}
+              aria-label="Save & regenerate"
+              title="Save & regenerate"
             >
-              Save & regenerate
+              <SendIcon />
             </button>
           </>
         ) : aborting ? (

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -377,22 +377,15 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
         )}
         <div className="spacer" />
         {variant === "edit" ? (
-          <>
-            <span className="edit-regenerate-hint">
-              Replies after this message will be discarded and regenerated.
-            </span>
-            <div className="spacer" />
-            <button className="btn subtle" onClick={onAbort}>Cancel</button>
-            <button
-              className="btn primary icon"
-              onClick={submit}
-              disabled={busy || (!text.trim() && !hasActiveAttachment)}
-              aria-label="Save & regenerate"
-              title="Save & regenerate"
-            >
-              <SendIcon />
-            </button>
-          </>
+          <button
+            className="btn primary icon"
+            onClick={submit}
+            disabled={busy || (!text.trim() && !hasActiveAttachment)}
+            aria-label="Save & regenerate"
+            title="Save & regenerate"
+          >
+            <SendIcon />
+          </button>
         ) : aborting ? (
           <button
             className="btn danger icon"

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -785,14 +785,6 @@ button {
 .user-edit-input:focus {
   border-color: var(--vscode-focusBorder);
 }
-.user-edit-warning {
-  padding: 5px 8px;
-  border-left: 2px solid var(--vscode-charts-yellow, #d29922);
-  border-radius: 0 4px 4px 0;
-  background: var(--vscode-editorWidget-background);
-  color: var(--vscode-descriptionForeground);
-  font-size: 11px;
-}
 .user-edit-actions {
   display: flex;
   justify-content: flex-end;

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -731,6 +731,10 @@ button {
 .msg.role-user.is-editing {
   cursor: default;
   padding: 8px;
+  /* Keep a solid fill so the sticky-pinned bubble doesn't go transparent
+     the moment the mouse leaves it — without this, chat messages scrolling
+     behind the bubble bleed through and the edit UI looks broken. */
+  background: var(--vscode-input-background);
   border-color: var(--vscode-focusBorder);
 }
 .user-edit-hint {
@@ -1697,6 +1701,20 @@ button {
   min-width: 0;
 }
 .promptbox-row .spacer { flex: 1; }
+/* Subdued note in the edit variant of PromptBox, reminding the user that
+   submitting will revert + regenerate every reply after the edited
+   message. Sits left-aligned in the action row, ahead of the spacer so
+   Cancel + Save stay anchored to the right. */
+.edit-regenerate-hint {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--vscode-descriptionForeground);
+  font-size: 11px;
+  font-style: italic;
+}
 
 /* ===== System reminder callout ===== */
 .system-reminder {

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -730,12 +730,19 @@ button {
 }
 .msg.role-user.is-editing {
   cursor: default;
-  padding: 8px;
+  /* Tight, compact edit affordance — minimal outer padding so the embedded
+     textarea + Save button feel like a single in-place editor rather than
+     a panel. Click-outside cancels the edit, so no Cancel button is
+     needed in the action row. */
+  padding: 4px;
   /* Keep a solid fill so the sticky-pinned bubble doesn't go transparent
      the moment the mouse leaves it — without this, chat messages scrolling
      behind the bubble bleed through and the edit UI looks broken. */
   background: var(--vscode-input-background);
   border-color: var(--vscode-focusBorder);
+}
+.msg.role-user.is-editing .promptbox-row {
+  margin-top: 3px;
 }
 .user-edit-hint {
   position: absolute;
@@ -1701,20 +1708,6 @@ button {
   min-width: 0;
 }
 .promptbox-row .spacer { flex: 1; }
-/* Subdued note in the edit variant of PromptBox, reminding the user that
-   submitting will revert + regenerate every reply after the edited
-   message. Sits left-aligned in the action row, ahead of the spacer so
-   Cancel + Save stay anchored to the right. */
-.edit-regenerate-hint {
-  flex: 0 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--vscode-descriptionForeground);
-  font-size: 11px;
-  font-style: italic;
-}
 
 /* ===== System reminder callout ===== */
 .system-reminder {


### PR DESCRIPTION
Closes #34.

## Summary
Three small fixes around the user-message edit-in-place flow, all from a single round of testing.

### 1. Opaque background on the edit-mode bubble
`.msg.role-user.is-editing` previously had only `background: transparent` and relied on the `.is-editable:hover` gradient (over `--vscode-input-background`) for its solid fill. The moment your mouse left the bubble the fill vanished and chat content scrolling behind the sticky bubble bled through, making the edit UI look broken.

Add an explicit `background: var(--vscode-input-background)` to `.is-editing` so it stays solid at rest regardless of hover.

### 2. Regenerate notice in the edit PromptBox
Saving an edit reverts opencode's session past this message and re-runs the prompt — every assistant reply after the edited message is discarded. The UI never said so before. Now there's a subdued italic line in the action row reading "Replies after this message will be discarded and regenerated."

### 3. "Save & regenerate" → circular icon button
Matches the main composer's Send button visually (`.btn.primary.icon` + `<SendIcon />`). Accessible name stays `"Save & regenerate"` via `aria-label` + `title` so screen readers and tests keep working. Cancel stays as a labelled text button — it's a "back out" affordance, not the primary action.

## Incidental cleanup
A stray heredoc EOF marker (`)"`) snuck into `CHANGELOG.md` during an earlier botched edit on PR #30. Removed.

## Release
- `package.json` 0.3.2 → 0.3.4 (skips 0.3.3, which is reserved for the in-flight #33 — order-independent; either PR can land first).
- CHANGELOG entry under [0.3.4].

## Test plan
- [x] `bun run test` — 399 / 399 (test queries updated to use `getByRole("button", { name: /save .{0,3}regenerate/i })` since the button no longer has visible text content)
- [x] `bun run check-types` — clean
- [ ] Visual smoke (dev host): click a past user message → bubble opens edit mode. Move mouse off the bubble — background stays solid. Edit some text — see the italic regenerate notice and the circular Save icon. Click Save — opencode revert + regenerate fires.
- [ ] After merge: bundle with 0.3.1 / 0.3.2 / 0.3.3 contents in the next release tag.