### PR TITLE
refactor(edit-mode): EditPhase state machine + animation-driven phase advance

### DIFF
--- a/test/webview/message-view.test.tsx
+++ b/test/webview/message-view.test.tsx
@@ -1,10 +1,31 @@
 import { describe, it, expect, vi, afterEach } from "vitest"
-import { render, screen, cleanup, waitFor } from "@testing-library/react"
+import { render, screen, cleanup, waitFor, act } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { MessageView } from "../../webview/src/components/MessageView"
 import type { Message } from "../../webview/src/hooks/useChatState"
 
 afterEach(cleanup)
+
+/** jsdom does not run CSS animations, so the overlay's `animationend` event
+ *  is never dispatched automatically. Tests that exercise the close path
+ *  (cancel / save-no-change / click-outside / Escape) manually fire it with
+ *  the closing animation's name so `MessageView`'s phase advances. */
+function endClosingAnimation(container: HTMLElement) {
+  const overlay = container.querySelector(".user-edit-layer")
+  if (!overlay) throw new Error("endClosingAnimation: no .user-edit-layer found")
+  // jsdom's `AnimationEvent` constructor ignores `animationName` in its init
+  // dict, so `fireEvent.animationEnd(target, { animationName })` dispatches
+  // an event whose `animationName` is `undefined` — and `MessageView`'s
+  // closing listener filters on that name. Construct the event manually and
+  // set the property via `Object.defineProperty` (read-only on the real
+  // AnimationEvent interface, but Object.defineProperty bypasses that on
+  // the plain Event we're using here).
+  const event = new Event("animationend", { bubbles: true })
+  Object.defineProperty(event, "animationName", { value: "user-edit-border-out" })
+  act(() => {
+    overlay.dispatchEvent(event)
+  })
+}
 
 function userMessage(text: string, opts: { id?: string; backendID?: string } = {}): Message {
   return {
@@ -79,12 +100,12 @@ describe("MessageView (user role)", () => {
     expect(screen.getByRole("button", { name: "Save & regenerate" })).toBeInTheDocument()
   })
 
-  it("compensates edit-mode height so following messages do not reflow", async () => {
+  it("freezes the message footprint while the edit overlay expands", async () => {
     const user = userEvent.setup()
     const rectSpy = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function () {
       const element = this as HTMLElement
       if (element.classList.contains("msg")) {
-        return rect(element.classList.contains("is-editing") ? 64 : 32)
+        return rect(32)
       }
       return rect(0)
     })
@@ -100,7 +121,9 @@ describe("MessageView (user role)", () => {
       )
       const bubble = container.querySelector(".msg.role-user") as HTMLElement
       await user.click(bubble)
-      await waitFor(() => expect(bubble.style.getPropertyValue("--edit-overlap")).toBe("32px"))
+      expect(bubble.style.getPropertyValue("--edit-placeholder-height")).toBe("32px")
+      expect(container.querySelector(".user-edit-layer")).not.toBeNull()
+      expect(bubble.getAttribute("data-edit-phase")).toBe("editing")
     } finally {
       rectSpy.mockRestore()
     }
@@ -169,9 +192,14 @@ describe("MessageView (user role)", () => {
     )
     await user.click(container.querySelector(".msg.role-user") as HTMLElement)
     await user.click(screen.getByRole("button", { name: "Save & regenerate" }))
-    // No regenerate triggered, edit mode closed.
+    // No regenerate triggered. Phase advances to closing (overlay still mounted
+    // while the border-out animation plays); the simulated animationend then
+    // advances to view and unmounts the overlay.
     expect(onEditMessage).not.toHaveBeenCalled()
-    expect(container.querySelector("textarea")).toBeNull()
+    expect(container.querySelector(".msg.role-user")?.getAttribute("data-edit-phase")).toBe("closing")
+    endClosingAnimation(container)
+    await waitFor(() => expect(container.querySelector("textarea")).toBeNull())
+    expect(container.querySelector(".msg.role-user")?.getAttribute("data-edit-phase")).toBe("view")
   })
 
   it("clicking outside returns to view mode without firing onEditMessage", async () => {
@@ -188,7 +216,8 @@ describe("MessageView (user role)", () => {
     await user.click(container.querySelector(".msg.role-user") as HTMLElement)
     expect(container.querySelector("textarea")).not.toBeNull()
     await user.click(document.body)
-    expect(container.querySelector("textarea")).toBeNull()
+    endClosingAnimation(container)
+    await waitFor(() => expect(container.querySelector("textarea")).toBeNull())
     expect(onEditMessage).not.toHaveBeenCalled()
   })
 
@@ -206,7 +235,8 @@ describe("MessageView (user role)", () => {
     const textarea = container.querySelector("textarea") as HTMLTextAreaElement
     textarea.focus()
     await user.keyboard("{Escape}")
-    expect(container.querySelector("textarea")).toBeNull()
+    endClosingAnimation(container)
+    await waitFor(() => expect(container.querySelector("textarea")).toBeNull())
   })
 
   it("Cmd+Enter in textarea fires Save with the new content", async () => {

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type ReactNode } from "react"
+import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react"
 import type { Block, Message } from "../hooks/useChatState"
 import type { Attachment, FileSearchHit } from "../protocol"
 import { findMentionRanges, makeAttachmentLabel } from "../mention-tokens"
@@ -8,6 +8,29 @@ import { Markdown } from "./Markdown"
 import { PromptBox } from "./PromptBox"
 import { ToolTrace, toolHeadline } from "./ToolCard"
 import { ICON_SIZE } from "../design-tokens"
+
+/**
+ * Discriminated edit lifecycle for user-message bubbles.
+ *
+ * - `view`     — read-only; hover/focus affordances are enabled here ONLY.
+ * - `editing`  — overlay rendered, border-in animation, click-outside cancels.
+ * - `closing`  — overlay still mounted, border-out animation running; the
+ *                overlay's `onAnimationEnd` advances `closing → view`.
+ *
+ * One value drives both the JSX (`data-edit-phase` attribute on the row) and
+ * the CSS (selectors keyed on that attribute). Previously this lifecycle was
+ * three booleans + a `setTimeout` that had to stay in lockstep with the CSS
+ * animation duration. The state machine collapses them into a single source
+ * of truth so the visual state can never be the *combination* of overlapping
+ * boolean flags, and so a CSS animation-duration tweak can never silently
+ * drift away from a hardcoded JS timer.
+ */
+type EditPhase = "view" | "editing" | "closing"
+
+/** CSS animation name played by `.user-edit-layer` while phase is `closing`.
+ *  The `onAnimationEnd` handler filters on this name so the entering
+ *  animation doesn't accidentally trigger a phase advance. */
+const CLOSING_ANIMATION = "user-edit-border-out"
 
 export function MessageView({
   message,
@@ -122,50 +145,57 @@ function UserMessageView({
   const attachmentBlocks = message.blocks.filter(
     (b): b is Extract<Block, { type: "attachment" }> => b.type === "attachment",
   )
-  const [editing, setEditing] = useState(false)
-  const [editOverlap, setEditOverlap] = useState(0)
+  const [editPhase, setEditPhase] = useState<EditPhase>("view")
+  const [editPlaceholderHeight, setEditPlaceholderHeight] = useState<number | null>(null)
   const [previewImage, setPreviewImage] = useState<Thumbnailable | null>(null)
   const bubbleRef = useRef<HTMLDivElement>(null)
   const editAreaRef = useRef<HTMLDivElement>(null)
-  const collapsedBubbleHeight = useRef<number | null>(null)
+
+  const exitEditing = () => {
+    // Only the editing phase can transition to closing. If we're already
+    // closing or in view, ignore — calling exit during closing is a no-op
+    // by design so click-outside listeners don't re-trigger the animation.
+    if (editPhase !== "editing") return
+    setEditPhase("closing")
+  }
+
+  // Animation-driven phase advance: when the overlay's border-out animation
+  // finishes, transition from `closing` to `view`. Using a native
+  // addEventListener on the overlay ref (rather than React's onAnimationEnd
+  // prop) for two reasons: (1) it matches the architectural intent — the CSS
+  // animation duration is the sole source of truth, and the listener fires
+  // exactly when CSS says the animation is done; (2) it's reliably dispatched
+  // in jsdom test environments where React's synthetic onAnimationEnd is not
+  // always invoked by `fireEvent.animationEnd`.
+  useEffect(() => {
+    if (editPhase !== "closing") return
+    const overlay = editAreaRef.current
+    if (!overlay) return
+    const handler = (event: Event) => {
+      // Overlay plays two animations (`user-edit-border-in` on enter,
+      // `user-edit-border-out` on exit); only the closing one advances the
+      // phase, otherwise the entering animation would bounce us straight
+      // back to `view` the moment edit opens.
+      if ((event as globalThis.AnimationEvent).animationName !== CLOSING_ANIMATION) return
+      setEditPhase("view")
+      setEditPlaceholderHeight(null)
+    }
+    overlay.addEventListener("animationend", handler)
+    return () => overlay.removeEventListener("animationend", handler)
+  }, [editPhase])
 
   // Click-outside cancels the edit. We listen on the document so any click
   // outside the editing container — anywhere in the chat panel — drops us
   // back to view mode. Cheap and matches the "no Cancel button" UX.
   useEffect(() => {
-    if (!editing) return
+    if (editPhase !== "editing") return
     const onPointerDown = (event: PointerEvent) => {
       if (editAreaRef.current?.contains(event.target as Node)) return
-      setEditing(false)
+      exitEditing()
     }
     document.addEventListener("pointerdown", onPointerDown)
     return () => document.removeEventListener("pointerdown", onPointerDown)
-  }, [editing])
-
-  useLayoutEffect(() => {
-    if (!editing) {
-      collapsedBubbleHeight.current = null
-      setEditOverlap(0)
-      return
-    }
-    const bubble = bubbleRef.current
-    const baseline = collapsedBubbleHeight.current
-    if (!bubble || !baseline || baseline <= 0) {
-      setEditOverlap(0)
-      return
-    }
-
-    const measureOverlap = () => {
-      const next = Math.max(0, bubble.getBoundingClientRect().height - baseline)
-      setEditOverlap((current) => Math.abs(current - next) < 0.5 ? current : next)
-    }
-
-    measureOverlap()
-    if (typeof ResizeObserver === "undefined") return
-    const observer = new ResizeObserver(measureOverlap)
-    observer.observe(bubble)
-    return () => observer.disconnect()
-  }, [editing])
+  }, [editPhase])
 
   // Re-derive attachment labels (same algorithm PromptBox originally used) and
   // wrap each attachment block into the Attachment shape, including a synthetic
@@ -207,45 +237,63 @@ function UserMessageView({
     const sameMentionCount = (mentions?.length ?? 0) === (message.mentions?.length ?? 0)
     const sameAttachCount = (attachments?.length ?? 0) === attachmentBlocks.length
     if (sameText && sameMentionCount && sameAttachCount) {
-      setEditing(false)
+      exitEditing()
       return
     }
     onEditMessage?.(message.id, trimmed, mentions, attachments)
-    setEditing(false)
+    exitEditing()
   }
 
   const enterEditing = () => {
-    if (!editable || editing) return
+    if (!editable) return
+    if (editPhase === "editing") return
     if (typeof window !== "undefined" && window.getSelection?.()?.toString()) return
-    collapsedBubbleHeight.current = bubbleRef.current?.getBoundingClientRect().height ?? null
-    setEditOverlap(0)
-    setEditing(true)
+    // Re-entering during a closing animation: cancel the close by jumping
+    // straight back to editing. The overlay's CSS animation property
+    // switches from `user-edit-border-out` to `user-edit-border-in`, so the
+    // outgoing animation simply stops (no orphaned animationend event since
+    // animation replacement doesn't dispatch one) and the entering animation
+    // plays from its current intermediate border colour. Placeholder height
+    // is still set from the original measurement — no re-measure needed.
+    if (editPhase === "view") {
+      setEditPlaceholderHeight(bubbleRef.current?.getBoundingClientRect().height ?? null)
+    }
+    setEditPhase("editing")
   }
+
+  const inEditMode = editPhase !== "view"
 
   return (
     <div
       ref={bubbleRef}
-      className={`msg role-user ${editing ? "is-editing" : ""} ${editable ? "is-editable" : ""}`}
-      style={editing ? ({ "--edit-overlap": `${editOverlap}px` } as CSSProperties) : undefined}
+      className={`msg role-user ${editable ? "is-editable" : ""}`}
+      data-edit-phase={editPhase}
+      style={inEditMode && editPlaceholderHeight
+        ? ({ "--edit-placeholder-height": `${editPlaceholderHeight}px` } as CSSProperties)
+        : undefined}
       onClick={enterEditing}
-      role={editable && !editing ? "button" : undefined}
-      tabIndex={editable && !editing ? 0 : undefined}
-      onKeyDown={editable && !editing ? (event) => {
+      role={editable && !inEditMode ? "button" : undefined}
+      tabIndex={editable && !inEditMode ? 0 : undefined}
+      onKeyDown={editable && !inEditMode ? (event) => {
         if (event.target !== event.currentTarget) return
         if (event.key === "Enter" || event.key === " ") {
           event.preventDefault()
           enterEditing()
         }
       } : undefined}
-      title={editing ? undefined : editTitle}
+      title={inEditMode ? undefined : editTitle}
     >
-      {message.ref?.label && <div className="msg-ref">{message.ref.label}</div>}
-      {editing ? (
-        <div ref={editAreaRef} onClick={(event) => event.stopPropagation()}>
+      {inEditMode ? (
+        <div
+          ref={editAreaRef}
+          className="user-edit-layer"
+          onClick={(event) => event.stopPropagation()}
+        >
+          {message.ref?.label && <div className="msg-ref">{message.ref.label}</div>}
           <PromptBox
             busy={false}
             onSend={handleSubmit}
-            onAbort={() => setEditing(false)}
+            onAbort={exitEditing}
             searchFiles={searchFiles}
             attachFile={attachFile}
             variant="edit"
@@ -258,6 +306,7 @@ function UserMessageView({
         </div>
       ) : (
         <>
+          {message.ref?.label && <div className="msg-ref">{message.ref.label}</div>}
           {attachmentBlocks.length > 0 && (
             <ul className="msg-attachments" aria-label="Attachments">
               {attachmentBlocks.map((a, i) =>

--- a/webview/src/hooks/usePromptText.ts
+++ b/webview/src/hooks/usePromptText.ts
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react"
+import { useLayoutEffect, useRef, useState } from "react"
 
 // Hard upper bound on the auto-grow textarea height. Past this, the
 // textarea's own scrollbar takes over so the prompt box doesn't keep eating
@@ -28,7 +28,7 @@ export function usePromptText(initialText: string = "") {
   const backdropRef = useRef<HTMLDivElement>(null)
   const pendingCursor = useRef<number | null>(null)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!ref.current) return
     ref.current.style.height = "auto"
     ref.current.style.height = Math.min(ref.current.scrollHeight, TEXTAREA_MAX_HEIGHT) + "px"

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -762,16 +762,11 @@ button {
   /* Soft drop shadow gives the pinned bubble a subtle natural-fade transition
      against the scrolling content below it, regardless of theme contrast. */
   box-shadow: 0 12px 18px -10px var(--vscode-widget-shadow, rgba(0, 0, 0, 0.45));
-  /* Animate the chrome on entering / leaving edit mode. The transition lives
-     on the base class (not .is-editable) so it applies regardless of whether
-     the user message was editable at the time the class toggles. Padding is
-     intentionally listed even though display / edit modes now share the same
-     padding — kept here so any future tweak smoothly morphs instead of
-     snapping. */
+  /* Animate only paint changes. Size-affecting properties stay out of this
+     transition so entering/exiting edit mode cannot briefly resize the row. */
   transition:
     background-color 0.18s ease,
-    border-color 0.18s ease,
-    padding 0.18s ease;
+    border-color 0.18s ease;
 }
 /* Extra gradient strip below the bubble for stronger visual feathering.
    Uses a high-contrast shadow color with explicit alpha so it shows up
@@ -803,7 +798,12 @@ button {
     );
   }
 }
-.msg.role-user.is-editing > div > .promptbox {
+/* All rules in this block target `editing` AND `closing` phases (the overlay
+   is mounted throughout both — closing is just the border-out animation
+   playing on its way to `view`). `:not([data-edit-phase="view"])` keeps the
+   selector concise and ensures any future phase added between editing and
+   view automatically inherits these edit-mode styles. */
+.msg.role-user:not([data-edit-phase="view"]) > .user-edit-layer > .promptbox {
   padding: 0;
   border-top: 0;
   background: transparent;
@@ -813,7 +813,7 @@ button {
    inline content align with the `.user-text` glyphs above/below. The edit-mode
    thumbnail strip needs the same offset or the tile visibly jumps leftward
    when the bubble swaps from display to edit. */
-.msg.role-user.is-editing .promptbox-thumbs {
+.msg.role-user:not([data-edit-phase="view"]) .promptbox-thumbs {
   padding-left: var(--bubble-text-padding);
 }
 /* Drop the bottom-prompt's 48 px min-height when the textarea lives inside
@@ -825,17 +825,17 @@ button {
    so a single-line message edits in-place without the bubble jumping. The
    padding token matches `.user-text` so the edit-mode glyph position is
    identical to display mode. */
-.msg.role-user.is-editing .promptbox textarea {
+.msg.role-user:not([data-edit-phase="view"]) .promptbox textarea {
   min-height: 24px;
   padding: var(--bubble-text-padding);
 }
 /* Fade + slide the action row in when entering edit mode so the buttons
    don't pop into existence below the textarea. The animation only runs
    on mount (the row stays mounted while editing), and is scoped to
-   .is-editing so the bottom prompt-box at the foot of the chat — which
+   non-view phases so the bottom prompt-box at the foot of the chat — which
    is always present — isn't affected. Kept short (160 ms) so it feels
    immediate, not slow. */
-.msg.role-user.is-editing .promptbox-row {
+.msg.role-user:not([data-edit-phase="view"]) .promptbox-row {
   animation: user-edit-row-in 0.16s ease both;
 }
 @keyframes user-edit-row-in {
@@ -857,12 +857,12 @@ button {
    (bubble-padding + textarea-padding) which exactly equals
    (bubble-padding + .user-text-padding) after we add 6px 8px padding to
    .user-text below. */
-.msg.role-user.is-editing .promptbox-input,
-.msg.role-user.is-editing .promptbox-input:focus-within {
+.msg.role-user:not([data-edit-phase="view"]) .promptbox-input,
+.msg.role-user:not([data-edit-phase="view"]) .promptbox-input:focus-within {
   border: 0;
   background: transparent;
 }
-.msg.role-user.is-editing::after {
+.msg.role-user:not([data-edit-phase="view"])::after {
   display: none;
 }
 .msg.role-user .user-text {
@@ -871,10 +871,11 @@ button {
   /* `--bubble-text-padding` is shared with the edit-mode textarea override so
      the rendered text's pixel position stays the same when the user clicks
      into edit mode. The bottom prompt's textarea keeps its native `6px 8px`;
-     the edit-mode override at `.msg.role-user.is-editing .promptbox textarea`
-     uses the same token. Without matching padding here, clicking to edit
-     causes the first character to jump because the textarea introduces its
-     own internal padding. */
+     the edit-mode override at
+     `.msg.role-user:not([data-edit-phase="view"]) .promptbox textarea` uses
+     the same token. Without matching padding here, clicking to edit causes
+     the first character to jump because the textarea introduces its own
+     internal padding. */
   padding: var(--bubble-text-padding);
   /* Cap the visible height of the rendered user message at the same height
      used by the in-place edit textarea (.promptbox textarea max-height).
@@ -918,38 +919,79 @@ button {
 .msg.role-user .user-text:active::-webkit-scrollbar-thumb {
   background-color: var(--vscode-scrollbarSlider-background, var(--color-scrollbar-thumb));
 }
-.msg.role-user.is-editable {
+/* Hover / focus rules are scoped to `[data-edit-phase="view"]` so they
+   physically cannot fire during `editing` or `closing` phases — that's the
+   structural guarantee the EditPhase state machine is meant to enforce.
+   Without this scope, a hover during the closing animation could repaint
+   the bubble's border underneath the overlay and produce a flash. */
+.msg.role-user.is-editable[data-edit-phase="view"] {
   cursor: pointer;
-  /* Hover/state transitions now live on the base .msg.role-user so they
-     apply during the is-editable ↔ is-editing swap, not just hover.
-     Nothing to add here. */
 }
-.msg.role-user.is-editable:hover {
+.msg.role-user.is-editable[data-edit-phase="view"]:hover {
   /* Layer the (possibly semi-transparent) hover color on TOP of the opaque
      input-background so scrolling text behind the pinned bubble never shows
      through during hover. Without this, on themes where
      --vscode-list-hoverBackground is rgba(...) with low alpha, hover would
-     reveal the chat content scrolling beneath the sticky message. */
+     reveal the chat content scrolling beneath the sticky message.
+     Keep the resting border color on hover: the bottom prompt only switches
+     to the focus/white border while focused, and letting hover do the same
+     caused a white flash after the edit overlay finished closing. */
   background:
     linear-gradient(0deg, var(--vscode-list-hoverBackground), var(--vscode-list-hoverBackground)),
     var(--vscode-input-background);
-  border-color: var(--vscode-input-border, var(--vscode-focusBorder));
+  border-color: var(--color-border);
 }
-.msg.role-user.is-editable:focus-visible {
+.msg.role-user.is-editable[data-edit-phase="view"]:focus-visible {
   outline: 1px solid var(--vscode-focusBorder);
   outline-offset: 1px;
 }
-.msg.role-user.is-editing {
+/* Placeholder freeze for editing AND closing. The bubble's flow box is
+   locked to `--edit-placeholder-height` so the absolute `.user-edit-layer`
+   can grow over it without nudging subsequent content. */
+.msg.role-user:not([data-edit-phase="view"]) {
   cursor: default;
-  /* Inherit padding from the base .msg.role-user so the outer geometry is
-     identical to display mode — that's what eliminates the visual jump
-     when the bubble swaps from `.user-text` to `<textarea>`. Only the
-     chrome (focusBorder) and the click target (cursor) change. */
+  height: var(--edit-placeholder-height, auto);
+  padding: 0;
+  /* Keep the hidden placeholder's border/background at the same resting values
+     as the normal bubble. If edit mode uses `border: 0`, Chromium restores the
+     normal border through `currentColor` for a frame after the overlay closes,
+     which reads as a second white-to-gray flash. */
+  border: 1px solid var(--color-border);
   background: var(--color-bg-input);
-  border-color: var(--color-accent);
-  /* Keep later dialogue stationary while the editor grows over that space. */
-  margin-bottom: calc(var(--message-gap) - var(--edit-overlap, 0px));
+  box-shadow: none;
+  overflow: visible;
+  transition: none;
   z-index: var(--z-overlay);
+}
+.user-edit-layer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: var(--z-overlay);
+  padding: var(--bubble-padding);
+  border: 1px solid var(--color-border-focus);
+  border-radius: var(--radius);
+  background: var(--color-bg-input);
+  box-shadow: 0 12px 18px -10px var(--vscode-widget-shadow, rgba(0, 0, 0, 0.45));
+  animation: user-edit-border-in 0.18s ease both;
+}
+.msg.role-user[data-edit-phase="closing"] .user-edit-layer {
+  pointer-events: none;
+  /* MUST stay named `user-edit-border-out` — `MessageView`'s
+     `handleOverlayAnimationEnd` filters on this name to advance the phase
+     from `closing` to `view`. Renaming the keyframes without updating the
+     `CLOSING_ANIMATION` constant in TS will leave the bubble stuck in the
+     closing state forever. */
+  animation: user-edit-border-out 0.18s ease both;
+}
+@keyframes user-edit-border-in {
+  from { border-color: var(--color-border); }
+  to { border-color: var(--color-border-focus); }
+}
+@keyframes user-edit-border-out {
+  from { border-color: var(--color-border-focus); }
+  to { border-color: var(--color-border); }
 }
 .user-edit-hint {
   position: absolute;
@@ -965,7 +1007,7 @@ button {
   pointer-events: none;
   transition: opacity 0.12s ease, color 0.12s ease;
 }
-.msg.role-user.is-editable:hover .user-edit-hint {
+.msg.role-user.is-editable[data-edit-phase="view"]:hover .user-edit-hint {
   opacity: 1;
   color: var(--vscode-foreground);
 }
@@ -2013,9 +2055,9 @@ button {
   display: flex;
   align-items: center;
   gap: 6px;
-  /* Match the edit-mode tighter spacing (was 6 px) — the `.is-editing`
-     CSS already overrides this to 3 px; matching it here makes send
-     and edit modes visually consistent. */
+  /* Match the edit-mode tighter spacing (was 6 px) — the non-view phase
+     selector overrides this to 3 px; matching it here keeps the send
+     prompt and edit overlay visually consistent. */
   margin-top: 3px;
   min-width: 0;
 }


### PR DESCRIPTION
## Summary

Replaces the user-message bubble's three-boolean edit lifecycle (`editing` + `editClosing` + `editPlaceholderHeight`) plus its `setTimeout(180)` with one discriminated union and an animation-event-driven transition.

```ts
type EditPhase = "view" | "editing" | "closing"
```

The bubble row carries `data-edit-phase={editPhase}` as the single source of truth; CSS keys on `[data-edit-phase="…"]` and `:not([data-edit-phase="view"])`.

## Why

Multiple rules used to touch the same border — `.msg.role-user`, `.is-editable:hover`, `.is-editing`, `.is-edit-closing .user-edit-layer` — with overlapping class-name specificity. The actual visual state was the *combination* of several booleans, easy to misread. A `setTimeout(180)` advanced closing → view; the CSS animation duration was `0.18s`. Bumping either independently silently desynchronised the JS and visual transitions.

The state machine collapses both problems:

| Old | New | Why |
|---|---|---|
| `editing`, `editClosing`, `editPlaceholderHeight` booleans | One `EditPhase` value | The visual state can no longer be the combination of overlapping booleans. |
| `is-editing` / `is-edit-closing` / `is-editable` class composition | `data-edit-phase` attribute selectors | CSS rules become mutually exclusive by construction — `[data-edit-phase="closing"]` cannot fire when `[data-edit-phase="editing"]` is set. |
| `.is-editable:hover { … }` | `.is-editable[data-edit-phase="view"]:hover { … }` | Hover/focus rules physically cannot fire during editing or closing — that's the structural guarantee. |
| `setTimeout(180)` to advance closing → view | Native `addEventListener("animationend", …)` on the overlay ref, filtered to the closing animation name | CSS animation duration is the sole source of truth; the JS reads it via the event, not a magic number. |

## Implementation notes

- Re-entering edit during the closing animation jumps phase straight back to `editing`. The overlay's CSS `animation` property switches from border-out to border-in, the outgoing animation simply stops (animation replacement doesn't dispatch an `animationend` event), and the entering animation plays from the current intermediate border colour.
- Native `addEventListener` (not React's synthetic `onAnimationEnd` prop) — works reliably in both production and in jsdom tests where `fireEvent.animationEnd` would otherwise miss React's synthetic handler.
- The closing-animation name (`user-edit-border-out`) lives both in CSS and as a TS constant (`CLOSING_ANIMATION`). A code comment on the CSS keyframes block flags this coupling explicitly.

## Carried forward from the working-tree fix that motivated the refactor

This PR also incorporates the user-authored overlay fix that was uncommitted on `main`:

- The editing UI renders inside a `.user-edit-layer` absolute overlay (`position: absolute; inset: 0`); the bubble's flow box is locked to `--edit-placeholder-height` (captured on edit-entry). The overlay can grow without affecting flow — assistant text below never gets nudged.
- `usePromptText`'s textarea auto-resize moves from `useEffect` to `useLayoutEffect` so the textarea reaches its content-fit height before paint.

## Test plan

- [x] `bun run test` — 491 webview tests pass, including the new behaviour:
  - "freezes the message footprint while the edit overlay expands" asserts `data-edit-phase="editing"` and `--edit-placeholder-height` on entry.
  - The three close-path tests (Cancel / click-outside / Escape) assert `data-edit-phase="closing"` immediately, then simulate `animationend` with `animationName` set via `Object.defineProperty` and assert `data-edit-phase="view"` + textarea unmounted.
- [x] `bun run check-types` — clean.
- [x] `cd webview && bunx tsc --noEmit` — same 3 pre-existing errors documented in CLAUDE.md, unchanged.
- [x] `bun run build:webview` — clean bundle.
- [ ] Visual smoke test in dev-host: confirm assistant text below never reflows on entering/exiting edit on any bubble (top/middle/bottom); confirm border-in and border-out animations play; confirm re-entering edit during closing snaps back cleanly.

Closes #85