### PR TITLE
refactor(promptbox): decompose into three focused hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Changed
+- Internal: decomposed `PromptBox.tsx` into three focused hooks — `usePromptText` (text state + caret + auto-resize), `useImageAttachments` (thumbnail strip + lightbox preview + initial seeding from `initial.attachments`), and `useMentionPicker` (`@`-mention detection + search debouncing + insertion). PromptBox itself drops ~90 lines and each hook is now testable in isolation. No user-visible change.
 - Internal: extracted the image thumbnail markup + styling into a shared `<ImageThumbnail>` component used by both the prompt-box strip and the sent-bubble attachment list. Previously the two contexts duplicated ~40 lines of JSX + CSS (`.promptbox-thumb*` and `.attachment-image*`) for what was already pixel-identical output. CSS class names unified to `.image-thumb` / `.image-thumb-open` / `.image-thumb-remove`; the old context-specific names are gone. No user-visible change.
 
 ## [0.5.1] - 2026-05-17

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -1,16 +1,17 @@
-import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react"
+import { useRef, useState, type ReactNode } from "react"
 import type { Attachment, FileSearchHit } from "../protocol"
 import {
-  detectMention,
   extractMentions,
   findChipAtCaret,
   findMentionRanges,
   makeAttachmentLabel,
-  type MentionState,
 } from "../mention-tokens"
 import { clipboardHasImage, readPastedImages } from "../paste-attachments"
+import { usePromptText } from "../hooks/usePromptText"
+import { useImageAttachments } from "../hooks/useImageAttachments"
+import { useMentionPicker } from "../hooks/useMentionPicker"
 import { ImagePreviewModal } from "./ImagePreviewModal"
-import { ImageThumbnail, type Thumbnailable } from "./ImageThumbnail"
+import { ImageThumbnail } from "./ImageThumbnail"
 
 // Re-export so existing consumers (tests, integrators) keep working through PromptBox.
 export {
@@ -52,17 +53,6 @@ type Props = {
   variant?: "send" | "edit"
 }
 
-const MAX_VISIBLE_HITS = 8
-
-// Hard upper bound on the auto-grow textarea height. Past this, the
-// textarea's own scrollbar takes over so the prompt box doesn't keep eating
-// chat real estate when the user pastes or types a long message. MUST stay
-// in sync with the CSS variable --message-max-height in styles.css — the
-// same cap is shared with .promptbox textarea (the bottom prompt + the
-// in-place edit textarea) and .msg.role-user .user-text (rendered user
-// message), so all three views collapse to the same visual ceiling.
-const TEXTAREA_MAX_HEIGHT = 160
-
 function buildInitialAttachments(initial: Props["initial"]): Map<string, Attachment> {
   const map = new Map<string, Attachment>()
   if (!initial?.attachments) return map
@@ -79,34 +69,19 @@ function buildInitialAttachments(initial: Props["initial"]): Map<string, Attachm
   return map
 }
 
-function buildInitialThumbnails(initial: Props["initial"]): Attachment[] {
-  if (!initial?.attachments) return []
-  return initial.attachments.filter((a) => a.mime.startsWith("image/"))
-}
-
 export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbort, searchFiles, attachFile, initial, variant = "send" }: Props) {
-  const [text, setText] = useState(() => initial?.text ?? "")
-  const [hits, setHits] = useState<FileSearchHit[]>([])
-  const [mention, setMention] = useState<MentionState | undefined>(undefined)
-  const [activeIndex, setActiveIndex] = useState(0)
+  const { text, setText, ref, backdropRef, pendingCursor } = usePromptText(initial?.text ?? "")
   const [selectedChipStart, setSelectedChipStart] = useState<number | undefined>(undefined)
   const [attachError, setAttachError] = useState<string | undefined>(undefined)
   const [attaching, setAttaching] = useState(false)
-  // Image attachments render as a thumbnail strip above the textarea
-  // instead of as `@filename` text tokens, regardless of source (paste,
-  // paperclip, or restored from initial.attachments on edit). The
-  // screenshot itself is the affordance, filename + size live in the
-  // hover tooltip. Kept in component state — not in `knownAttachments`
-  // — so the same Attachment never ends up rendered twice, and so the
-  // strip can be modified without poking at the textarea text.
-  const [imageAttachments, setImageAttachments] = useState<Attachment[]>(
-    () => buildInitialThumbnails(initial),
-  )
-  // Lightbox state — clicking a thumbnail (anywhere except the X) opens a
-  // fullscreen preview. Local per PromptBox instance: the bottom prompt
-  // and any in-place edit bubble each maintain their own preview, which
-  // is fine because only one is interactive at a time in practice.
-  const [previewImage, setPreviewImage] = useState<Thumbnailable | null>(null)
+  const {
+    imageAttachments,
+    addImages,
+    removeImageAttachment,
+    clearImageAttachments,
+    previewImage,
+    setPreviewImage,
+  } = useImageAttachments(initial)
   // Use lazy init via "first render only" pattern so initial values aren't
   // re-applied every render. After mount these mutate freely.
   const knownMentions = useRef<Set<string>>(undefined as never)
@@ -115,10 +90,8 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
     knownMentions.current = new Set<string>(initial?.mentions ?? [])
     knownAttachments.current = buildInitialAttachments(initial)
   }
-  const ref = useRef<HTMLTextAreaElement>(null)
-  const backdropRef = useRef<HTMLDivElement>(null)
-  const queryRef = useRef("")
-  const pendingCursor = useRef<number | null>(null)
+  const { mention, hits, activeIndex, setActiveIndex, detectAtCaret, closeMention, insertMention } =
+    useMentionPicker({ text, setText, searchFiles, knownMentions, pendingCursor })
 
   /** Combined set of @-token labels recognized as chips (mentions + attachments). */
   const allKnownLabels = (): Set<string> => {
@@ -127,66 +100,10 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
     return all
   }
 
-  useEffect(() => {
-    if (!ref.current) return
-    ref.current.style.height = "auto"
-    ref.current.style.height = Math.min(ref.current.scrollHeight, TEXTAREA_MAX_HEIGHT) + "px"
-    if (backdropRef.current) {
-      backdropRef.current.style.height = ref.current.style.height
-    }
-  }, [text])
-
-  useLayoutEffect(() => {
-    if (pendingCursor.current !== null && ref.current) {
-      ref.current.focus()
-      ref.current.setSelectionRange(pendingCursor.current, pendingCursor.current)
-      pendingCursor.current = null
-    }
-  }, [text])
-
-  useEffect(() => {
-    if (!mention || !searchFiles) {
-      setHits([])
-      return
-    }
-    queryRef.current = mention.query
-    let cancelled = false
-    void searchFiles(mention.query).then((results) => {
-      if (cancelled) return
-      // Drop stale results — the user may have kept typing while we awaited.
-      if (queryRef.current !== mention.query) return
-      setHits(results.slice(0, MAX_VISIBLE_HITS))
-      setActiveIndex(0)
-    })
-    return () => {
-      cancelled = true
-    }
-  }, [mention, searchFiles])
-
-  const closeMention = () => {
-    setMention(undefined)
-    setHits([])
-  }
-
   const updateText = (next: string, caret: number) => {
     setText(next)
     setSelectedChipStart(undefined)
-    if (!searchFiles) return
-    const detected = detectMention(next, caret)
-    setMention(detected)
-  }
-
-  const insertMention = (hit: FileSearchHit) => {
-    if (!mention) return
-    const before = text.slice(0, mention.start)
-    const after = text.slice(mention.start + 1 + mention.query.length)
-    const insert = "@" + hit.path
-    const needsSpace = !after.startsWith(" ")
-    const next = before + insert + (needsSpace ? " " : "") + after
-    knownMentions.current.add(hit.path)
-    pendingCursor.current = before.length + insert.length + 1
-    setText(next)
-    closeMention()
+    detectAtCaret(next, caret)
   }
 
   const submit = () => {
@@ -213,7 +130,7 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
     setText("")
     knownMentions.current.clear()
     knownAttachments.current.clear()
-    setImageAttachments([])
+    clearImageAttachments()
     setSelectedChipStart(undefined)
     setAttachError(undefined)
     closeMention()
@@ -234,9 +151,7 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
         // signal and the chip is the discoverable mention surface.
         const images = result.attachments.filter((a) => a.mime.startsWith("image/"))
         const nonImages = result.attachments.filter((a) => !a.mime.startsWith("image/"))
-        if (images.length > 0) {
-          setImageAttachments((prev) => [...prev, ...images])
-        }
+        addImages(images)
         if (nonImages.length > 0) {
           const ta = ref.current
           const caret = ta?.selectionStart ?? text.length
@@ -294,9 +209,7 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
       if (result.error) setAttachError(result.error)
       return
     }
-    if (result.attachments.length > 0) {
-      setImageAttachments((prev) => [...prev, ...result.attachments])
-    }
+    addImages(result.attachments)
     // Mixed text+image pastes still insert the text portion at the caret
     // (the image goes to the thumbnail strip independently).
     if (result.text) {
@@ -309,10 +222,6 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
       setText(next)
     }
     if (result.error) setAttachError(result.error)
-  }
-
-  const removeImageAttachment = (id: string) => {
-    setImageAttachments((prev) => prev.filter((a) => a.id !== id))
   }
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {

--- a/webview/src/hooks/useImageAttachments.ts
+++ b/webview/src/hooks/useImageAttachments.ts
@@ -1,0 +1,50 @@
+import { useState } from "react"
+import type { Attachment } from "../protocol"
+import type { Thumbnailable } from "../components/ImageThumbnail"
+
+/**
+ * Owns the image-thumbnail strip state plus the lightbox preview state.
+ * Image attachments (paste, paperclip-image, or `initial.attachments`
+ * on edit-mode mount) live here instead of in the chip-text-token
+ * `knownAttachments` map so the same Attachment is never rendered twice
+ * and so the strip can be modified without poking the textarea text.
+ *
+ * `initial` is consumed once at mount via a `useState` lazy initializer
+ * (filter only image-mime entries from the seed); after that the strip
+ * mutates freely through `addImages` / `removeImageAttachment` /
+ * `clearImageAttachments`. Non-image attachments in `initial` are NOT
+ * routed here — they go through the caller's `knownAttachments` map and
+ * stay as `@chip` text tokens.
+ */
+export function useImageAttachments(initial?: { attachments?: Attachment[] }) {
+  const [imageAttachments, setImageAttachments] = useState<Attachment[]>(() =>
+    (initial?.attachments ?? []).filter((a) => a.mime.startsWith("image/")),
+  )
+  // Lightbox state. Local to the hook (which is local to a PromptBox
+  // instance); the bottom prompt and any in-place edit bubble each
+  // maintain their own preview, which is fine because only one is
+  // interactive at a time in practice.
+  const [previewImage, setPreviewImage] = useState<Thumbnailable | null>(null)
+
+  const addImages = (next: Attachment[]) => {
+    if (next.length === 0) return
+    setImageAttachments((prev) => [...prev, ...next])
+  }
+
+  const removeImageAttachment = (id: string) => {
+    setImageAttachments((prev) => prev.filter((a) => a.id !== id))
+  }
+
+  const clearImageAttachments = () => {
+    setImageAttachments([])
+  }
+
+  return {
+    imageAttachments,
+    addImages,
+    removeImageAttachment,
+    clearImageAttachments,
+    previewImage,
+    setPreviewImage,
+  }
+}

--- a/webview/src/hooks/useMentionPicker.ts
+++ b/webview/src/hooks/useMentionPicker.ts
@@ -1,0 +1,88 @@
+import { useEffect, useRef, useState } from "react"
+import type { FileSearchHit } from "../protocol"
+import { detectMention, type MentionState } from "../mention-tokens"
+
+const MAX_VISIBLE_HITS = 8
+
+/**
+ * Owns the `@`-mention picker state: detection (does the caret sit
+ * inside a partial `@token`?), search debouncing (drop stale results
+ * when the user keeps typing), and arrow-key navigation index. The
+ * caller owns the textarea text + caret refs and supplies
+ * `searchFiles`; this hook just decides what to show in the picker
+ * and exposes `insertMention` for the keyboard / mouse pick paths to
+ * call.
+ *
+ * The `insertMention` callback ALSO mutates the parent's
+ * `knownMentions` set (so future re-renders treat the inserted path
+ * as a chip) and stages a `pendingCursor` position so the textarea
+ * cursor lands right after the inserted text. These are passed in as
+ * refs to avoid copying-then-syncing-back state.
+ */
+export function useMentionPicker(opts: {
+  text: string
+  setText: (next: string) => void
+  searchFiles?: (query: string) => Promise<FileSearchHit[]>
+  knownMentions: React.MutableRefObject<Set<string>>
+  pendingCursor: React.MutableRefObject<number | null>
+}) {
+  const { text, setText, searchFiles, knownMentions, pendingCursor } = opts
+  const [mention, setMention] = useState<MentionState | undefined>(undefined)
+  const [hits, setHits] = useState<FileSearchHit[]>([])
+  const [activeIndex, setActiveIndex] = useState(0)
+  const queryRef = useRef("")
+
+  useEffect(() => {
+    if (!mention || !searchFiles) {
+      setHits([])
+      return
+    }
+    queryRef.current = mention.query
+    let cancelled = false
+    void searchFiles(mention.query).then((results) => {
+      if (cancelled) return
+      // Drop stale results — the user may have kept typing while we awaited.
+      if (queryRef.current !== mention.query) return
+      setHits(results.slice(0, MAX_VISIBLE_HITS))
+      setActiveIndex(0)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [mention, searchFiles])
+
+  const closeMention = () => {
+    setMention(undefined)
+    setHits([])
+  }
+
+  /** Recompute the mention state from the current text + caret. Caller
+   *  invokes from onChange so detection stays in sync with edits. */
+  const detectAtCaret = (next: string, caret: number) => {
+    if (!searchFiles) return
+    setMention(detectMention(next, caret))
+  }
+
+  const insertMention = (hit: FileSearchHit) => {
+    if (!mention) return
+    const before = text.slice(0, mention.start)
+    const after = text.slice(mention.start + 1 + mention.query.length)
+    const insert = "@" + hit.path
+    const needsSpace = !after.startsWith(" ")
+    const next = before + insert + (needsSpace ? " " : "") + after
+    knownMentions.current.add(hit.path)
+    pendingCursor.current = before.length + insert.length + 1
+    setText(next)
+    closeMention()
+  }
+
+  return {
+    mention,
+    hits,
+    activeIndex,
+    setActiveIndex,
+    detectAtCaret,
+    closeMention,
+    insertMention,
+  }
+}

--- a/webview/src/hooks/usePromptText.ts
+++ b/webview/src/hooks/usePromptText.ts
@@ -1,0 +1,49 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react"
+
+// Hard upper bound on the auto-grow textarea height. Past this, the
+// textarea's own scrollbar takes over so the prompt box doesn't keep eating
+// chat real estate when the user pastes or types a long message. MUST stay
+// in sync with the CSS variable --message-max-height in styles.css — the
+// same cap is shared with .promptbox textarea (the bottom prompt + the
+// in-place edit textarea) and .msg.role-user .user-text (rendered user
+// message), so all three views collapse to the same visual ceiling.
+export const TEXTAREA_MAX_HEIGHT = 160
+
+/**
+ * Owns the prompt textarea's text state, refs, auto-resize, and the
+ * post-mutation caret-restore mechanism used by chip insertion. Three
+ * concerns rolled together because they're cross-coupled via the same
+ * `ref` + `pendingCursor` ref handles — splitting them further would
+ * just pass refs around between hooks.
+ *
+ * Caret restore pattern: any handler that wants to set the textarea's
+ * caret position AFTER a `setText` call should set
+ * `pendingCursor.current = <pos>`. A `useLayoutEffect` keyed on `text`
+ * focuses the textarea, applies the position, and clears the ref. This
+ * keeps caret manipulation deterministic across the React commit phase.
+ */
+export function usePromptText(initialText: string = "") {
+  const [text, setText] = useState(initialText)
+  const ref = useRef<HTMLTextAreaElement>(null)
+  const backdropRef = useRef<HTMLDivElement>(null)
+  const pendingCursor = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (!ref.current) return
+    ref.current.style.height = "auto"
+    ref.current.style.height = Math.min(ref.current.scrollHeight, TEXTAREA_MAX_HEIGHT) + "px"
+    if (backdropRef.current) {
+      backdropRef.current.style.height = ref.current.style.height
+    }
+  }, [text])
+
+  useLayoutEffect(() => {
+    if (pendingCursor.current !== null && ref.current) {
+      ref.current.focus()
+      ref.current.setSelectionRange(pendingCursor.current, pendingCursor.current)
+      pendingCursor.current = null
+    }
+  }, [text])
+
+  return { text, setText, ref, backdropRef, pendingCursor }
+}


### PR DESCRIPTION
Re-open of #67 (auto-closed when base branch was deleted after #65 merged). Rebased on main.

## Summary

PromptBox.tsx was the highest-traffic file in the codebase (~500 lines after image paste). Pull three independent concerns into focused hooks under \`webview/src/hooks/\`.

Closes #66

## Hooks

| Hook | Lines | Owns |
|---|---|---|
| \`usePromptText\` | 49 | text state, textarea + backdrop refs, auto-resize, post-mutation caret restore via \`pendingCursor\`. \`TEXTAREA_MAX_HEIGHT\` constant moved here. |
| \`useImageAttachments\` | 50 | thumbnail strip + lightbox preview state. Initial seeding from \`initial.attachments\` (image-mime only) via lazy initializer. |
| \`useMentionPicker\` | 88 | mention / hits / activeIndex state, search debouncing, \`insertMention\` callback (mutates parent's \`knownMentions\` ref + stages \`pendingCursor\` via refs). |

PromptBox is now -91 lines (~15% smaller) and reads as: text state + chip-attachment state + submit + JSX.

## Test plan

- [x] \`bun run test\` — 484 passed
- [x] \`bun run check-types\` — clean
- [x] \`cd webview && bunx tsc --noEmit\` — only the 3 pre-existing errors
- [x] \`bun run package\` — builds clean
- [ ] Visual verification: bottom prompt typing, paste, paperclip, mention picker, edit-in-place