### PR TITLE
fix(chat): pin status-bar dot and stopped dot with flex: 0 0 auto (0.3.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.5]
+
+### Fixed
+- Status-bar connection dot stays perfectly round at narrow side-panel widths. The dot is a flex item inside `display: flex; flex-direction: row` and had default `flex-shrink: 1`, so the algorithm squeezed its width below 8 px while keeping height at 8 px — a vertical ellipse. Added `flex: 0 0 auto`. Same defensive `flex: 0 0 auto` added to `.msg-stopped::before` (the dot on Stopped assistant messages) since it lives in an `inline-flex` parent.
+
 ## [0.3.4]
 
 ### Fixed
@@ -118,7 +123,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Tests
 - 360+ tests across four phases: unit (Vitest + node/jsdom), integration (`@vscode/test-electron`), component (Vitest + React Testing Library), and E2E against a mock opencode HTTP/SSE server.
 
-[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.3.4...HEAD
+[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.3.5...HEAD
+[0.3.5]: https://github.com/arthurzengg/opencui/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/arthurzengg/opencui/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/arthurzengg/opencui/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/arthurzengg/opencui/compare/v0.3.1...v0.3.2

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -47,6 +47,11 @@ button {
 .statusbar.is-quiet .status-text { display: none; }
 
 .statusbar .dot {
+  /* Pin both axes so the flex algorithm can't squeeze the dot horizontally
+     when the bar gets tight (which would turn it into a vertical ellipse).
+     Same defence already applied to the .btn.icon and .history-trigger
+     icons. */
+  flex: 0 0 auto;
   width: 8px;
   height: 8px;
   border-radius: 50%;
@@ -820,6 +825,9 @@ button {
 .msg-stopped::before {
   content: "";
   display: inline-block;
+  /* Same defence as the statusbar dot — `.msg-stopped` is `inline-flex`
+     so this pseudo-element is a flex item. */
+  flex: 0 0 auto;
   width: 6px;
   height: 6px;
   border-radius: 50%;


### PR DESCRIPTION
Closes #36.

## Summary
The status-bar green/yellow/red connection dot was rendering as a vertical ellipse at narrow side-panel widths. It lives in `display: flex; flex-direction: row` with default `flex-shrink: 1`, so the algorithm squeezed its 8 px width while keeping its 8 px height → ellipse.

Add `flex: 0 0 auto` to:
- `.statusbar .dot` (the bug)
- `.msg-stopped::before` (the dot in the "● Stopped" badge — same flex-item pattern, fixed defensively)

## Audit
All other circular icons in the codebase already pin their shape — none affected:
- `.btn.icon` (Send / Stop) — `flex: 0 0 auto`
- `.history-trigger`, `.new-chat-trigger` — `flex: 0 0 auto`
- `.trace-todo-status` — `flex: 0 0 12px`
- `.question-option-marker` — `flex: 0 0 auto`
- `.history-clock`, `.new-chat-icon`, `.trace-todo-status::after` — not flex items

## Release
- `package.json` 0.3.4 → 0.3.5 (patch)
- CHANGELOG entry under [0.3.5]

## Test plan
- [x] `bun run test` — 399 / 399
- [x] `bun run check-types` — clean
- [ ] Visual smoke (dev host): drag the side panel narrow → status dot stays perfectly round. Press Stop and confirm Stopped badge dot also stays round.
- [ ] After merge: tag `v0.3.5` + create GitHub Release; workflow auto-publishes.