### PR TITLE
chore(release): cut v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.3] - 2026-05-17
+
+### Fixed
+- Editing a sent user-message bubble no longer shoves the assistant reply (and everything below it) down the page. `UserMessageView` measures the bubble's collapsed height on edit-entry, observes the editing height with `ResizeObserver`, and exposes the delta as a `--edit-overlap` CSS variable that the bubble subtracts from its own `margin-bottom`. Combined with a raised `z-index`, the editor visually overlaps the subsequent content while it's expanded, so the surrounding dialogue stays anchored in place. Exiting edit mode restores the original layout without a snap. Closes #73.
+
+### Changed
+- Edit-mode prompt uses a compact one-row textarea (`rows={1}`) as its starting height so the initial editor matches the collapsed bubble; the bottom send composer keeps its two-row default.
+- User-message bubble padding is now uniform 4 px on all sides (was 8 × 10 outer + 6 × 8 inner), so the text-to-border distance is consistent vertically and horizontally and the edit-mode height delta is smaller to begin with. Sibling rules (`.msg-ref`, `.msg-attachments`, `.promptbox-thumbs`, the edit-mode textarea) move in lockstep to keep glyphs aligned across display and edit modes.
+- Bottom prompt's focus border switches from `--vscode-focusBorder` (hard blue) to `--vscode-foreground` (theme-adaptive, matches the text color) so the active-state cue reads as a calm divider rather than a screaming accent.
+
 ## [0.5.2] - 2026-05-17
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
Patch release for the edit-mode UX polish merged in #74 — overlap compensation so editing doesn't reflow the dialogue, compact one-row edit textarea, uniform 4 px bubble padding, theme-adaptive bottom-prompt focus border.

Closes #75

After merge:

\`\`\`bash
git checkout main && git pull
git tag v0.5.3
git push origin v0.5.3
gh release create v0.5.3 --title "v0.5.3" --notes-from-tag
\`\`\`