### PR TITLE
refactor(thumbnails): extract shared ImageThumbnail component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- Internal: extracted the image thumbnail markup + styling into a shared `<ImageThumbnail>` component used by both the prompt-box strip and the sent-bubble attachment list. Previously the two contexts duplicated ~40 lines of JSX + CSS (`.promptbox-thumb*` and `.attachment-image*`) for what was already pixel-identical output. CSS class names unified to `.image-thumb` / `.image-thumb-open` / `.image-thumb-remove`; the old context-specific names are gone. No user-visible change.
+
 ## [0.5.1] - 2026-05-17
 
 ### Fixed

--- a/test/webview/message-view.test.tsx
+++ b/test/webview/message-view.test.tsx
@@ -429,13 +429,13 @@ describe("MessageView edit preserves mentions + attachments", () => {
     const { container } = render(
       <MessageView message={message} processOpen={false} processOnly={false} />,
     )
-    const tile = container.querySelector(".attachment-image") as HTMLElement | null
+    const tile = container.querySelector(".image-thumb") as HTMLElement | null
     expect(tile).not.toBeNull()
     // No chip pill, no filename text — the image is the affordance.
     expect(container.querySelector(".attachment-tile")).toBeNull()
     expect(tile?.textContent?.trim()).toBe("")
     // Filename + size still discoverable via the tooltip.
-    expect(tile?.getAttribute("title")).toBe("pasted-image.png")
+    expect(tile?.getAttribute("title")).toContain("pasted-image.png")
     // The image itself uses the data URL.
     const img = tile?.querySelector("img") as HTMLImageElement | null
     expect(img?.getAttribute("src")).toMatch(/^data:image\/png;base64,/)
@@ -485,7 +485,7 @@ describe("MessageView edit preserves mentions + attachments", () => {
     // The filename still shows for non-image attachments — these come from
     // the paperclip flow and carry user-meaningful names.
     expect(chip?.textContent).toContain("spec.pdf")
-    expect(container.querySelector(".attachment-image")).toBeNull()
+    expect(container.querySelector(".image-thumb")).toBeNull()
   })
 
   it("renders an attachment label as a chip in the read-only bubble too", () => {
@@ -569,7 +569,7 @@ describe("MessageView edit preserves mentions + attachments", () => {
     )
     await user.click(container.querySelector(".msg.role-user") as HTMLElement)
     // Thumbnail visible inside the edit bubble's PromptBox.
-    expect(container.querySelector(".promptbox-thumb")).not.toBeNull()
+    expect(container.querySelector(".image-thumb")).not.toBeNull()
     const textarea = container.querySelector("textarea") as HTMLTextAreaElement
     await user.clear(textarea)
     await user.type(textarea, "describe this image")
@@ -611,7 +611,7 @@ describe("MessageView edit preserves mentions + attachments", () => {
     await user.click(container.querySelector(".msg.role-user") as HTMLElement)
     const removeBtn = screen.getByRole("button", { name: /Remove pasted-image\.png/i })
     await user.click(removeBtn)
-    expect(container.querySelector(".promptbox-thumb")).toBeNull()
+    expect(container.querySelector(".image-thumb")).toBeNull()
     const textarea = container.querySelector("textarea") as HTMLTextAreaElement
     await user.clear(textarea)
     await user.type(textarea, "no image now")

--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -739,7 +739,7 @@ describe("PromptBox attachments (inline @chip flow)", () => {
     )
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
     await user.click(screen.getByRole("button", { name: /Attach/i }))
-    await waitFor(() => expect(container.querySelector(".promptbox-thumb")).not.toBeNull())
+    await waitFor(() => expect(container.querySelector(".image-thumb")).not.toBeNull())
     // Image attachment goes to the thumbnail strip — no `@chip` text and no mention-chip
     expect(textarea.value).toBe("")
     expect(container.querySelector(".mention-chip")).toBeNull()
@@ -755,10 +755,10 @@ describe("PromptBox attachments (inline @chip flow)", () => {
     )
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
     await user.click(screen.getByRole("button", { name: /Attach/i }))
-    await waitFor(() => expect(container.querySelector(".promptbox-thumb")).not.toBeNull())
+    await waitFor(() => expect(container.querySelector(".image-thumb")).not.toBeNull())
     expect(textarea.value).toBe("@spec.pdf ")
     expect(container.querySelectorAll(".mention-chip")).toHaveLength(1)
-    expect(container.querySelectorAll(".promptbox-thumb")).toHaveLength(1)
+    expect(container.querySelectorAll(".image-thumb")).toHaveLength(1)
   })
 
   it("Send forwards a paperclip-uploaded image via the thumbnail flow", async () => {
@@ -770,7 +770,7 @@ describe("PromptBox attachments (inline @chip flow)", () => {
       <PromptBox busy={false} onSend={onSend} onAbort={vi.fn()} attachFile={attachFile} />,
     )
     await user.click(screen.getByRole("button", { name: /Attach/i }))
-    await waitFor(() => expect(container.querySelector(".promptbox-thumb")).not.toBeNull())
+    await waitFor(() => expect(container.querySelector(".image-thumb")).not.toBeNull())
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
     await user.click(textarea)
     await user.keyboard("describe this{Enter}")
@@ -870,13 +870,13 @@ describe("PromptBox image paste from clipboard", () => {
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
     const file = new File([new Uint8Array(100)], "image.png", { type: "image/png" })
     textarea.dispatchEvent(pasteEvent(makePasteData([file])))
-    await waitFor(() => expect(container.querySelector(".promptbox-thumb")).not.toBeNull())
+    await waitFor(() => expect(container.querySelector(".image-thumb")).not.toBeNull())
     // Textarea stays empty — no `@pasted-image.png` text token.
     expect(textarea.value).toBe("")
     // No mention-chip either.
     expect(container.querySelector(".mention-chip")).toBeNull()
     // The thumbnail has an <img> with the base64 data URL.
-    const img = container.querySelector(".promptbox-thumb img") as HTMLImageElement | null
+    const img = container.querySelector(".image-thumb img") as HTMLImageElement | null
     expect(img?.getAttribute("src")).toMatch(/^data:image\/png;base64,/)
   })
 
@@ -885,8 +885,8 @@ describe("PromptBox image paste from clipboard", () => {
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
     const file = new File([new Uint8Array(100)], "image.png", { type: "image/png" })
     textarea.dispatchEvent(pasteEvent(makePasteData([file])))
-    await waitFor(() => expect(container.querySelector(".promptbox-thumb")).not.toBeNull())
-    const tile = container.querySelector(".promptbox-thumb")!
+    await waitFor(() => expect(container.querySelector(".image-thumb")).not.toBeNull())
+    const tile = container.querySelector(".image-thumb")!
     expect(tile.getAttribute("title")).toMatch(/pasted-image\.png/)
     expect(tile.textContent?.trim()).toBe("")
   })
@@ -897,7 +897,7 @@ describe("PromptBox image paste from clipboard", () => {
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
     const file = new File([new Uint8Array(100)], "image.png", { type: "image/png" })
     textarea.dispatchEvent(pasteEvent(makePasteData([file])))
-    await waitFor(() => expect(container.querySelector(".promptbox-thumb")).not.toBeNull())
+    await waitFor(() => expect(container.querySelector(".image-thumb")).not.toBeNull())
     const user = userEvent.setup()
     await user.click(textarea)
     await user.keyboard("look at this{Enter}")
@@ -915,11 +915,11 @@ describe("PromptBox image paste from clipboard", () => {
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
     const file = new File([new Uint8Array(100)], "image.png", { type: "image/png" })
     textarea.dispatchEvent(pasteEvent(makePasteData([file])))
-    await waitFor(() => expect(container.querySelector(".promptbox-thumb")).not.toBeNull())
+    await waitFor(() => expect(container.querySelector(".image-thumb")).not.toBeNull())
     const user = userEvent.setup()
     await user.click(textarea)
     await user.keyboard("ok{Enter}")
-    await waitFor(() => expect(container.querySelector(".promptbox-thumb")).toBeNull())
+    await waitFor(() => expect(container.querySelector(".image-thumb")).toBeNull())
   })
 
   it("enables send with only a pasted image (no text required)", async () => {
@@ -928,7 +928,7 @@ describe("PromptBox image paste from clipboard", () => {
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
     const file = new File([new Uint8Array(100)], "image.png", { type: "image/png" })
     textarea.dispatchEvent(pasteEvent(makePasteData([file])))
-    await waitFor(() => expect(container.querySelector(".promptbox-thumb")).not.toBeNull())
+    await waitFor(() => expect(container.querySelector(".image-thumb")).not.toBeNull())
     const sendBtn = screen.getByRole("button", { name: /^Send$/i })
     expect((sendBtn as HTMLButtonElement).disabled).toBe(false)
   })
@@ -938,11 +938,11 @@ describe("PromptBox image paste from clipboard", () => {
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
     const file = new File([new Uint8Array(100)], "image.png", { type: "image/png" })
     textarea.dispatchEvent(pasteEvent(makePasteData([file])))
-    await waitFor(() => expect(container.querySelector(".promptbox-thumb")).not.toBeNull())
+    await waitFor(() => expect(container.querySelector(".image-thumb")).not.toBeNull())
     const user = userEvent.setup()
     const removeBtn = screen.getByRole("button", { name: /Remove pasted-image\.png/i })
     await user.click(removeBtn)
-    expect(container.querySelector(".promptbox-thumb")).toBeNull()
+    expect(container.querySelector(".image-thumb")).toBeNull()
   })
 
   it("does not intercept pure-text paste (default browser behavior runs)", async () => {
@@ -961,7 +961,7 @@ describe("PromptBox image paste from clipboard", () => {
     textarea.dispatchEvent(pasteEvent(makePasteData([huge])))
     await waitFor(() => expect(screen.getByText(/over 10 MB/i)).toBeInTheDocument())
     // No thumbnail, no text.
-    expect(container.querySelector(".promptbox-thumb")).toBeNull()
+    expect(container.querySelector(".image-thumb")).toBeNull()
     expect(textarea.value).toBe("")
   })
 
@@ -971,7 +971,7 @@ describe("PromptBox image paste from clipboard", () => {
     const a = new File([new Uint8Array(100)], "image.png", { type: "image/png" })
     const b = new File([new Uint8Array(100)], "image.png", { type: "image/jpeg" })
     textarea.dispatchEvent(pasteEvent(makePasteData([a, b])))
-    await waitFor(() => expect(container.querySelectorAll(".promptbox-thumb").length).toBe(2))
+    await waitFor(() => expect(container.querySelectorAll(".image-thumb").length).toBe(2))
   })
 
   it("pasted text alongside an image goes into the textarea, image to thumbnail", async () => {
@@ -979,7 +979,7 @@ describe("PromptBox image paste from clipboard", () => {
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
     const file = new File([new Uint8Array(100)], "image.png", { type: "image/png" })
     textarea.dispatchEvent(pasteEvent(makePasteData([file], "from clipboard")))
-    await waitFor(() => expect(container.querySelector(".promptbox-thumb")).not.toBeNull())
+    await waitFor(() => expect(container.querySelector(".image-thumb")).not.toBeNull())
     expect(textarea.value).toBe("from clipboard")
   })
 
@@ -988,7 +988,7 @@ describe("PromptBox image paste from clipboard", () => {
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
     const file = new File([new Uint8Array(100)], "image.png", { type: "image/png" })
     textarea.dispatchEvent(pasteEvent(makePasteData([file])))
-    await waitFor(() => expect(container.querySelector(".promptbox-thumb")).not.toBeNull())
+    await waitFor(() => expect(container.querySelector(".image-thumb")).not.toBeNull())
     const user = userEvent.setup()
     const openBtn = screen.getByRole("button", { name: /Preview pasted-image\.png/i })
     await user.click(openBtn)
@@ -1001,12 +1001,12 @@ describe("PromptBox image paste from clipboard", () => {
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
     const file = new File([new Uint8Array(100)], "image.png", { type: "image/png" })
     textarea.dispatchEvent(pasteEvent(makePasteData([file])))
-    await waitFor(() => expect(container.querySelector(".promptbox-thumb")).not.toBeNull())
+    await waitFor(() => expect(container.querySelector(".image-thumb")).not.toBeNull())
     const user = userEvent.setup()
     const removeBtn = screen.getByRole("button", { name: /Remove pasted-image\.png/i })
     await user.click(removeBtn)
     expect(screen.queryByRole("dialog")).toBeNull()
-    expect(container.querySelector(".promptbox-thumb")).toBeNull()
+    expect(container.querySelector(".image-thumb")).toBeNull()
   })
 
   it("lightbox closes on Esc key", async () => {
@@ -1014,7 +1014,7 @@ describe("PromptBox image paste from clipboard", () => {
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
     const file = new File([new Uint8Array(100)], "image.png", { type: "image/png" })
     textarea.dispatchEvent(pasteEvent(makePasteData([file])))
-    await waitFor(() => expect(container.querySelector(".promptbox-thumb")).not.toBeNull())
+    await waitFor(() => expect(container.querySelector(".image-thumb")).not.toBeNull())
     const user = userEvent.setup()
     await user.click(screen.getByRole("button", { name: /Preview pasted-image\.png/i }))
     expect(screen.getByRole("dialog")).toBeInTheDocument()
@@ -1027,7 +1027,7 @@ describe("PromptBox image paste from clipboard", () => {
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
     const file = new File([new Uint8Array(100)], "image.png", { type: "image/png" })
     textarea.dispatchEvent(pasteEvent(makePasteData([file])))
-    await waitFor(() => expect(container.querySelector(".promptbox-thumb")).not.toBeNull())
+    await waitFor(() => expect(container.querySelector(".image-thumb")).not.toBeNull())
     const user = userEvent.setup()
     await user.click(screen.getByRole("button", { name: /Preview pasted-image\.png/i }))
     // Click on the image itself — should NOT close.
@@ -1043,7 +1043,7 @@ describe("PromptBox image paste from clipboard", () => {
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
     const file = new File([new Uint8Array(100)], "image.png", { type: "image/png" })
     textarea.dispatchEvent(pasteEvent(makePasteData([file])))
-    await waitFor(() => expect(container.querySelector(".promptbox-thumb")).not.toBeNull())
+    await waitFor(() => expect(container.querySelector(".image-thumb")).not.toBeNull())
     const user = userEvent.setup()
     await user.click(screen.getByRole("button", { name: /Preview pasted-image\.png/i }))
     await user.click(screen.getByRole("button", { name: /Close preview/i }))

--- a/webview/src/components/ImageThumbnail.tsx
+++ b/webview/src/components/ImageThumbnail.tsx
@@ -1,0 +1,62 @@
+import type { Attachment } from "../protocol"
+import { formatBytes } from "../mention-tokens"
+
+/** The minimum shape ImageThumbnail needs. `id` is only required when
+ *  `onRemove` is wired up (paperclip/paste flow); read-only sent bubbles
+ *  rebuild attachment blocks from message history without an id field. */
+export type Thumbnailable = Pick<Attachment, "mime" | "filename" | "dataUrl" | "bytes"> & {
+  id?: string
+}
+
+type Props = {
+  attachment: Thumbnailable
+  /** Open the lightbox preview when the tile body is clicked. */
+  onPreview: (attachment: Thumbnailable) => void
+  /** Optional X-corner remove button. Provided in editable contexts
+   *  (prompt strip, edit-in-place bubble); omitted in read-only sent
+   *  bubbles. */
+  onRemove?: (id: string) => void
+}
+
+/**
+ * Shared 28 × 28 image tile used by both the prompt-box thumbnail strip
+ * and the sent-bubble attachment list. Checkerboard background keeps
+ * transparent PNGs visible; the open-button + remove-button are
+ * siblings (never nested) so clicking the X never opens the preview
+ * and `stopPropagation` on the open button prevents bubbling into a
+ * parent click handler (matters for the sent-bubble case where the
+ * surrounding `.msg.role-user` listens for click-to-edit).
+ */
+export function ImageThumbnail({ attachment, onPreview, onRemove }: Props) {
+  return (
+    <li className="image-thumb" title={`${attachment.filename} · ${formatBytes(attachment.bytes)}`}>
+      <button
+        type="button"
+        className="image-thumb-open"
+        aria-label={`Preview ${attachment.filename}`}
+        onClick={(e) => {
+          e.stopPropagation()
+          onPreview(attachment)
+        }}
+      >
+        <img src={attachment.dataUrl} alt="" />
+      </button>
+      {onRemove && attachment.id && (
+        <button
+          type="button"
+          className="image-thumb-remove"
+          aria-label={`Remove ${attachment.filename}`}
+          title="Remove"
+          onClick={(e) => {
+            e.stopPropagation()
+            onRemove(attachment.id!)
+          }}
+        >
+          <svg width="8" height="8" viewBox="0 0 8 8" aria-hidden="true">
+            <path d="M1 1l6 6M7 1l-6 6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          </svg>
+        </button>
+      )}
+    </li>
+  )
+}

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -3,6 +3,7 @@ import type { Block, Message } from "../hooks/useChatState"
 import type { Attachment, FileSearchHit } from "../protocol"
 import { findMentionRanges, makeAttachmentLabel } from "../mention-tokens"
 import { ImagePreviewModal } from "./ImagePreviewModal"
+import { ImageThumbnail, type Thumbnailable } from "./ImageThumbnail"
 import { Markdown } from "./Markdown"
 import { PromptBox } from "./PromptBox"
 import { ToolTrace, toolHeadline } from "./ToolCard"
@@ -121,7 +122,7 @@ function UserMessageView({
     (b): b is Extract<Block, { type: "attachment" }> => b.type === "attachment",
   )
   const [editing, setEditing] = useState(false)
-  const [previewImage, setPreviewImage] = useState<Attachment | null>(null)
+  const [previewImage, setPreviewImage] = useState<Thumbnailable | null>(null)
   const editAreaRef = useRef<HTMLDivElement>(null)
 
   // Click-outside cancels the edit. We listen on the document so any click
@@ -228,29 +229,13 @@ function UserMessageView({
             <ul className="msg-attachments" aria-label="Attachments">
               {attachmentBlocks.map((a, i) =>
                 a.mime.startsWith("image/") ? (
-                  // Image attachments render as a bare thumbnail — no chip
-                  // pill, no filename text — matching the prompt-box paste
-                  // strip. Synthesised paste names ("pasted-image.png")
-                  // carry no signal; the image itself is the affordance.
-                  // Filename + size live in the hover tooltip. Click opens
-                  // the lightbox.
-                  <li key={i} className="attachment-image" title={a.filename}>
-                    <button
-                      type="button"
-                      className="attachment-image-open"
-                      aria-label={`Preview ${a.filename}`}
-                      onClick={(e) => {
-                        // Don't bubble up — the user-message bubble has an
-                        // outer click handler that flips into edit mode,
-                        // and we don't want previewing an image to also
-                        // start an edit session.
-                        e.stopPropagation()
-                        setPreviewImage(a)
-                      }}
-                    >
-                      <img src={a.dataUrl} alt={a.filename} />
-                    </button>
-                  </li>
+                  // Image attachments render as a bare thumbnail — matches
+                  // the prompt-box strip. ImageThumbnail's open-button
+                  // stopPropagations so previewing doesn't also flip the
+                  // bubble into edit mode (the surrounding `.msg.role-user`
+                  // listens for click-to-edit). No `onRemove` here — the
+                  // sent bubble is read-only.
+                  <ImageThumbnail key={i} attachment={a} onPreview={setPreviewImage} />
                 ) : (
                   <li key={i} className="attachment-tile readonly" title={a.filename}>
                     <span className="attachment-icon" aria-hidden>{badgeForFilename(a.filename)}</span>

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -5,12 +5,12 @@ import {
   extractMentions,
   findChipAtCaret,
   findMentionRanges,
-  formatBytes,
   makeAttachmentLabel,
   type MentionState,
 } from "../mention-tokens"
 import { clipboardHasImage, readPastedImages } from "../paste-attachments"
 import { ImagePreviewModal } from "./ImagePreviewModal"
+import { ImageThumbnail, type Thumbnailable } from "./ImageThumbnail"
 
 // Re-export so existing consumers (tests, integrators) keep working through PromptBox.
 export {
@@ -106,7 +106,7 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
   // fullscreen preview. Local per PromptBox instance: the bottom prompt
   // and any in-place edit bubble each maintain their own preview, which
   // is fine because only one is interactive at a time in practice.
-  const [previewImage, setPreviewImage] = useState<Attachment | null>(null)
+  const [previewImage, setPreviewImage] = useState<Thumbnailable | null>(null)
   // Use lazy init via "first render only" pattern so initial values aren't
   // re-applied every render. After mount these mutate freely.
   const knownMentions = useRef<Set<string>>(undefined as never)
@@ -409,27 +409,12 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
       {imageAttachments.length > 0 && (
         <ul className="promptbox-thumbs" aria-label="Image attachments">
           {imageAttachments.map((a) => (
-            <li key={a.id} className="promptbox-thumb" title={`${a.filename} · ${formatBytes(a.bytes)}`}>
-              <button
-                type="button"
-                className="promptbox-thumb-open"
-                aria-label={`Preview ${a.filename}`}
-                onClick={() => setPreviewImage(a)}
-              >
-                <img src={a.dataUrl} alt="" />
-              </button>
-              <button
-                type="button"
-                className="promptbox-thumb-remove"
-                aria-label={`Remove ${a.filename}`}
-                title="Remove"
-                onClick={() => removeImageAttachment(a.id)}
-              >
-                <svg width="8" height="8" viewBox="0 0 8 8" aria-hidden="true">
-                  <path d="M1 1l6 6M7 1l-6 6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-                </svg>
-              </button>
-            </li>
+            <ImageThumbnail
+              key={a.id}
+              attachment={a}
+              onPreview={setPreviewImage}
+              onRemove={removeImageAttachment}
+            />
           ))}
         </ul>
       )}

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -2013,48 +2013,9 @@ button {
   line-height: 1.4;
   max-width: 220px;
 }
-/* Image attachments in the rendered user bubble. Same 36 × 36 size as
-   the prompt-box paste thumbnail strip so the "before send" and
-   "after send" views are visually consistent — sender sees the same
-   tile shape in both contexts. No chip pill, no filename text; the
-   image itself is the affordance, filename + size live in the hover
-   tooltip. The checkerboard background keeps transparent PNGs visible
-   against the bubble fill. */
-.attachment-image {
-  /* List wrapper only — same shape / role as .promptbox-thumb. The
-     click-to-preview button below carries all the visuals so the tile
-     is one full-area target. */
-  display: inline-block;
-  width: 28px;
-  height: 28px;
-}
-.attachment-image-open {
-  display: block;
-  width: 100%;
-  height: 100%;
-  padding: 0;
-  border-radius: 4px;
-  overflow: hidden;
-  border: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
-  background-color: var(--vscode-input-background);
-  cursor: zoom-in;
-  background-image:
-    linear-gradient(45deg, rgba(127, 127, 127, 0.18) 25%, transparent 25%),
-    linear-gradient(-45deg, rgba(127, 127, 127, 0.18) 25%, transparent 25%),
-    linear-gradient(45deg, transparent 75%, rgba(127, 127, 127, 0.18) 75%),
-    linear-gradient(-45deg, transparent 75%, rgba(127, 127, 127, 0.18) 75%);
-  background-size: 8px 8px;
-  background-position: 0 0, 0 4px, 4px -4px, -4px 0;
-}
-.attachment-image-open:hover {
-  border-color: var(--vscode-focusBorder, var(--vscode-widget-border));
-}
-.attachment-image-open img {
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
+/* Image attachments in the rendered user bubble use the shared
+   `.image-thumb` tile (see definition above near `.promptbox-thumbs`).
+   The `.msg-attachments` `<ul>` container handles padding and gap. */
 
 /* ===== Image preview lightbox ===== */
 .image-preview-overlay {
@@ -2138,16 +2099,18 @@ button {
   flex-wrap: wrap;
   gap: 6px;
 }
-.promptbox-thumb {
-  /* Container only — positioning context for the open-button + remove
-     button siblings below. Visuals (background, border) live on
-     `.promptbox-thumb-open` so the whole tile is one clickable target
-     except for the X corner. */
+/* Shared 28 × 28 image tile used by both the prompt-box thumbnail strip
+   (`.promptbox-thumbs > .image-thumb`) and the sent-bubble attachment
+   list (`.msg-attachments > .image-thumb`). The `<li>` is just a
+   positioning shell; visuals live on `.image-thumb-open` and the
+   optional remove button on `.image-thumb-remove`. */
+.image-thumb {
   position: relative;
+  display: inline-block;
   width: 28px;
   height: 28px;
 }
-.promptbox-thumb-open {
+.image-thumb-open {
   display: block;
   width: 100%;
   height: 100%;
@@ -2155,7 +2118,7 @@ button {
   border-radius: 4px;
   overflow: hidden;
   background-color: var(--vscode-input-background);
-  border: 1px solid var(--vscode-input-border, transparent);
+  border: 1px solid var(--vscode-widget-border, var(--vscode-panel-border, transparent));
   cursor: zoom-in;
   /* Subtle checkerboard so transparent PNGs don't render as a blank
      square against the same-coloured input background. */
@@ -2167,16 +2130,16 @@ button {
   background-size: 8px 8px;
   background-position: 0 0, 0 4px, 4px -4px, -4px 0;
 }
-.promptbox-thumb-open:hover {
-  border-color: var(--vscode-focusBorder, var(--vscode-input-border, rgba(255, 255, 255, 0.2)));
+.image-thumb-open:hover {
+  border-color: var(--vscode-focusBorder, var(--vscode-widget-border));
 }
-.promptbox-thumb-open img {
+.image-thumb-open img {
   display: block;
   width: 100%;
   height: 100%;
   object-fit: cover;
 }
-.promptbox-thumb-remove {
+.image-thumb-remove {
   position: absolute;
   top: 1px;
   right: 1px;
@@ -2194,11 +2157,11 @@ button {
   opacity: 0;
   transition: opacity 0.12s ease;
 }
-.promptbox-thumb:hover .promptbox-thumb-remove,
-.promptbox-thumb-remove:focus-visible {
+.image-thumb:hover .image-thumb-remove,
+.image-thumb-remove:focus-visible {
   opacity: 1;
 }
-.promptbox-thumb-remove:hover {
+.image-thumb-remove:hover {
   background: rgba(0, 0, 0, 0.78);
 }
 .icon-btn.attach-btn {


### PR DESCRIPTION
## Summary

Pull the duplicated thumbnail-tile markup + CSS out of PromptBox and MessageView into a single \`<ImageThumbnail>\` component. The two contexts were already pixel-identical — same 28-px checkerboard tile, same open-button → lightbox, same border / hover. Only difference: the input strip has a hover-X to remove, the sent bubble doesn't.

Closes #64

## How

- New \`webview/src/components/ImageThumbnail.tsx\` — props \`{ attachment, onPreview, onRemove? }\`. Both internal buttons \`stopPropagation\` so they never bubble into surrounding click-to-edit handlers.
- Exported \`Thumbnailable\` type (width-relaxed \`Pick<Attachment>\` with optional \`id\`) — \`ChatBlock\` attachments in message history don't carry an \`id\`, so the type lets both contexts share the contract without a cast.
- CSS unified: drop \`.promptbox-thumb*\` and \`.attachment-image*\`; introduce \`.image-thumb\` / \`.image-thumb-open\` / \`.image-thumb-remove\` used by both.
- Tests bulk-renamed; one MessageView title assertion relaxed to \`.toContain\` since the shared tooltip now includes formatted size.

## Test plan

- [x] \`bun run test\` — 484 passed (no count change; existing coverage held)
- [x] \`bun run check-types\` — clean
- [x] \`cd webview && bunx tsc --noEmit\` — only the 3 pre-existing errors
- [x] \`bun run package\` — single-file webview builds clean
- [ ] Visual verification in a dev host:
  - [ ] Paste a screenshot → strip thumbnail looks the same as before
  - [ ] Send the message → bubble thumbnail looks the same as before
  - [ ] Click either thumbnail → lightbox still opens
  - [ ] Hover strip thumbnail → X appears; click → removes