### PR TITLE
fix(chat): pull edit overlay 1px outward to cover placeholder border

### DIFF
--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -958,9 +958,13 @@ button {
 }
 .user-edit-layer {
   position: absolute;
-  top: 0;
-  right: 0;
-  left: 0;
+  /* Cover the placeholder's border box, not its padding box. The placeholder
+     keeps a real 1px resting border to avoid close-time color flashes; without
+     this offset the edit overlay starts inside that border and the textarea
+     glyphs land 1px lower/right than `.user-text`. */
+  top: -1px;
+  right: -1px;
+  left: -1px;
   z-index: var(--z-overlay);
   padding: var(--bubble-padding);
   border: 1px solid var(--color-border-focus);


### PR DESCRIPTION
## Summary

- Shift \`.user-edit-layer\` by \`-1px\` on top / left / right so its border overlaps the placeholder's 1px border instead of sitting inside it.
- Fixes the subtle "the words still move a little bit" glyph shift when entering edit mode.

## Why

With \`box-sizing: border-box\` globally, the placeholder bubble's 1px border is inside its outer rect. \`position: absolute; top: 0\` on \`.user-edit-layer\` resolved relative to the placeholder's padding box (per the spec), not its border box, so the overlay's border landed 1px below + inset from the placeholder's outer edge. The textarea inside cascaded that offset, so glyphs ended up 1px lower and 1px more inset than the view-mode \`.user-text\`.

Pulling the overlay outward by exactly the placeholder's border width makes the borders pixel-overlap; glyph positions are now identical across view and edit. Bottom intentionally stays at \`auto\` — the overlay can still extend below the bubble's box when it's taller than the placeholder (action row), and that visual is correct.

## Test plan

- [x] \`bun run test\` — 491/491 pass.
- [x] \`bun run check-types\` — clean.
- [ ] Visual: open a chat, click an existing user message — glyphs should not shift when the textarea takes over.

Closes #97