### PR TITLE
chore(release): cut v0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.6.5] - 2026-05-18
+
+### Fixed
+- Entering edit mode on a user-message bubble no longer shifts the textarea glyphs 1px down + inset from where the rendered `.user-text` painted in view mode. With `box-sizing: border-box` set globally, the placeholder bubble's `border: 1px` lives inside its outer rect, and `position: absolute; top/left/right: 0` on `.user-edit-layer` resolves relative to the placeholder's *padding box* (per the CSS spec) — not its border box — so the overlay's own border landed 1px inside the placeholder's edge, and the textarea inside cascaded that offset. Pulling the overlay outward by `-1px` on top, left, and right makes the overlay's border overlap the placeholder's border pixel-for-pixel; glyph positions are now identical across view and edit. Bottom intentionally stays `auto` — the overlay still grows downward when its action row makes it taller than the placeholder, which is correct (the placeholder freeze keeps following content anchored regardless). Closes #97.
+
 ## [0.6.4] - 2026-05-18
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Bump \`package.json\` from 0.6.4 → 0.6.5.
- CHANGELOG entry for 0.6.5 covering #97 / #98 (edit-overlay border-box alignment fix).

## Test plan

- [x] \`bun run test\` — 491/491 pass (verified pre-merge on #98).
- [x] \`bun run check-types\` — clean.
- [ ] Post-merge: tag \`v0.6.5\` on main, push, create GitHub Release → \`release.yml\` workflow publishes to the VS Code Marketplace.

Closes #99