### PR TITLE
refactor(ui): introduce design-token layer for colors, spacing, icon sizes

### DIFF
--- a/webview/src/components/ImagePreviewModal.tsx
+++ b/webview/src/components/ImagePreviewModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react"
+import { ICON_SIZE } from "../design-tokens"
 
 type Props = {
   src: { dataUrl: string; filename: string } | null
@@ -41,7 +42,7 @@ export function ImagePreviewModal({ src, onClose }: Props) {
           onClose()
         }}
       >
-        <svg width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+        <svg width={ICON_SIZE.lg} height={ICON_SIZE.lg} viewBox="0 0 14 14" aria-hidden="true">
           <path d="M2 2l10 10M12 2L2 12" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
         </svg>
       </button>

--- a/webview/src/components/ImageThumbnail.tsx
+++ b/webview/src/components/ImageThumbnail.tsx
@@ -1,5 +1,6 @@
 import type { Attachment } from "../protocol"
 import { formatBytes } from "../mention-tokens"
+import { ICON_SIZE } from "../design-tokens"
 
 /** The minimum shape ImageThumbnail needs. `id` is only required when
  *  `onRemove` is wired up (paperclip/paste flow); read-only sent bubbles
@@ -52,7 +53,7 @@ export function ImageThumbnail({ attachment, onPreview, onRemove }: Props) {
             onRemove(attachment.id!)
           }}
         >
-          <svg width="8" height="8" viewBox="0 0 8 8" aria-hidden="true">
+          <svg width={ICON_SIZE.xs} height={ICON_SIZE.xs} viewBox="0 0 8 8" aria-hidden="true">
             <path d="M1 1l6 6M7 1l-6 6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
           </svg>
         </button>

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -7,6 +7,7 @@ import { ImageThumbnail, type Thumbnailable } from "./ImageThumbnail"
 import { Markdown } from "./Markdown"
 import { PromptBox } from "./PromptBox"
 import { ToolTrace, toolHeadline } from "./ToolCard"
+import { ICON_SIZE } from "../design-tokens"
 
 export function MessageView({
   message,
@@ -282,7 +283,7 @@ function UserMessageView({
           )}
           {canEdit && (
             <span className="user-edit-hint" aria-hidden="true">
-              <svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+              <svg viewBox="0 0 16 16" width={ICON_SIZE.md} height={ICON_SIZE.md} fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M3 8h7a3 3 0 0 1 0 6H6.5"/>
                 <polyline points="5.5,5 3,8 5.5,11"/>
               </svg>

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -12,6 +12,7 @@ import { useImageAttachments } from "../hooks/useImageAttachments"
 import { useMentionPicker } from "../hooks/useMentionPicker"
 import { ImagePreviewModal } from "./ImagePreviewModal"
 import { ImageThumbnail } from "./ImageThumbnail"
+import { ICON_SIZE } from "../design-tokens"
 
 // Re-export so existing consumers (tests, integrators) keep working through PromptBox.
 export {
@@ -383,7 +384,7 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
             disabled={attaching || busy}
             onClick={handleAttachClick}
           >
-            <svg width="14" height="14" viewBox="0 0 16 16" aria-hidden="true">
+            <svg width={ICON_SIZE.lg} height={ICON_SIZE.lg} viewBox="0 0 16 16" aria-hidden="true">
               <path
                 d="M10.5 2.5a3 3 0 0 1 3 3v6.5a3.5 3.5 0 0 1-7 0V5a2 2 0 1 1 4 0v6.5a1.5 1.5 0 0 1-3 0V5.5"
                 fill="none"
@@ -443,9 +444,9 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
 function SendIcon() {
   // Same `display: block` reasoning as StopIcon — removes the SVG's
   // default inline baseline drift so the arrow sits on the button's
-  // exact centre line. 10×10 in an 18-px button → 4-px margin per side.
+  // exact centre line. `ICON_SIZE.sm` in an 18-px button → 4-px margin per side.
   return (
-    <svg width="10" height="10" viewBox="0 0 16 16" fill="none" aria-hidden="true" style={{ display: "block" }}>
+    <svg width={ICON_SIZE.sm} height={ICON_SIZE.sm} viewBox="0 0 16 16" fill="none" aria-hidden="true" style={{ display: "block" }}>
       <path
         d="M8 13.5 V2.5 M3.5 7 L8 2.5 L12.5 7"
         stroke="currentColor"
@@ -458,11 +459,12 @@ function SendIcon() {
 }
 
 function StopIcon() {
-  // 8×8 in an 18-px button → 5-px margin on each side. Even numbers avoid
-  // the sub-pixel rounding that made the square look slightly off-centre
-  // at 7×7.
+  // `ICON_SIZE.xs` in an 18-px button → 5-px margin on each side. Even
+  // numbers avoid the sub-pixel rounding that made the square look slightly
+  // off-centre at 7×7. The inner `<rect>` is the icon SHAPE (10×10 viewBox
+  // coordinate), not the icon size — leave it untouched.
   return (
-    <svg width="8" height="8" viewBox="0 0 10 10" aria-hidden="true" style={{ display: "block" }}>
+    <svg width={ICON_SIZE.xs} height={ICON_SIZE.xs} viewBox="0 0 10 10" aria-hidden="true" style={{ display: "block" }}>
       <rect x="0" y="0" width="10" height="10" rx="1.5" fill="currentColor" />
     </svg>
   )

--- a/webview/src/design-tokens.ts
+++ b/webview/src/design-tokens.ts
@@ -1,0 +1,42 @@
+/**
+ * Design tokens for things React owns (SVG attributes, inline numeric props).
+ * Style tokens (colors, spacing, radii, shadows) live in `styles.css` as CSS
+ * variables on `:root`. The two layers exist so the design system has ONE
+ * source of truth per value type — pixels for icons here, everything else
+ * in CSS — and a typo like `width={11}` becomes a compile error.
+ */
+
+/**
+ * Icon-pixel sizes for inline SVG icons. Maps to the four visual scales the
+ * UI actually uses, no more. If you need a new size, prefer extending this
+ * scale (e.g. `xl: 18`) rather than inlining a literal.
+ */
+export const ICON_SIZE = {
+  /** Tiny X buttons (thumbnail remove, stop-square inside send button). */
+  xs: 8,
+  /** Send arrow inside the bottom prompt's primary button. */
+  sm: 10,
+  /** Edit-mode hint on user bubbles, similar small affordances. */
+  md: 12,
+  /** Paperclip, modal-level close, statusbar buttons. */
+  lg: 14,
+} as const
+
+/**
+ * Z-index tiers. Use these over magic numbers so the stacking order is
+ * documented in one place. Higher number = paints on top of lower.
+ */
+export const Z = {
+  /** Default in-flow content (code blocks, inline highlights). */
+  base: 1,
+  /** Sticky user-message bubble that pins to the top of the messages scroll. */
+  bubbleSticky: 2,
+  /** Floating UI within the chat: mention popover (open), prompt action row,
+   *  review panel, the editing bubble while expanded. */
+  overlay: 4,
+  /** Top-of-screen dropdowns: model/agent selector, history list,
+   *  thinking-dots indicator. */
+  popover: 20,
+  /** Full-screen modal layer: image preview lightbox. */
+  modal: 1000,
+} as const

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -1,8 +1,66 @@
 * { box-sizing: border-box; }
 
 :root {
-  --radius: 6px;
-  --gap: 8px;
+  /* ───── Design tokens ─────────────────────────────────────────────────────
+     One source of truth for the values used across the webview. Component
+     rules below should reference these instead of inlining literals so that
+     "make all icons larger" or "soften the focus border" is a one-line
+     change. Numeric companions for things React owns (SVG width/height,
+     z-index in JSX) live in `webview/src/design-tokens.ts`.
+     ─────────────────────────────────────────────────────────────────────── */
+
+  /* === Spacing scale ===
+     The webview uses six discrete spacing values across paddings/gaps. */
+  --space-1: 4px;
+  --space-2: 6px;
+  --space-3: 8px;
+  --space-4: 10px;
+  --space-5: 12px;
+  --space-6: 16px;
+
+  /* === Radii ===
+     `--radius` is the long-standing default used by most surfaces and is
+     kept at 6px so the existing visuals don't shift. */
+  --radius-sm:   3px;
+  --radius:      6px;
+  --radius-lg:   10px;
+  --radius-pill: 50%;
+
+  /* === Z-index tiers ===
+     Mirrored in `design-tokens.ts` as `Z.*` for JSX consumers. */
+  --z-base:           1;
+  --z-bubble-sticky:  2;
+  --z-overlay:        4;
+  --z-popover:        20;
+  --z-modal:          1000;
+
+  /* === Semantic colors mapped to the active VS Code theme === */
+  --color-fg:           var(--vscode-foreground);
+  --color-fg-muted:     var(--vscode-descriptionForeground);
+  --color-bg-input:     var(--vscode-input-background);
+  --color-bg-panel:     var(--vscode-sideBar-background);
+  --color-border:       var(--vscode-input-border, transparent);
+  --color-border-focus: var(--vscode-foreground); /* intentional: text colour, not focusBorder blue */
+  --color-accent:       var(--vscode-focusBorder);
+
+  /* === Fixed UI colors (theme-independent) ===
+     Status dots and the recurring scrollbar-thumb grey used in multiple
+     scrollers. */
+  --color-status-default:  #888;
+  --color-status-ok:       #3fb950;
+  --color-status-warn:     #d29922;
+  --color-status-err:      #f85149;
+  --color-status-pending:  #58a6ff;
+  --color-scrollbar-thumb: rgba(121, 121, 121, 0.4);
+
+  /* === Component bindings ===
+     Per-component spacing tokens. Centralising these names is what keeps
+     the four "must-be-equal" padding values across `.msg.role-user`,
+     `.user-text`, `.msg-ref`, `.msg-attachments`, and the edit-mode
+     textarea aligned — they used to be coupled only by code comments. */
+  --bubble-padding:      var(--space-1);
+  --bubble-text-padding: var(--space-1);
+  --message-gap:         var(--space-6);
   /* Shared max-height for the bottom prompt textarea AND the rendered
      user message bubble. Keeping the two in lockstep is what makes the
      in-place edit affordance feel like "the same input as the bottom
@@ -10,7 +68,10 @@
      also update TEXTAREA_MAX_HEIGHT in webview/src/components/PromptBox.tsx
      — the JS clamp on textarea.style.height must match this cap or the
      CSS scrollbar will fight with the inline style. */
-  --message-max-height: 160px;
+  --message-max-height:  160px;
+
+  /* === Legacy aliases === */
+  --gap: var(--space-3);
 }
 
 html, body, #root {
@@ -66,14 +127,14 @@ button {
   display: inline-block;
   width: 8px;
   height: 8px;
-  border-radius: 50%;
-  background: #888;
+  border-radius: var(--radius-pill);
+  background: var(--color-status-default);
 }
-.statusbar .dot.ok { background: #3fb950; }
-.statusbar .dot.warn { background: #d29922; }
-.statusbar .dot.err { background: #f85149; }
+.statusbar .dot.ok { background: var(--color-status-ok); }
+.statusbar .dot.warn { background: var(--color-status-warn); }
+.statusbar .dot.err { background: var(--color-status-err); }
 .statusbar .dot.pending {
-  background: #58a6ff;
+  background: var(--color-status-pending);
   animation: dot-pulse 1.4s ease-in-out infinite;
 }
 @keyframes dot-pulse {
@@ -170,7 +231,7 @@ button {
      popover lands. */
   top: calc(100% + 2px);
   right: 10px;
-  z-index: 20;
+  z-index: var(--z-popover);
   width: min(300px, calc(100vw - 20px));
   display: flex;
   flex-direction: column;
@@ -306,7 +367,7 @@ button {
   position: absolute;
   top: calc(100% + 2px);
   right: 10px;
-  z-index: 20;
+  z-index: var(--z-popover);
   width: min(360px, calc(100vw - 20px));
   max-height: min(420px, calc(100vh - 70px));
   display: flex;
@@ -606,7 +667,7 @@ button {
   transition: scrollbar-color 0.18s ease;
 }
 .messages:hover {
-  scrollbar-color: var(--vscode-scrollbarSlider-background, rgba(121, 121, 121, 0.4)) transparent;
+  scrollbar-color: var(--vscode-scrollbarSlider-background, var(--color-scrollbar-thumb)) transparent;
 }
 
 /* Per-turn container: each user message + its following assistant messages
@@ -634,7 +695,7 @@ button {
   transition: background-color 0.18s ease;
 }
 .messages:hover::-webkit-scrollbar-thumb {
-  background-color: var(--vscode-scrollbarSlider-background, rgba(121, 121, 121, 0.4));
+  background-color: var(--vscode-scrollbarSlider-background, var(--color-scrollbar-thumb));
 }
 .messages::-webkit-scrollbar-thumb:hover {
   background-color: var(--vscode-scrollbarSlider-hoverBackground, rgba(100, 100, 100, 0.7));
@@ -676,7 +737,6 @@ button {
 }
 
 .msg {
-  --message-gap: 16px;
   margin-bottom: var(--message-gap);
 }
 
@@ -687,13 +747,13 @@ button {
      user scrolls into a different turn, the next user message takes over the
      pinned slot — Claude.ai / ChatGPT-style "section header" pattern. */
   top: 0;
-  z-index: 2;
-  padding: 4px;
+  z-index: var(--z-bubble-sticky);
+  padding: var(--bubble-padding);
   /* Solid opaque background so scrolling content underneath never bleeds
      through, even when a hover/list color is layered on top. */
-  background: var(--vscode-input-background);
-  background-color: var(--vscode-input-background);
-  border: 1px solid var(--vscode-input-border, transparent);
+  background: var(--color-bg-input);
+  background-color: var(--color-bg-input);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius);
   word-break: break-word;
   /* Soft drop shadow gives the pinned bubble a subtle natural-fade transition
@@ -745,25 +805,26 @@ button {
   border-top: 0;
   background: transparent;
 }
-/* In display mode `.msg-attachments` has `padding-left: 4px` to align
-   the thumbnail strip with `.user-text` content. The edit-mode
-   thumbnail strip needs the same offset or the tile visibly jumps
-   leftward when the bubble swaps from display to edit. */
+/* `.msg-attachments`, `.msg-ref`, and this rule all share `--bubble-text-padding`
+   on their left edge so the thumbnail strip, the message-id label, and any
+   inline content align with the `.user-text` glyphs above/below. The edit-mode
+   thumbnail strip needs the same offset or the tile visibly jumps leftward
+   when the bubble swaps from display to edit. */
 .msg.role-user.is-editing .promptbox-thumbs {
-  padding-left: 4px;
+  padding-left: var(--bubble-text-padding);
 }
 /* Drop the bottom-prompt's 48 px min-height when the textarea lives inside
    an edit bubble — for short user messages, the JS already sizes the
    textarea to its content (Math.min(scrollHeight, …)), and a 48 px floor
    would force the bubble to suddenly grow ~20 px taller the moment the
    user clicks to edit a 1-line message. 24 px ≈ one line of text plus the
-   4+4 vertical padding, so a single-line message edits in-place without
-   the bubble jumping. The padding override drops the textarea from the
-   bottom-prompt's `6px 8px` to a uniform 4 px so the edit-mode glyph
-   position matches `.user-text` above. */
+   `--bubble-text-padding` vertical padding (4+4 at the current token value),
+   so a single-line message edits in-place without the bubble jumping. The
+   padding token matches `.user-text` so the edit-mode glyph position is
+   identical to display mode. */
 .msg.role-user.is-editing .promptbox textarea {
   min-height: 24px;
-  padding: 4px;
+  padding: var(--bubble-text-padding);
 }
 /* Fade + slide the action row in when entering edit mode so the buttons
    don't pop into existence below the textarea. The animation only runs
@@ -804,14 +865,14 @@ button {
 .msg.role-user .user-text {
   white-space: pre-wrap;
   word-break: break-word;
-  /* Mirror the edit-mode textarea's padding so the rendered text's pixel
-     position stays the same when the user clicks into edit mode. The bottom
-     prompt's textarea keeps its native `6px 8px`; the edit-mode override at
-     `.msg.role-user.is-editing .promptbox textarea` brings it down to a
-     uniform 4 px to match this rule. Without matching padding here, clicking
-     to edit causes the first character to jump because the textarea
-     introduces its own internal padding. */
-  padding: 4px;
+  /* `--bubble-text-padding` is shared with the edit-mode textarea override so
+     the rendered text's pixel position stays the same when the user clicks
+     into edit mode. The bottom prompt's textarea keeps its native `6px 8px`;
+     the edit-mode override at `.msg.role-user.is-editing .promptbox textarea`
+     uses the same token. Without matching padding here, clicking to edit
+     causes the first character to jump because the textarea introduces its
+     own internal padding. */
+  padding: var(--bubble-text-padding);
   /* Cap the visible height of the rendered user message at the same height
      used by the in-place edit textarea (.promptbox textarea max-height).
      Both reference --message-max-height so the rendered-message view, the
@@ -834,7 +895,7 @@ button {
   transition: scrollbar-color 0.18s ease;
 }
 .msg.role-user .user-text:hover {
-  scrollbar-color: var(--vscode-scrollbarSlider-background, rgba(121, 121, 121, 0.4)) transparent;
+  scrollbar-color: var(--vscode-scrollbarSlider-background, var(--color-scrollbar-thumb)) transparent;
 }
 .msg.role-user .user-text::-webkit-scrollbar {
   width: 8px;
@@ -852,7 +913,7 @@ button {
 }
 .msg.role-user .user-text:hover::-webkit-scrollbar-thumb,
 .msg.role-user .user-text:active::-webkit-scrollbar-thumb {
-  background-color: var(--vscode-scrollbarSlider-background, rgba(121, 121, 121, 0.4));
+  background-color: var(--vscode-scrollbarSlider-background, var(--color-scrollbar-thumb));
 }
 .msg.role-user.is-editable {
   cursor: pointer;
@@ -881,11 +942,11 @@ button {
      identical to display mode — that's what eliminates the visual jump
      when the bubble swaps from `.user-text` to `<textarea>`. Only the
      chrome (focusBorder) and the click target (cursor) change. */
-  background: var(--vscode-input-background);
-  border-color: var(--vscode-focusBorder);
+  background: var(--color-bg-input);
+  border-color: var(--color-accent);
   /* Keep later dialogue stationary while the editor grows over that space. */
   margin-bottom: calc(var(--message-gap) - var(--edit-overlap, 0px));
-  z-index: 4;
+  z-index: var(--z-overlay);
 }
 .user-edit-hint {
   position: absolute;
@@ -937,11 +998,10 @@ button {
 .msg-ref {
   font-size: 11px;
   opacity: 0.6;
-  margin-bottom: 4px;
-  /* Align with the .user-text content below — .user-text has
-     `padding-left: 4px`, so the ref label needs the same 4 px nudge
-     or it appears 4 px to the left of the text glyphs in the same bubble. */
-  padding-left: 4px;
+  margin-bottom: var(--space-1);
+  /* Align with the .user-text content below — shares `--bubble-text-padding`
+     so the ref label glyphs line up with the message text below. */
+  padding-left: var(--bubble-text-padding);
 }
 
 .msg-error {
@@ -1410,7 +1470,7 @@ button {
 .permission {
   position: sticky;
   bottom: 0;
-  z-index: 4;
+  z-index: var(--z-overlay);
   margin: 0 10px 8px;
   padding: 10px;
   border: 1px solid var(--vscode-focusBorder);
@@ -1443,7 +1503,7 @@ button {
 .question {
   position: sticky;
   bottom: 0;
-  z-index: 4;
+  z-index: var(--z-overlay);
   margin: 0 10px 8px;
   padding: 10px;
   border: 1px solid var(--vscode-focusBorder);
@@ -1853,7 +1913,7 @@ button {
   border: 1px solid var(--vscode-input-border, transparent);
   border-radius: var(--radius);
 }
-.promptbox-input:focus-within { border-color: var(--vscode-foreground); }
+.promptbox-input:focus-within { border-color: var(--color-border-focus); }
 .promptbox-backdrop {
   position: absolute;
   inset: 0;
@@ -1913,7 +1973,7 @@ button {
   line-height: inherit;
   outline: none;
   position: relative;
-  z-index: 1;
+  z-index: var(--z-base);
   box-sizing: border-box;
   display: block;
   /* Firefox: thin scrollbar that brightens on hover, matching .messages. */
@@ -1923,7 +1983,7 @@ button {
 }
 .promptbox textarea:hover,
 .promptbox textarea:focus {
-  scrollbar-color: var(--vscode-scrollbarSlider-background, rgba(121, 121, 121, 0.4)) transparent;
+  scrollbar-color: var(--vscode-scrollbarSlider-background, var(--color-scrollbar-thumb)) transparent;
 }
 /* Chromium / WebKit: same pattern as .messages — thumb invisible at rest,
    appears on hover / focus / active scroll. */
@@ -1944,7 +2004,7 @@ button {
 .promptbox textarea:hover::-webkit-scrollbar-thumb,
 .promptbox textarea:focus::-webkit-scrollbar-thumb,
 .promptbox textarea:active::-webkit-scrollbar-thumb {
-  background-color: var(--vscode-scrollbarSlider-background, rgba(121, 121, 121, 0.4));
+  background-color: var(--vscode-scrollbarSlider-background, var(--color-scrollbar-thumb));
 }
 .promptbox-row {
   display: flex;
@@ -2026,7 +2086,7 @@ button {
 .image-preview-overlay {
   position: fixed;
   inset: 0;
-  z-index: 1000;
+  z-index: var(--z-modal);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2186,12 +2246,13 @@ button {
 .icon-btn.attach-btn:disabled { opacity: 0.4; cursor: default; }
 .msg-attachments {
   list-style: none;
-  margin: 0 0 6px 0;
-  /* Align with .user-text content below (padding-left: 4); see .msg-ref. */
-  padding: 0 0 0 4px;
+  margin: 0 0 var(--space-2) 0;
+  /* Shares `--bubble-text-padding` with `.user-text` so attachment tiles align
+     with the text glyphs below. See `.msg-ref` for the same alignment pattern. */
+  padding: 0 0 0 var(--bubble-text-padding);
   display: flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .mention-popover {
@@ -2208,7 +2269,7 @@ button {
   border: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
   border-radius: var(--radius);
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
-  z-index: 20;
+  z-index: var(--z-popover);
 }
 /* In edit-in-place mode the message bubble is stuck at the top of the scroll
    container, so a picker drawn above the textarea gets clipped by the status


### PR DESCRIPTION
## Summary

Adds a design-token layer so colors, spacing, icon sizes, radii, and z-index tiers have one source of truth instead of being spread across the codebase as inline literals.

- **CSS tokens** live at the top of `webview/src/styles.css` under `:root`. Spacing scale (`--space-1` … `--space-6`), radii, semantic theme colors (`--color-fg`, `--color-bg-input`, `--color-border-focus`, etc.), status dot colors, scrollbar grey, and component bindings (`--bubble-padding`, `--bubble-text-padding`, `--message-gap`).
- **TS constants** live in `webview/src/design-tokens.ts` for things React owns: `ICON_SIZE.{xs,sm,md,lg}` and `Z.*`. A typo like `width={11}` is now a compile error.

## Substitutions in this pass

| Surface | Sites |
|---|---|
| SVG icon sizes → `ICON_SIZE.*` | 6 (ImageThumbnail, ImagePreviewModal, PromptBox attach/send/stop, MessageView edit hint) |
| z-index literals → `var(--z-*)` | 7 |
| Status dot hexes → `var(--color-status-*)` | 5 |
| Scrollbar thumb rgba → `var(--color-scrollbar-thumb)` | 6 |
| Bubble padding chain → `var(--bubble-padding)` / `--bubble-text-padding` | 6 (`.msg.role-user`, `.user-text`, `.msg-ref`, `.msg-attachments`, edit-mode textarea, edit-mode thumbnail strip) |
| Edit-mode bubble bg/border/z → semantic tokens | 1 rule |

## Token system at a glance

```css
:root {
  --space-1: 4px;  /* … through --space-6: 16px */
  --radius-sm: 3px;  --radius: 6px;  --radius-lg: 10px;  --radius-pill: 50%;
  --z-base: 1;  --z-bubble-sticky: 2;  --z-overlay: 4;
  --z-popover: 20;  --z-modal: 1000;
  --color-fg: var(--vscode-foreground);
  --color-border-focus: var(--vscode-foreground);  /* the recent white-not-blue */
  --color-status-{default,ok,warn,err,pending}: …;
  --bubble-padding: var(--space-1);
  --bubble-text-padding: var(--space-1);
}
```

```ts
export const ICON_SIZE = { xs: 8, sm: 10, md: 12, lg: 14 } as const
export const Z = { base: 1, bubbleSticky: 2, overlay: 4, popover: 20, modal: 1000 } as const
```

## Notes for review

- Pure refactor. Zero visual or behavioural change — every substitution maps the previous literal to a token holding the same value.
- The token block is intentionally larger than what's already substituted. Future PRs that touch unrelated areas (e.g. Markdown styling, ReviewPanel) can keep migrating to tokens as they go; nothing forces a big-bang substitution.
- `--gap: var(--space-3)` kept as a legacy alias so the handful of existing `var(--gap)` consumers don't need touching.
- The four hardcoded `rgba(80, 140, 255, …)` mention-chip colors and the compound `rgba(0, 0, 0, …)` box-shadow specs were left inline — they're fallbacks for VS Code vars (mention chip) or part of multi-value shorthand (shadows) where a token wouldn't compose cleanly. Worth a follow-up if you want them tokenised.

## Test plan

- [x] `bun run test` — 482 tests pass.
- [x] `bun run check-types` (host) — clean.
- [x] `cd webview && bunx tsc --noEmit` — same 3 pre-existing errors documented in CLAUDE.md, unchanged.
- [x] `bun run build:webview` — clean (+2 kB from new TS module + expanded `:root`).
- [ ] Visual smoke test in dev-host: chat bubbles, edit-mode, status bar dots, scrollbar, image preview lightbox, mention picker, send/stop/attach icons all render identical to main.

Closes #77