### PR TITLE
fix(chat): center status-bar text with dot (0.3.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.6]
+
+### Fixed
+- Status-bar text ("connecting…" / "error · …") now sits on the same horizontal centerline as the dot and the right-side icons. The text inherited the bar's default `line-height` (~1.2), which inflated its text-box; `align-items: center` then landed the geometric centre of the inflated box a hair above the dot's centre. Pinned `line-height: 1` on `.statusbar .status-text` and made `.dot` `display: inline-block` so its `<span>` doesn't pick up baseline quirks.
+
 ## [0.3.5]
 
 ### Fixed
@@ -123,7 +128,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Tests
 - 360+ tests across four phases: unit (Vitest + node/jsdom), integration (`@vscode/test-electron`), component (Vitest + React Testing Library), and E2E against a mock opencode HTTP/SSE server.
 
-[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.3.5...HEAD
+[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.3.6...HEAD
+[0.3.6]: https://github.com/arthurzengg/opencui/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/arthurzengg/opencui/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/arthurzengg/opencui/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/arthurzengg/opencui/compare/v0.3.2...v0.3.3

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -52,6 +52,10 @@ button {
      Same defence already applied to the .btn.icon and .history-trigger
      icons. */
   flex: 0 0 auto;
+  /* The dot is rendered as a <span>; explicit inline-block removes the
+     baseline-alignment quirks some browsers apply to inline boxes, so the
+     flex `align-items: center` lands the dot on the exact bar centerline. */
+  display: inline-block;
   width: 8px;
   height: 8px;
   border-radius: 50%;
@@ -63,6 +67,11 @@ button {
 
 .statusbar .status-text {
   min-width: 0;
+  /* Tight line-height so the text-box hugs the glyph height. Without this,
+     the inherited default (~1.2) inflates the box and `align-items: center`
+     lands the text on the geometric centre of the inflated box — visually
+     a hair above the centre of the 8 px dot next to it. */
+  line-height: 1;
   opacity: 0.75;
   overflow: hidden;
   white-space: nowrap;


### PR DESCRIPTION
Closes #38.

## Summary
The "connecting…" / "error · …" status text didn't visually line up with the dot or the right-side icons — it sat a hair too high.

Cause: `.statusbar` is `align-items: center`, which centers items by their **geometric** center. `.status-text` was inheriting the bar's default `line-height: ~1.2`, inflating its text-box; the geometric centre then landed above where the eye expects the glyphs to sit.

## Fix
- `.statusbar .status-text { line-height: 1 }` — tight text-box so geometric centre matches visual centre.
- `.statusbar .dot { display: inline-block }` — its `<span>` no longer picks up baseline-alignment quirks.

## Release
- `package.json` 0.3.5 → 0.3.6 (patch)
- CHANGELOG entry under [0.3.6]
- **Not releasing yet** — per your instruction. Hold for your go-ahead.

## Test plan
- [x] `bun run test` — 399 / 399
- [x] `bun run check-types` — clean
- [ ] Visual smoke (dev host): the warn/connecting and error states should align with the dot and the right-side icons on the same horizontal centerline.