### PR TITLE
chore(release): cut v0.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.6.6] - 2026-05-18
+
+### Changed
+- Internal: hoisted the bubble's border width into a shared CSS token (`--bubble-border-width: 1px`) so the placeholder bubble and the absolute edit overlay stay structurally coupled instead of agreeing only through hand-matched literals. The 0.6.5 fix that pulled `.user-edit-layer` outward by `-1px` on top/left/right correctly aligned the overlay's border with the placeholder's, but the relationship between the two was encoded in two unrelated declarations (`.msg.role-user { border: 1px }` and `.user-edit-layer { top/left/right: -1px; border: 1px }`) — bumping the placeholder's border to 2px would have silently broken alignment again. Three rules now reference `var(--bubble-border-width)`: the resting `.msg.role-user` border, the edit-mode placeholder border (re-asserted to prevent the close-time color flash), and the overlay's `top/left/right` offsets + its own border-width. Identical pattern to how `--bubble-padding` / `--bubble-text-padding` already couple `.user-text` and the edit-mode textarea. Zero visual or behavioural change at the current `1px` value — the alignment invariant is now enforced by structure instead of by code review. Closes #101.
+
 ## [0.6.5] - 2026-05-18
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Bump \`package.json\` from 0.6.5 → 0.6.6.
- CHANGELOG entry for 0.6.6 covering #101 / #102 (token hoist for placeholder + overlay coupling).

## Test plan

- [x] \`bun run test\` — 491/491 pass (verified pre-merge on #102).
- [x] \`bun run check-types\` — clean.
- [ ] Post-merge: tag \`v0.6.6\` on main, push, create GitHub Release → \`release.yml\` workflow publishes to the VS Code Marketplace.

Closes #103