### PR TITLE
chore(release): cut v0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.6.4] - 2026-05-18
+
+### Changed
+- Docs: trimmed the README from 176 lines to 69 by dropping the maintainer-focused sections (Tests, Packaging, Backend management, six per-feature subsections) and folding the remaining user-facing prose into an 8-bullet Highlights list. Adds four screenshots (welcome panel, Model · Agent · Effort picker, per-workspace chat history, edit-and-regenerate flow) in a compact 2×2 grid above the fold. Each image is width-constrained via an HTML `<table>` + `<img width="340">` so the two tall portrait shots don't dominate. The VS Code Marketplace listing renders relative-path PNGs and inline HTML natively, so the new listing has an actual visual hook for first-time browsers instead of just text. Closes #71, #93.
+
 ## [0.6.3] - 2026-05-17
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
Patch release for the README trim + 4-screenshot grid merged in #72. Gives the Marketplace listing an above-the-fold visual hook for first-time browsers — the single highest-leverage install-conversion lever for a VS Code extension.

Closes #95

After merge:

\`\`\`bash
git checkout main && git pull
git tag v0.6.4
git push origin v0.6.4
gh release create v0.6.4 --title "v0.6.4" --notes-from-tag
\`\`\`