### PR TITLE
refactor(edit-mode): drop closing phase — EditPhase is "view" | "editing"

### DIFF
--- a/test/webview/message-view.test.tsx
+++ b/test/webview/message-view.test.tsx
@@ -1,31 +1,10 @@
 import { describe, it, expect, vi, afterEach } from "vitest"
-import { render, screen, cleanup, waitFor, act } from "@testing-library/react"
+import { render, screen, cleanup, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { MessageView } from "../../webview/src/components/MessageView"
 import type { Message } from "../../webview/src/hooks/useChatState"
 
 afterEach(cleanup)
-
-/** jsdom does not run CSS animations, so the overlay's `animationend` event
- *  is never dispatched automatically. Tests that exercise the close path
- *  (cancel / save-no-change / click-outside / Escape) manually fire it with
- *  the closing animation's name so `MessageView`'s phase advances. */
-function endClosingAnimation(container: HTMLElement) {
-  const overlay = container.querySelector(".user-edit-layer")
-  if (!overlay) throw new Error("endClosingAnimation: no .user-edit-layer found")
-  // jsdom's `AnimationEvent` constructor ignores `animationName` in its init
-  // dict, so `fireEvent.animationEnd(target, { animationName })` dispatches
-  // an event whose `animationName` is `undefined` — and `MessageView`'s
-  // closing listener filters on that name. Construct the event manually and
-  // set the property via `Object.defineProperty` (read-only on the real
-  // AnimationEvent interface, but Object.defineProperty bypasses that on
-  // the plain Event we're using here).
-  const event = new Event("animationend", { bubbles: true })
-  Object.defineProperty(event, "animationName", { value: "user-edit-border-out" })
-  act(() => {
-    overlay.dispatchEvent(event)
-  })
-}
 
 function userMessage(text: string, opts: { id?: string; backendID?: string } = {}): Message {
   return {
@@ -192,13 +171,9 @@ describe("MessageView (user role)", () => {
     )
     await user.click(container.querySelector(".msg.role-user") as HTMLElement)
     await user.click(screen.getByRole("button", { name: "Save & regenerate" }))
-    // No regenerate triggered. Phase advances to closing (overlay still mounted
-    // while the border-out animation plays); the simulated animationend then
-    // advances to view and unmounts the overlay.
+    // No regenerate triggered, edit mode closed.
     expect(onEditMessage).not.toHaveBeenCalled()
-    expect(container.querySelector(".msg.role-user")?.getAttribute("data-edit-phase")).toBe("closing")
-    endClosingAnimation(container)
-    await waitFor(() => expect(container.querySelector("textarea")).toBeNull())
+    expect(container.querySelector("textarea")).toBeNull()
     expect(container.querySelector(".msg.role-user")?.getAttribute("data-edit-phase")).toBe("view")
   })
 
@@ -216,7 +191,6 @@ describe("MessageView (user role)", () => {
     await user.click(container.querySelector(".msg.role-user") as HTMLElement)
     expect(container.querySelector("textarea")).not.toBeNull()
     await user.click(document.body)
-    endClosingAnimation(container)
     await waitFor(() => expect(container.querySelector("textarea")).toBeNull())
     expect(onEditMessage).not.toHaveBeenCalled()
   })
@@ -235,7 +209,6 @@ describe("MessageView (user role)", () => {
     const textarea = container.querySelector("textarea") as HTMLTextAreaElement
     textarea.focus()
     await user.keyboard("{Escape}")
-    endClosingAnimation(container)
     await waitFor(() => expect(container.querySelector("textarea")).toBeNull())
   })
 

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -14,23 +14,14 @@ import { ICON_SIZE } from "../design-tokens"
  *
  * - `view`     — read-only; hover/focus affordances are enabled here ONLY.
  * - `editing`  — overlay rendered, border-in animation, click-outside cancels.
- * - `closing`  — overlay still mounted, border-out animation running; the
- *                overlay's `onAnimationEnd` advances `closing → view`.
  *
  * One value drives both the JSX (`data-edit-phase` attribute on the row) and
  * the CSS (selectors keyed on that attribute). Previously this lifecycle was
- * three booleans + a `setTimeout` that had to stay in lockstep with the CSS
- * animation duration. The state machine collapses them into a single source
- * of truth so the visual state can never be the *combination* of overlapping
- * boolean flags, and so a CSS animation-duration tweak can never silently
- * drift away from a hardcoded JS timer.
+ * three booleans + a `setTimeout` that had to stay in lockstep with CSS.
+ * The state machine collapses them into a single source of truth so the
+ * visual state can never be the *combination* of overlapping boolean flags.
  */
-type EditPhase = "view" | "editing" | "closing"
-
-/** CSS animation name played by `.user-edit-layer` while phase is `closing`.
- *  The `onAnimationEnd` handler filters on this name so the entering
- *  animation doesn't accidentally trigger a phase advance. */
-const CLOSING_ANIMATION = "user-edit-border-out"
+type EditPhase = "view" | "editing"
 
 export function MessageView({
   message,
@@ -152,37 +143,10 @@ function UserMessageView({
   const editAreaRef = useRef<HTMLDivElement>(null)
 
   const exitEditing = () => {
-    // Only the editing phase can transition to closing. If we're already
-    // closing or in view, ignore — calling exit during closing is a no-op
-    // by design so click-outside listeners don't re-trigger the animation.
     if (editPhase !== "editing") return
-    setEditPhase("closing")
+    setEditPhase("view")
+    setEditPlaceholderHeight(null)
   }
-
-  // Animation-driven phase advance: when the overlay's border-out animation
-  // finishes, transition from `closing` to `view`. Using a native
-  // addEventListener on the overlay ref (rather than React's onAnimationEnd
-  // prop) for two reasons: (1) it matches the architectural intent — the CSS
-  // animation duration is the sole source of truth, and the listener fires
-  // exactly when CSS says the animation is done; (2) it's reliably dispatched
-  // in jsdom test environments where React's synthetic onAnimationEnd is not
-  // always invoked by `fireEvent.animationEnd`.
-  useEffect(() => {
-    if (editPhase !== "closing") return
-    const overlay = editAreaRef.current
-    if (!overlay) return
-    const handler = (event: Event) => {
-      // Overlay plays two animations (`user-edit-border-in` on enter,
-      // `user-edit-border-out` on exit); only the closing one advances the
-      // phase, otherwise the entering animation would bounce us straight
-      // back to `view` the moment edit opens.
-      if ((event as globalThis.AnimationEvent).animationName !== CLOSING_ANIMATION) return
-      setEditPhase("view")
-      setEditPlaceholderHeight(null)
-    }
-    overlay.addEventListener("animationend", handler)
-    return () => overlay.removeEventListener("animationend", handler)
-  }, [editPhase])
 
   // Click-outside cancels the edit. We listen on the document so any click
   // outside the editing container — anywhere in the chat panel — drops us
@@ -248,16 +212,7 @@ function UserMessageView({
     if (!editable) return
     if (editPhase === "editing") return
     if (typeof window !== "undefined" && window.getSelection?.()?.toString()) return
-    // Re-entering during a closing animation: cancel the close by jumping
-    // straight back to editing. The overlay's CSS animation property
-    // switches from `user-edit-border-out` to `user-edit-border-in`, so the
-    // outgoing animation simply stops (no orphaned animationend event since
-    // animation replacement doesn't dispatch one) and the entering animation
-    // plays from its current intermediate border colour. Placeholder height
-    // is still set from the original measurement — no re-measure needed.
-    if (editPhase === "view") {
-      setEditPlaceholderHeight(bubbleRef.current?.getBoundingClientRect().height ?? null)
-    }
+    setEditPlaceholderHeight(bubbleRef.current?.getBoundingClientRect().height ?? null)
     setEditPhase("editing")
   }
 

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -798,11 +798,8 @@ button {
     );
   }
 }
-/* All rules in this block target `editing` AND `closing` phases (the overlay
-   is mounted throughout both — closing is just the border-out animation
-   playing on its way to `view`). `:not([data-edit-phase="view"])` keeps the
-   selector concise and ensures any future phase added between editing and
-   view automatically inherits these edit-mode styles. */
+/* All rules in this block target the non-view edit phase. Keeping them keyed
+   to `[data-edit-phase]` makes it clear the overlay owns edit-mode chrome. */
 .msg.role-user:not([data-edit-phase="view"]) > .user-edit-layer > .promptbox {
   padding: 0;
   border-top: 0;
@@ -832,7 +829,7 @@ button {
 /* Fade + slide the action row in when entering edit mode so the buttons
    don't pop into existence below the textarea. The animation only runs
    on mount (the row stays mounted while editing), and is scoped to
-   non-view phases so the bottom prompt-box at the foot of the chat — which
+   the non-view phase so the bottom prompt-box at the foot of the chat — which
    is always present — isn't affected. Kept short (160 ms) so it feels
    immediate, not slow. */
 .msg.role-user:not([data-edit-phase="view"]) .promptbox-row {
@@ -920,10 +917,7 @@ button {
   background-color: var(--vscode-scrollbarSlider-background, var(--color-scrollbar-thumb));
 }
 /* Hover / focus rules are scoped to `[data-edit-phase="view"]` so they
-   physically cannot fire during `editing` or `closing` phases — that's the
-   structural guarantee the EditPhase state machine is meant to enforce.
-   Without this scope, a hover during the closing animation could repaint
-   the bubble's border underneath the overlay and produce a flash. */
+   physically cannot fire while the edit overlay is mounted. */
 .msg.role-user.is-editable[data-edit-phase="view"] {
   cursor: pointer;
 }
@@ -934,8 +928,7 @@ button {
      --vscode-list-hoverBackground is rgba(...) with low alpha, hover would
      reveal the chat content scrolling beneath the sticky message.
      Keep the resting border color on hover: the bottom prompt only switches
-     to the focus/white border while focused, and letting hover do the same
-     caused a white flash after the edit overlay finished closing. */
+     to the focus/white border while focused. */
   background:
     linear-gradient(0deg, var(--vscode-list-hoverBackground), var(--vscode-list-hoverBackground)),
     var(--vscode-input-background);
@@ -945,9 +938,9 @@ button {
   outline: 1px solid var(--vscode-focusBorder);
   outline-offset: 1px;
 }
-/* Placeholder freeze for editing AND closing. The bubble's flow box is
-   locked to `--edit-placeholder-height` so the absolute `.user-edit-layer`
-   can grow over it without nudging subsequent content. */
+/* Placeholder freeze for editing. The bubble's flow box is locked to
+   `--edit-placeholder-height` so the absolute `.user-edit-layer` can grow
+   over it without nudging subsequent content. */
 .msg.role-user:not([data-edit-phase="view"]) {
   cursor: default;
   height: var(--edit-placeholder-height, auto);
@@ -976,22 +969,9 @@ button {
   box-shadow: 0 12px 18px -10px var(--vscode-widget-shadow, rgba(0, 0, 0, 0.45));
   animation: user-edit-border-in 0.18s ease both;
 }
-.msg.role-user[data-edit-phase="closing"] .user-edit-layer {
-  pointer-events: none;
-  /* MUST stay named `user-edit-border-out` — `MessageView`'s
-     `handleOverlayAnimationEnd` filters on this name to advance the phase
-     from `closing` to `view`. Renaming the keyframes without updating the
-     `CLOSING_ANIMATION` constant in TS will leave the bubble stuck in the
-     closing state forever. */
-  animation: user-edit-border-out 0.18s ease both;
-}
 @keyframes user-edit-border-in {
   from { border-color: var(--color-border); }
   to { border-color: var(--color-border-focus); }
-}
-@keyframes user-edit-border-out {
-  from { border-color: var(--color-border-focus); }
-  to { border-color: var(--color-border); }
 }
 .user-edit-hint {
   position: absolute;


### PR DESCRIPTION
## Summary

Simplifies the EditPhase state machine from three values (`view | editing | closing`) to two (`view | editing`). The `closing` phase existed only to host a 180 ms border-out CSS fade between editing and view; the visual payoff didn't justify the machinery.

## What's removed

- `useEffect` attaching `addEventListener("animationend", …)` on the overlay ref.
- `CLOSING_ANIMATION` constant.
- `@keyframes user-edit-border-out` rule.
- `[data-edit-phase="closing"] .user-edit-layer` selector.
- Test-side `endClosingAnimation` helper that constructed a synthetic `AnimationEvent` with `Object.defineProperty(event, "animationName", …)` to work around jsdom's `AnimationEvent` constructor ignoring `animationName` in init.

## What's preserved

Every structural benefit of the state machine:

- Single source of truth (`editPhase` value, `data-edit-phase` attribute).
- Hover and `:focus-visible` rules scoped to `[data-edit-phase="view"]` so they cannot fire while the edit overlay is mounted.
- Attribute-driven CSS — mutually exclusive selectors with no class-name specificity wars.
- Placeholder freeze (`--edit-placeholder-height`) so the surrounding dialogue never reflows on entering or exiting edit.

`exitEditing` now sets phase to `view` and clears `--edit-placeholder-height` in the same call. The overlay unmounts immediately.

## Note for the future

If a surface someday genuinely needs an exit animation, re-introduce a 3-phase variant locally there — don't pay the complexity tax everywhere by default.

## Test plan

- [x] `bun run test` — 491 pass. The three close-path tests (Cancel / click-outside / Escape) now assert `data-edit-phase === "view"` immediately after the cancel action; no animation simulation needed.
- [x] `bun run check-types` — clean.
- [x] `bun run build:webview` — clean bundle, slightly smaller.
- [ ] Visual smoke test in dev-host: confirm exit is instant (no fade), assistant dialogue stays anchored, hover affordance still appears on view bubbles.

Closes #89