### PR TITLE
feat(chat): render oh-my-openagent XML envelopes as markdown

### DIFF
--- a/test/webview/markdown.test.tsx
+++ b/test/webview/markdown.test.tsx
@@ -1,6 +1,10 @@
 import { describe, it, expect, afterEach } from "vitest"
 import { render, cleanup } from "@testing-library/react"
-import { Markdown, normalizeMath } from "../../webview/src/components/Markdown"
+import {
+  Markdown,
+  normalizeMath,
+  normalizeAgentEnvelopes,
+} from "../../webview/src/components/Markdown"
 
 afterEach(cleanup)
 
@@ -61,6 +65,85 @@ describe("normalizeMath", () => {
     const out = normalizeMath("Costs $5; equation \\(a^2 + b^2\\)")
     expect(out).toContain("\\$5")
     expect(out).toMatch(/\$a\^2 \+ b\^2\$/)
+  })
+})
+
+describe("normalizeAgentEnvelopes", () => {
+  it("converts <analysis>…</analysis> to a bold-labelled markdown block", () => {
+    const out = normalizeAgentEnvelopes("<analysis>I checked the imports.</analysis>")
+    expect(out).toContain("**Analysis**")
+    expect(out).toContain("I checked the imports.")
+    expect(out).not.toMatch(/<\/?analysis>/i)
+  })
+
+  it("converts <answer>…</answer> to a bold-labelled markdown block", () => {
+    const out = normalizeAgentEnvelopes("<answer>The hit is in foo.ts.</answer>")
+    expect(out).toContain("**Answer**")
+    expect(out).toContain("The hit is in foo.ts.")
+    expect(out).not.toMatch(/<\/?answer>/i)
+  })
+
+  it("converts <next_steps>…</next_steps> with a spaced label", () => {
+    const out = normalizeAgentEnvelopes("<next_steps>Read foo.ts and re-run tests.</next_steps>")
+    expect(out).toContain("**Next steps**")
+    expect(out).toContain("Read foo.ts and re-run tests.")
+    expect(out).not.toMatch(/<\/?next_steps>/i)
+  })
+
+  it("strips the outer <results> wrapper and transforms inner tags", () => {
+    const out = normalizeAgentEnvelopes(
+      "<results><answer>found</answer><next_steps>open it</next_steps></results>",
+    )
+    expect(out).toContain("**Answer**")
+    expect(out).toContain("**Next steps**")
+    expect(out).not.toMatch(/<\/?results>/i)
+    expect(out).not.toMatch(/<\/?answer>/i)
+  })
+
+  it("renders <files> as a bulleted list of code-spanned paths", () => {
+    const out = normalizeAgentEnvelopes("<files>\n/abs/foo.ts\n/abs/bar.ts\n</files>")
+    expect(out).toContain("**Files**")
+    expect(out).toContain("- `/abs/foo.ts`")
+    expect(out).toContain("- `/abs/bar.ts`")
+    expect(out).not.toMatch(/<\/?files>/i)
+  })
+
+  it("emits nothing for an empty <files> block", () => {
+    const out = normalizeAgentEnvelopes("before<files></files>after")
+    expect(out).not.toMatch(/<\/?files>/i)
+    expect(out).not.toMatch(/\*\*Files\*\*/)
+    expect(out).toContain("before")
+    expect(out).toContain("after")
+  })
+
+  it("leaves envelope tags inside fenced code blocks untouched", () => {
+    const input = "Outside <analysis>x</analysis>\n\n```ts\nconst s = \"<analysis>literal</analysis>\"\n```"
+    const out = normalizeAgentEnvelopes(input)
+    expect(out).toContain("**Analysis**")
+    expect(out).toContain('const s = "<analysis>literal</analysis>"')
+  })
+
+  it("is a no-op when no envelope tags are present", () => {
+    const input = "plain **markdown** with no XML"
+    expect(normalizeAgentEnvelopes(input)).toBe(input)
+  })
+
+  it("handles the full oh-my-openagent explore envelope end-to-end", () => {
+    const input =
+      "<analysis>Searched grep.</analysis>\n" +
+      "<results>\n" +
+      "<files>\n/Users/a/foo.ts\n/Users/a/bar.ts\n</files>\n" +
+      "<answer>Two hits — both call the helper.</answer>\n" +
+      "<next_steps>Open foo.ts first.</next_steps>\n" +
+      "</results>"
+    const out = normalizeAgentEnvelopes(input)
+    expect(out).toContain("**Analysis**")
+    expect(out).toContain("**Files**")
+    expect(out).toContain("- `/Users/a/foo.ts`")
+    expect(out).toContain("**Answer**")
+    expect(out).toContain("**Next steps**")
+    // No raw tags survive.
+    expect(out).not.toMatch(/<\/?(analysis|results|files|answer|next_steps)>/i)
   })
 })
 
@@ -138,5 +221,16 @@ describe("Markdown component", () => {
     expect(() => {
       render(<Markdown text="$\\frac{1}{$" />)
     }).not.toThrow()
+  })
+
+  it("renders oh-my-openagent's <files> envelope as a bulleted list with code paths", () => {
+    const { container } = render(
+      <Markdown text={"<files>\n/abs/foo.ts\n/abs/bar.ts\n</files>"} />,
+    )
+    // Bold label, two list items, each path wrapped in a <code> span.
+    expect(container.querySelector("strong")?.textContent).toBe("Files")
+    expect(container.querySelectorAll("li")).toHaveLength(2)
+    const codes = Array.from(container.querySelectorAll("li code")).map((c) => c.textContent)
+    expect(codes).toEqual(["/abs/foo.ts", "/abs/bar.ts"])
   })
 })

--- a/webview/src/components/Markdown.tsx
+++ b/webview/src/components/Markdown.tsx
@@ -17,6 +17,68 @@ const I_OPEN = ""
 const I_CLOSE = ""
 
 /**
+ * Some agent packs (notably oh-my-openagent's `explore` agent) emit their
+ * answer wrapped in literal XML envelopes:
+ *
+ *   <analysis>…reasoning…</analysis>
+ *   <results>
+ *     <files>/abs/path/foo.ts\n/abs/path/bar.ts</files>
+ *     <answer>…</answer>
+ *     <next_steps>…</next_steps>
+ *   </results>
+ *
+ * react-markdown escapes raw HTML, so without this pre-processor the user
+ * sees the literal tags in their bubble. We don't accept arbitrary HTML
+ * pass-through (XSS risk in a webview), so instead we transform a small
+ * known set of envelope tags into bold-labelled markdown sections.
+ *
+ * Applied OUTSIDE fenced code blocks so that a teaching example like
+ * ```ts
+ *   "<analysis>..."
+ * ```
+ * survives unmodified.
+ */
+const ENVELOPE_LABELS: Record<string, string> = {
+  analysis: "Analysis",
+  answer: "Answer",
+  next_steps: "Next steps",
+}
+
+export function normalizeAgentEnvelopes(input: string): string {
+  const out: string[] = []
+  const fence = /```[\s\S]*?```|~~~[\s\S]*?~~~/g
+  let last = 0
+  let m: RegExpExecArray | null
+  while ((m = fence.exec(input)) !== null) {
+    out.push(rewriteEnvelopesOutsideCode(input.slice(last, m.index)))
+    out.push(m[0])
+    last = m.index + m[0].length
+  }
+  out.push(rewriteEnvelopesOutsideCode(input.slice(last)))
+  return out.join("")
+}
+
+function rewriteEnvelopesOutsideCode(s: string): string {
+  // Strip the outer <results>…</results> wrapper — its inner tags carry the
+  // meaningful content. We leave any unrecognized inner tags as-is on
+  // purpose; surfacing them as raw text is a useful signal that the agent
+  // pack has shapes opencui doesn't render yet.
+  let out = s.replace(/<\/?results>\s*/gi, "\n\n")
+  // <files>: one path per line → bulleted list of code-spanned paths so the
+  // narrow sidebar renders each on its own row.
+  out = out.replace(/<files>([\s\S]*?)<\/files>/gi, (_, body: string) => {
+    const items = body.split("\n").map((l) => l.trim()).filter(Boolean)
+    if (items.length === 0) return ""
+    return `\n\n**Files**\n\n${items.map((p) => `- \`${p}\``).join("\n")}\n\n`
+  })
+  for (const [tag, label] of Object.entries(ENVELOPE_LABELS)) {
+    const re = new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`, "gi")
+    out = out.replace(re, (_, body: string) => `\n\n**${label}**\n\n${body.trim()}\n\n`)
+  }
+  return out
+}
+
+/**
  * remark-math wants `$…$` (inline) and `$$…$$` (display). Reasoning models
  * commonly emit LaTeX `\(…\)` / `\[…\]` instead, and prose containing
  * currency like `$5 and $10` would otherwise parse as accidental math.
@@ -124,7 +186,7 @@ export function Markdown({ text }: Props) {
         rehypePlugins={[[rehypeKatex, katexOptions]]}
         components={components}
       >
-        {normalizeMath(text)}
+        {normalizeMath(normalizeAgentEnvelopes(text))}
       </ReactMarkdown>
     </div>
   )


### PR DESCRIPTION
## Summary
- New `normalizeAgentEnvelopes()` pre-processor in `Markdown.tsx`, chained ahead of `normalizeMath()`. Transforms `<analysis>` / `<answer>` / `<next_steps>` / `<files>` into bold-labelled markdown sections; strips the outer `<results>` wrapper.
- `<files>` gets a bulleted list of code-spanned paths so each one wraps to its own row in the narrow sidebar.
- Fence-aware: code-fenced examples containing literal envelope tags survive unmodified.
- Unknown tags fall through unchanged on purpose — they're a useful signal that an agent pack uses a shape opencui doesn't render yet.

## Test plan
- [x] `bun run test` — 503/503 pass (10 new envelope tests, 1 new integration test).
- [x] `bun run check-types` — clean.
- [ ] Visual: install oh-my-openagent's `explore` agent locally, ask a "where is X?" question, confirm the `<results>` envelope renders as bold-headed sections + bullet-listed file paths in the sidebar.

Closes #111