### PR TITLE
fix(chat): direction-aware scroll lock during streaming (0.3.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.8]
+
+### Fixed
+- Auto-scroll no longer fights the user during streaming. The chat container's `onScroll` handler used to re-engage stick-to-bottom whenever the view was within 80 px of the bottom — but each `textDelta` re-scrolled to the bottom, so a small upward gesture stayed inside the threshold and the next delta yanked the view back down. Replaced the position-only heuristic with a direction-aware one: programmatic scrolls are flagged and ignored, any user-initiated `scrollTop` *decrease* (wheel / touch / keyboard) immediately disengages stick mode, and stick mode only re-engages when the user lands within 8 px of the bottom on their own.
+
 ## [0.3.7]
 
 ### Fixed
@@ -134,7 +139,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Tests
 - 360+ tests across four phases: unit (Vitest + node/jsdom), integration (`@vscode/test-electron`), component (Vitest + React Testing Library), and E2E against a mock opencode HTTP/SSE server.
 
-[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.3.7...HEAD
+[Unreleased]: https://github.com/arthurzengg/opencui/compare/v0.3.8...HEAD
+[0.3.8]: https://github.com/arthurzengg/opencui/compare/v0.3.7...v0.3.8
 [0.3.7]: https://github.com/arthurzengg/opencui/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/arthurzengg/opencui/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/arthurzengg/opencui/compare/v0.3.4...v0.3.5

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",

--- a/test/host/stream-watchdog.test.ts
+++ b/test/host/stream-watchdog.test.ts
@@ -33,7 +33,7 @@ describe("subscribeSession watchdog", () => {
         onSessionIdle: () => idleCount++,
         onTextDelta: () => {},
       },
-      { watchdogMs: 30 },
+      { watchdogMs: 50 },
     )
     await subscription.ready
     await server.awaitClient()
@@ -48,7 +48,7 @@ describe("subscribeSession watchdog", () => {
     expect(idleCount).toBe(0)
 
     // Wait past the watchdog window with no further events.
-    await wait(120)
+    await wait(200)
     subscription.abort()
     expect(idleCount).toBe(1)
     expect(server.statusPollCount()).toBeGreaterThanOrEqual(1)
@@ -66,18 +66,18 @@ describe("subscribeSession watchdog", () => {
         onSessionIdle: () => idleCount++,
         onTextDelta: () => {},
       },
-      { watchdogMs: 60 },
+      { watchdogMs: 120 },
     )
     await subscription.ready
     await server.awaitClient()
 
-    // Stream events every 25 ms — each one resets the watchdog.
+    // Stream events every 40 ms — each one resets the watchdog.
     for (let i = 0; i < 5; i++) {
       server.push({
         type: "message.part.updated",
         part: { messageID: "msg_a", sessionID: "ses_test", id: `p${i}`, type: "text", text: `x${i}` },
       })
-      await wait(25)
+      await wait(40)
     }
 
     subscription.abort()
@@ -98,7 +98,7 @@ describe("subscribeSession watchdog", () => {
         onSessionIdle: () => idleCount++,
         onTextDelta: () => {},
       },
-      { watchdogMs: 30 },
+      { watchdogMs: 50 },
     )
     await subscription.ready
     await server.awaitClient()
@@ -109,14 +109,14 @@ describe("subscribeSession watchdog", () => {
     })
 
     // First watchdog fire sees busy → should NOT emit idle.
-    await wait(60)
+    await wait(150)
     expect(idleCount).toBe(0)
     expect(server.statusPollCount()).toBeGreaterThanOrEqual(1)
     const firstPolls = server.statusPollCount()
 
     // Server flips to idle → next watchdog tick recovers.
     server.setSessionStatus("ses_test", { type: "idle" })
-    await wait(60)
+    await wait(150)
     subscription.abort()
     expect(idleCount).toBe(1)
     expect(server.statusPollCount()).toBeGreaterThan(firstPolls)
@@ -134,12 +134,12 @@ describe("subscribeSession watchdog", () => {
         onSessionIdle: () => idleCount++,
         onTextDelta: () => {},
       },
-      { watchdogMs: 30 },
+      { watchdogMs: 50 },
     )
     await subscription.ready
     await server.awaitClient()
 
-    await wait(80)
+    await wait(150)
     subscription.abort()
     expect(idleCount).toBe(0)
     expect(server.statusPollCount()).toBe(0)
@@ -156,7 +156,7 @@ describe("subscribeSession watchdog", () => {
         onSessionIdle: () => {},
         onTextDelta: () => {},
       },
-      { watchdogMs: 20 },
+      { watchdogMs: 50 },
     )
     await subscription.ready
     await server.awaitClient()
@@ -167,7 +167,7 @@ describe("subscribeSession watchdog", () => {
     subscription.abort()
 
     const baseline = server.statusPollCount()
-    await wait(80)
+    await wait(150)
     // Watchdog should have been cancelled by abort, no further polls.
     expect(server.statusPollCount()).toBe(baseline)
   })
@@ -184,7 +184,7 @@ describe("subscribeSession watchdog", () => {
         onSessionIdle: () => idleCount++,
         onTextDelta: () => {},
       },
-      { watchdogMs: 30 },
+      { watchdogMs: 50 },
     )
     await subscription.ready
     await server.awaitClient()
@@ -192,9 +192,9 @@ describe("subscribeSession watchdog", () => {
       type: "message.part.updated",
       part: { messageID: "msg_a", sessionID: "ses_test", id: "p1", type: "text", text: "hi" },
     })
-    await wait(5)
+    await wait(10)
     server.push({ type: "session.idle", sessionID: "ses_test" })
-    await wait(60)
+    await wait(150)
     subscription.abort()
     expect(idleCount).toBe(1)
     expect(server.statusPollCount()).toBe(0)

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -31,6 +31,22 @@ export default function App() {
   } = useChatState()
   const scrollRef = useRef<HTMLDivElement>(null)
   const stickToBottom = useRef(true)
+  // Tracks whether the next onScroll fired from our own scrollTop= write
+  // (so the synthetic event doesn't masquerade as a user gesture and
+  // re-engage stick mode on every text delta).
+  const programmaticScroll = useRef(false)
+  const lastScrollTop = useRef(0)
+  // Distance-from-bottom threshold for *re-engaging* stick mode once the
+  // user has manually disengaged it. Smaller than the old 80 px because we
+  // now use scroll direction, not just position.
+  const STICK_REENGAGE_PX = 8
+
+  const scrollToBottom = () => {
+    if (!scrollRef.current) return
+    programmaticScroll.current = true
+    scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+    lastScrollTop.current = scrollRef.current.scrollTop
+  }
   const [reviewRequest, setReviewRequest] = useState<{ path: string; key: number }>()
   const openReviewFile = (path: string) => {
     setReviewRequest((current) => ({ path, key: (current?.key ?? 0) + 1 }))
@@ -84,8 +100,8 @@ export default function App() {
   const activeProcessID = state.messages.findLast((m) => m.role === "assistant" && m.pending)?.id
 
   useEffect(() => {
-    if (!scrollRef.current || !stickToBottom.current) return
-    scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+    if (!stickToBottom.current) return
+    scrollToBottom()
   }, [state.messages])
 
   // When the user opens a different conversation from the History menu, jump
@@ -95,9 +111,8 @@ export default function App() {
   useEffect(() => {
     if (!scrollRef.current || !state.conversationID) return
     requestAnimationFrame(() => {
-      if (!scrollRef.current) return
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
       stickToBottom.current = true
+      scrollToBottom()
     })
   }, [state.conversationID])
 
@@ -121,7 +136,28 @@ export default function App() {
         ref={scrollRef}
         onScroll={(e) => {
           const el = e.currentTarget
-          stickToBottom.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80
+          // Consume the synthetic onScroll fired by our own scrollTop= write
+          // so it never gets interpreted as a user gesture (which would
+          // re-assert stick mode every text delta).
+          if (programmaticScroll.current) {
+            programmaticScroll.current = false
+            lastScrollTop.current = el.scrollTop
+            return
+          }
+          const prev = lastScrollTop.current
+          const curr = el.scrollTop
+          lastScrollTop.current = curr
+          if (curr < prev) {
+            // Any user-initiated upward movement breaks stick mode regardless
+            // of distance to bottom — even one wheel notch.
+            stickToBottom.current = false
+            return
+          }
+          // Downward (or no) movement: re-engage stick only when the user
+          // has actually reached the bottom on their own.
+          if (el.scrollHeight - curr - el.clientHeight <= STICK_REENGAGE_PX) {
+            stickToBottom.current = true
+          }
         }}
       >
         {state.messages.length === 0 && (


### PR DESCRIPTION
## Summary

Auto-scroll no longer fights the user during streaming. Closes #42.

### Before

`webview/src/App.tsx` re-engaged stick-to-bottom whenever the view was **within 80 px of the bottom**. Each `textDelta` triggered a programmatic `scrollTop = scrollHeight`, so a small upward gesture (≈30 px wheel notch) stayed inside the 80 px threshold and the next delta yanked the view back. The synthetic `onScroll` fired by our own write also re-asserted "near bottom" immediately after each programmatic scroll.

### After

Direction-aware lock:

1. **Programmatic scrolls are flagged** via a `programmaticScroll` ref and the corresponding `onScroll` is consumed — it never gets read as a user gesture.
2. **Any decrease in `scrollTop`** (wheel / touch / keyboard) immediately disengages stick mode, regardless of distance to bottom.
3. **Re-engages** only when the user themselves lands within 8 px of the bottom.

Conversation-switching behaviour preserved: opening a different conversation still snaps to the bottom and re-enables stick.

## Test plan

- [x] `bun run test` — 408/408 passing.
- [x] `bun run check-types` — clean.
- [x] `cd webview && bunx tsc --noEmit` — same 3 pre-existing errors documented in CLAUDE.md.
- [ ] Visual verification in dev host:
  - During streaming, one wheel notch up should keep the view stationary; further deltas should not pull it down.
  - Manually scrolling back to the bottom should re-engage auto-follow.
  - Switching conversations should still snap to the bottom.

### Drive-by

Bumped a handful of timing margins in `test/host/stream-watchdog.test.ts` — the tests passed in isolation but were flaky under the full parallel suite (SSE delivery + 30 ms timer + HTTP poll occasionally exceeded the prior 60 ms wait).

## Not releasing

Per workflow — merge but don't release until you've verified in the dev host.

Closes #42