### PR TITLE
chore(release): cut v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-05-17
+
+### Changed
+- Internal: simplified the EditPhase state machine from three values (`view | editing | closing`) to two (`view | editing`). The `closing` phase existed only to host a 180 ms border-out CSS fade between editing and view; the visual payoff didn't justify the machinery. Removed: the `useEffect` attaching an `animationend` listener on the overlay, the `CLOSING_ANIMATION` constant coupling JS to a CSS keyframes name, the `@keyframes user-edit-border-out` rule + its `[data-edit-phase="closing"]` selector, and the test-side `endClosingAnimation` helper that constructed a synthetic `AnimationEvent` with `animationName` set via `Object.defineProperty` to work around jsdom's constructor limitation. Every structural benefit of the state machine is preserved — single source of truth, scoped hover/focus rules, attribute-driven CSS, placeholder freeze. `exitEditing` now sets phase to `view` and clears the placeholder height in the same call; the overlay unmounts immediately. If a surface ever genuinely needs an exit animation, re-introduce a 3-phase variant locally there. Closes #89.
+
 ## [0.6.2] - 2026-05-17
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
Patch release for the EditPhase simplification merged in #90. The state machine drops from three values to two; the closing-phase machinery (animation listener, CSS keyframes for the out fade, jsdom test workaround) is gone. Exit edit mode is now instant.

Closes #91

After merge:

\`\`\`bash
git checkout main && git pull
git tag v0.6.3
git push origin v0.6.3
gh release create v0.6.3 --title "v0.6.3" --notes-from-tag
\`\`\`