### PR TITLE
chore(release): cut v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-05-17
+
+### Fixed
+- Status-bar dot (`connecting…` / `continuing…` / error states) was visually drifting below the adjacent text glyph because the dot and label were sibling flex children of `.statusbar`, each centred by its own box centre. Extracted a dedicated `<StatusIndicator>` component that gives the dot + label a shared inline line-box with `vertical-align: middle`, aligning by font x-height (the perceived text middle) instead of by box centre. The alignment relationship now lives inside the component rather than as a hidden contract in the bar's JSX, so future edits to `StatusBar` can't re-introduce the drift. Generalises to any future surface that needs a small marker next to text (assistant status, permission badge, tool-trace bullet) — drop in `<StatusIndicator kind="…" label="…" />` instead of redoing the alignment workaround. Closes #81.
+
 ## [0.6.0] - 2026-05-17
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
Patch release for the `<StatusIndicator>` extraction merged in #82. Fixes the status-bar dot drift visually and structurally so it can't regress.

Closes #83

After merge:

\`\`\`bash
git checkout main && git pull
git tag v0.6.1
git push origin v0.6.1
gh release create v0.6.1 --title "v0.6.1" --notes-from-tag
\`\`\`