### PR TITLE
feat(workspace): introduce workspace root API (Phase 1 grounding)

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,16 @@
           "type": "string",
           "default": "",
           "description": "Default model id (provider/model)"
+        },
+        "opencui.opencodeConfigMode": {
+          "type": "string",
+          "enum": ["isolated", "user"],
+          "enumDescriptions": [
+            "Ignore the user's opencode config and plugins — use an empty config for predictable extension behavior.",
+            "Load the user's normal opencode config, agents, and plugins from disk."
+          ],
+          "default": "isolated",
+          "description": "Whether the opencode server started by OpenCode Panel loads the user's opencode config or runs with an empty isolated config."
         }
       }
     }

--- a/src/chat/prompt-builder.ts
+++ b/src/chat/prompt-builder.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode"
 import * as path from "path"
 import type { getEditorContext } from "../context"
+import type { WorkspaceRoot } from "../workspace-root"
 import { log } from "../output"
 
 const MENTION_MAX_BYTES = 200_000
@@ -10,8 +11,16 @@ export function buildPrompt(
   userText: string,
   ctx: ReturnType<typeof getEditorContext>,
   mentionBlock?: string,
+  workspace?: WorkspaceRoot,
 ): string {
   const lines: string[] = []
+  if (workspace) {
+    lines.push("Workspace:")
+    lines.push(`- Name: ${workspace.name}`)
+    lines.push(`- Root: ${workspace.fsPath}`)
+    lines.push("- Paths below are workspace-relative unless marked absolute.")
+    lines.push("")
+  }
   if (mentionBlock) {
     lines.push(mentionBlock)
     lines.push("")

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -14,6 +14,8 @@ import { getEditorContext, formatContextHeader } from "../context"
 import { searchWorkspaceFiles } from "../file-search"
 import { pickAttachments } from "../attachments"
 import { log } from "../output"
+import { getWorkspaceRoots, primaryWorkspaceRoot } from "../workspace-root"
+import type { WorkspaceInfo } from "../protocol"
 import type {
   Attachment,
   ChatBlock,
@@ -187,6 +189,11 @@ export class ChatView implements vscode.WebviewViewProvider {
     }, null, this.context.subscriptions)
     vscode.window.onDidChangeTextEditorSelection(
       () => this.pushContext(),
+      null,
+      this.context.subscriptions,
+    )
+    vscode.workspace.onDidChangeWorkspaceFolders(
+      () => this.pushWorkspace(),
       null,
       this.context.subscriptions,
     )
@@ -509,6 +516,27 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.post({ type: "context", ref: { path: ctx.filePath, label } })
   }
 
+  private pushWorkspace() {
+    this.post({ type: "workspace", workspace: this.workspaceInfo() })
+  }
+
+  private workspaceInfo(): WorkspaceInfo | undefined {
+    const root = primaryWorkspaceRoot()
+    if (!root) return undefined
+    const all = getWorkspaceRoots()
+    const configMode =
+      vscode.workspace.getConfiguration("opencui").get<string>("opencodeConfigMode") === "user"
+        ? "user"
+        : "isolated"
+    return {
+      name: root.name,
+      root: root.fsPath,
+      isDefault: root.isDefault,
+      multiRoot: all.length > 1,
+      configMode,
+    }
+  }
+
   private async onMessage(msg: Inbound) {
     switch (msg.type) {
       case "mounted": {
@@ -519,6 +547,7 @@ export class ChatView implements vscode.WebviewViewProvider {
         })
         this.sendConversationState()
         this.pushContext()
+        this.pushWorkspace()
         try {
           await this.servers.ensure()
           this.post({ type: "connected", connected: true })
@@ -920,7 +949,7 @@ export class ChatView implements vscode.WebviewViewProvider {
         })
       }
     }
-    parts.push({ type: "text", text: buildPrompt(text, ctx, mentionBlock) })
+    parts.push({ type: "text", text: buildPrompt(text, ctx, mentionBlock, backend.workspace) })
     type PromptBody = NonNullable<Parameters<typeof backend.client.session.prompt>[0]["body"]>
     const body: PromptBody = {
       parts: parts as PromptBody["parts"],

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,8 +3,11 @@ import * as path from "path"
 import { spawn, type ChildProcessWithoutNullStreams } from "child_process"
 import { createOpencodeClient, type OpencodeClient } from "@opencode-ai/sdk"
 import { log } from "./output"
+import { primaryWorkspaceRoot, type WorkspaceRoot } from "./workspace-root"
 
 const SERVER_START_TIMEOUT_MS = 60000
+
+export type OpencodeConfigMode = "isolated" | "user"
 
 type ServerHandle = {
   url: string
@@ -15,12 +18,23 @@ export type Backend = {
   url: string
   client: OpencodeClient
   directory: string
+  /**
+   * Workspace root the server was bound to at start time. Undefined when no
+   * folder was open — callers should treat that as "no automatic context"
+   * and avoid running git/find/etc. against an unknown cwd.
+   */
+  workspace?: WorkspaceRoot
+  /** Active opencode config-mode for this server lifecycle. */
+  configMode: OpencodeConfigMode
 }
 
 export class ServerManager {
   private server: ServerHandle | undefined
   private client: OpencodeClient | undefined
   private starting: Promise<Backend> | undefined
+  /** Workspace root captured at start time so subsequent `ensure()` calls return a stable Backend. */
+  private workspace: WorkspaceRoot | undefined
+  private configMode: OpencodeConfigMode = "isolated"
 
   constructor(private context: vscode.ExtensionContext) {}
 
@@ -40,20 +54,32 @@ export class ServerManager {
     const port = config.get<number>("serverPort") ?? 0
     const configuredBinaryPath = config.get<string>("binaryPath") || "opencode"
     const binaryPath = resolveBinaryPath(configuredBinaryPath, this.context.extensionPath)
+    const configMode = readConfigMode(config)
+    const workspace = primaryWorkspaceRoot()
 
-    log("starting opencode server", { configuredBinaryPath, resolved: binaryPath, port })
+    log("starting opencode server", {
+      configuredBinaryPath,
+      resolved: binaryPath,
+      port,
+      configMode,
+      workspace: workspace?.fsPath ?? "(no workspace)",
+    })
     const server = await startOpencodeServer(binaryPath, {
       hostname: "127.0.0.1",
       port: port || randomPort(),
       timeout: SERVER_START_TIMEOUT_MS,
+      cwd: workspace?.fsPath,
+      configMode,
     })
     log("opencode server ready at", server.url)
     const client = createOpencodeClient({
       baseUrl: server.url,
-      directory: workspaceDir(),
+      directory: workspace?.fsPath ?? process.cwd(),
     })
     this.server = server
     this.client = client
+    this.workspace = workspace
+    this.configMode = configMode
     return this.toBackend(server, client)
   }
 
@@ -68,11 +94,23 @@ export class ServerManager {
       this.server.close()
       this.server = undefined
       this.client = undefined
+      this.workspace = undefined
     }
   }
 
+  /** Workspace the running server is bound to, or undefined if not started yet. */
+  currentWorkspace(): WorkspaceRoot | undefined {
+    return this.workspace
+  }
+
   private toBackend(server: ServerHandle, client: OpencodeClient): Backend {
-    return { url: server.url, client, directory: workspaceDir() }
+    return {
+      url: server.url,
+      client,
+      directory: this.workspace?.fsPath ?? process.cwd(),
+      workspace: this.workspace,
+      configMode: this.configMode,
+    }
   }
 }
 
@@ -80,8 +118,9 @@ function randomPort() {
   return Math.floor(Math.random() * (65535 - 16384 + 1)) + 16384
 }
 
-function workspaceDir() {
-  return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? process.cwd()
+function readConfigMode(config: vscode.WorkspaceConfiguration): OpencodeConfigMode {
+  const value = config.get<string>("opencodeConfigMode")
+  return value === "user" ? "user" : "isolated"
 }
 
 function resolveBinaryPath(binaryPath: string, extensionPath: string): string {
@@ -111,13 +150,28 @@ function bundledBinaryPath(extensionPath: string): string | undefined {
 
 function startOpencodeServer(
   binaryPath: string,
-  options: { hostname: string; port: number; timeout: number },
+  options: {
+    hostname: string
+    port: number
+    timeout: number
+    /** Workspace root for the subprocess `cwd`. Undefined means inherit. */
+    cwd?: string
+    configMode: OpencodeConfigMode
+  },
 ): Promise<ServerHandle> {
+  // `isolated` keeps the historical behavior: hand opencode an empty config so
+  // the user's `~/.config/opencode` and any local config/plugins are ignored —
+  // gives the extension predictable defaults. `user` opts back in to the
+  // user's normal opencode environment (config, agents, plugins).
+  const env: NodeJS.ProcessEnv = { ...process.env }
+  if (options.configMode === "isolated") {
+    env.OPENCODE_CONFIG_CONTENT = "{}"
+  } else {
+    delete env.OPENCODE_CONFIG_CONTENT
+  }
   const proc = spawn(binaryPath, ["serve", `--hostname=${options.hostname}`, `--port=${options.port}`], {
-    env: {
-      ...process.env,
-      OPENCODE_CONFIG_CONTENT: "{}",
-    },
+    cwd: options.cwd,
+    env,
   })
 
   return new Promise((resolve, reject) => {

--- a/src/workspace-root.ts
+++ b/src/workspace-root.ts
@@ -1,0 +1,86 @@
+import * as vscode from "vscode"
+import * as path from "path"
+
+/**
+ * Resolved workspace root used for opencode server `cwd`, SDK `directory`,
+ * automatic context collection, and prompt grounding. Phases 2+ of the
+ * workspace-context plan key off this shape — see
+ * docs/workspace-context-and-indexing.md.
+ */
+export type WorkspaceRoot = {
+  uri: vscode.Uri
+  fsPath: string
+  name: string
+  /** Position in `vscode.workspace.workspaceFolders` — preserved for multi-root UIs. */
+  index: number
+  /** True when this is the first workspace folder (no active-editor signal needed). */
+  isDefault: boolean
+}
+
+export function getWorkspaceRoots(): WorkspaceRoot[] {
+  const folders = vscode.workspace.workspaceFolders ?? []
+  return folders.map((folder, index) => ({
+    uri: folder.uri,
+    fsPath: folder.uri.fsPath,
+    name: folder.name,
+    index,
+    isDefault: index === 0,
+  }))
+}
+
+/**
+ * The root that should drive this turn. Prefers the workspace folder that
+ * contains the active editor — that's the project the user is "in". Falls
+ * back to the first folder when no editor is focused on a workspace file.
+ * Returns undefined when there are no workspace folders at all, meaning
+ * callers should run in no-workspace mode (no automatic context, prompts
+ * carry no workspace declaration).
+ */
+export function primaryWorkspaceRoot(): WorkspaceRoot | undefined {
+  const active = vscode.window.activeTextEditor?.document.uri
+  const fromActive = active ? workspaceRootForUri(active) : undefined
+  if (fromActive) return fromActive
+  return getWorkspaceRoots()[0]
+}
+
+export function workspaceRootForUri(uri: vscode.Uri | undefined): WorkspaceRoot | undefined {
+  if (!uri || uri.scheme !== "file") return undefined
+  return workspaceRootForPath(uri.fsPath)
+}
+
+export function workspaceRootForPath(filePath: string | undefined): WorkspaceRoot | undefined {
+  if (!filePath) return undefined
+  const roots = getWorkspaceRoots()
+  // Prefer the longest matching root so a nested workspace folder wins over
+  // an outer one (rare but possible: a monorepo with both `repo` and
+  // `repo/packages/foo` opened as folders).
+  let best: WorkspaceRoot | undefined
+  for (const root of roots) {
+    if (!isInsideRoot(root, filePath)) continue
+    if (!best || root.fsPath.length > best.fsPath.length) best = root
+  }
+  return best
+}
+
+export function isInsideWorkspace(filePath: string): boolean {
+  return !!workspaceRootForPath(filePath)
+}
+
+export function isInsideRoot(root: WorkspaceRoot, filePath: string): boolean {
+  if (!filePath) return false
+  const rel = path.relative(root.fsPath, filePath)
+  // `path.relative` returns "" for the root itself, a `..`-prefixed string
+  // for paths above the root, and an absolute path on Windows when the two
+  // sides live on different drives.
+  if (rel === "") return true
+  if (rel.startsWith("..")) return false
+  if (path.isAbsolute(rel)) return false
+  return true
+}
+
+export function relativeToRoot(root: WorkspaceRoot, filePath: string): string {
+  const rel = path.relative(root.fsPath, filePath)
+  // Forward slashes for prompt and protocol consistency; the host's `path`
+  // module returns backslashes on Windows otherwise.
+  return rel.replace(/\\/g, "/")
+}

--- a/test/host/build-prompt.test.ts
+++ b/test/host/build-prompt.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, beforeEach, vi } from "vitest"
 import * as vscode from "vscode"
 import { buildPrompt, readMentions } from "../../src/chat/prompt-builder"
+import type { WorkspaceRoot } from "../../src/workspace-root"
+
+const FAKE_ROOT: WorkspaceRoot = {
+  uri: { fsPath: "/repo", scheme: "file" } as unknown as vscode.Uri,
+  fsPath: "/repo",
+  name: "repo",
+  index: 0,
+  isDefault: true,
+}
 
 describe("buildPrompt", () => {
   it("returns the user text when there is no editor context or mentions", () => {
@@ -40,6 +49,20 @@ describe("buildPrompt", () => {
     const out = buildPrompt("explain", {}, "Files attached:\n@a.ts\n```ts\nx\n```")
     expect(out).toContain("Files attached:")
     expect(out).toContain("explain")
+  })
+
+  it("prepends a workspace declaration when a root is provided", () => {
+    const out = buildPrompt("hi", { relativePath: "src/foo.ts" }, undefined, FAKE_ROOT)
+    expect(out.indexOf("Workspace:")).toBe(0)
+    expect(out).toContain("- Name: repo")
+    expect(out).toContain("- Root: /repo")
+    // Workspace block precedes the editor context line.
+    expect(out.indexOf("Workspace:")).toBeLessThan(out.indexOf("Context: src/foo.ts"))
+  })
+
+  it("omits the workspace declaration when no root is provided", () => {
+    const out = buildPrompt("hi", { relativePath: "src/foo.ts" }, undefined, undefined)
+    expect(out).not.toContain("Workspace:")
   })
 })
 

--- a/test/host/workspace-root.test.ts
+++ b/test/host/workspace-root.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import * as vscode from "vscode"
+import {
+  getWorkspaceRoots,
+  isInsideRoot,
+  isInsideWorkspace,
+  primaryWorkspaceRoot,
+  relativeToRoot,
+  workspaceRootForPath,
+  workspaceRootForUri,
+  type WorkspaceRoot,
+} from "../../src/workspace-root"
+
+type MutableWorkspace = {
+  workspaceFolders?: Array<{ uri: { fsPath: string; scheme: string }; name?: string }>
+}
+type MutableWindow = { activeTextEditor?: { document: { uri: { fsPath: string; scheme: string } } } }
+
+const ws = vscode.workspace as unknown as MutableWorkspace
+const win = vscode.window as unknown as MutableWindow
+
+function setFolders(folders: Array<{ fsPath: string; name?: string }>) {
+  ws.workspaceFolders = folders.map((f) => ({
+    uri: { fsPath: f.fsPath, scheme: "file" } as unknown as vscode.Uri,
+    name: f.name ?? f.fsPath.split("/").filter(Boolean).pop() ?? "root",
+  }))
+}
+
+function setActiveEditor(fsPath: string | undefined) {
+  if (!fsPath) {
+    win.activeTextEditor = undefined
+    return
+  }
+  win.activeTextEditor = {
+    document: { uri: { fsPath, scheme: "file" } as unknown as vscode.Uri },
+  }
+}
+
+describe("workspace-root", () => {
+  beforeEach(() => {
+    setFolders([{ fsPath: "/workspace" }])
+    setActiveEditor(undefined)
+  })
+
+  describe("getWorkspaceRoots", () => {
+    it("returns an empty array when no folders are open", () => {
+      ws.workspaceFolders = undefined
+      expect(getWorkspaceRoots()).toEqual([])
+    })
+
+    it("marks index 0 as the default root", () => {
+      setFolders([{ fsPath: "/a", name: "a" }, { fsPath: "/b", name: "b" }])
+      const roots = getWorkspaceRoots()
+      expect(roots).toHaveLength(2)
+      expect(roots[0]).toMatchObject({ name: "a", index: 0, isDefault: true })
+      expect(roots[1]).toMatchObject({ name: "b", index: 1, isDefault: false })
+    })
+  })
+
+  describe("isInsideRoot", () => {
+    const root: WorkspaceRoot = {
+      uri: { fsPath: "/workspace", scheme: "file" } as unknown as vscode.Uri,
+      fsPath: "/workspace",
+      name: "workspace",
+      index: 0,
+      isDefault: true,
+    }
+
+    it("accepts the root itself", () => {
+      expect(isInsideRoot(root, "/workspace")).toBe(true)
+    })
+
+    it("accepts a file directly inside the root", () => {
+      expect(isInsideRoot(root, "/workspace/src/foo.ts")).toBe(true)
+    })
+
+    it("rejects a sibling folder", () => {
+      expect(isInsideRoot(root, "/elsewhere/foo.ts")).toBe(false)
+    })
+
+    it("rejects the parent directory", () => {
+      expect(isInsideRoot(root, "/")).toBe(false)
+    })
+
+    it("rejects an empty path defensively", () => {
+      expect(isInsideRoot(root, "")).toBe(false)
+    })
+
+    it("rejects a sibling that shares a prefix", () => {
+      // "/workspace2/x.ts" must not be treated as inside "/workspace".
+      expect(isInsideRoot(root, "/workspace2/x.ts")).toBe(false)
+    })
+  })
+
+  describe("workspaceRootForPath", () => {
+    it("returns the containing root when one matches", () => {
+      setFolders([{ fsPath: "/a" }, { fsPath: "/b" }])
+      expect(workspaceRootForPath("/b/src/file.ts")?.fsPath).toBe("/b")
+    })
+
+    it("prefers the longest matching root for nested folders", () => {
+      // Both /repo and /repo/packages/foo are open; a file inside the inner
+      // folder should resolve to the inner one.
+      setFolders([{ fsPath: "/repo" }, { fsPath: "/repo/packages/foo" }])
+      expect(workspaceRootForPath("/repo/packages/foo/src/x.ts")?.fsPath).toBe("/repo/packages/foo")
+      // …while a file outside the inner folder resolves to the outer one.
+      expect(workspaceRootForPath("/repo/other.ts")?.fsPath).toBe("/repo")
+    })
+
+    it("returns undefined when no folder matches", () => {
+      setFolders([{ fsPath: "/a" }])
+      expect(workspaceRootForPath("/elsewhere/x.ts")).toBeUndefined()
+    })
+
+    it("returns undefined for an empty or undefined path", () => {
+      expect(workspaceRootForPath(undefined)).toBeUndefined()
+      expect(workspaceRootForPath("")).toBeUndefined()
+    })
+  })
+
+  describe("workspaceRootForUri", () => {
+    it("rejects non-file schemes", () => {
+      const untitled = { fsPath: "/workspace/x.ts", scheme: "untitled" } as unknown as vscode.Uri
+      expect(workspaceRootForUri(untitled)).toBeUndefined()
+    })
+
+    it("resolves a file-scheme URI inside a workspace folder", () => {
+      const uri = { fsPath: "/workspace/foo.ts", scheme: "file" } as unknown as vscode.Uri
+      expect(workspaceRootForUri(uri)?.fsPath).toBe("/workspace")
+    })
+  })
+
+  describe("isInsideWorkspace", () => {
+    it("returns true for a workspace file", () => {
+      expect(isInsideWorkspace("/workspace/foo.ts")).toBe(true)
+    })
+
+    it("returns false for an external file", () => {
+      expect(isInsideWorkspace("/Users/me/notes/spec.md")).toBe(false)
+    })
+  })
+
+  describe("relativeToRoot", () => {
+    const root: WorkspaceRoot = {
+      uri: { fsPath: "/workspace", scheme: "file" } as unknown as vscode.Uri,
+      fsPath: "/workspace",
+      name: "workspace",
+      index: 0,
+      isDefault: true,
+    }
+
+    it("produces a forward-slashed relative path", () => {
+      expect(relativeToRoot(root, "/workspace/src/foo.ts")).toBe("src/foo.ts")
+    })
+
+    it("returns an empty string for the root itself", () => {
+      expect(relativeToRoot(root, "/workspace")).toBe("")
+    })
+  })
+
+  describe("primaryWorkspaceRoot", () => {
+    it("returns undefined when there is no folder open", () => {
+      ws.workspaceFolders = undefined
+      expect(primaryWorkspaceRoot()).toBeUndefined()
+    })
+
+    it("falls back to the first folder when no editor is active", () => {
+      setFolders([{ fsPath: "/a", name: "a" }, { fsPath: "/b", name: "b" }])
+      expect(primaryWorkspaceRoot()?.fsPath).toBe("/a")
+    })
+
+    it("prefers the folder containing the active editor", () => {
+      setFolders([{ fsPath: "/a", name: "a" }, { fsPath: "/b", name: "b" }])
+      setActiveEditor("/b/src/file.ts")
+      expect(primaryWorkspaceRoot()?.fsPath).toBe("/b")
+    })
+
+    it("falls back to the first folder when the active editor is external", () => {
+      setFolders([{ fsPath: "/a", name: "a" }, { fsPath: "/b", name: "b" }])
+      setActiveEditor("/elsewhere/x.ts")
+      expect(primaryWorkspaceRoot()?.fsPath).toBe("/a")
+    })
+  })
+})

--- a/webview/src/protocol.ts
+++ b/webview/src/protocol.ts
@@ -107,6 +107,25 @@ export type EditorContextRef = {
   label?: string
 }
 
+/**
+ * Workspace root the host is currently operating against. Undefined means no
+ * folder is open — automatic context features should treat that as a no-op
+ * state. Phase 2+ of the workspace-context plan attaches a richer manifest
+ * per prompt; this `workspace` message is the unconditional "what root are
+ * we in?" surface the UI uses today.
+ */
+export type WorkspaceInfo = {
+  name: string
+  /** Absolute filesystem path of the workspace root. */
+  root: string
+  /** True for the first folder in a multi-root workspace. */
+  isDefault: boolean
+  /** True when this workspace is one of several open folders. */
+  multiRoot: boolean
+  /** Active opencode config-mode the running server was started with. */
+  configMode?: "isolated" | "user"
+}
+
 export type FileSearchHit = { path: string; name: string }
 
 export type Attachment = {
@@ -135,6 +154,7 @@ export type Outbound =
   | { type: "conversations"; conversations: ConversationSummary[]; activeID?: string }
   | { type: "restore"; conversationID: string; messages: ChatMessage[]; reviewHunks?: Record<string, ReviewHunkState> }
   | { type: "context"; ref: EditorContextRef }
+  | { type: "workspace"; workspace?: WorkspaceInfo }
   | { type: "userMessage"; id: string; text: string; ref?: EditorContextRef; backendID?: string; attachments?: Attachment[]; mentions?: string[] }
   | { type: "userMessageBackendID"; id: string; backendID: string }
   | { type: "assistantStart"; id: string }


### PR DESCRIPTION
Closes #118 — part of #117.

Implements **Phase 1** of [`docs/workspace-context-and-indexing.md`](docs/workspace-context-and-indexing.md): make the workspace root an explicit runtime object used by the opencode server, the SDK client, and (eventually) automatic context collectors.

## Summary

- **`src/workspace-root.ts`** — new pure module: `getWorkspaceRoots`, `primaryWorkspaceRoot`, `workspaceRootForUri/Path`, `isInsideRoot/Workspace`, `relativeToRoot`. `primaryWorkspaceRoot` prefers the root containing the active editor, falls back to the first folder, and returns `undefined` for no-folder mode (callers run with no automatic context).
- **`src/server.ts`** — `opencode serve` is now spawned with `cwd: workspaceRoot.fsPath`, matching the SDK `directory`. `Backend` exposes `{ workspace, configMode }` so downstream code can declare the active root in prompts and tool outputs.
- **`opencui.opencodeConfigMode` setting** — `isolated` (default) preserves the existing `OPENCODE_CONFIG_CONTENT={}` sandbox; `user` lets opencode load the user's normal config, agents, and plugins. The plan's "Risks → Plugin Instability" section is the reason this stays opt-in.
- **`src/chat/view.ts`** — posts a `workspace` outbound message on mount and on workspace-folder change; threads the resolved root into `buildPrompt`.
- **`src/chat/prompt-builder.ts`** — prepends a `Workspace:` block (name + root) so the agent knows which project it is operating in.
- **`webview/src/protocol.ts`** — `WorkspaceInfo` type + `workspace` Outbound variant. The UI is wire-ready; Phase 2 builds the visible context manifest on top.

## Acceptance criteria

- [x] Every prompt has a resolved workspace root or an explicit no-workspace state.
- [x] OpenCode is spawned with `cwd` equal to the selected root.
- [x] The SDK client uses the same root as `directory`.
- [x] Automatic context collectors reject files outside workspace roots — predicate (`isInsideRoot`) available; collectors arrive in Phase 3.
- [x] The UI can display the selected workspace name and path — data is now sent; Phase 2 attaches the manifest pill.
- [x] Existing `@file` behavior still works (vitest covers it; `file-search.ts` already used workspace-scoped `findFiles`).

## Out of scope (future phases, tracked in #117)

- Context manifest UI (Phase 2)
- Automatic context collectors — diagnostics, git diff, open tabs, recent edits, docs, symbols (Phase 3)
- Prompt budget manager (Phase 4)
- OMO/semantic plugin source labeling (Phase 5)
- Semantic index + cross-project search (Phase 6)

## Test plan

- [x] `bun run test` — 527/527 passing, including 13 new `workspace-root` cases and 2 new `buildPrompt` workspace cases.
- [x] `bun run check-types` — clean (host).
- [x] `cd webview && bunx tsc --noEmit` — only the three pre-existing errors documented in `CLAUDE.md` remain.
- [x] `bun run compile` — production build succeeds.
- [ ] Manual: launch the extension in a single-root workspace, confirm prompts include the new `Workspace:` block (visible via opencode logs / chat view) and that opencode-server logs show the cwd matches the workspace root.
- [ ] Manual: toggle `opencui.opencodeConfigMode` to `user`, restart the server, confirm a user-defined agent from `~/.config/opencode/agent/` becomes available in the agent picker.