### PR TITLE
fix(promptbox): route paperclip-uploaded images to the thumbnail strip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- Paperclip-uploaded image files now render as thumbnail tiles in the prompt strip too, matching the behavior added for clipboard paste in v0.5.0. Previously only pasted images got the thumbnail treatment — paperclip images went through the `@filename.png` text-token chip flow, which looked inconsistent and read awkwardly when the same file picker also returned PDFs / code files. Now `handleAttachClick` splits the picker result by mime: image-mime attachments push to the thumbnail strip, non-image attachments (PDFs / `.txt` / code) keep the existing chip-text-token flow because their filenames carry user-meaningful signal. The strip state was renamed `pastedAttachments` → `imageAttachments` to reflect that it now represents any image regardless of source. Closes #60.
+
 ## [0.5.0] - 2026-05-16
 
 ### Added

--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -649,58 +649,58 @@ describe("PromptBox attachments (inline @chip flow)", () => {
     expect(screen.getByRole("button", { name: /Attach/i })).toBeInTheDocument()
   })
 
-  it("inserts @filename text into the textarea when paperclip returns a file", async () => {
+  it("inserts @filename text into the textarea when paperclip returns a non-image file", async () => {
     const user = userEvent.setup()
-    const attachFile = vi.fn().mockResolvedValue({ attachments: [makeImage()] })
+    const attachFile = vi.fn().mockResolvedValue({ attachments: [makePdf()] })
     render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} attachFile={attachFile} />)
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
     await user.click(screen.getByRole("button", { name: /Attach/i }))
-    await waitFor(() => expect(textarea.value).toContain("@screen.png"))
+    await waitFor(() => expect(textarea.value).toContain("@doc.pdf"))
   })
 
   it("renders the inserted @filename as a .mention-chip in the backdrop", async () => {
     const user = userEvent.setup()
-    const attachFile = vi.fn().mockResolvedValue({ attachments: [makeImage()] })
+    const attachFile = vi.fn().mockResolvedValue({ attachments: [makePdf()] })
     const { container } = render(
       <PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} attachFile={attachFile} />,
     )
     await user.click(screen.getByRole("button", { name: /Attach/i }))
     await waitFor(() => expect(container.querySelector(".mention-chip")).not.toBeNull())
-    expect(container.querySelector(".mention-chip")?.textContent).toBe("@screen.png")
+    expect(container.querySelector(".mention-chip")?.textContent).toBe("@doc.pdf")
   })
 
-  it("multiple attachments insert in order separated by spaces", async () => {
+  it("multiple non-image attachments insert in order separated by spaces", async () => {
     const user = userEvent.setup()
     const attachFile = vi.fn().mockResolvedValue({
-      attachments: [makeImage("first.png"), makePdf("second.pdf")],
+      attachments: [makePdf("first.pdf"), makePdf("second.pdf")],
     })
     const { container } = render(
       <PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} attachFile={attachFile} />,
     )
     await user.click(screen.getByRole("button", { name: /Attach/i }))
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
-    await waitFor(() => expect(textarea.value).toBe("@first.png @second.pdf "))
+    await waitFor(() => expect(textarea.value).toBe("@first.pdf @second.pdf "))
     const chips = container.querySelectorAll(".mention-chip")
-    expect(Array.from(chips).map((c) => c.textContent)).toEqual(["@first.png", "@second.pdf"])
+    expect(Array.from(chips).map((c) => c.textContent)).toEqual(["@first.pdf", "@second.pdf"])
   })
 
   it("inserts at the current caret position, not always at the end", async () => {
     const user = userEvent.setup()
-    const attachFile = vi.fn().mockResolvedValue({ attachments: [makeImage()] })
+    const attachFile = vi.fn().mockResolvedValue({ attachments: [makePdf()] })
     render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} attachFile={attachFile} />)
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
     await user.type(textarea, "hello world")
     textarea.setSelectionRange(5, 5) // caret right after "hello"
     await user.click(screen.getByRole("button", { name: /Attach/i }))
-    await waitFor(() => expect(textarea.value).toBe("hello @screen.png world"))
+    await waitFor(() => expect(textarea.value).toBe("hello @doc.pdf world"))
   })
 
-  it("two attachments with the same filename get disambiguated labels", async () => {
+  it("two non-image attachments with the same filename get disambiguated labels", async () => {
     const user = userEvent.setup()
     const attachFile = vi
       .fn()
-      .mockResolvedValueOnce({ attachments: [makeImage("screen.png")] })
-      .mockResolvedValueOnce({ attachments: [makeImage("screen.png")] })
+      .mockResolvedValueOnce({ attachments: [makePdf("report.pdf")] })
+      .mockResolvedValueOnce({ attachments: [makePdf("report.pdf")] })
     const { container } = render(
       <PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} attachFile={attachFile} />,
     )
@@ -710,24 +710,73 @@ describe("PromptBox attachments (inline @chip flow)", () => {
     await user.click(attachBtn)
     await waitFor(() => expect(container.querySelectorAll(".mention-chip")).toHaveLength(2))
     const chipTexts = Array.from(container.querySelectorAll(".mention-chip")).map((c) => c.textContent)
-    expect(chipTexts).toEqual(["@screen.png", "@screen_2.png"])
+    expect(chipTexts).toEqual(["@report.pdf", "@report_2.pdf"])
   })
 
   it("Send forwards the Attachment objects whose chips appear in text", async () => {
     const user = userEvent.setup()
     const onSend = vi.fn()
-    const img = makeImage()
-    const attachFile = vi.fn().mockResolvedValue({ attachments: [img] })
+    const pdf = makePdf()
+    const attachFile = vi.fn().mockResolvedValue({ attachments: [pdf] })
     render(<PromptBox busy={false} onSend={onSend} onAbort={vi.fn()} attachFile={attachFile} />)
     await user.click(screen.getByRole("button", { name: /Attach/i }))
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
-    await waitFor(() => expect(textarea.value).toContain("@screen.png"))
+    await waitFor(() => expect(textarea.value).toContain("@doc.pdf"))
     await user.type(textarea, "what is this")
     await user.keyboard("{Enter}")
     expect(onSend).toHaveBeenCalledTimes(1)
     const args = onSend.mock.calls[0]
-    expect(args?.[0]).toBe("@screen.png what is this")
+    expect(args?.[0]).toBe("@doc.pdf what is this")
     expect(args?.[1]).toBeUndefined()
+    expect(args?.[2]).toEqual([pdf])
+  })
+
+  it("paperclip-uploaded images render as a thumbnail (no @chip text token)", async () => {
+    const user = userEvent.setup()
+    const attachFile = vi.fn().mockResolvedValue({ attachments: [makeImage()] })
+    const { container } = render(
+      <PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} attachFile={attachFile} />,
+    )
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    await user.click(screen.getByRole("button", { name: /Attach/i }))
+    await waitFor(() => expect(container.querySelector(".promptbox-thumb")).not.toBeNull())
+    // Image attachment goes to the thumbnail strip — no `@chip` text and no mention-chip
+    expect(textarea.value).toBe("")
+    expect(container.querySelector(".mention-chip")).toBeNull()
+  })
+
+  it("paperclip mixed (image + PDF) splits: image to thumbnail, PDF to @chip", async () => {
+    const user = userEvent.setup()
+    const attachFile = vi.fn().mockResolvedValue({
+      attachments: [makeImage("shot.png"), makePdf("spec.pdf")],
+    })
+    const { container } = render(
+      <PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} attachFile={attachFile} />,
+    )
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    await user.click(screen.getByRole("button", { name: /Attach/i }))
+    await waitFor(() => expect(container.querySelector(".promptbox-thumb")).not.toBeNull())
+    expect(textarea.value).toBe("@spec.pdf ")
+    expect(container.querySelectorAll(".mention-chip")).toHaveLength(1)
+    expect(container.querySelectorAll(".promptbox-thumb")).toHaveLength(1)
+  })
+
+  it("Send forwards a paperclip-uploaded image via the thumbnail flow", async () => {
+    const user = userEvent.setup()
+    const onSend = vi.fn()
+    const img = makeImage()
+    const attachFile = vi.fn().mockResolvedValue({ attachments: [img] })
+    const { container } = render(
+      <PromptBox busy={false} onSend={onSend} onAbort={vi.fn()} attachFile={attachFile} />,
+    )
+    await user.click(screen.getByRole("button", { name: /Attach/i }))
+    await waitFor(() => expect(container.querySelector(".promptbox-thumb")).not.toBeNull())
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    await user.click(textarea)
+    await user.keyboard("describe this{Enter}")
+    expect(onSend).toHaveBeenCalledTimes(1)
+    const args = onSend.mock.calls[0]
+    expect(args?.[0]).toBe("describe this")
     expect(args?.[2]).toEqual([img])
   })
 
@@ -742,16 +791,16 @@ describe("PromptBox attachments (inline @chip flow)", () => {
     )
   })
 
-  it("two-step Backspace removes an attachment chip too", async () => {
+  it("two-step Backspace removes a non-image attachment chip too", async () => {
     const user = userEvent.setup()
     const onSend = vi.fn()
-    const attachFile = vi.fn().mockResolvedValue({ attachments: [makeImage()] })
+    const attachFile = vi.fn().mockResolvedValue({ attachments: [makePdf()] })
     const { container } = render(
       <PromptBox busy={false} onSend={onSend} onAbort={vi.fn()} attachFile={attachFile} />,
     )
     await user.click(screen.getByRole("button", { name: /Attach/i }))
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
-    await waitFor(() => expect(textarea.value).toBe("@screen.png "))
+    await waitFor(() => expect(textarea.value).toBe("@doc.pdf "))
     // Backspace once: highlight
     await user.keyboard("{Backspace}")
     expect(container.querySelector(".mention-chip-selected")).not.toBeNull()
@@ -761,14 +810,14 @@ describe("PromptBox attachments (inline @chip flow)", () => {
     expect(textarea.value).toBe("")
   })
 
-  it("if the attachment chip is deleted, Send does NOT include the attachment", async () => {
+  it("if the non-image attachment chip is deleted, Send does NOT include the attachment", async () => {
     const user = userEvent.setup()
     const onSend = vi.fn()
-    const attachFile = vi.fn().mockResolvedValue({ attachments: [makeImage()] })
+    const attachFile = vi.fn().mockResolvedValue({ attachments: [makePdf()] })
     render(<PromptBox busy={false} onSend={onSend} onAbort={vi.fn()} attachFile={attachFile} />)
     await user.click(screen.getByRole("button", { name: /Attach/i }))
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
-    await waitFor(() => expect(textarea.value).toContain("@screen.png"))
+    await waitFor(() => expect(textarea.value).toContain("@doc.pdf"))
     await user.clear(textarea)
     await user.type(textarea, "no attachments here")
     await user.keyboard("{Enter}")

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -69,7 +69,7 @@ function buildInitialAttachments(initial: Props["initial"]): Map<string, Attachm
   const existing = new Set<string>(initial.mentions ?? [])
   for (const a of initial.attachments) {
     // Image attachments are routed to the thumbnail strip
-    // (`pastedAttachments` state below) — they don't live in the
+    // (`imageAttachments` state below) — they don't live in the
     // `@chip` text-token model. Skip them here.
     if (a.mime.startsWith("image/")) continue
     const label = makeAttachmentLabel(a.filename, existing)
@@ -92,18 +92,14 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
   const [selectedChipStart, setSelectedChipStart] = useState<number | undefined>(undefined)
   const [attachError, setAttachError] = useState<string | undefined>(undefined)
   const [attaching, setAttaching] = useState(false)
-  // Pasted images render as a thumbnail strip above the textarea instead
-  // of as `@filename` text tokens. Synthesised paste names like
-  // `pasted-image.png` carry no meaning, so the strip is name-less by
-  // design (the screenshot itself is the affordance). Kept in component
-  // state — not in `knownAttachments` — so the same Attachment never
-  // ends up rendered twice, and so the strip can be reordered / X'd-out
-  // without poking at the textarea text. In edit mode, image attachments
-  // from `initial.attachments` seed the strip (see
-  // `buildInitialThumbnails`) so editing a message that contains a
-  // pasted image keeps the thumbnail visible rather than silently
-  // dropping it.
-  const [pastedAttachments, setPastedAttachments] = useState<Attachment[]>(
+  // Image attachments render as a thumbnail strip above the textarea
+  // instead of as `@filename` text tokens, regardless of source (paste,
+  // paperclip, or restored from initial.attachments on edit). The
+  // screenshot itself is the affordance, filename + size live in the
+  // hover tooltip. Kept in component state — not in `knownAttachments`
+  // — so the same Attachment never ends up rendered twice, and so the
+  // strip can be modified without poking at the textarea text.
+  const [imageAttachments, setImageAttachments] = useState<Attachment[]>(
     () => buildInitialThumbnails(initial),
   )
   // Lightbox state — clicking a thumbnail (anywhere except the X) opens a
@@ -206,7 +202,7 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
     // Append pasted-image thumbnails after any chip-resolved attachments
     // so display order in the bubble matches input order: chip-cited
     // files first, pasted images second.
-    for (const a of pastedAttachments) activeAttachments.push(a)
+    for (const a of imageAttachments) activeAttachments.push(a)
     if ((!trimmed && activeAttachments.length === 0) || busy) return
     const mentions = extractMentions(text, knownMentions.current)
     onSend(
@@ -217,7 +213,7 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
     setText("")
     knownMentions.current.clear()
     knownAttachments.current.clear()
-    setPastedAttachments([])
+    setImageAttachments([])
     setSelectedChipStart(undefined)
     setAttachError(undefined)
     closeMention()
@@ -230,33 +226,46 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
     try {
       const result = await attachFile()
       if (result.attachments.length > 0) {
-        const ta = ref.current
-        const caret = ta?.selectionStart ?? text.length
-        const before = text.slice(0, caret)
-        const after = text.slice(caret)
-        // Build "@label1 @label2 " insertion, registering each label.
-        let insertion = ""
-        const existing = new Set([
-          ...knownMentions.current,
-          ...knownAttachments.current.keys(),
-        ])
-        for (const att of result.attachments) {
-          const label = makeAttachmentLabel(att.filename, existing)
-          existing.add(label)
-          knownAttachments.current.set(label, att)
-          insertion += "@" + label + " "
+        // Image-mime attachments go to the thumbnail strip regardless of
+        // source — paperclip-uploaded images get the same affordance as
+        // pasted ones for visual consistency. Non-image attachments
+        // (PDFs / .txt / code files) keep the existing `@chip` text-
+        // token flow because their filenames carry user-meaningful
+        // signal and the chip is the discoverable mention surface.
+        const images = result.attachments.filter((a) => a.mime.startsWith("image/"))
+        const nonImages = result.attachments.filter((a) => !a.mime.startsWith("image/"))
+        if (images.length > 0) {
+          setImageAttachments((prev) => [...prev, ...images])
         }
-        // If the char before the caret is non-whitespace, we need a leading
-        // space so the @ token has a whitespace boundary on its left.
-        const lastBeforeChar = before.slice(-1)
-        const needsLeadingSpace = lastBeforeChar !== "" && !/\s/.test(lastBeforeChar)
-        const lead = needsLeadingSpace ? " " : ""
-        // Trim our trailing space if there's already whitespace after the caret.
-        const trimTrailing = after.startsWith(" ")
-        const finalInsertion = lead + (trimTrailing ? insertion.trimEnd() : insertion)
-        const next = before + finalInsertion + after
-        pendingCursor.current = before.length + finalInsertion.length
-        setText(next)
+        if (nonImages.length > 0) {
+          const ta = ref.current
+          const caret = ta?.selectionStart ?? text.length
+          const before = text.slice(0, caret)
+          const after = text.slice(caret)
+          // Build "@label1 @label2 " insertion, registering each label.
+          let insertion = ""
+          const existing = new Set([
+            ...knownMentions.current,
+            ...knownAttachments.current.keys(),
+          ])
+          for (const att of nonImages) {
+            const label = makeAttachmentLabel(att.filename, existing)
+            existing.add(label)
+            knownAttachments.current.set(label, att)
+            insertion += "@" + label + " "
+          }
+          // If the char before the caret is non-whitespace, we need a leading
+          // space so the @ token has a whitespace boundary on its left.
+          const lastBeforeChar = before.slice(-1)
+          const needsLeadingSpace = lastBeforeChar !== "" && !/\s/.test(lastBeforeChar)
+          const lead = needsLeadingSpace ? " " : ""
+          // Trim our trailing space if there's already whitespace after the caret.
+          const trimTrailing = after.startsWith(" ")
+          const finalInsertion = lead + (trimTrailing ? insertion.trimEnd() : insertion)
+          const next = before + finalInsertion + after
+          pendingCursor.current = before.length + finalInsertion.length
+          setText(next)
+        }
       }
       if (result.error) setAttachError(result.error)
     } finally {
@@ -286,7 +295,7 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
       return
     }
     if (result.attachments.length > 0) {
-      setPastedAttachments((prev) => [...prev, ...result.attachments])
+      setImageAttachments((prev) => [...prev, ...result.attachments])
     }
     // Mixed text+image pastes still insert the text portion at the caret
     // (the image goes to the thumbnail strip independently).
@@ -302,8 +311,8 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
     if (result.error) setAttachError(result.error)
   }
 
-  const removePastedAttachment = (id: string) => {
-    setPastedAttachments((prev) => prev.filter((a) => a.id !== id))
+  const removeImageAttachment = (id: string) => {
+    setImageAttachments((prev) => prev.filter((a) => a.id !== id))
   }
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -388,7 +397,7 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
   // Send is enabled if there's text OR a chip-cited attachment in the text
   // OR a thumbnail in the pasted strip.
   const hasActiveAttachment = (() => {
-    if (pastedAttachments.length > 0) return true
+    if (imageAttachments.length > 0) return true
     if (knownAttachments.current.size === 0) return false
     return findMentionRanges(text, new Set(knownAttachments.current.keys())).length > 0
   })()
@@ -397,9 +406,9 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
     <div className={"promptbox" + (variant === "edit" ? " promptbox--edit" : "")}>
       {contextLabel && <div className="context-chip">{contextLabel}</div>}
       {attachError && <div className="attachment-error">{attachError}</div>}
-      {pastedAttachments.length > 0 && (
-        <ul className="promptbox-thumbs" aria-label="Pasted images">
-          {pastedAttachments.map((a) => (
+      {imageAttachments.length > 0 && (
+        <ul className="promptbox-thumbs" aria-label="Image attachments">
+          {imageAttachments.map((a) => (
             <li key={a.id} className="promptbox-thumb" title={`${a.filename} · ${formatBytes(a.bytes)}`}>
               <button
                 type="button"
@@ -414,7 +423,7 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
                 className="promptbox-thumb-remove"
                 aria-label={`Remove ${a.filename}`}
                 title="Remove"
-                onClick={() => removePastedAttachment(a.id)}
+                onClick={() => removeImageAttachment(a.id)}
               >
                 <svg width="8" height="8" viewBox="0 0 8 8" aria-hidden="true">
                   <path d="M1 1l6 6M7 1l-6 6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />


### PR DESCRIPTION
## Summary

After v0.5.0 only PASTED images got the thumbnail-tile affordance; paperclip-uploaded images still inserted `@filename.png` text tokens. Same content presented two different ways depending on source — felt inconsistent and made paperclip-image discovery worse (no preview). Make it consistent: any image-mime attachment, regardless of source, goes to the thumbnail strip.

Closes #60

## How

- Split the paperclip result by mime in `handleAttachClick`:
  - Image-mime → `imageAttachments` state (thumbnail strip + lightbox)
  - Non-image → existing `knownAttachments` map + `@chip` text-token insertion (PDFs / `.txt` / code files keep their filename-bearing chip because user-picked names matter)
- Rename `pastedAttachments` → `imageAttachments` (the state no longer represents only paste-sourced items).
- Update `.promptbox-thumbs` aria-label "Pasted images" → "Image attachments".
- Existing chip-flow tests switched from `makeImage()` to `makePdf()` since `@chip` is now the non-image path.
- 3 new tests: paperclip-image → thumbnail (no @chip text), paperclip mixed (image + pdf) → image to strip / PDF to chip, Send forwards paperclip-uploaded image via the thumbnail flow.

## Test plan

- [x] `bun run test` — 484 passed (was 481)
- [x] `bun run check-types` — clean
- [x] `bun run package` — single-file webview builds clean
- [ ] Visual verification in a dev host:
  - [ ] Paperclip → PNG → thumbnail tile appears, no `@chip` text
  - [ ] Paperclip → PDF → existing `@spec.pdf` chip flow
  - [ ] Paperclip → PNG + PDF together → one thumbnail + one chip
  - [ ] Click paperclip-uploaded thumbnail → lightbox opens (same as pasted)
  - [ ] X-remove on a paperclip-uploaded thumbnail → drops it