### PR TITLE
fix(chat): add session-status watchdog and tighten terminal-finish check (0.3.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.7]
+
+### Fixed
+- Conversation-end detection no longer relies solely on the SSE `session.idle` event. A 30-second watchdog now polls `client.session.status({ directory })` when no events have been seen during a busy turn — if opencode reports `idle`, the host emits `sessionIdle` itself. Previously a dropped SSE connection, a server crash mid-turn, or a reconnect after the idle event fired could leave the UI stuck on "Working…" forever. The watchdog resets on every routed event and only fires while busy.
+- `assistantEnd` for a per-message `finish: "stop"` (or any non-`tool-calls` reason) is now also gated on the message having no active tool parts. Some providers return `finish: "stop"` while the assistant message still has running tool calls; the previous check only looked at the finish reason and cleared the per-message spinner prematurely. Matches opencode's own loop-exit condition in `packages/opencode/src/session/prompt.ts`.
+
 ## [0.3.6]
 
 ### Fixed
@@ -128,7 +134,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Tests
 - 360+ tests across four phases: unit (Vitest + node/jsdom), integration (`@vscode/test-electron`), component (Vitest + React Testing Library), and E2E against a mock opencode HTTP/SSE server.
 
-[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.3.6...HEAD
+[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.3.7...HEAD
+[0.3.7]: https://github.com/arthurzengg/opencui/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/arthurzengg/opencui/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/arthurzengg/opencui/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/arthurzengg/opencui/compare/v0.3.3...v0.3.4

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",

--- a/src/chat/stream.ts
+++ b/src/chat/stream.ts
@@ -92,18 +92,39 @@ export type Subscription = {
   abort: () => void
 }
 
+export type SubscriptionOptions = {
+  /**
+   * Watchdog interval. If no SSE events arrive for this many milliseconds
+   * while we believe the session is busy, the host actively polls
+   * `/session/status` to recover from a dropped/missed `session.idle`.
+   * Defaults to 30 s; tests pass shorter values.
+   */
+  watchdogMs?: number
+}
+
+const DEFAULT_WATCHDOG_MS = 30_000
+
 /**
  * Long-lived subscription to session events. Does NOT close on message finish —
  * stays open until abort() is called. This lets the UI capture follow-up
  * assistant turns that are auto-triggered by background-task reminders,
  * permission replies, or any other opencode-side continuation.
+ *
+ * Recovery: a watchdog timer arms while the session is observed busy and
+ * resets on every routed event. If the timer fires (no SSE events for
+ * `watchdogMs`), the host calls `client.session.status({ directory })`
+ * directly — if opencode reports idle, we emit `onSessionIdle` ourselves.
+ * Without this, a dropped SSE connection at the wrong moment leaves the
+ * UI permanently in "Working…".
  */
 export function subscribeSession(
   backend: Backend,
   sessionID: string,
   handlers: StreamHandlers,
+  options: SubscriptionOptions = {},
 ): Subscription {
   const controller = new AbortController()
+  const watchdogMs = options.watchdogMs ?? DEFAULT_WATCHDOG_MS
 
   const seenLen = new Map<string, number>()
   const seenAssistantMessages = new Set<string>()
@@ -111,6 +132,18 @@ export function subscribeSession(
   const assistantFinished = new Set<string>()
   const toolStatus = new Map<string, string>()
   const seenPatches = new Set<string>()
+
+  // messageID → set of tool part IDs that are still pending/running.
+  // Used to defer per-message `assistantEnd` until all tool calls terminate:
+  // some providers return `finish: "stop"` while the message still has
+  // running tool parts, so the finish reason alone isn't sufficient.
+  const activeToolParts = new Map<string, Set<string>>()
+  // messageID → payload waiting on tool-part completion before assistantEnd fires.
+  const pendingFinish = new Map<string, { finish: string; usage?: MessageUsage }>()
+
+  let watchdogTimer: ReturnType<typeof setTimeout> | null = null
+  let busyTracked = false
+  let stopped = false
 
   let readyResolve: () => void = () => {}
   let readyReject: (e: unknown) => void = () => {}
@@ -142,32 +175,101 @@ export function subscribeSession(
     log(`[sse] ${type}`)
     switch (type) {
       case "message.updated":
-        return onMessageUpdated(props?.info)
+        onMessageUpdated(props?.info)
+        markActivity(props?.info?.sessionID)
+        return
       case "message.part.updated":
-        return onPartUpdated(props?.part)
+        onPartUpdated(props?.part)
+        markActivity(props?.part?.sessionID)
+        return
       case "message.part.delta":
-        return onPartDelta(props)
+        onPartDelta(props)
+        markActivity(props?.sessionID)
+        return
       case "permission.asked":
       case "permission.updated":
-        return onPermissionUpdated(props)
+        onPermissionUpdated(props)
+        markActivity(props?.sessionID)
+        return
       case "question.asked":
-        return onQuestionAsked(props)
+        onQuestionAsked(props)
+        markActivity(props?.sessionID)
+        return
       case "question.replied":
       case "question.rejected":
-        return onQuestionResolved(props)
+        onQuestionResolved(props)
+        markActivity(props?.sessionID)
+        return
       case "message.removed":
-        return onMessageRemoved(props)
+        onMessageRemoved(props)
+        markActivity(props?.sessionID)
+        return
       case "tui.toast.show":
         return onToast(props)
       case "session.error":
         return onSessionError(props?.error)
       case "session.idle":
-        if (props?.sessionID === sessionID) handlers.onSessionIdle?.()
+        if (props?.sessionID === sessionID) markIdle()
         return
       case "session.status":
-        if (props?.sessionID === sessionID && props?.status?.type === "idle") handlers.onSessionIdle?.()
-        if (props?.sessionID === sessionID && props?.status?.type && props.status.type !== "idle") handlers.onSessionBusy?.()
+        if (props?.sessionID !== sessionID) return
+        if (props?.status?.type === "idle") {
+          markIdle()
+        } else if (props?.status?.type) {
+          handlers.onSessionBusy?.()
+          markActivity(sessionID)
+        }
         return
+    }
+  }
+
+  function markActivity(eventSessionID: string | undefined) {
+    if (eventSessionID !== sessionID) return
+    busyTracked = true
+    armWatchdog()
+  }
+
+  function markIdle() {
+    busyTracked = false
+    clearWatchdog()
+    handlers.onSessionIdle?.()
+  }
+
+  function clearWatchdog() {
+    if (watchdogTimer) {
+      clearTimeout(watchdogTimer)
+      watchdogTimer = null
+    }
+  }
+
+  function armWatchdog() {
+    clearWatchdog()
+    if (!busyTracked || stopped) return
+    watchdogTimer = setTimeout(runWatchdog, watchdogMs)
+  }
+
+  async function runWatchdog() {
+    watchdogTimer = null
+    if (stopped || !busyTracked) return
+    log(`[watchdog] no SSE events for ${watchdogMs}ms, polling /session/status`)
+    try {
+      const result = await backend.client.session.status({
+        query: { directory: backend.directory },
+      })
+      if (stopped) return
+      const statuses = (result?.data ?? {}) as Record<string, { type?: string } | undefined>
+      const status = statuses[sessionID]
+      if (!status || status.type === "idle") {
+        log("[watchdog] server reports idle — emitting onSessionIdle")
+        markIdle()
+        return
+      }
+      log(`[watchdog] server reports ${status.type} — re-arming`)
+      armWatchdog()
+    } catch (err) {
+      if (stopped) return
+      log("[watchdog] poll failed, re-arming", err)
+      armWatchdog()
     }
   }
 
@@ -201,6 +303,16 @@ export function subscribeSession(
       // receive more parts when the agent resumes, so DO NOT emit assistantEnd
       // for that. Only terminal finish reasons end the message.
       if (isTerminalFinish(info.finish)) {
+        // Some providers return `finish: "stop"` while the assistant message
+        // still has running tool parts — opencode's own loop-exit check
+        // (packages/opencode/src/session/prompt.ts) also gates on no active
+        // tool calls. Mirror that here so we don't clear the spinner before
+        // the tool parts settle.
+        const active = activeToolParts.get(mid)
+        if (active && active.size > 0) {
+          pendingFinish.set(mid, { finish: info.finish, usage: extractUsage(info) })
+          return
+        }
         assistantFinished.add(mid)
         handlers.onAssistantEnd?.(mid, {
           finish: info.finish,
@@ -208,6 +320,17 @@ export function subscribeSession(
         })
       }
     }
+  }
+
+  function maybeFlushPendingFinish(messageID: string) {
+    if (assistantFinished.has(messageID)) return
+    const active = activeToolParts.get(messageID)
+    if (active && active.size > 0) return
+    const pending = pendingFinish.get(messageID)
+    if (!pending) return
+    pendingFinish.delete(messageID)
+    assistantFinished.add(messageID)
+    handlers.onAssistantEnd?.(messageID, pending)
   }
 
   function onPartUpdated(part: any) {
@@ -239,6 +362,18 @@ export function subscribeSession(
       const key = part.callID as string
       const curr = part.state.status as ToolUpdate["status"]
       toolStatus.set(key, curr)
+      // Track unfinished tool parts per message; flush a deferred
+      // assistantEnd once everything settles.
+      const partKey = (part.id as string | undefined) ?? key
+      const isTerminal = curr === "completed" || curr === "error"
+      const set = activeToolParts.get(messageID) ?? new Set<string>()
+      if (isTerminal) {
+        set.delete(partKey)
+      } else {
+        set.add(partKey)
+      }
+      if (set.size > 0) activeToolParts.set(messageID, set)
+      else activeToolParts.delete(messageID)
       if (curr === "running" || curr === "completed" || curr === "error") {
         handlers.onTool?.(messageID, {
           callID: key,
@@ -251,6 +386,7 @@ export function subscribeSession(
           error: part.state.error,
         })
       }
+      if (isTerminal) maybeFlushPendingFinish(messageID)
       return
     }
     if (part.type === "patch" && part.hash && Array.isArray(part.files)) {
@@ -332,7 +468,14 @@ export function subscribeSession(
     handlers.onSessionError?.(msg)
   }
 
-  return { ready, abort: () => controller.abort() }
+  return {
+    ready,
+    abort: () => {
+      stopped = true
+      clearWatchdog()
+      controller.abort()
+    },
+  }
 }
 
 function eventPayload(payload: unknown): { type?: string; properties?: any } | undefined {

--- a/test/host/mock-opencode-server.ts
+++ b/test/host/mock-opencode-server.ts
@@ -25,6 +25,13 @@ export type MockOpencodeServer = {
   prompts: Array<{ sessionID: string; body: unknown }>
   /** Records of every revert call. */
   reverts: Array<{ sessionID: string; body: unknown }>
+  /**
+   * Configure what GET /session/status returns. Pass `undefined` to clear
+   * the entry. Tests use this to drive the watchdog's recovery path.
+   */
+  setSessionStatus: (sessionID: string, status: { type: "idle" | "busy" | "retry" } | undefined) => void
+  /** Number of times GET /session/status has been called. */
+  statusPollCount: () => number
   close: () => Promise<void>
 }
 
@@ -32,6 +39,8 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
   const sseClients: ServerResponse[] = []
   const prompts: Array<{ sessionID: string; body: unknown }> = []
   const reverts: Array<{ sessionID: string; body: unknown }> = []
+  const sessionStatuses = new Map<string, { type: "idle" | "busy" | "retry" }>()
+  let statusPolls = 0
   let clientResolver: (() => void) | undefined
 
   const server: Server = createServer((req: IncomingMessage, res: ServerResponse) => {
@@ -134,6 +143,15 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
       return
     }
 
+    // Session status (used by the watchdog recovery path)
+    if (path === "/session/status" && req.method === "GET") {
+      statusPolls++
+      const body: Record<string, { type: string }> = {}
+      for (const [sid, status] of sessionStatuses) body[sid] = status
+      reply(res, 200, body)
+      return
+    }
+
     // Health (used by some SDK clients before connecting)
     if (path === "/" && req.method === "GET") {
       reply(res, 200, { ok: true })
@@ -163,6 +181,13 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
     },
     prompts,
     reverts,
+    setSessionStatus(sessionID, status) {
+      if (status) sessionStatuses.set(sessionID, status)
+      else sessionStatuses.delete(sessionID)
+    },
+    statusPollCount() {
+      return statusPolls
+    },
     async close() {
       for (const c of sseClients) c.end()
       await new Promise<void>((resolve) => server.close(() => resolve()))

--- a/test/host/stream-watchdog.test.ts
+++ b/test/host/stream-watchdog.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { createOpencodeClient } from "@opencode-ai/sdk"
+import { startMockOpencode, type MockOpencodeServer } from "./mock-opencode-server"
+import { subscribeSession } from "../../src/chat/stream"
+
+let server: MockOpencodeServer
+
+beforeEach(async () => {
+  server = await startMockOpencode()
+})
+
+afterEach(async () => {
+  await server.close()
+})
+
+function makeBackend() {
+  const client = createOpencodeClient({ baseUrl: server.url })
+  return { url: server.url, client, directory: "/tmp" }
+}
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+describe("subscribeSession watchdog", () => {
+  it("fires onSessionIdle when /session/status reports idle after no events", async () => {
+    let idleCount = 0
+    const backend = makeBackend()
+    server.setSessionStatus("ses_test", { type: "idle" })
+
+    const subscription = subscribeSession(
+      backend,
+      "ses_test",
+      {
+        onSessionIdle: () => idleCount++,
+        onTextDelta: () => {},
+      },
+      { watchdogMs: 30 },
+    )
+    await subscription.ready
+    await server.awaitClient()
+
+    // Activity sets busyTracked → watchdog arms.
+    server.push({
+      type: "message.part.updated",
+      part: { messageID: "msg_a", sessionID: "ses_test", id: "p1", type: "text", text: "hi" },
+    })
+    // Allow the SSE chunk to flow before idle.
+    await wait(10)
+    expect(idleCount).toBe(0)
+
+    // Wait past the watchdog window with no further events.
+    await wait(120)
+    subscription.abort()
+    expect(idleCount).toBe(1)
+    expect(server.statusPollCount()).toBeGreaterThanOrEqual(1)
+  })
+
+  it("resets on every routed event and does not fire while activity continues", async () => {
+    let idleCount = 0
+    const backend = makeBackend()
+    server.setSessionStatus("ses_test", { type: "idle" })
+
+    const subscription = subscribeSession(
+      backend,
+      "ses_test",
+      {
+        onSessionIdle: () => idleCount++,
+        onTextDelta: () => {},
+      },
+      { watchdogMs: 60 },
+    )
+    await subscription.ready
+    await server.awaitClient()
+
+    // Stream events every 25 ms — each one resets the watchdog.
+    for (let i = 0; i < 5; i++) {
+      server.push({
+        type: "message.part.updated",
+        part: { messageID: "msg_a", sessionID: "ses_test", id: `p${i}`, type: "text", text: `x${i}` },
+      })
+      await wait(25)
+    }
+
+    subscription.abort()
+    // No watchdog should have fired because activity was steady.
+    expect(idleCount).toBe(0)
+    expect(server.statusPollCount()).toBe(0)
+  })
+
+  it("re-arms the watchdog when /session/status reports busy", async () => {
+    let idleCount = 0
+    const backend = makeBackend()
+    server.setSessionStatus("ses_test", { type: "busy" })
+
+    const subscription = subscribeSession(
+      backend,
+      "ses_test",
+      {
+        onSessionIdle: () => idleCount++,
+        onTextDelta: () => {},
+      },
+      { watchdogMs: 30 },
+    )
+    await subscription.ready
+    await server.awaitClient()
+
+    server.push({
+      type: "message.part.updated",
+      part: { messageID: "msg_a", sessionID: "ses_test", id: "p1", type: "text", text: "hi" },
+    })
+
+    // First watchdog fire sees busy → should NOT emit idle.
+    await wait(60)
+    expect(idleCount).toBe(0)
+    expect(server.statusPollCount()).toBeGreaterThanOrEqual(1)
+    const firstPolls = server.statusPollCount()
+
+    // Server flips to idle → next watchdog tick recovers.
+    server.setSessionStatus("ses_test", { type: "idle" })
+    await wait(60)
+    subscription.abort()
+    expect(idleCount).toBe(1)
+    expect(server.statusPollCount()).toBeGreaterThan(firstPolls)
+  })
+
+  it("does not arm the watchdog before any activity", async () => {
+    let idleCount = 0
+    const backend = makeBackend()
+    server.setSessionStatus("ses_test", { type: "idle" })
+
+    const subscription = subscribeSession(
+      backend,
+      "ses_test",
+      {
+        onSessionIdle: () => idleCount++,
+        onTextDelta: () => {},
+      },
+      { watchdogMs: 30 },
+    )
+    await subscription.ready
+    await server.awaitClient()
+
+    await wait(80)
+    subscription.abort()
+    expect(idleCount).toBe(0)
+    expect(server.statusPollCount()).toBe(0)
+  })
+
+  it("stops the watchdog after abort", async () => {
+    const backend = makeBackend()
+    server.setSessionStatus("ses_test", { type: "idle" })
+
+    const subscription = subscribeSession(
+      backend,
+      "ses_test",
+      {
+        onSessionIdle: () => {},
+        onTextDelta: () => {},
+      },
+      { watchdogMs: 20 },
+    )
+    await subscription.ready
+    await server.awaitClient()
+    server.push({
+      type: "message.part.updated",
+      part: { messageID: "msg_a", sessionID: "ses_test", id: "p1", type: "text", text: "hi" },
+    })
+    subscription.abort()
+
+    const baseline = server.statusPollCount()
+    await wait(80)
+    // Watchdog should have been cancelled by abort, no further polls.
+    expect(server.statusPollCount()).toBe(baseline)
+  })
+
+  it("session.idle event clears the watchdog (no poll)", async () => {
+    let idleCount = 0
+    const backend = makeBackend()
+    server.setSessionStatus("ses_test", { type: "idle" })
+
+    const subscription = subscribeSession(
+      backend,
+      "ses_test",
+      {
+        onSessionIdle: () => idleCount++,
+        onTextDelta: () => {},
+      },
+      { watchdogMs: 30 },
+    )
+    await subscription.ready
+    await server.awaitClient()
+    server.push({
+      type: "message.part.updated",
+      part: { messageID: "msg_a", sessionID: "ses_test", id: "p1", type: "text", text: "hi" },
+    })
+    await wait(5)
+    server.push({ type: "session.idle", sessionID: "ses_test" })
+    await wait(60)
+    subscription.abort()
+    expect(idleCount).toBe(1)
+    expect(server.statusPollCount()).toBe(0)
+  })
+})
+
+describe("subscribeSession terminal-finish gating", () => {
+  it("defers assistantEnd while a tool part is still running, fires when it completes", async () => {
+    const ends: Array<{ mid: string; finish?: string }> = []
+    const backend = makeBackend()
+    server.setSessionStatus("ses_test", { type: "idle" })
+
+    const subscription = subscribeSession(
+      backend,
+      "ses_test",
+      {
+        onAssistantEnd: (mid, payload) => ends.push({ mid, finish: payload.finish }),
+        onTextDelta: () => {},
+        onTool: () => {},
+      },
+      // Large watchdog — we don't want it to interfere here.
+      { watchdogMs: 10_000 },
+    )
+    await subscription.ready
+    await server.awaitClient()
+
+    // A running tool part for msg_a.
+    server.push({
+      type: "message.part.updated",
+      part: {
+        messageID: "msg_a",
+        sessionID: "ses_test",
+        id: "tp1",
+        callID: "call_1",
+        tool: "bash",
+        type: "tool",
+        state: { status: "running" },
+      },
+    })
+    await wait(10)
+
+    // Provider returns finish: "stop" while the tool is still running.
+    server.push({
+      type: "message.updated",
+      info: { id: "msg_a", role: "assistant", sessionID: "ses_test", finish: "stop" },
+    })
+    await wait(20)
+    expect(ends).toHaveLength(0)
+
+    // Tool part terminates → deferred assistantEnd fires.
+    server.push({
+      type: "message.part.updated",
+      part: {
+        messageID: "msg_a",
+        sessionID: "ses_test",
+        id: "tp1",
+        callID: "call_1",
+        tool: "bash",
+        type: "tool",
+        state: { status: "completed" },
+      },
+    })
+    await wait(20)
+    subscription.abort()
+
+    expect(ends).toHaveLength(1)
+    expect(ends[0]).toEqual({ mid: "msg_a", finish: "stop" })
+  })
+
+  it("emits assistantEnd immediately when finish arrives with no active tool parts", async () => {
+    const ends: Array<{ mid: string }> = []
+    const backend = makeBackend()
+    server.setSessionStatus("ses_test", { type: "idle" })
+
+    const subscription = subscribeSession(
+      backend,
+      "ses_test",
+      {
+        onAssistantEnd: (mid) => ends.push({ mid }),
+        onTextDelta: () => {},
+      },
+      { watchdogMs: 10_000 },
+    )
+    await subscription.ready
+    await server.awaitClient()
+
+    server.push({
+      type: "message.updated",
+      info: { id: "msg_b", role: "assistant", sessionID: "ses_test", finish: "stop" },
+    })
+    await wait(20)
+    subscription.abort()
+    expect(ends).toEqual([{ mid: "msg_b" }])
+  })
+
+  it("does not fire assistantEnd for finish: tool-calls (existing behaviour)", async () => {
+    const ends: Array<{ mid: string }> = []
+    const backend = makeBackend()
+    server.setSessionStatus("ses_test", { type: "idle" })
+
+    const subscription = subscribeSession(
+      backend,
+      "ses_test",
+      {
+        onAssistantEnd: (mid) => ends.push({ mid }),
+        onTextDelta: () => {},
+      },
+      { watchdogMs: 10_000 },
+    )
+    await subscription.ready
+    await server.awaitClient()
+
+    server.push({
+      type: "message.updated",
+      info: { id: "msg_c", role: "assistant", sessionID: "ses_test", finish: "tool-calls" },
+    })
+    await wait(20)
+    subscription.abort()
+    expect(ends).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## Summary

Two correctness fixes for how the extension determines a conversation/turn has ended. Both grounded in inspection of canonical [opencode](https://github.com/anomalyco/opencode) and a production harness ([oh-my-openagent](https://github.com/code-yeongyu/oh-my-openagent)).

### 1. Watchdog for missed `session.idle`

Before: re-enabling Send / clearing "Working…" depended **entirely** on the SSE `session.idle` event. SSE drop, opencode crash, or a reconnect after the idle event fired → UI stuck on "Working…" forever (the recurring stuck-Working bug).

After: `subscribeSession` arms a 30 s watchdog while the session is observed busy. Every routed SSE event resets the timer. If it fires, the host calls `client.session.status({ directory })` and trusts the HTTP response — emits `onSessionIdle` if opencode reports idle. Watchdog disarms on `session.idle` / `session.status: idle` and on `abort()`.

### 2. Tighter `isTerminalFinish`

Before: any `finish` other than `tool-calls` was treated as terminal, regardless of pending tool parts. Some providers return `finish: "stop"` while the assistant message still has running tool calls → spinner cleared before message was actually done.

After: per-message active-tool-parts tracking. When `message.updated` arrives with a terminal-looking finish but the message still has unfinished tool parts, the `assistantEnd` payload is parked in `pendingFinish` and only emitted once the last tool part settles. Mirrors opencode's own loop-exit condition in `packages/opencode/src/session/prompt.ts` (which also gates on `!hasToolCalls` in addition to the finish reason).

## Files

- `src/chat/stream.ts` — watchdog timer + active-tool-part tracking + deferred `assistantEnd` flush.
- `test/host/mock-opencode-server.ts` — added `GET /session/status` handler with `setSessionStatus()` / `statusPollCount()` test helpers.
- `test/host/stream-watchdog.test.ts` (new) — 9 tests covering both flows.
- `package.json`, `CHANGELOG.md` — 0.3.6 → 0.3.7.

## Test plan

- [x] `bun run test` — 408/408 passing.
- [x] `bun run check-types` — clean.
- [x] `cd webview && bunx tsc --noEmit` — 3 pre-existing errors documented in CLAUDE.md; nothing new from this PR.
- [ ] Visual verification in dev host: trigger a long-running tool turn, watch console for `[watchdog]` logs, confirm UI never hangs on artificial SSE disconnect.

## Not releasing

Per workflow, this PR will be merged but not tagged/released until you've verified in the dev host.

Closes #40