### PR TITLE
feat(context-manifest): per-prompt manifest pill (Phase 2)

### DIFF
--- a/src/chat/prompt-builder.ts
+++ b/src/chat/prompt-builder.ts
@@ -39,35 +39,64 @@ export function buildPrompt(
   return lines.join("\n")
 }
 
-export async function readMentions(mentions?: string[]): Promise<string | undefined> {
-  if (!mentions || mentions.length === 0) return undefined
+export type MentionReadResult = {
+  /** Prompt block to splice into `buildPrompt`'s `mentionBlock` slot. */
+  block?: string
+  /**
+   * Per-mention byte accounting used by the manifest builder. Only entries
+   * we actually attempted to read live here — successful reads (truncated or
+   * not) and capped reads are still recorded so the manifest can render the
+   * right status. Failed reads land in `failed` instead.
+   */
+  bytes: Record<string, { included: number; original: number }>
+  /** Mentions skipped because we hit the per-prompt file/byte cap. */
+  capped: string[]
+  /** Mentions whose underlying file read threw (ENOENT etc.). */
+  failed: string[]
+}
+
+export async function readMentions(mentions?: string[]): Promise<MentionReadResult> {
+  if (!mentions || mentions.length === 0) {
+    return { bytes: {}, capped: [], failed: [] }
+  }
   const folder = vscode.workspace.workspaceFolders?.[0]
-  if (!folder) return undefined
+  if (!folder) return { bytes: {}, capped: [], failed: [] }
   const seen = new Set<string>()
   const blocks: string[] = []
+  const bytes: Record<string, { included: number; original: number }> = {}
+  const capped: string[] = []
+  const failed: string[] = []
   let totalBytes = 0
   for (const rel of mentions) {
-    if (blocks.length >= MENTION_MAX_FILES) break
     if (!rel || seen.has(rel)) continue
     seen.add(rel)
+    if (blocks.length >= MENTION_MAX_FILES) {
+      capped.push(rel)
+      continue
+    }
     const uri = path.isAbsolute(rel) ? vscode.Uri.file(rel) : vscode.Uri.joinPath(folder.uri, rel)
     try {
       const buf = await vscode.workspace.fs.readFile(uri)
       const remaining = MENTION_MAX_BYTES - totalBytes
-      if (remaining <= 0) break
+      if (remaining <= 0) {
+        capped.push(rel)
+        continue
+      }
       const truncated = buf.byteLength > remaining
       const slice = truncated ? buf.slice(0, remaining) : buf
       const content = Buffer.from(slice).toString("utf8")
       const lang = guessFenceLang(rel)
       const note = truncated ? ` (truncated to ${remaining} bytes)` : ""
       blocks.push(`@${rel}${note}\n\`\`\`${lang}\n${content}\n\`\`\``)
+      bytes[rel] = { included: slice.byteLength, original: buf.byteLength }
       totalBytes += slice.byteLength
     } catch (e) {
       log("readMentions: skipping", rel, e)
+      failed.push(rel)
     }
   }
-  if (blocks.length === 0) return undefined
-  return ["Files attached:", ...blocks].join("\n")
+  const block = blocks.length > 0 ? ["Files attached:", ...blocks].join("\n") : undefined
+  return { block, bytes, capped, failed }
 }
 
 function guessFenceLang(rel: string): string {

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -38,6 +38,7 @@ import { relativeToCwd, samePath } from "./paths"
 import { isTextReviewPath, reviewKey, splitReviewDiff } from "./diff"
 import { reviewChanges } from "./review-changes"
 import { buildPrompt, readMentions } from "./prompt-builder"
+import { buildManifest } from "../workspace-context/manifest"
 import { toWire } from "./wire-format"
 import {
   applyCode,
@@ -429,6 +430,12 @@ export class ChatView implements vscode.WebviewViewProvider {
       case "userMessageBackendID":
         this.messages = this.messages.map((m) =>
           m.id === msg.id ? { ...m, backendID: msg.backendID } : m,
+        )
+        this.saveActive()
+        return
+      case "userMessageContext":
+        this.messages = this.messages.map((m) =>
+          m.id === msg.id ? { ...m, context: msg.context } : m,
         )
         this.saveActive()
         return
@@ -932,7 +939,42 @@ export class ChatView implements vscode.WebviewViewProvider {
     }
 
     const sel = this.prefs.get()
-    const mentionBlock = await readMentions(mentions)
+    const mentionResult = await readMentions(mentions)
+    const manifest = buildManifest({
+      workspace: backend.workspace,
+      workspaceInfo: this.workspaceInfo(),
+      configMode: backend.configMode,
+      editor: ctx,
+      mentions,
+      attachments,
+      mentionBytes: mentionResult.bytes,
+    })
+    // Tag capped/failed mentions explicitly so the manifest shows them.
+    for (const rel of mentionResult.capped) {
+      manifest.items.push({
+        id: `mention_skipped_${rel}`,
+        source: "mention",
+        kind: "file",
+        label: rel,
+        path: rel,
+        reason: "Skipped: per-prompt mention cap exceeded",
+        status: "skipped",
+      })
+      manifest.totals.skippedItems += 1
+    }
+    for (const rel of mentionResult.failed) {
+      manifest.items.push({
+        id: `mention_failed_${rel}`,
+        source: "mention",
+        kind: "file",
+        label: rel,
+        path: rel,
+        reason: "Skipped: file unreadable (ENOENT or permission denied)",
+        status: "skipped",
+      })
+      manifest.totals.skippedItems += 1
+    }
+    this.post({ type: "userMessageContext", id: userMessageID, context: manifest })
     const parts: Array<Record<string, unknown>> = []
     if (attachments) {
       for (const a of attachments) {
@@ -949,7 +991,7 @@ export class ChatView implements vscode.WebviewViewProvider {
         })
       }
     }
-    parts.push({ type: "text", text: buildPrompt(text, ctx, mentionBlock, backend.workspace) })
+    parts.push({ type: "text", text: buildPrompt(text, ctx, mentionResult.block, backend.workspace) })
     type PromptBody = NonNullable<Parameters<typeof backend.client.session.prompt>[0]["body"]>
     const body: PromptBody = {
       parts: parts as PromptBody["parts"],

--- a/src/workspace-context/manifest.ts
+++ b/src/workspace-context/manifest.ts
@@ -1,0 +1,210 @@
+import * as path from "path"
+import type {
+  Attachment,
+  PromptContextManifest,
+  PromptContextManifestItem,
+  WorkspaceInfo,
+} from "../protocol"
+import type { OpencodeConfigMode } from "../server"
+import type { EditorContext } from "../context"
+import { isInsideRoot, type WorkspaceRoot } from "../workspace-root"
+
+export type ManifestInputs = {
+  workspace?: WorkspaceRoot
+  workspaceInfo?: WorkspaceInfo
+  configMode: OpencodeConfigMode
+  editor: EditorContext
+  mentions?: string[]
+  attachments?: Attachment[]
+  /**
+   * Bytes already read for each mention path, keyed by the same string we use
+   * as the mention. Lets the manifest report truncation when the prompt
+   * builder hit the per-prompt cap. Phase 4 will populate this consistently
+   * with the budget manager — for now the host plugs in mention sizes it
+   * already computed in `readMentions`.
+   */
+  mentionBytes?: Record<string, { included: number; original: number }>
+}
+
+/**
+ * Build the manifest the host attaches to a `userMessage`. Pure for testing —
+ * the builder doesn't read the filesystem itself; the host fills the byte
+ * counts before calling.
+ */
+export function buildManifest(inputs: ManifestInputs): PromptContextManifest {
+  const items: PromptContextManifestItem[] = []
+
+  // Active editor — workspace-relative when inside a root, marked external
+  // otherwise. Selections are surfaced as a distinct item so the user can
+  // see we sent the snippet.
+  if (inputs.editor.relativePath || inputs.editor.filePath) {
+    const editorItem = makeEditorItem(inputs.workspace, inputs.editor)
+    if (editorItem) items.push(editorItem)
+  }
+  if (inputs.editor.selection) {
+    items.push({
+      id: itemID("selection"),
+      source: "editor",
+      kind: "selection",
+      label: editorSelectionLabel(inputs.editor),
+      path: inputs.editor.relativePath,
+      reason: "Active selection in the focused editor",
+      status: "included",
+      bytes: byteLengthOf(inputs.editor.selection.text),
+      priority: 2,
+    })
+  }
+
+  // Manual mentions — Phase 1's @file flow. Workspace-relative when possible;
+  // absolute paths are kept as-is and tagged `external` when outside every
+  // open root.
+  for (const rel of inputs.mentions ?? []) {
+    const item = makeMentionItem(rel, inputs.workspace, inputs.mentionBytes?.[rel])
+    items.push(item)
+  }
+
+  // Attachments — paperclip flow. The dataURL itself isn't part of the prompt
+  // budget (it goes as a separate `parts[]` entry to opencode), but we still
+  // surface bytes so the user sees the size and we mark a `sourcePath` as
+  // external when it lives outside the workspace.
+  for (const attachment of inputs.attachments ?? []) {
+    items.push(makeAttachmentItem(attachment, inputs.workspace))
+  }
+
+  const totals = computeTotals(items)
+  return {
+    version: 1,
+    workspace: inputs.workspaceInfo,
+    opencode: {
+      directory: inputs.workspace?.fsPath,
+      configMode: inputs.configMode,
+    },
+    totals,
+    items,
+  }
+}
+
+function makeEditorItem(
+  workspace: WorkspaceRoot | undefined,
+  editor: EditorContext,
+): PromptContextManifestItem | undefined {
+  const filePath = editor.filePath
+  if (!filePath) {
+    // `relativePath` without `filePath` only happens for synthetic editor
+    // contexts (e.g. untitled docs). We still want to record the label.
+    if (!editor.relativePath) return undefined
+    return {
+      id: itemID("editor"),
+      source: "editor",
+      kind: "file",
+      label: editor.relativePath,
+      path: editor.relativePath,
+      reason: "Currently focused editor",
+      status: "included",
+      priority: 6,
+    }
+  }
+  const external = !workspace || !isInsideRoot(workspace, filePath)
+  return {
+    id: itemID("editor"),
+    source: external ? "external" : "editor",
+    kind: "file",
+    label: editor.relativePath ?? path.basename(filePath),
+    path: external ? filePath : editor.relativePath,
+    root: workspace?.fsPath,
+    reason: external
+      ? "Active editor is outside the workspace; surfaced as external context"
+      : "Currently focused editor",
+    status: "included",
+    external,
+    priority: 6,
+  }
+}
+
+function makeMentionItem(
+  rel: string,
+  workspace: WorkspaceRoot | undefined,
+  bytes: { included: number; original: number } | undefined,
+): PromptContextManifestItem {
+  const absolute = path.isAbsolute(rel)
+  const external = absolute && (!workspace || !isInsideRoot(workspace, rel))
+  const status: PromptContextManifestItem["status"] =
+    bytes && bytes.included < bytes.original ? "truncated" : "included"
+  return {
+    id: itemID("mention"),
+    source: external ? "external" : "mention",
+    kind: "file",
+    label: rel,
+    path: rel,
+    root: external ? undefined : workspace?.fsPath,
+    reason: external
+      ? "Manually mentioned file outside the workspace"
+      : "Manually mentioned file (@-picker)",
+    status,
+    bytes: bytes?.included,
+    external,
+    priority: 1,
+  }
+}
+
+function makeAttachmentItem(
+  attachment: Attachment,
+  workspace: WorkspaceRoot | undefined,
+): PromptContextManifestItem {
+  const external =
+    attachment.sourcePath != null &&
+    (!workspace || !isInsideRoot(workspace, attachment.sourcePath))
+  return {
+    id: itemID("attachment"),
+    source: "attachment",
+    kind: "file",
+    label: attachment.filename,
+    path: attachment.sourcePath ?? attachment.filename,
+    root: external ? undefined : workspace?.fsPath,
+    reason: external
+      ? "Attachment from outside the workspace"
+      : "Attachment via the paperclip flow",
+    status: "included",
+    bytes: attachment.bytes,
+    external,
+    priority: 3,
+  }
+}
+
+function computeTotals(items: PromptContextManifestItem[]) {
+  let includedItems = 0
+  let skippedItems = 0
+  let truncatedItems = 0
+  let includedBytes = 0
+  for (const item of items) {
+    if (item.status === "included") includedItems += 1
+    else if (item.status === "truncated") {
+      includedItems += 1
+      truncatedItems += 1
+    } else if (item.status === "skipped") skippedItems += 1
+    if (item.bytes && (item.status === "included" || item.status === "truncated")) {
+      includedBytes += item.bytes
+    }
+  }
+  return { includedItems, skippedItems, truncatedItems, includedBytes, budgetBytes: 0 }
+}
+
+function editorSelectionLabel(editor: EditorContext): string {
+  const sel = editor.selection
+  if (!sel) return editor.relativePath ?? "selection"
+  const base = editor.relativePath ?? "selection"
+  return sel.startLine === sel.endLine
+    ? `${base}#L${sel.startLine}`
+    : `${base}#L${sel.startLine}-${sel.endLine}`
+}
+
+function byteLengthOf(text: string): number {
+  if (typeof Buffer !== "undefined") return Buffer.byteLength(text, "utf8")
+  return new TextEncoder().encode(text).byteLength
+}
+
+let counter = 0
+function itemID(prefix: string): string {
+  counter += 1
+  return `${prefix}_${counter}`
+}

--- a/test/host/build-prompt.test.ts
+++ b/test/host/build-prompt.test.ts
@@ -71,9 +71,14 @@ describe("readMentions", () => {
     vi.mocked(vscode.workspace.fs.readFile).mockReset()
   })
 
-  it("returns undefined for empty mentions", async () => {
-    expect(await readMentions(undefined)).toBeUndefined()
-    expect(await readMentions([])).toBeUndefined()
+  it("returns empty state for empty mentions", async () => {
+    const a = await readMentions(undefined)
+    expect(a.block).toBeUndefined()
+    expect(a.bytes).toEqual({})
+    expect(a.capped).toEqual([])
+    expect(a.failed).toEqual([])
+    const b = await readMentions([])
+    expect(b.block).toBeUndefined()
   })
 
   it("returns a fenced block per file with the @path header", async () => {
@@ -81,10 +86,14 @@ describe("readMentions", () => {
       new TextEncoder().encode("export const x = 1\n"),
     )
     const out = await readMentions(["src/foo.ts"])
-    expect(out).toContain("Files attached:")
-    expect(out).toContain("@src/foo.ts")
-    expect(out).toContain("```ts")
-    expect(out).toContain("export const x = 1")
+    expect(out.block).toContain("Files attached:")
+    expect(out.block).toContain("@src/foo.ts")
+    expect(out.block).toContain("```ts")
+    expect(out.block).toContain("export const x = 1")
+    expect(out.bytes["src/foo.ts"]).toMatchObject({
+      included: expect.any(Number),
+      original: expect.any(Number),
+    })
   })
 
   it("dedups repeated mention paths", async () => {
@@ -92,26 +101,28 @@ describe("readMentions", () => {
       new TextEncoder().encode("hello"),
     )
     const out = await readMentions(["src/foo.ts", "src/foo.ts"])
-    expect(out).toBeDefined()
-    // Only one occurrence of the @path header
-    const matches = out!.match(/@src\/foo\.ts/g)
+    expect(out.block).toBeDefined()
+    const matches = out.block!.match(/@src\/foo\.ts/g)
     expect(matches).toHaveLength(1)
   })
 
-  it("skips files that fail to read but keeps going", async () => {
+  it("records failed reads in `failed`", async () => {
     vi.mocked(vscode.workspace.fs.readFile)
       .mockRejectedValueOnce(new Error("ENOENT"))
       .mockResolvedValueOnce(new TextEncoder().encode("good"))
     const out = await readMentions(["bad.ts", "good.ts"])
-    expect(out).toBeDefined()
-    expect(out).toContain("@good.ts")
-    expect(out).not.toContain("@bad.ts")
+    expect(out.block).toContain("@good.ts")
+    expect(out.block).not.toContain("@bad.ts")
+    expect(out.failed).toEqual(["bad.ts"])
+    expect(out.bytes["good.ts"]).toBeDefined()
+    expect(out.bytes["bad.ts"]).toBeUndefined()
   })
 
-  it("returns undefined when every read fails", async () => {
+  it("returns no block when every read fails", async () => {
     vi.mocked(vscode.workspace.fs.readFile).mockRejectedValue(new Error("nope"))
     const out = await readMentions(["x.ts", "y.ts"])
-    expect(out).toBeUndefined()
+    expect(out.block).toBeUndefined()
+    expect(out.failed).toEqual(["x.ts", "y.ts"])
   })
 
   it("picks a sensible fence language from extension", async () => {
@@ -119,6 +130,6 @@ describe("readMentions", () => {
       new TextEncoder().encode("body { color: red; }"),
     )
     const out = await readMentions(["styles.css"])
-    expect(out).toContain("```css")
+    expect(out.block).toContain("```css")
   })
 })

--- a/test/host/manifest.test.ts
+++ b/test/host/manifest.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest"
+import * as vscode from "vscode"
+import { buildManifest } from "../../src/workspace-context/manifest"
+import type { WorkspaceRoot } from "../../src/workspace-root"
+
+const ROOT: WorkspaceRoot = {
+  uri: { fsPath: "/repo", scheme: "file" } as unknown as vscode.Uri,
+  fsPath: "/repo",
+  name: "repo",
+  index: 0,
+  isDefault: true,
+}
+
+const WORKSPACE_INFO = {
+  name: "repo",
+  root: "/repo",
+  isDefault: true,
+  multiRoot: false,
+  configMode: "isolated" as const,
+}
+
+describe("buildManifest", () => {
+  it("emits an empty items array when nothing is attached", () => {
+    const m = buildManifest({
+      workspace: ROOT,
+      workspaceInfo: WORKSPACE_INFO,
+      configMode: "isolated",
+      editor: {},
+    })
+    expect(m.items).toEqual([])
+    expect(m.totals.includedItems).toBe(0)
+    expect(m.workspace).toEqual(WORKSPACE_INFO)
+    expect(m.opencode?.configMode).toBe("isolated")
+  })
+
+  it("adds an active-editor item when relativePath is present", () => {
+    const m = buildManifest({
+      workspace: ROOT,
+      workspaceInfo: WORKSPACE_INFO,
+      configMode: "isolated",
+      editor: {
+        filePath: "/repo/src/foo.ts",
+        relativePath: "src/foo.ts",
+        language: "ts",
+      },
+    })
+    const editorItem = m.items.find((i) => i.source === "editor")
+    expect(editorItem).toBeDefined()
+    expect(editorItem?.path).toBe("src/foo.ts")
+    expect(editorItem?.external).toBeFalsy()
+  })
+
+  it("marks the editor item external when it lives outside the workspace", () => {
+    const m = buildManifest({
+      workspace: ROOT,
+      workspaceInfo: WORKSPACE_INFO,
+      configMode: "isolated",
+      editor: {
+        filePath: "/Users/me/notes/spec.md",
+        relativePath: "../../../Users/me/notes/spec.md",
+        language: "md",
+      },
+    })
+    const editorItem = m.items.find((i) => i.source === "external")
+    expect(editorItem).toBeDefined()
+    expect(editorItem?.external).toBe(true)
+  })
+
+  it("adds a selection item with the L<start>-<end> label", () => {
+    const m = buildManifest({
+      workspace: ROOT,
+      workspaceInfo: WORKSPACE_INFO,
+      configMode: "isolated",
+      editor: {
+        filePath: "/repo/src/foo.ts",
+        relativePath: "src/foo.ts",
+        language: "ts",
+        selection: { startLine: 3, endLine: 5, text: "const x = 1" },
+      },
+    })
+    const selectionItem = m.items.find((i) => i.kind === "selection")
+    expect(selectionItem).toBeDefined()
+    expect(selectionItem?.label).toBe("src/foo.ts#L3-5")
+    expect(selectionItem?.bytes).toBe("const x = 1".length)
+  })
+
+  it("classifies absolute external mentions and includes byte counts", () => {
+    const m = buildManifest({
+      workspace: ROOT,
+      workspaceInfo: WORKSPACE_INFO,
+      configMode: "isolated",
+      editor: {},
+      mentions: ["src/inside.ts", "/elsewhere/outside.md"],
+      mentionBytes: {
+        "src/inside.ts": { included: 100, original: 100 },
+        "/elsewhere/outside.md": { included: 50, original: 50 },
+      },
+    })
+    const inside = m.items.find((i) => i.label === "src/inside.ts")
+    const outside = m.items.find((i) => i.label === "/elsewhere/outside.md")
+    expect(inside?.source).toBe("mention")
+    expect(inside?.external).toBeFalsy()
+    expect(outside?.source).toBe("external")
+    expect(outside?.external).toBe(true)
+    expect(m.totals.includedBytes).toBe(150)
+  })
+
+  it("marks mentions as truncated when included < original", () => {
+    const m = buildManifest({
+      workspace: ROOT,
+      workspaceInfo: WORKSPACE_INFO,
+      configMode: "isolated",
+      editor: {},
+      mentions: ["big.ts"],
+      mentionBytes: { "big.ts": { included: 200, original: 1000 } },
+    })
+    const item = m.items.find((i) => i.path === "big.ts")
+    expect(item?.status).toBe("truncated")
+    expect(m.totals.truncatedItems).toBe(1)
+    expect(m.totals.includedItems).toBe(1)
+  })
+
+  it("includes attachment items with bytes", () => {
+    const m = buildManifest({
+      workspace: ROOT,
+      workspaceInfo: WORKSPACE_INFO,
+      configMode: "isolated",
+      editor: {},
+      attachments: [
+        {
+          id: "att_1",
+          mime: "image/png",
+          filename: "screen.png",
+          dataUrl: "data:image/png;base64,xxx",
+          bytes: 4096,
+          sourcePath: "/repo/screens/screen.png",
+        },
+      ],
+    })
+    const item = m.items.find((i) => i.source === "attachment")
+    expect(item?.label).toBe("screen.png")
+    expect(item?.bytes).toBe(4096)
+    expect(item?.external).toBeFalsy()
+  })
+
+  it("flags external attachments when sourcePath is outside the workspace", () => {
+    const m = buildManifest({
+      workspace: ROOT,
+      workspaceInfo: WORKSPACE_INFO,
+      configMode: "isolated",
+      editor: {},
+      attachments: [
+        {
+          id: "att_2",
+          mime: "application/pdf",
+          filename: "spec.pdf",
+          dataUrl: "data:application/pdf;base64,xxx",
+          bytes: 1024,
+          sourcePath: "/Users/me/spec.pdf",
+        },
+      ],
+    })
+    const item = m.items.find((i) => i.source === "attachment")
+    expect(item?.external).toBe(true)
+  })
+
+  it("threads configMode through into opencode metadata", () => {
+    const m = buildManifest({
+      workspace: ROOT,
+      workspaceInfo: WORKSPACE_INFO,
+      configMode: "user",
+      editor: {},
+    })
+    expect(m.opencode?.configMode).toBe("user")
+  })
+})

--- a/test/webview/context-manifest.test.tsx
+++ b/test/webview/context-manifest.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, afterEach } from "vitest"
+import { render, screen, fireEvent, cleanup } from "@testing-library/react"
+import { ContextManifest } from "../../webview/src/components/ContextManifest"
+import type { PromptContextManifest } from "../../webview/src/protocol"
+
+afterEach(cleanup)
+
+function manifest(overrides: Partial<PromptContextManifest> = {}): PromptContextManifest {
+  return {
+    version: 1,
+    workspace: {
+      name: "repo",
+      root: "/repo",
+      isDefault: true,
+      multiRoot: false,
+      configMode: "isolated",
+    },
+    opencode: { directory: "/repo", configMode: "isolated" },
+    totals: { includedItems: 0, skippedItems: 0, truncatedItems: 0, includedBytes: 0, budgetBytes: 0 },
+    items: [],
+    ...overrides,
+  }
+}
+
+describe("ContextManifest", () => {
+  it("renders nothing when no workspace and no items", () => {
+    const { container } = render(
+      <ContextManifest context={manifest({ workspace: undefined, items: [] })} />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("renders the workspace pill when only the workspace is present", () => {
+    render(<ContextManifest context={manifest()} />)
+    expect(screen.getByText("Context")).toBeInTheDocument()
+    expect(screen.getByText(/repo/)).toBeInTheDocument()
+  })
+
+  it("shows the included count and bytes in the pill", () => {
+    render(
+      <ContextManifest
+        context={manifest({
+          items: [
+            { id: "1", source: "mention", kind: "file", label: "a.ts", reason: "", status: "included", bytes: 100 },
+            { id: "2", source: "mention", kind: "file", label: "b.ts", reason: "", status: "included", bytes: 200 },
+          ],
+          totals: { includedItems: 2, skippedItems: 0, truncatedItems: 0, includedBytes: 300, budgetBytes: 0 },
+        })}
+      />,
+    )
+    expect(screen.getByText(/2 items/)).toBeInTheDocument()
+    expect(screen.getByText(/300 B/)).toBeInTheDocument()
+  })
+
+  it("reports truncated and skipped counts in the pill summary", () => {
+    render(
+      <ContextManifest
+        context={manifest({
+          items: [
+            { id: "1", source: "mention", kind: "file", label: "big.ts", reason: "", status: "truncated", bytes: 200 },
+            { id: "2", source: "mention", kind: "file", label: "miss.ts", reason: "", status: "skipped" },
+          ],
+          totals: { includedItems: 1, skippedItems: 1, truncatedItems: 1, includedBytes: 200, budgetBytes: 0 },
+        })}
+      />,
+    )
+    expect(screen.getByText(/1 truncated/)).toBeInTheDocument()
+    expect(screen.getByText(/1 skipped/)).toBeInTheDocument()
+  })
+
+  it("expands and collapses on header click", () => {
+    render(
+      <ContextManifest
+        context={manifest({
+          items: [
+            { id: "1", source: "mention", kind: "file", label: "a.ts", reason: "Mentioned", status: "included" },
+          ],
+        })}
+      />,
+    )
+    // Collapsed → item not visible (only one occurrence in the summary path).
+    expect(screen.queryByText("a.ts")).not.toBeInTheDocument()
+    fireEvent.click(screen.getByText("Context").closest("button")!)
+    expect(screen.getByText("a.ts")).toBeInTheDocument()
+    expect(screen.getByText("Mentions")).toBeInTheDocument()
+  })
+
+  it("renders an `external` badge for external items", () => {
+    render(
+      <ContextManifest
+        context={manifest({
+          items: [
+            {
+              id: "1",
+              source: "external",
+              kind: "file",
+              label: "/elsewhere/file.md",
+              reason: "Outside workspace",
+              status: "included",
+              external: true,
+            },
+          ],
+        })}
+      />,
+    )
+    fireEvent.click(screen.getByText("Context").closest("button")!)
+    expect(screen.getByText("external")).toBeInTheDocument()
+  })
+})

--- a/webview/src/components/ContextManifest.tsx
+++ b/webview/src/components/ContextManifest.tsx
@@ -1,0 +1,148 @@
+import { useState } from "react"
+import type {
+  PromptContextManifest,
+  PromptContextManifestItem,
+  PromptContextManifestItemSource,
+} from "../protocol"
+
+type Props = { context: PromptContextManifest }
+
+const SOURCE_LABELS: Record<PromptContextManifestItemSource, string> = {
+  editor: "Active editor",
+  mention: "Mentions",
+  attachment: "Attachments",
+  openTab: "Open tabs",
+  git: "Git",
+  diagnostic: "Diagnostics",
+  recentEdit: "Recent edits",
+  doc: "Docs",
+  symbol: "Symbols",
+  semantic: "Semantic",
+  opencode: "OpenCode",
+  omo: "OMO",
+  external: "External",
+}
+
+const SOURCE_ORDER: PromptContextManifestItemSource[] = [
+  "mention",
+  "editor",
+  "attachment",
+  "git",
+  "diagnostic",
+  "openTab",
+  "recentEdit",
+  "doc",
+  "symbol",
+  "semantic",
+  "opencode",
+  "omo",
+  "external",
+]
+
+/**
+ * Compact pill ("Context: N items · NN KB · workspace") that expands into a
+ * grouped list of manifest items. Hidden when there's no signal at all
+ * (no workspace, no items). Phases 3+ append more sources; this component
+ * doesn't need changes per phase because it dispatches on `item.source`.
+ */
+export function ContextManifest({ context }: Props) {
+  const [open, setOpen] = useState(false)
+  const items = context.items ?? []
+  const showPill = Boolean(context.workspace) || items.length > 0
+  if (!showPill) return null
+
+  const { included, skipped, truncated, bytes } = summarize(context)
+  const workspaceLabel = context.workspace?.name
+
+  return (
+    <div className={`context-pill ${open ? "is-open" : ""}`}>
+      <button
+        type="button"
+        className="context-pill-head"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        title="Show context details"
+      >
+        <span className="context-pill-label">Context</span>
+        <span className="context-pill-stats">
+          {included} {included === 1 ? "item" : "items"}
+          {truncated > 0 ? ` · ${truncated} truncated` : ""}
+          {skipped > 0 ? ` · ${skipped} skipped` : ""}
+          {bytes > 0 ? ` · ${formatBytes(bytes)}` : ""}
+          {workspaceLabel ? ` · ${workspaceLabel}` : ""}
+        </span>
+        <span className={`context-pill-caret ${open ? "is-open" : ""}`}>›</span>
+      </button>
+      {open && (
+        <div className="context-pill-body">
+          {context.workspace && (
+            <div className="context-section">
+              <div className="context-section-head">Workspace</div>
+              <div className="context-section-row">
+                <span className="context-row-label">{context.workspace.name}</span>
+                <span className="context-row-meta">{context.workspace.root}</span>
+              </div>
+              {context.opencode && (
+                <div className="context-section-row">
+                  <span className="context-row-label">Config mode</span>
+                  <span className="context-row-meta">{context.opencode.configMode}</span>
+                </div>
+              )}
+            </div>
+          )}
+          {renderGroups(items)}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function renderGroups(items: PromptContextManifestItem[]) {
+  const grouped = new Map<PromptContextManifestItemSource, PromptContextManifestItem[]>()
+  for (const item of items) {
+    const list = grouped.get(item.source) ?? []
+    list.push(item)
+    grouped.set(item.source, list)
+  }
+  const order = SOURCE_ORDER.filter((s) => grouped.has(s))
+  return order.map((source) => (
+    <div key={source} className="context-section">
+      <div className="context-section-head">{SOURCE_LABELS[source]}</div>
+      {grouped.get(source)!.map((item) => (
+        <div key={item.id} className={`context-section-row status-${item.status}`}>
+          <span className="context-row-label">{item.label}</span>
+          <span className="context-row-meta">
+            {statusBadge(item.status)}
+            {item.external ? <span className="context-badge external">external</span> : null}
+            {item.bytes ? <span className="context-row-bytes">{formatBytes(item.bytes)}</span> : null}
+          </span>
+        </div>
+      ))}
+    </div>
+  ))
+}
+
+function statusBadge(status: PromptContextManifestItem["status"]) {
+  if (status === "included") return null
+  return <span className={`context-badge ${status}`}>{status}</span>
+}
+
+function summarize(context: PromptContextManifest) {
+  let included = 0
+  let skipped = 0
+  let truncated = 0
+  for (const item of context.items ?? []) {
+    if (item.status === "included") included += 1
+    else if (item.status === "truncated") {
+      included += 1
+      truncated += 1
+    } else if (item.status === "skipped") skipped += 1
+  }
+  return { included, skipped, truncated, bytes: context.totals?.includedBytes ?? 0 }
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(bytes < 10240 ? 1 : 0)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -7,6 +7,7 @@ import { ImageThumbnail, type Thumbnailable } from "./ImageThumbnail"
 import { Markdown } from "./Markdown"
 import { PromptBox } from "./PromptBox"
 import { ToolTrace, toolHeadline } from "./ToolCard"
+import { ContextManifest } from "./ContextManifest"
 import { ICON_SIZE } from "../design-tokens"
 
 /**
@@ -285,6 +286,7 @@ function UserMessageView({
           {originalText && (
             <div className="user-text">{renderMentionedText(originalText, knownLabels)}</div>
           )}
+          {message.context && <ContextManifest context={message.context} />}
           {canEdit && (
             <span className="user-edit-hint" aria-hidden="true">
               <svg viewBox="0 0 16 16" width={ICON_SIZE.md} height={ICON_SIZE.md} fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -176,6 +176,13 @@ export function reducer(state: ChatState, action: Action): ChatState {
           m.id === action.id ? { ...m, backendID: action.backendID } : m,
         ),
       }
+    case "userMessageContext":
+      return {
+        ...state,
+        messages: state.messages.map((m) =>
+          m.id === action.id ? { ...m, context: action.context } : m,
+        ),
+      }
     case "assistantStart":
       return {
         ...state,

--- a/webview/src/protocol.ts
+++ b/webview/src/protocol.ts
@@ -65,6 +65,12 @@ export type ChatMessage = {
    * tokens in the text should still be treated as file context attachments.
    */
   mentions?: string[]
+  /**
+   * Manifest of context the host attached when this turn was sent. Persisted
+   * so historical messages can show what was included. Always set for new
+   * messages, undefined for messages from before the manifest landed.
+   */
+  context?: PromptContextManifest
 }
 
 export type ConversationSummary = {
@@ -128,6 +134,72 @@ export type WorkspaceInfo = {
 
 export type FileSearchHit = { path: string; name: string }
 
+/**
+ * Per-prompt manifest of what context the host attached to a user turn.
+ * Built by the host in `src/workspace-context/manifest.ts`, rendered by the
+ * `ContextManifest` component in the user-message bubble. Persisted on
+ * `ChatMessage.context` so historical turns can still surface what they
+ * actually sent. Phases 3+ append more items (collectors, semantic hits);
+ * the shape stays stable.
+ */
+export type PromptContextManifest = {
+  version: 1
+  workspace?: WorkspaceInfo
+  opencode?: {
+    directory?: string
+    configMode: "isolated" | "user"
+  }
+  totals: {
+    includedItems: number
+    skippedItems: number
+    truncatedItems: number
+    includedBytes: number
+    /** Phase 4+ budget; 0 means "no budget enforced yet". */
+    budgetBytes: number
+  }
+  items: PromptContextManifestItem[]
+}
+
+export type PromptContextManifestItemSource =
+  | "editor"
+  | "mention"
+  | "attachment"
+  | "openTab"
+  | "git"
+  | "diagnostic"
+  | "recentEdit"
+  | "doc"
+  | "symbol"
+  | "semantic"
+  | "opencode"
+  | "omo"
+  | "external"
+
+export type PromptContextManifestItemKind =
+  | "file"
+  | "selection"
+  | "snippet"
+  | "diff"
+  | "diagnostic"
+  | "symbol"
+  | "summary"
+  | "indexResult"
+
+export type PromptContextManifestItem = {
+  id: string
+  source: PromptContextManifestItemSource
+  kind: PromptContextManifestItemKind
+  label: string
+  path?: string
+  root?: string
+  reason: string
+  status: "included" | "skipped" | "truncated" | "available"
+  bytes?: number
+  budgetBytes?: number
+  external?: boolean
+  priority?: number
+}
+
 export type Attachment = {
   /** Stable id used to dedup / remove an attachment in the prompt UI. */
   id: string
@@ -155,8 +227,15 @@ export type Outbound =
   | { type: "restore"; conversationID: string; messages: ChatMessage[]; reviewHunks?: Record<string, ReviewHunkState> }
   | { type: "context"; ref: EditorContextRef }
   | { type: "workspace"; workspace?: WorkspaceInfo }
-  | { type: "userMessage"; id: string; text: string; ref?: EditorContextRef; backendID?: string; attachments?: Attachment[]; mentions?: string[] }
+  | { type: "userMessage"; id: string; text: string; ref?: EditorContextRef; backendID?: string; attachments?: Attachment[]; mentions?: string[]; context?: PromptContextManifest }
   | { type: "userMessageBackendID"; id: string; backendID: string }
+  /**
+   * Followup to `userMessage` after the host finishes reading mentions and
+   * builds the full manifest. Sent as a separate event so the user message
+   * bubble appears instantly (no waiting on file I/O) and the manifest pill
+   * fills in once the host knows the included/truncated/skipped state.
+   */
+  | { type: "userMessageContext"; id: string; context: PromptContextManifest }
   | { type: "assistantStart"; id: string }
   | { type: "textDelta"; id: string; delta: string }
   | { type: "reasoningDelta"; id: string; delta: string }

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -1117,6 +1117,108 @@ button {
   font-size: 0.9em;
 }
 
+/* Context manifest pill — collapsed by default, expands into a grouped list
+   of the items the host attached to this prompt (workspace, mentions,
+   attachments, plus Phase 3+ automatic collectors). */
+.context-pill {
+  margin-top: 8px;
+  border: 1px solid var(--vscode-editorWidget-border, transparent);
+  border-radius: 6px;
+  background: var(--vscode-editorWidget-background);
+  font-size: 11px;
+  overflow: hidden;
+}
+.context-pill-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 4px 8px;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+.context-pill-head:hover {
+  background: var(--vscode-list-hoverBackground);
+}
+.context-pill-label {
+  font-weight: 600;
+  opacity: 0.75;
+}
+.context-pill-stats {
+  flex: 1;
+  opacity: 0.65;
+  font-variant-numeric: tabular-nums;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.context-pill-caret {
+  display: inline-block;
+  transition: transform 120ms ease;
+  opacity: 0.5;
+}
+.context-pill-caret.is-open {
+  transform: rotate(90deg);
+}
+.context-pill-body {
+  padding: 6px 8px 8px;
+  border-top: 1px solid var(--vscode-editorWidget-border, transparent);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.context-section-head {
+  font-weight: 600;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.6;
+  margin-bottom: 2px;
+}
+.context-section-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 0;
+  font-size: 11px;
+}
+.context-section-row.status-skipped {
+  opacity: 0.55;
+}
+.context-row-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--vscode-editor-font-family);
+}
+.context-row-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+}
+.context-row-bytes {
+  opacity: 0.6;
+}
+.context-badge {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 4px;
+  border-radius: 3px;
+  border: 1px solid currentColor;
+  opacity: 0.7;
+}
+.context-badge.truncated { color: var(--vscode-charts-yellow); }
+.context-badge.skipped   { color: var(--vscode-descriptionForeground); }
+.context-badge.external  { color: var(--vscode-charts-blue); }
+
+
 .thinking-dots {
   display: inline-block;
   padding: 6px 2px;


### PR DESCRIPTION
Closes #120 — part of #117.

Implements **Phase 2** of [`docs/workspace-context-and-indexing.md`](docs/workspace-context-and-indexing.md): every prompt now produces a structured manifest of the context the host sent, rendered as a compact pill in the user-message bubble.

## Summary

- **`src/workspace-context/manifest.ts`** — pure host-side builder. Inputs: workspace, editor context, mentions, attachments + per-mention byte counts. Outputs a `PromptContextManifest` with items classified by `source` and `totals` for included/skipped/truncated/bytes.
- **`src/chat/prompt-builder.ts`** — `readMentions` now returns `MentionReadResult` with per-mention byte counts, `capped` (over-budget), and `failed` (read errors). The manifest uses these to mark truncations and skips accurately.
- **`src/chat/view.ts`** — after `readMentions` resolves, builds the manifest and posts a new `userMessageContext` event. The user bubble still appears instantly (no I/O wait); the pill fills in once mentions are read.
- **`webview/src/protocol.ts`** — `PromptContextManifest` / `PromptContextManifestItem` types; `Outbound.userMessage` carries optional `context`; new `userMessageContext` event; `ChatMessage.context` persists the manifest so historical turns show their context.
- **`webview/src/components/ContextManifest.tsx`** — collapsed pill ("Context · N items · KB · workspace") + expanded grouped list with `truncated` / `skipped` / `external` badges. The component dispatches on `item.source`, so Phase 3+ collectors don't need component changes.

## Why a separate event for the manifest

Posting `userMessage` first, then `userMessageContext` after `readMentions` keeps the bubble snappy. With large mentions, building the manifest at send-time would otherwise add visible latency before the user sees their own message.

## Test plan

- [x] `bun run test` — 542/542 passing, including 11 new manifest builder cases + 6 new ContextManifest component cases.
- [x] `bun run check-types` — clean (host).
- [x] `cd webview && bunx tsc --noEmit` — only the three pre-existing errors documented in `CLAUDE.md` remain.
- [ ] Manual: send a prompt with `@file` mentions and a paperclip attachment, confirm the pill shows the right item counts and the expanded list groups them by source.

## Out of scope

- Automatic context collectors (open tabs / diagnostics / git diff / …) — Phase 3 (#121).
- Budget enforcement (`budgetBytes: 0` currently) — Phase 4 (#122).
- Source labeling for OMO / semantic plugins — Phase 5 (#123).
- Semantic index — Phase 6 (#124).