### PR TITLE
chore(release): cut v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-05-17
+
 ### Changed
 - Internal: decomposed `PromptBox.tsx` into three focused hooks — `usePromptText` (text state + caret + auto-resize), `useImageAttachments` (thumbnail strip + lightbox preview + initial seeding from `initial.attachments`), and `useMentionPicker` (`@`-mention detection + search debouncing + insertion). PromptBox itself drops ~90 lines and each hook is now testable in isolation. No user-visible change.
 - Internal: extracted the image thumbnail markup + styling into a shared `<ImageThumbnail>` component used by both the prompt-box strip and the sent-bubble attachment list. Previously the two contexts duplicated ~40 lines of JSX + CSS (`.promptbox-thumb*` and `.attachment-image*`) for what was already pixel-identical output. CSS class names unified to `.image-thumb` / `.image-thumb-open` / `.image-thumb-remove`; the old context-specific names are gone. No user-visible change.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
Patch bump for internal restructuring (#65 + #68). No user-visible change.

Closes #69

After merge:
```bash
git checkout main && git pull
git tag v0.5.2
git push origin v0.5.2
gh release create v0.5.2 --title "v0.5.2" --notes-from-tag
```