### PR TITLE
refactor(statusbar): extract <StatusIndicator> to lock dot+label alignment

### DIFF
--- a/test/webview/status-indicator.test.tsx
+++ b/test/webview/status-indicator.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, afterEach } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+import { StatusIndicator } from "../../webview/src/components/StatusIndicator"
+
+afterEach(cleanup)
+
+describe("StatusIndicator", () => {
+  it("renders dot only when no label is provided", () => {
+    const { container } = render(<StatusIndicator kind="ok" />)
+    expect(container.querySelector(".status-indicator-dot.ok")).not.toBeNull()
+    expect(container.querySelector(".status-indicator-label")).toBeNull()
+  })
+
+  it("renders dot + label together when label is provided", () => {
+    render(<StatusIndicator kind="warn" label="connecting…" />)
+    expect(screen.getByText("connecting…")).toBeInTheDocument()
+  })
+
+  it.each([
+    ["default", "default"],
+    ["ok", "ok"],
+    ["warn", "warn"],
+    ["err", "err"],
+    ["pending", "pending"],
+  ] as const)("applies the %s kind class to the dot", (kind, expectedClass) => {
+    const { container } = render(<StatusIndicator kind={kind} />)
+    expect(container.querySelector(`.status-indicator-dot.${expectedClass}`)).not.toBeNull()
+  })
+
+  it("forwards the title attribute to the wrapper for native tooltips", () => {
+    const { container } = render(
+      <StatusIndicator kind="err" label="boom" title="error · boom" />,
+    )
+    const wrapper = container.querySelector(".status-indicator")
+    expect(wrapper?.getAttribute("title")).toBe("error · boom")
+  })
+
+  it("co-locates dot + label so they share one inline line-box (regression: previously they were sibling flex children that misaligned vertically)", () => {
+    const { container } = render(<StatusIndicator kind="warn" label="connecting…" />)
+    const wrapper = container.querySelector(".status-indicator")
+    const dot = container.querySelector(".status-indicator-dot")
+    const label = container.querySelector(".status-indicator-label")
+    expect(wrapper).not.toBeNull()
+    // Both must be children of the same wrapper element — that's the structural
+    // guarantee that prevents the bar's flex layout from centering them
+    // independently and misaligning them.
+    expect(dot?.parentElement).toBe(wrapper)
+    expect(label?.parentElement).toBe(wrapper)
+  })
+})

--- a/webview/src/components/StatusBar.tsx
+++ b/webview/src/components/StatusBar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react"
 import type { ConversationSummary, Selection } from "../protocol"
+import { StatusIndicator, type StatusIndicatorKind } from "./StatusIndicator"
 
 type Props = {
   connected: boolean
@@ -38,23 +39,34 @@ export function StatusBar({
   const active = conversations.find((c) => c.id === activeConversationID)
 
   const showStatus = !connected || Boolean(error) || Boolean(continuationPending)
-  const statusLabel = error
+  const statusLabel: string | undefined = error
     ? `error · ${error}`
     : !connected
       ? "connecting…"
       : continuationPending
         ? "continuing…"
-        : ""
-  const dotKind = error ? "err" : continuationPending ? "pending" : connected ? "ok" : "warn"
+        : undefined
+  const dotKind: StatusIndicatorKind = error
+    ? "err"
+    : continuationPending
+      ? "pending"
+      : connected
+        ? "ok"
+        : "warn"
+  const statusTitle = error
+    ? `error · ${error}`
+    : continuationPending
+      ? "continuing…"
+      : connected
+        ? "connected"
+        : "connecting…"
   return (
-    <div className={`statusbar ${showStatus ? "" : "is-quiet"}`}>
-      <span
-        className={`dot ${dotKind}`}
-        title={error ? `error · ${error}` : continuationPending ? "continuing…" : connected ? "connected" : "connecting…"}
+    <div className="statusbar">
+      <StatusIndicator
+        kind={dotKind}
+        label={showStatus ? statusLabel : undefined}
+        title={statusTitle}
       />
-      {showStatus && statusLabel && (
-        <span className="status-text">{statusLabel}</span>
-      )}
       <div className="spacer" />
       <SelectorMenu
         agent={agent}

--- a/webview/src/components/StatusIndicator.tsx
+++ b/webview/src/components/StatusIndicator.tsx
@@ -1,0 +1,32 @@
+/**
+ * Small marker (coloured dot) + optional label, locked together so they
+ * always sit on the same visual line.
+ *
+ * Why a dedicated component instead of rendering the dot + label as
+ * siblings of whatever parent needs them: flex parents centre each child
+ * by its own box centre, which makes a small (8 px) dot look detached
+ * from the larger text glyph next to it. Inside this component the two
+ * pieces share an inline line-box and align via `vertical-align: middle`,
+ * which centres by font x-height (the perceived text midpoint). Callers
+ * just place a `<StatusIndicator …>` and never see the alignment seams.
+ */
+
+export type StatusIndicatorKind = "default" | "ok" | "warn" | "err" | "pending"
+
+type Props = {
+  /** Drives the dot colour. `pending` additionally animates a pulse. */
+  kind: StatusIndicatorKind
+  /** Optional inline label shown to the right of the dot. */
+  label?: string
+  /** Native tooltip applied to the wrapper. */
+  title?: string
+}
+
+export function StatusIndicator({ kind, label, title }: Props) {
+  return (
+    <span className="status-indicator" title={title}>
+      <span className={`status-indicator-dot ${kind}`} />
+      {label && <span className="status-indicator-label">{label}</span>}
+    </span>
+  )
+}

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -113,27 +113,38 @@ button {
   background: var(--vscode-sideBarSectionHeader-background);
   min-width: 0;
 }
-.statusbar.is-quiet .status-text { display: none; }
+.statusbar .spacer { flex: 1; }
 
-.statusbar .dot {
-  /* Pin both axes so the flex algorithm can't squeeze the dot horizontally
-     when the bar gets tight (which would turn it into a vertical ellipse).
-     Same defence already applied to the .btn.icon and .history-trigger
-     icons. */
-  flex: 0 0 auto;
-  /* The dot is rendered as a <span>; explicit inline-block removes the
-     baseline-alignment quirks some browsers apply to inline boxes, so the
-     flex `align-items: center` lands the dot on the exact bar centerline. */
+/* ===== StatusIndicator =====
+   Coloured marker dot + optional label. Component-scoped so any surface
+   (status bar, permission badge, etc.) can drop one in without redoing
+   the alignment dance.
+
+   Why the inline-block wrapper + `vertical-align: middle` on children:
+   sibling flex children get centred by their own box centres, which
+   makes a small 8 px dot visually sit below the larger text glyph next
+   to it. Giving the pair a shared inline line-box (`display: inline-block`
+   with `line-height: 1` to hug the glyph height) and using
+   `vertical-align: middle` aligns by font x-height — the perceived text
+   midpoint — instead. The two pieces stay locked together regardless of
+   what the parent flex layout does. */
+.status-indicator {
+  display: inline-block;
+  white-space: nowrap;
+  line-height: 1;
+}
+.status-indicator-dot {
+  vertical-align: middle;
   display: inline-block;
   width: 8px;
   height: 8px;
   border-radius: var(--radius-pill);
   background: var(--color-status-default);
 }
-.statusbar .dot.ok { background: var(--color-status-ok); }
-.statusbar .dot.warn { background: var(--color-status-warn); }
-.statusbar .dot.err { background: var(--color-status-err); }
-.statusbar .dot.pending {
+.status-indicator-dot.ok      { background: var(--color-status-ok); }
+.status-indicator-dot.warn    { background: var(--color-status-warn); }
+.status-indicator-dot.err     { background: var(--color-status-err); }
+.status-indicator-dot.pending {
   background: var(--color-status-pending);
   animation: dot-pulse 1.4s ease-in-out infinite;
 }
@@ -142,22 +153,14 @@ button {
   50% { opacity: 0.4; }
 }
 @media (prefers-reduced-motion: reduce) {
-  .statusbar .dot.pending { animation: none; }
+  .status-indicator-dot.pending { animation: none; }
 }
-
-.statusbar .status-text {
-  min-width: 0;
-  /* Tight line-height so the text-box hugs the glyph height. Without this,
-     the inherited default (~1.2) inflates the box and `align-items: center`
-     lands the text on the geometric centre of the inflated box — visually
-     a hair above the centre of the 8 px dot next to it. */
-  line-height: 1;
+.status-indicator-label {
+  vertical-align: middle;
+  margin-left: var(--space-3);
   opacity: 0.75;
-  overflow: hidden;
   white-space: nowrap;
-  text-overflow: ellipsis;
 }
-.statusbar .spacer { flex: 1; }
 
 .selector-menu {
   flex: 0 1 auto;


### PR DESCRIPTION
## Summary

Extracts a dedicated `<StatusIndicator>` component so the dot+label alignment relationship is owned by the component, not hidden in the status bar's JSX.

### Why

Previously the dot and the text label were sibling flex children of `.statusbar`. The bar's `align-items: center` aligned each by its own box centre, which made the small 8 px dot visually drift below the larger text glyph next to it. Every fix attempt (line-height tweaks, translateY nudges, inline-block cluster wrapper) patched the symptom — the structural cause was that the alignment lived in `StatusBar`'s JSX, where any future edit could re-introduce the bug.

### What

| Change | File |
|---|---|
| New component (~30 lines): 5 `kind`s, optional `label` + `title`, owns the cluster CSS internally | `webview/src/components/StatusIndicator.tsx` |
| Bar swaps inline cluster JSX for `<StatusIndicator …>` | `webview/src/components/StatusBar.tsx` |
| CSS class names move from bar-scoped (`.status-cluster`, `.dot`, `.status-text`) to component-scoped (`.status-indicator`, `.status-indicator-dot`, `.status-indicator-label`); the now-dead `.is-quiet` rule is removed | `webview/src/styles.css` |
| Component tests: dot-only, dot+label, kind→class mapping, title forwarding, and a regression test that asserts dot+label share one wrapper element | `test/webview/status-indicator.test.tsx` |

### API

```tsx
import { StatusIndicator } from "./StatusIndicator"

<StatusIndicator kind="warn" label="connecting…" title="connecting…" />
<StatusIndicator kind="ok" />  // dot only (the quiet state)
```

`kind` is `"default" | "ok" | "warn" | "err" | "pending"`. `pending` automatically pulses.

### Generalises

Anywhere a small marker sits next to text (assistant status row, permission badge, tool-trace bullet) can now drop in `<StatusIndicator …>` instead of reinventing the alignment workaround. That's the structural answer to "how do I make sure this misunderstanding never happens again."

## Test plan

- [x] `bun run test` — 491 pass (482 prior + 5 new in `status-indicator.test.tsx`). Existing `statusbar.test.tsx` still passes since it asserts on text content, not class names.
- [x] `bun run check-types` — clean.
- [x] `cd webview && bunx tsc --noEmit` — same 3 pre-existing errors documented in CLAUDE.md, unchanged.
- [x] `bun run build:webview` — clean.
- [ ] Visual smoke test in dev-host: status bar shows dot+label correctly aligned in `connecting…`, `continuing…`, `error · …`, and quiet-connected states.

Closes #81