### PR TITLE
fix(chat): render markdown inside reasoning blocks

### DIFF
--- a/test/webview/message-view.test.tsx
+++ b/test/webview/message-view.test.tsx
@@ -271,6 +271,45 @@ describe("MessageView (assistant role)", () => {
     expect(screen.getByText(/0\.0025/)).toBeInTheDocument()
     expect(screen.getByText(/150 tokens/)).toBeInTheDocument()
   })
+
+  it("renders markdown in reasoning body when a title is extracted", () => {
+    const msg = {
+      id: "a-reason-titled",
+      role: "assistant",
+      blocks: [
+        {
+          type: "reasoning",
+          text: "## Approach\n\n- decode the input\n- dispatch to `handler`\n- emit a result",
+        },
+      ],
+    } as Message
+    const { container } = render(
+      <MessageView message={msg} processOpen={true} processOnly={false} />,
+    )
+    expect(container.querySelector(".process-text-title")?.textContent).toBe("Approach")
+    expect(container.querySelectorAll(".process-text li").length).toBe(3)
+    expect(container.querySelector(".process-text code")?.textContent).toBe("handler")
+  })
+
+  it("renders markdown headings in reasoning body when no title is extracted", () => {
+    const msg = {
+      id: "a-reason-notitle",
+      role: "assistant",
+      blocks: [
+        {
+          type: "reasoning",
+          // Long first line defeats textTitle's <8-word guard, so the whole
+          // block flows through Markdown without title extraction.
+          text: "This reasoning has a very long first sentence that should never be promoted to a panel title field.\n\n## Sub-Heading\n\n- one\n- two",
+        },
+      ],
+    } as Message
+    const { container } = render(
+      <MessageView message={msg} processOpen={true} processOnly={false} />,
+    )
+    expect(container.querySelector(".process-text h2")?.textContent).toBe("Sub-Heading")
+    expect(container.querySelectorAll(".process-text li").length).toBe(2)
+  })
 })
 
 describe("MessageView edit preserves mentions + attachments", () => {

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -482,12 +482,12 @@ function renderBlocks(blocks: Block[], processMode = false, onReviewFile?: (path
 function ProcessText({ text }: { text: string }) {
   if (!text.trim()) return null
   const title = textTitle(text)
-  if (!title) return <div className="process-text">{text}</div>
+  if (!title) return <div className="process-text"><Markdown text={text} /></div>
   const body = stripDuplicateTitle(text, title)
   return (
     <div className="process-text">
       <div className="process-text-title">{title}</div>
-      {body && <div>{body}</div>}
+      {body && <Markdown text={body} />}
     </div>
   )
 }

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -1196,6 +1196,10 @@ button {
   line-height: 1.45;
   white-space: pre-wrap;
 }
+/* Markdown body inside ProcessText (reasoning blocks emit headings/lists/code).
+   `remarkBreaks` handles line breaks via <br>, so pre-wrap would only
+   re-introduce visual gaps around block elements — reset it here. */
+.process-text .md { white-space: normal; }
 .process-text-title {
   margin-bottom: 8px;
   color: var(--vscode-descriptionForeground);


### PR DESCRIPTION
## Summary
- Reasoning content with markdown markers (headings, bullets, fences) was rendering as raw `##` / `-` / backticks because `ProcessText` wrapped the body in a plain `<div>`.
- Swap to the existing `<Markdown>` component (GFM + math + breaks + Shiki). Title extraction stays — short single-line summaries still get the bold chip.
- Neutralise `white-space: pre-wrap` for nested `.md` so block elements don't get double-spaced.

## Test plan
- [x] `bun run test` — 493/493 pass (2 new reasoning-markdown tests added; titled + untitled code paths).
- [x] `bun run check-types` — clean.
- [x] webview `tsc --noEmit` — only the 3 pre-existing errors documented in CLAUDE.md (findLast / boolean|undefined); unrelated.
- [ ] Visual: open the panel with a thinking-enabled model and confirm `## Approach` / bullet lists / inline code render correctly.

Closes #105