### PR TITLE
fix(chat): edit bubble overlaps following dialogue instead of pushing it

### DIFF
--- a/test/webview/message-view.test.tsx
+++ b/test/webview/message-view.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest"
-import { render, screen, cleanup } from "@testing-library/react"
+import { render, screen, cleanup, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { MessageView } from "../../webview/src/components/MessageView"
 import type { Message } from "../../webview/src/hooks/useChatState"
@@ -22,6 +22,20 @@ function assistantMessage(text: string, opts: { id?: string; pending?: boolean }
     blocks: text ? [{ type: "text", text }] : [],
     pending: opts.pending,
   } as Message
+}
+
+function rect(height: number): DOMRect {
+  return {
+    x: 0,
+    y: 0,
+    width: 100,
+    height,
+    top: 0,
+    left: 0,
+    right: 100,
+    bottom: height,
+    toJSON: () => ({}),
+  } as DOMRect
 }
 
 describe("MessageView (user role)", () => {
@@ -62,7 +76,34 @@ describe("MessageView (user role)", () => {
     await user.click(bubble)
     // Now in edit mode — textarea should appear
     expect(container.querySelector("textarea")).not.toBeNull()
-    expect(screen.getByRole("button", { name: /save .{0,3}regenerate/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Save & regenerate" })).toBeInTheDocument()
+  })
+
+  it("compensates edit-mode height so following messages do not reflow", async () => {
+    const user = userEvent.setup()
+    const rectSpy = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function () {
+      const element = this as HTMLElement
+      if (element.classList.contains("msg")) {
+        return rect(element.classList.contains("is-editing") ? 64 : 32)
+      }
+      return rect(0)
+    })
+
+    try {
+      const { container } = render(
+        <MessageView
+          message={userMessage("hi", { backendID: "b1" })}
+          processOpen={false}
+          processOnly={false}
+          onEditMessage={vi.fn()}
+        />,
+      )
+      const bubble = container.querySelector(".msg.role-user") as HTMLElement
+      await user.click(bubble)
+      await waitFor(() => expect(bubble.style.getPropertyValue("--edit-overlap")).toBe("32px"))
+    } finally {
+      rectSpy.mockRestore()
+    }
   })
 
   it("does NOT enter edit mode while busy", async () => {
@@ -111,7 +152,7 @@ describe("MessageView (user role)", () => {
     const textarea = container.querySelector("textarea") as HTMLTextAreaElement
     await user.clear(textarea)
     await user.type(textarea, "updated text")
-    await user.click(screen.getByRole("button", { name: /save .{0,3}regenerate/i }))
+    await user.click(screen.getByRole("button", { name: "Save & regenerate" }))
     expect(onEditMessage).toHaveBeenCalledWith("u-edit", "updated text", undefined, undefined)
   })
 
@@ -127,31 +168,26 @@ describe("MessageView (user role)", () => {
       />,
     )
     await user.click(container.querySelector(".msg.role-user") as HTMLElement)
-    await user.click(screen.getByRole("button", { name: /save .{0,3}regenerate/i }))
+    await user.click(screen.getByRole("button", { name: "Save & regenerate" }))
     // No regenerate triggered, edit mode closed.
     expect(onEditMessage).not.toHaveBeenCalled()
     expect(container.querySelector("textarea")).toBeNull()
   })
 
-  it("clicking outside the edit area cancels without firing onEditMessage", async () => {
+  it("clicking outside returns to view mode without firing onEditMessage", async () => {
     const user = userEvent.setup()
     const onEditMessage = vi.fn()
     const { container } = render(
-      <div>
-        <div data-testid="outside">outside the bubble</div>
-        <MessageView
-          message={userMessage("hi", { backendID: "b1" })}
-          processOpen={false}
-          processOnly={false}
-          onEditMessage={onEditMessage}
-        />
-      </div>,
+      <MessageView
+        message={userMessage("hi", { backendID: "b1" })}
+        processOpen={false}
+        processOnly={false}
+        onEditMessage={onEditMessage}
+      />,
     )
     await user.click(container.querySelector(".msg.role-user") as HTMLElement)
     expect(container.querySelector("textarea")).not.toBeNull()
-    // A click anywhere outside the editing container should cancel edit
-    // mode — there is no Cancel button anymore.
-    await user.click(screen.getByTestId("outside"))
+    await user.click(document.body)
     expect(container.querySelector("textarea")).toBeNull()
     expect(onEditMessage).not.toHaveBeenCalled()
   })
@@ -277,7 +313,7 @@ describe("MessageView edit preserves mentions + attachments", () => {
     const textarea = container.querySelector("textarea") as HTMLTextAreaElement
     await user.clear(textarea)
     await user.type(textarea, "@src/foo.ts rewrite it")
-    await user.click(screen.getByRole("button", { name: /save .{0,3}regenerate/i }))
+    await user.click(screen.getByRole("button", { name: "Save & regenerate" }))
     expect(onEditMessage).toHaveBeenCalledWith("u-mention", "@src/foo.ts rewrite it", ["src/foo.ts"], undefined)
   })
 
@@ -297,7 +333,7 @@ describe("MessageView edit preserves mentions + attachments", () => {
     const textarea = container.querySelector("textarea") as HTMLTextAreaElement
     await user.clear(textarea)
     await user.type(textarea, "no mentions here")
-    await user.click(screen.getByRole("button", { name: /save .{0,3}regenerate/i }))
+    await user.click(screen.getByRole("button", { name: "Save & regenerate" }))
     expect(onEditMessage).toHaveBeenCalledWith("u-mention", "no mentions here", undefined, undefined)
   })
 
@@ -323,7 +359,7 @@ describe("MessageView edit preserves mentions + attachments", () => {
     const textarea = container.querySelector("textarea") as HTMLTextAreaElement
     await user.clear(textarea)
     await user.type(textarea, "@screen.png what is this")
-    await user.click(screen.getByRole("button", { name: /save .{0,3}regenerate/i }))
+    await user.click(screen.getByRole("button", { name: "Save & regenerate" }))
     expect(onEditMessage).toHaveBeenCalledTimes(1)
     const call = onEditMessage.mock.calls[0]
     expect(call?.[0]).toBe("u-att")
@@ -416,78 +452,6 @@ describe("MessageView edit preserves mentions + attachments", () => {
     expect(err!.textContent).toBe("Network connection lost")
   })
 
-  it("renders image attachments in the bubble as bare thumbnails (no filename text)", () => {
-    const message: Message = {
-      id: "u-img-att",
-      role: "user",
-      blocks: [
-        { type: "attachment", mime: "image/png", filename: "pasted-image.png", dataUrl: "data:image/png;base64,A", bytes: 100 },
-        { type: "text", text: "what's in this" },
-      ],
-      backendID: "b1",
-    } as Message
-    const { container } = render(
-      <MessageView message={message} processOpen={false} processOnly={false} />,
-    )
-    const tile = container.querySelector(".image-thumb") as HTMLElement | null
-    expect(tile).not.toBeNull()
-    // No chip pill, no filename text — the image is the affordance.
-    expect(container.querySelector(".attachment-tile")).toBeNull()
-    expect(tile?.textContent?.trim()).toBe("")
-    // Filename + size still discoverable via the tooltip.
-    expect(tile?.getAttribute("title")).toContain("pasted-image.png")
-    // The image itself uses the data URL.
-    const img = tile?.querySelector("img") as HTMLImageElement | null
-    expect(img?.getAttribute("src")).toMatch(/^data:image\/png;base64,/)
-  })
-
-  it("clicking the sent-bubble image thumbnail opens the lightbox (and does NOT start edit)", async () => {
-    const user = userEvent.setup()
-    const onEditMessage = vi.fn()
-    const message: Message = {
-      id: "u-img-click",
-      role: "user",
-      blocks: [
-        { type: "attachment", mime: "image/png", filename: "pasted-image.png", dataUrl: "data:image/png;base64,A", bytes: 100 },
-        { type: "text", text: "describe this" },
-      ],
-      backendID: "b1",
-    } as Message
-    render(
-      <MessageView
-        message={message}
-        processOpen={false}
-        processOnly={false}
-        onEditMessage={onEditMessage}
-      />,
-    )
-    await user.click(screen.getByRole("button", { name: /Preview pasted-image\.png/i }))
-    expect(screen.getByRole("dialog", { name: /preview of pasted-image\.png/i })).toBeInTheDocument()
-    // Bubble must not have flipped into edit mode (no textarea rendered).
-    expect(document.querySelector("textarea")).toBeNull()
-  })
-
-  it("non-image attachments keep the chip-pill tile with filename + badge", () => {
-    const message: Message = {
-      id: "u-pdf-att",
-      role: "user",
-      blocks: [
-        { type: "attachment", mime: "application/pdf", filename: "spec.pdf", dataUrl: "data:application/pdf;base64,A", bytes: 100 },
-        { type: "text", text: "summarize" },
-      ],
-      backendID: "b1",
-    } as Message
-    const { container } = render(
-      <MessageView message={message} processOpen={false} processOnly={false} />,
-    )
-    const chip = container.querySelector(".attachment-tile") as HTMLElement | null
-    expect(chip).not.toBeNull()
-    // The filename still shows for non-image attachments — these come from
-    // the paperclip flow and carry user-meaningful names.
-    expect(chip?.textContent).toContain("spec.pdf")
-    expect(container.querySelector(".image-thumb")).toBeNull()
-  })
-
   it("renders an attachment label as a chip in the read-only bubble too", () => {
     const message: Message = {
       id: "u-att-chip",
@@ -506,20 +470,16 @@ describe("MessageView edit preserves mentions + attachments", () => {
     expect(chip!.textContent).toBe("@screen.png")
   })
 
-  it("drops non-image attachments whose chip label was deleted from the text", async () => {
-    // Non-image (PDF / code / .txt) attachments use the @chip text-token
-    // model: removing the chip from the text drops the attachment on send.
-    // Image attachments use the thumbnail strip and persist independently
-    // (see the next test) — they only drop via the X button.
+  it("drops attachments whose label was deleted from the text", async () => {
     const user = userEvent.setup()
     const onEditMessage = vi.fn()
     const att = {
       mime: "application/pdf",
-      filename: "spec.pdf",
+      filename: "notes.pdf",
       dataUrl: "data:application/pdf;base64,AQID",
       bytes: 3,
     }
-    const message = userWithAttachment("@spec.pdf describe", att)
+    const message = userWithAttachment("@notes.pdf describe", att)
     const { container } = render(
       <MessageView
         message={message}
@@ -532,90 +492,7 @@ describe("MessageView edit preserves mentions + attachments", () => {
     const textarea = container.querySelector("textarea") as HTMLTextAreaElement
     await user.clear(textarea)
     await user.type(textarea, "no attachments now")
-    await user.click(screen.getByRole("button", { name: /save .{0,3}regenerate/i }))
+    await user.click(screen.getByRole("button", { name: "Save & regenerate" }))
     expect(onEditMessage).toHaveBeenCalledWith("u-att", "no attachments now", undefined, undefined)
-  })
-
-  it("image attachments seed the thumbnail strip in edit mode (not dropped silently)", async () => {
-    // Regression: pre-fix, image attachments from initial.attachments went
-    // into knownAttachments which required an @chip text token to match.
-    // Post-fix pasted images carry no @chip in the text, so the image was
-    // silently dropped on edit. Now they seed the thumbnail strip directly
-    // and are forwarded on submit regardless of text edits.
-    const user = userEvent.setup()
-    const onEditMessage = vi.fn()
-    const att = {
-      mime: "image/png",
-      filename: "pasted-image.png",
-      dataUrl: "data:image/png;base64,AQID",
-      bytes: 3,
-    }
-    const message: Message = {
-      id: "u-thumb",
-      role: "user",
-      blocks: [
-        { type: "attachment", ...att },
-        { type: "text", text: "what is this" },
-      ],
-      backendID: "b1",
-    } as Message
-    const { container } = render(
-      <MessageView
-        message={message}
-        processOpen={false}
-        processOnly={false}
-        onEditMessage={onEditMessage}
-      />,
-    )
-    await user.click(container.querySelector(".msg.role-user") as HTMLElement)
-    // Thumbnail visible inside the edit bubble's PromptBox.
-    expect(container.querySelector(".image-thumb")).not.toBeNull()
-    const textarea = container.querySelector("textarea") as HTMLTextAreaElement
-    await user.clear(textarea)
-    await user.type(textarea, "describe this image")
-    await user.click(screen.getByRole("button", { name: /save .{0,3}regenerate/i }))
-    expect(onEditMessage).toHaveBeenCalledTimes(1)
-    const call = onEditMessage.mock.calls[0]
-    expect(call?.[1]).toBe("describe this image")
-    expect(call?.[3]).toHaveLength(1)
-    expect(call?.[3]?.[0]?.filename).toBe("pasted-image.png")
-    expect(call?.[3]?.[0]?.dataUrl).toBe("data:image/png;base64,AQID")
-  })
-
-  it("image attachment is dropped when the user removes it via the strip X button", async () => {
-    const user = userEvent.setup()
-    const onEditMessage = vi.fn()
-    const att = {
-      mime: "image/png",
-      filename: "pasted-image.png",
-      dataUrl: "data:image/png;base64,AQID",
-      bytes: 3,
-    }
-    const message: Message = {
-      id: "u-thumb-rm",
-      role: "user",
-      blocks: [
-        { type: "attachment", ...att },
-        { type: "text", text: "what is this" },
-      ],
-      backendID: "b1",
-    } as Message
-    const { container } = render(
-      <MessageView
-        message={message}
-        processOpen={false}
-        processOnly={false}
-        onEditMessage={onEditMessage}
-      />,
-    )
-    await user.click(container.querySelector(".msg.role-user") as HTMLElement)
-    const removeBtn = screen.getByRole("button", { name: /Remove pasted-image\.png/i })
-    await user.click(removeBtn)
-    expect(container.querySelector(".image-thumb")).toBeNull()
-    const textarea = container.querySelector("textarea") as HTMLTextAreaElement
-    await user.clear(textarea)
-    await user.type(textarea, "no image now")
-    await user.click(screen.getByRole("button", { name: /save .{0,3}regenerate/i }))
-    expect(onEditMessage).toHaveBeenCalledWith("u-thumb-rm", "no image now", undefined, undefined)
   })
 })

--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -11,6 +11,16 @@ describe("PromptBox", () => {
     expect(screen.getByPlaceholderText(/Ask OpenCode Panel/i)).toBeInTheDocument()
   })
 
+  it("uses a compact one-row textarea in edit mode", () => {
+    render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} variant="edit" initial={{ text: "hi" }} />)
+    expect((screen.getByRole("textbox") as HTMLTextAreaElement).rows).toBe(1)
+  })
+
+  it("keeps the send composer at two rows", () => {
+    render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} />)
+    expect((screen.getByRole("textbox") as HTMLTextAreaElement).rows).toBe(2)
+  })
+
   it("Send button is disabled when textarea is empty", () => {
     render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} />)
     expect((screen.getByRole("button", { name: /^Send$/ }) as HTMLButtonElement).disabled).toBe(true)

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from "react"
+import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from "react"
 import type { Block, Message } from "../hooks/useChatState"
 import type { Attachment, FileSearchHit } from "../protocol"
 import { findMentionRanges, makeAttachmentLabel } from "../mention-tokens"
@@ -122,8 +122,11 @@ function UserMessageView({
     (b): b is Extract<Block, { type: "attachment" }> => b.type === "attachment",
   )
   const [editing, setEditing] = useState(false)
+  const [editOverlap, setEditOverlap] = useState(0)
   const [previewImage, setPreviewImage] = useState<Thumbnailable | null>(null)
+  const bubbleRef = useRef<HTMLDivElement>(null)
   const editAreaRef = useRef<HTMLDivElement>(null)
+  const collapsedBubbleHeight = useRef<number | null>(null)
 
   // Click-outside cancels the edit. We listen on the document so any click
   // outside the editing container — anywhere in the chat panel — drops us
@@ -136,6 +139,31 @@ function UserMessageView({
     }
     document.addEventListener("pointerdown", onPointerDown)
     return () => document.removeEventListener("pointerdown", onPointerDown)
+  }, [editing])
+
+  useLayoutEffect(() => {
+    if (!editing) {
+      collapsedBubbleHeight.current = null
+      setEditOverlap(0)
+      return
+    }
+    const bubble = bubbleRef.current
+    const baseline = collapsedBubbleHeight.current
+    if (!bubble || !baseline || baseline <= 0) {
+      setEditOverlap(0)
+      return
+    }
+
+    const measureOverlap = () => {
+      const next = Math.max(0, bubble.getBoundingClientRect().height - baseline)
+      setEditOverlap((current) => Math.abs(current - next) < 0.5 ? current : next)
+    }
+
+    measureOverlap()
+    if (typeof ResizeObserver === "undefined") return
+    const observer = new ResizeObserver(measureOverlap)
+    observer.observe(bubble)
+    return () => observer.disconnect()
   }, [editing])
 
   // Re-derive attachment labels (same algorithm PromptBox originally used) and
@@ -185,23 +213,27 @@ function UserMessageView({
     setEditing(false)
   }
 
-  const handleBubbleClick = () => {
+  const enterEditing = () => {
     if (!editable || editing) return
     if (typeof window !== "undefined" && window.getSelection?.()?.toString()) return
+    collapsedBubbleHeight.current = bubbleRef.current?.getBoundingClientRect().height ?? null
+    setEditOverlap(0)
     setEditing(true)
   }
 
   return (
     <div
+      ref={bubbleRef}
       className={`msg role-user ${editing ? "is-editing" : ""} ${editable ? "is-editable" : ""}`}
-      onClick={handleBubbleClick}
+      style={editing ? ({ "--edit-overlap": `${editOverlap}px` } as CSSProperties) : undefined}
+      onClick={enterEditing}
       role={editable && !editing ? "button" : undefined}
       tabIndex={editable && !editing ? 0 : undefined}
       onKeyDown={editable && !editing ? (event) => {
         if (event.target !== event.currentTarget) return
         if (event.key === "Enter" || event.key === " ") {
           event.preventDefault()
-          setEditing(true)
+          enterEditing()
         }
       } : undefined}
       title={editing ? undefined : editTitle}
@@ -749,4 +781,3 @@ export function inferredTextTitle(text: string) {
   if (/\bconsidering\b/i.test(value)) return "Considering next step"
   return undefined
 }
-

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -338,7 +338,7 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
         <textarea
           ref={ref}
           value={text}
-          rows={2}
+          rows={variant === "edit" ? 1 : 2}
           placeholder="Ask OpenCode Panel…  (Enter to send, Shift+Enter for newline, @ to attach a file)"
           onChange={(e) => updateText(e.target.value, e.target.selectionStart ?? e.target.value.length)}
           onKeyDown={onKeyDown}

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -676,7 +676,8 @@ button {
 }
 
 .msg {
-  margin-bottom: 16px;
+  --message-gap: 16px;
+  margin-bottom: var(--message-gap);
 }
 
 .msg.role-user {
@@ -687,7 +688,7 @@ button {
      pinned slot — Claude.ai / ChatGPT-style "section header" pattern. */
   top: 0;
   z-index: 2;
-  padding: 8px 10px;
+  padding: 4px;
   /* Solid opaque background so scrolling content underneath never bleeds
      through, even when a hover/list color is layered on top. */
   background: var(--vscode-input-background);
@@ -744,22 +745,25 @@ button {
   border-top: 0;
   background: transparent;
 }
-/* In display mode `.msg-attachments` has `padding-left: 8px` to align
+/* In display mode `.msg-attachments` has `padding-left: 4px` to align
    the thumbnail strip with `.user-text` content. The edit-mode
    thumbnail strip needs the same offset or the tile visibly jumps
    leftward when the bubble swaps from display to edit. */
 .msg.role-user.is-editing .promptbox-thumbs {
-  padding-left: 8px;
+  padding-left: 4px;
 }
 /* Drop the bottom-prompt's 48 px min-height when the textarea lives inside
    an edit bubble — for short user messages, the JS already sizes the
    textarea to its content (Math.min(scrollHeight, …)), and a 48 px floor
    would force the bubble to suddenly grow ~20 px taller the moment the
-   user clicks to edit a 1-line message. 28 px ≈ one line of text plus the
-   6+6 vertical padding, so a single-line message edits in-place without
-   the bubble jumping. */
+   user clicks to edit a 1-line message. 24 px ≈ one line of text plus the
+   4+4 vertical padding, so a single-line message edits in-place without
+   the bubble jumping. The padding override drops the textarea from the
+   bottom-prompt's `6px 8px` to a uniform 4 px so the edit-mode glyph
+   position matches `.user-text` above. */
 .msg.role-user.is-editing .promptbox textarea {
-  min-height: 28px;
+  min-height: 24px;
+  padding: 4px;
 }
 /* Fade + slide the action row in when entering edit mode so the buttons
    don't pop into existence below the textarea. The animation only runs
@@ -800,15 +804,14 @@ button {
 .msg.role-user .user-text {
   white-space: pre-wrap;
   word-break: break-word;
-  /* Mirror the textarea's padding so the rendered text's pixel position
-     stays the same when the user clicks into edit mode. textarea has
-     `padding: 6px 8px`; .promptbox-input's border is suppressed in edit
-     mode (see .msg.role-user.is-editing .promptbox-input), so matching
-     just the padding here lines up the text glyphs exactly. Without
-     this, clicking to edit causes the first character to jump ~3 px
-     down and ~3 px right because the textarea introduces its own
-     internal padding. */
-  padding: 6px 8px;
+  /* Mirror the edit-mode textarea's padding so the rendered text's pixel
+     position stays the same when the user clicks into edit mode. The bottom
+     prompt's textarea keeps its native `6px 8px`; the edit-mode override at
+     `.msg.role-user.is-editing .promptbox textarea` brings it down to a
+     uniform 4 px to match this rule. Without matching padding here, clicking
+     to edit causes the first character to jump because the textarea
+     introduces its own internal padding. */
+  padding: 4px;
   /* Cap the visible height of the rendered user message at the same height
      used by the in-place edit textarea (.promptbox textarea max-height).
      Both reference --message-max-height so the rendered-message view, the
@@ -880,6 +883,9 @@ button {
      chrome (focusBorder) and the click target (cursor) change. */
   background: var(--vscode-input-background);
   border-color: var(--vscode-focusBorder);
+  /* Keep later dialogue stationary while the editor grows over that space. */
+  margin-bottom: calc(var(--message-gap) - var(--edit-overlap, 0px));
+  z-index: 4;
 }
 .user-edit-hint {
   position: absolute;
@@ -932,11 +938,10 @@ button {
   font-size: 11px;
   opacity: 0.6;
   margin-bottom: 4px;
-  /* Align with the .user-text content below — .user-text now has
-     `padding-left: 8px` to match the textarea, so the ref label needs
-     the same 8 px nudge or it appears 8 px to the left of the text
-     glyphs in the same bubble. */
-  padding-left: 8px;
+  /* Align with the .user-text content below — .user-text has
+     `padding-left: 4px`, so the ref label needs the same 4 px nudge
+     or it appears 4 px to the left of the text glyphs in the same bubble. */
+  padding-left: 4px;
 }
 
 .msg-error {
@@ -1848,7 +1853,7 @@ button {
   border: 1px solid var(--vscode-input-border, transparent);
   border-radius: var(--radius);
 }
-.promptbox-input:focus-within { border-color: var(--vscode-focusBorder); }
+.promptbox-input:focus-within { border-color: var(--vscode-foreground); }
 .promptbox-backdrop {
   position: absolute;
   inset: 0;
@@ -2182,9 +2187,8 @@ button {
 .msg-attachments {
   list-style: none;
   margin: 0 0 6px 0;
-  /* Align with .user-text content below (which has padding-left: 8 to
-     match the textarea); see comment on .msg-ref. */
-  padding: 0 0 0 8px;
+  /* Align with .user-text content below (padding-left: 4); see .msg-ref. */
+  padding: 0 0 0 4px;
   display: flex;
   flex-wrap: wrap;
   gap: 4px;


### PR DESCRIPTION
## Summary

- Entering edit mode on a sent user-message bubble no longer shoves the assistant reply below it down the page.
- Compact one-row textarea is the initial edit-mode state (matches the collapsed bubble height); send composer keeps `rows={2}`.
- Compact-bubble padding follows through: uniform 4 px text-to-border on the user bubble, with sibling rules (`.msg-ref`, `.msg-attachments`, `.promptbox-thumbs`, edit-mode textarea) realigned so glyphs stay locked between display and edit.
- Bottom prompt focus border swaps `--vscode-focusBorder` (hard blue) for `--vscode-foreground` (theme-adaptive, matches text color).

## How

`UserMessageView` measures the bubble's collapsed height on edit-entry, observes the editing height with `ResizeObserver`, and exposes the delta as `--edit-overlap` on the bubble's inline style. CSS subtracts that overlap from the bubble's `margin-bottom` and raises `z-index` so the editor visually overlaps subsequent content instead of pushing it.

## Test plan

- [x] `bun run test` — 123 webview tests pass, including new `compensates edit-mode height so following messages do not reflow` and `rows={1}` / `rows={2}` variant tests.
- [x] `bun run check-types` — clean (the 3 pre-existing webview type errors in `App.tsx` + `MessageView.tsx:356` from CLAUDE.md are unchanged).
- [x] `bun run build:webview` — produces clean bundle.
- [ ] Visual: load Extension Development Host, click into any sent user message — assistant reply below should stay put while the bubble grows; exiting edit restores layout cleanly.
- [ ] Visual: bottom prompt focus border reads white-ish (not blue) when focused.

Closes #73