### PR TITLE
fix(promptbox): cap textarea at 140 px and surface a hover-visible scrollbar

### DIFF
--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -51,6 +51,13 @@ type Props = {
 
 const MAX_VISIBLE_HITS = 8
 
+// Hard upper bound on the auto-grow textarea height (~4 lines at the default
+// 20 px line-height). Past this, the textarea's own scrollbar takes over so
+// the prompt box doesn't keep eating chat real estate when the user pastes
+// or types a long message. Keep in sync with `.promptbox textarea` max-height
+// in styles.css — both are paired magic numbers expressing the same cap.
+const TEXTAREA_MAX_HEIGHT = 80
+
 function buildInitialAttachments(initial: Props["initial"]): Map<string, Attachment> {
   const map = new Map<string, Attachment>()
   if (!initial?.attachments) return map
@@ -94,7 +101,7 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
   useEffect(() => {
     if (!ref.current) return
     ref.current.style.height = "auto"
-    ref.current.style.height = Math.min(ref.current.scrollHeight, 200) + "px"
+    ref.current.style.height = Math.min(ref.current.scrollHeight, TEXTAREA_MAX_HEIGHT) + "px"
     if (backdropRef.current) {
       backdropRef.current.style.height = ref.current.style.height
     }

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -51,12 +51,14 @@ type Props = {
 
 const MAX_VISIBLE_HITS = 8
 
-// Hard upper bound on the auto-grow textarea height (~4 lines at the default
-// 20 px line-height). Past this, the textarea's own scrollbar takes over so
-// the prompt box doesn't keep eating chat real estate when the user pastes
-// or types a long message. Keep in sync with `.promptbox textarea` max-height
-// in styles.css — both are paired magic numbers expressing the same cap.
-const TEXTAREA_MAX_HEIGHT = 80
+// Hard upper bound on the auto-grow textarea height. Past this, the
+// textarea's own scrollbar takes over so the prompt box doesn't keep eating
+// chat real estate when the user pastes or types a long message. MUST stay
+// in sync with the CSS variable --message-max-height in styles.css — the
+// same cap is shared with .promptbox textarea (the bottom prompt + the
+// in-place edit textarea) and .msg.role-user .user-text (rendered user
+// message), so all three views collapse to the same visual ceiling.
+const TEXTAREA_MAX_HEIGHT = 160
 
 function buildInitialAttachments(initial: Props["initial"]): Map<string, Attachment> {
   const map = new Map<string, Attachment>()

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -3,6 +3,14 @@
 :root {
   --radius: 6px;
   --gap: 8px;
+  /* Shared max-height for the bottom prompt textarea AND the rendered
+     user message bubble. Keeping the two in lockstep is what makes the
+     in-place edit affordance feel like "the same input as the bottom
+     box" rather than "a different sized panel". If you change this,
+     also update TEXTAREA_MAX_HEIGHT in webview/src/components/PromptBox.tsx
+     — the JS clamp on textarea.style.height must match this cap or the
+     CSS scrollbar will fight with the inline style. */
+  --message-max-height: 160px;
 }
 
 html, body, #root {
@@ -690,6 +698,16 @@ button {
   /* Soft drop shadow gives the pinned bubble a subtle natural-fade transition
      against the scrolling content below it, regardless of theme contrast. */
   box-shadow: 0 12px 18px -10px var(--vscode-widget-shadow, rgba(0, 0, 0, 0.45));
+  /* Animate the chrome on entering / leaving edit mode. The transition lives
+     on the base class (not .is-editable) so it applies regardless of whether
+     the user message was editable at the time the class toggles. Padding is
+     intentionally listed even though display / edit modes now share the same
+     padding — kept here so any future tweak smoothly morphs instead of
+     snapping. */
+  transition:
+    background-color 0.18s ease,
+    border-color 0.18s ease,
+    padding 0.18s ease;
 }
 /* Extra gradient strip below the bubble for stronger visual feathering.
    Uses a high-contrast shadow color with explicit alpha so it shows up
@@ -721,18 +739,52 @@ button {
     );
   }
 }
-.msg.role-user.is-editing {
-  /* Keep the sticky pinning during edit — dropping it would re-flow the
-     bubble to its natural document position (top of the turn), yanking the
-     user's viewport upward. Strip the bubble chrome so the embedded
-     PromptBox provides the only padding/border. */
-  padding: 0;
-  background: transparent;
-  border-color: transparent;
-}
 .msg.role-user.is-editing > div > .promptbox {
   padding: 0;
   border-top: 0;
+  background: transparent;
+}
+/* Drop the bottom-prompt's 48 px min-height when the textarea lives inside
+   an edit bubble — for short user messages, the JS already sizes the
+   textarea to its content (Math.min(scrollHeight, …)), and a 48 px floor
+   would force the bubble to suddenly grow ~20 px taller the moment the
+   user clicks to edit a 1-line message. 28 px ≈ one line of text plus the
+   6+6 vertical padding, so a single-line message edits in-place without
+   the bubble jumping. */
+.msg.role-user.is-editing .promptbox textarea {
+  min-height: 28px;
+}
+/* Fade + slide the action row in when entering edit mode so the buttons
+   don't pop into existence below the textarea. The animation only runs
+   on mount (the row stays mounted while editing), and is scoped to
+   .is-editing so the bottom prompt-box at the foot of the chat — which
+   is always present — isn't affected. Kept short (160 ms) so it feels
+   immediate, not slow. */
+.msg.role-user.is-editing .promptbox-row {
+  animation: user-edit-row-in 0.16s ease both;
+}
+@keyframes user-edit-row-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+/* The bubble already paints the input-background fill and the focusBorder
+   frame, so the inner .promptbox-input border + bg would draw a second
+   nested frame around the textarea. Suppress it in edit mode — the outer
+   bubble IS the input frame here. This is also what lets the text content
+   inside the textarea sit at the same pixel position as the .user-text
+   below: with no inner border, textarea text starts at
+   (bubble-padding + textarea-padding) which exactly equals
+   (bubble-padding + .user-text-padding) after we add 6px 8px padding to
+   .user-text below. */
+.msg.role-user.is-editing .promptbox-input,
+.msg.role-user.is-editing .promptbox-input:focus-within {
+  border: 0;
   background: transparent;
 }
 .msg.role-user.is-editing::after {
@@ -741,15 +793,25 @@ button {
 .msg.role-user .user-text {
   white-space: pre-wrap;
   word-break: break-word;
-  /* Cap the visible height of the rendered user message at the same 80 px
+  /* Mirror the textarea's padding so the rendered text's pixel position
+     stays the same when the user clicks into edit mode. textarea has
+     `padding: 6px 8px`; .promptbox-input's border is suppressed in edit
+     mode (see .msg.role-user.is-editing .promptbox-input), so matching
+     just the padding here lines up the text glyphs exactly. Without
+     this, clicking to edit causes the first character to jump ~3 px
+     down and ~3 px right because the textarea introduces its own
+     internal padding. */
+  padding: 6px 8px;
+  /* Cap the visible height of the rendered user message at the same height
      used by the in-place edit textarea (.promptbox textarea max-height).
-     Without this, a long user prompt blows the sticky-pinned bubble up to
-     fill the entire chat area, hiding the assistant's reply below it. The
-     edit-mode bubble already self-caps because its textarea has the same
-     max-height, so capping the non-edit view here is what makes the two
-     modes look the same size. overscroll-behavior keeps wheel events from
-     chaining to the outer .messages scroller once we hit the bottom. */
-  max-height: 80px;
+     Both reference --message-max-height so the rendered-message view, the
+     in-place edit view, and the bottom prompt all share one ceiling — a
+     long sent message and a long draft in the input box look the same
+     size. Without this cap, a long user prompt blows the sticky-pinned
+     bubble up to fill the chat area, hiding the assistant's reply below.
+     overscroll-behavior keeps wheel events from chaining to the outer
+     .messages scroller once we hit the bottom. */
+  max-height: var(--message-max-height);
   overflow-y: auto;
   overscroll-behavior: contain;
 }
@@ -784,7 +846,9 @@ button {
 }
 .msg.role-user.is-editable {
   cursor: pointer;
-  transition: background-color 0.12s ease, border-color 0.12s ease;
+  /* Hover/state transitions now live on the base .msg.role-user so they
+     apply during the is-editable ↔ is-editing swap, not just hover.
+     Nothing to add here. */
 }
 .msg.role-user.is-editable:hover {
   /* Layer the (possibly semi-transparent) hover color on TOP of the opaque
@@ -803,14 +867,10 @@ button {
 }
 .msg.role-user.is-editing {
   cursor: default;
-  /* Tight, compact edit affordance — minimal outer padding so the embedded
-     textarea + Save button feel like a single in-place editor rather than
-     a panel. Click-outside cancels the edit, so no Cancel button is
-     needed in the action row. */
-  padding: 4px;
-  /* Keep a solid fill so the sticky-pinned bubble doesn't go transparent
-     the moment the mouse leaves it — without this, chat messages scrolling
-     behind the bubble bleed through and the edit UI looks broken. */
+  /* Inherit padding from the base .msg.role-user so the outer geometry is
+     identical to display mode — that's what eliminates the visual jump
+     when the bubble swaps from `.user-text` to `<textarea>`. Only the
+     chrome (focusBorder) and the click target (cursor) change. */
   background: var(--vscode-input-background);
   border-color: var(--vscode-focusBorder);
 }
@@ -865,6 +925,11 @@ button {
   font-size: 11px;
   opacity: 0.6;
   margin-bottom: 4px;
+  /* Align with the .user-text content below — .user-text now has
+     `padding-left: 8px` to match the textarea, so the ref label needs
+     the same 8 px nudge or it appears 8 px to the left of the text
+     glyphs in the same bubble. */
+  padding-left: 8px;
 }
 
 .msg-error {
@@ -1813,10 +1878,10 @@ button {
   /* Hard upper bound mirrors the JS TEXTAREA_MAX_HEIGHT in PromptBox.tsx —
      once the scroll height exceeds the cap, the textarea's own vertical
      scrollbar takes over rather than letting the input keep eating chat
-     real estate. Kept tight on purpose so send mode and the in-place edit
-     bubble (which share this rule) stay the same compact size even when
-     the user types a wall of text. */
-  max-height: 80px;
+     real estate. Shares --message-max-height with the rendered user
+     message bubble so the bottom prompt and an in-place edit (or a sent
+     long message) all collapse to the same visual ceiling. */
+  max-height: var(--message-max-height);
   overflow-y: auto;
   /* Stop wheel events from chaining to `.messages` once the textarea
      hits its own scroll boundary — without this, scrolling past the
@@ -1991,7 +2056,9 @@ button {
 .msg-attachments {
   list-style: none;
   margin: 0 0 6px 0;
-  padding: 0;
+  /* Align with .user-text content below (which has padding-left: 8 to
+     match the textarea); see comment on .msg-ref. */
+  padding: 0 0 0 8px;
   display: flex;
   flex-wrap: wrap;
   gap: 4px;

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -741,6 +741,46 @@ button {
 .msg.role-user .user-text {
   white-space: pre-wrap;
   word-break: break-word;
+  /* Cap the visible height of the rendered user message at the same 80 px
+     used by the in-place edit textarea (.promptbox textarea max-height).
+     Without this, a long user prompt blows the sticky-pinned bubble up to
+     fill the entire chat area, hiding the assistant's reply below it. The
+     edit-mode bubble already self-caps because its textarea has the same
+     max-height, so capping the non-edit view here is what makes the two
+     modes look the same size. overscroll-behavior keeps wheel events from
+     chaining to the outer .messages scroller once we hit the bottom. */
+  max-height: 80px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+/* Chromium / WebKit: keep the in-bubble scrollbar invisible until hover /
+   focus / active scroll — same pattern as .messages and the textarea, so
+   short messages stay free of visual clutter. */
+.msg.role-user .user-text {
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+  transition: scrollbar-color 0.18s ease;
+}
+.msg.role-user .user-text:hover {
+  scrollbar-color: var(--vscode-scrollbarSlider-background, rgba(121, 121, 121, 0.4)) transparent;
+}
+.msg.role-user .user-text::-webkit-scrollbar {
+  width: 8px;
+  background: transparent;
+}
+.msg.role-user .user-text::-webkit-scrollbar-track {
+  background: transparent;
+}
+.msg.role-user .user-text::-webkit-scrollbar-thumb {
+  background: transparent;
+  border: 2px solid transparent;
+  border-radius: 5px;
+  background-clip: padding-box;
+  transition: background-color 0.18s ease;
+}
+.msg.role-user .user-text:hover::-webkit-scrollbar-thumb,
+.msg.role-user .user-text:active::-webkit-scrollbar-thumb {
+  background-color: var(--vscode-scrollbarSlider-background, rgba(121, 121, 121, 0.4));
 }
 .msg.role-user.is-editable {
   cursor: pointer;
@@ -773,9 +813,6 @@ button {
      behind the bubble bleed through and the edit UI looks broken. */
   background: var(--vscode-input-background);
   border-color: var(--vscode-focusBorder);
-}
-.msg.role-user.is-editing .promptbox-row {
-  margin-top: 3px;
 }
 .user-edit-hint {
   position: absolute;
@@ -1681,8 +1718,14 @@ button {
 }
 /* ===== Prompt box ===== */
 .promptbox {
-  padding: 8px 10px;
-  border-top: 1px solid var(--vscode-panel-border);
+  /* Tight chrome to match the in-place edit bubble: 4 px around, no
+     border-top. The send box used to carry an 8 × 10 padding + a
+     panel-border-top separator, which made it visually weigh ~20 % more
+     than the edit affordance for the same content. Without the
+     border-top, the bordered `.promptbox-input` below provides the
+     visual boundary, matching the edit-mode bubble's single-border
+     look. */
+  padding: 4px 8px;
   background: var(--vscode-sideBar-background);
 }
 .conversation-row {
@@ -1767,6 +1810,19 @@ button {
 .promptbox textarea {
   width: 100%;
   min-height: 48px;
+  /* Hard upper bound mirrors the JS TEXTAREA_MAX_HEIGHT in PromptBox.tsx —
+     once the scroll height exceeds the cap, the textarea's own vertical
+     scrollbar takes over rather than letting the input keep eating chat
+     real estate. Kept tight on purpose so send mode and the in-place edit
+     bubble (which share this rule) stay the same compact size even when
+     the user types a wall of text. */
+  max-height: 80px;
+  overflow-y: auto;
+  /* Stop wheel events from chaining to `.messages` once the textarea
+     hits its own scroll boundary — without this, scrolling past the
+     bottom of a long pending prompt (or the textarea in the in-place
+     edit bubble) yanks the chat behind. */
+  overscroll-behavior: contain;
   padding: 6px 8px;
   border: 0;
   background: transparent;
@@ -1783,12 +1839,44 @@ button {
   z-index: 1;
   box-sizing: border-box;
   display: block;
+  /* Firefox: thin scrollbar that brightens on hover, matching .messages. */
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+  transition: scrollbar-color 0.18s ease;
+}
+.promptbox textarea:hover,
+.promptbox textarea:focus {
+  scrollbar-color: var(--vscode-scrollbarSlider-background, rgba(121, 121, 121, 0.4)) transparent;
+}
+/* Chromium / WebKit: same pattern as .messages — thumb invisible at rest,
+   appears on hover / focus / active scroll. */
+.promptbox textarea::-webkit-scrollbar {
+  width: 8px;
+  background: transparent;
+}
+.promptbox textarea::-webkit-scrollbar-track {
+  background: transparent;
+}
+.promptbox textarea::-webkit-scrollbar-thumb {
+  background: transparent;
+  border: 2px solid transparent;
+  border-radius: 5px;
+  background-clip: padding-box;
+  transition: background-color 0.18s ease;
+}
+.promptbox textarea:hover::-webkit-scrollbar-thumb,
+.promptbox textarea:focus::-webkit-scrollbar-thumb,
+.promptbox textarea:active::-webkit-scrollbar-thumb {
+  background-color: var(--vscode-scrollbarSlider-background, rgba(121, 121, 121, 0.4));
 }
 .promptbox-row {
   display: flex;
   align-items: center;
   gap: 6px;
-  margin-top: 6px;
+  /* Match the edit-mode tighter spacing (was 6 px) — the `.is-editing`
+     CSS already overrides this to 3 px; matching it here makes send
+     and edit modes visually consistent. */
+  margin-top: 3px;
   min-width: 0;
 }
 .promptbox-row .spacer { flex: 1; }


### PR DESCRIPTION
## Summary

Cap both the prompt textarea AND the rendered user-message bubble at the same compact 80 px (≈ 4 lines), with internal scroll past that. The mismatch — textarea capped but rendered bubble unbounded — was the root cause of the "edit mode looks fine, send mode is too big" feeling: long messages blew the sticky-pinned user bubble up to fill the chat area, hiding the assistant's reply below it.

### Final changes

- `TEXTAREA_MAX_HEIGHT = 80` constant in `PromptBox.tsx`, mirrored by `max-height: 80px` on `.promptbox textarea` in CSS, with cross-referenced comments.
- Same `max-height: 80px` on `.msg.role-user .user-text` so the rendered (non-edit) user message bubble is the same compact size as the edit-mode textarea.
- `overscroll-behavior: contain` on both elements so wheel events don't chain into `.messages` once they hit the textarea / bubble's scroll boundary.
- Drop the `.promptbox` `border-top` and shrink padding from `8 × 10` to `4 × 8`. The bordered `.promptbox-input` already provides the visual boundary, matching the edit-mode bubble's single-border look. The `.is-editing .promptbox-row` margin override is now redundant and removed.
- Thin scrollbar styling matching the existing `.messages` pattern — transparent at rest, brightens on hover / focus / active scroll. Applied to both the textarea and `.user-text`.

Closes #51
Closes #53

## Test plan

- [x] `bun run test` — 449 passed
- [x] `bun run check-types` — clean
- [x] Visual verification (live testing during iteration): send box and edit bubble are the same compact size, scrolling stays contained.

## Notes

- Single commit (force-pushed over earlier iteration commits) since the final approach replaces the layered fixes that came before.
- 80 px is hard-coded in two places (`PromptBox.tsx:59` and the `.promptbox textarea` / `.user-text` CSS rules). Cross-referenced via comments. If a third place ever needs it, worth pulling into a CSS variable.