### PR TITLE
chore(release): cut v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-16
+
 ### Added
 - Image paste from the clipboard. `Cmd+V` / `Ctrl+V` of a screenshot or any clipboard image (PNG / JPEG / GIF / WEBP / BMP / SVG) now attaches it directly to the prompt — no paperclip → file-dialog → save-to-disk round-trip. Pasted images render as a small thumbnail strip *above* the textarea (with a hover-X to remove and the filename + size in the tooltip), not as `@filename` text tokens — paste names like `pasted-image.png` carry no signal, so the screenshot itself is the affordance. Implemented entirely in the webview (the bytes are already in `clipboardData.items`, no host hop needed); pasted attachments fall through the existing send path that uses their inline data URL, so opencode receives them exactly like paperclip attachments. Pure-text paste keeps the default browser behaviour; mixed text + image pastes split — text goes to the textarea at the caret, image to the thumbnail strip. Send is enabled with only a thumbnail (no typed text required). Individual images cap at 10 MB to match `MAX_ATTACHMENT_BYTES` on the host. Closes #56.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bump \`package.json\` 0.4.0 → 0.5.0 and cut the dated CHANGELOG heading.

### Release contents

- **Added** — Clipboard image paste (#57, closes #56). \`Cmd+V\` of a screenshot attaches as a name-less thumbnail tile, hover-X to remove.
- **Changed** — Image attachments in sent bubbles render as bare 28-px thumbnails matching the input strip. Click any image thumbnail (input or bubble) to open a fullscreen lightbox preview.

Closes #58

## After merge

\`\`\`bash
git checkout main && git pull
git tag v0.5.0
git push origin v0.5.0
gh release create v0.5.0 --title "v0.5.0" --notes-from-tag
\`\`\`

The \`release: published\` event triggers \`.github/workflows/release.yml\` which type-checks, tests, builds, and publishes to the VS Code Marketplace via \`bunx @vscode/vsce publish\`.

## Test plan

- [x] CHANGELOG renders correctly under the new \`## [0.5.0]\` heading
- [x] Empty \`## [Unreleased]\` placeholder kept for next cycle
- [x] \`package.json\` version field updated
- [x] No code changes