### PR TITLE
chore(release): cut v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-05-17
+
+### Changed
+- Internal: introduced a design-token layer so the webview's colors, spacing, icon sizes, radii, and z-index tiers have one source of truth instead of being spread as inline literals. CSS tokens live at the top of `styles.css` (`--space-1` … `--space-6`, `--radius-*`, `--z-*`, `--color-fg`, `--color-bg-input`, `--color-border-focus`, `--color-status-*`, `--bubble-padding`, `--bubble-text-padding`, …); TS constants live in `webview/src/design-tokens.ts` (`ICON_SIZE.{xs,sm,md,lg}`, `Z.*`) for SVG attributes and any inline-style consumers — a typo like `width={11}` is now a compile error. Substituted call-sites in this pass: 6 SVG icons, 7 z-index literals, 5 status dot colors, 6 scrollbar-thumb fallbacks, the coupled bubble-padding chain across five rules (`.msg.role-user`, `.user-text`, `.msg-ref`, `.msg-attachments`, edit-mode textarea + thumbnail strip), and the edit-mode bubble's chrome. The five-rule coupling used to be held together only by code comments cross-referencing each other; "make the padding tighter" is now a one-line change. Pure refactor — zero visual or behavioural change. Closes #77.
+
 ## [0.5.3] - 2026-05-17
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
Minor release for the design-token layer merged in #78 — adds the foundation (`:root` CSS tokens + `webview/src/design-tokens.ts`) that future UI work will keep building on. Pure refactor; no user-visible change.

Closes #79

After merge:

\`\`\`bash
git checkout main && git pull
git tag v0.6.0
git push origin v0.6.0
gh release create v0.6.0 --title "v0.6.0" --notes-from-tag
\`\`\`