### PR TITLE
chore(release): cut v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-05-17
+
 ### Fixed
 - Paperclip-uploaded image files now render as thumbnail tiles in the prompt strip too, matching the behavior added for clipboard paste in v0.5.0. Previously only pasted images got the thumbnail treatment — paperclip images went through the `@filename.png` text-token chip flow, which looked inconsistent and read awkwardly when the same file picker also returned PDFs / code files. Now `handleAttachClick` splits the picker result by mime: image-mime attachments push to the thumbnail strip, non-image attachments (PDFs / `.txt` / code) keep the existing chip-text-token flow because their filenames carry user-meaningful signal. The strip state was renamed `pastedAttachments` → `imageAttachments` to reflect that it now represents any image regardless of source. Closes #60.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Patch bump for the paperclip-image-thumbnail consistency fix (#61, closes #60). \`package.json\` 0.5.0 → 0.5.1, CHANGELOG dated.

### Release contents

- **Fixed** — Paperclip-uploaded images now render as thumbnails in the prompt strip, matching the paste flow.

Closes #62

## After merge

\`\`\`bash
git checkout main && git pull
git tag v0.5.1
git push origin v0.5.1
gh release create v0.5.1 --title "v0.5.1" --notes-from-tag
\`\`\`