### PR TITLE
feat(auto-context): workspace-bound automatic collectors (Phase 3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,11 @@
           ],
           "default": "isolated",
           "description": "Whether the opencode server started by OpenCode Panel loads the user's opencode config or runs with an empty isolated config."
+        },
+        "opencui.context.enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Attach automatic workspace context (open tabs, diagnostics, git diff, recent edits, docs, symbols) to each prompt. Disable to send only the user's text + mentions."
         }
       }
     }

--- a/src/chat/prompt-builder.ts
+++ b/src/chat/prompt-builder.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode"
 import * as path from "path"
 import type { getEditorContext } from "../context"
 import type { WorkspaceRoot } from "../workspace-root"
+import type { PromptContextBlock } from "../workspace-context/types"
 import { log } from "../output"
 
 const MENTION_MAX_BYTES = 200_000
@@ -12,6 +13,7 @@ export function buildPrompt(
   ctx: ReturnType<typeof getEditorContext>,
   mentionBlock?: string,
   workspace?: WorkspaceRoot,
+  autoBlocks?: PromptContextBlock[],
 ): string {
   const lines: string[] = []
   if (workspace) {
@@ -34,6 +36,22 @@ export function buildPrompt(
       lines.push("```")
     }
     lines.push("")
+  }
+  if (autoBlocks && autoBlocks.length > 0) {
+    // Lowest-priority-number first so the most useful blocks land near the
+    // user request and the noisier hints (symbols, recent edits) sit higher.
+    const sorted = [...autoBlocks].sort((a, b) => a.priority - b.priority)
+    for (const block of sorted) {
+      lines.push(`## ${block.title}`)
+      if (block.path && block.language) {
+        lines.push("```" + block.language)
+        lines.push(block.content)
+        lines.push("```")
+      } else {
+        lines.push(block.content)
+      }
+      lines.push("")
+    }
   }
   lines.push(userText)
   return lines.join("\n")

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -39,6 +39,8 @@ import { isTextReviewPath, reviewKey, splitReviewDiff } from "./diff"
 import { reviewChanges } from "./review-changes"
 import { buildPrompt, readMentions } from "./prompt-builder"
 import { buildManifest } from "../workspace-context/manifest"
+import { collectAutoContext } from "../workspace-context/collector"
+import { RecentEditsTracker } from "../workspace-context/recent-edits"
 import { toWire } from "./wire-format"
 import {
   applyCode,
@@ -152,6 +154,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     private context: vscode.ExtensionContext,
     private servers: ServerManager,
     private prefs: Preferences,
+    private recentEdits: RecentEditsTracker,
   ) {
     migrateConversationsToWorkspace(context)
     this.conversations = context.workspaceState.get<SavedConversation[]>(CONVERSATIONS_KEY) ?? []
@@ -939,7 +942,19 @@ export class ChatView implements vscode.WebviewViewProvider {
     }
 
     const sel = this.prefs.get()
-    const mentionResult = await readMentions(mentions)
+    const contextEnabled = vscode.workspace.getConfiguration("opencui").get<boolean>("context.enabled") ?? true
+    const symbolFocus = collectSymbolFocus(ctx.relativePath, mentions)
+    const [mentionResult, auto] = await Promise.all([
+      readMentions(mentions),
+      backend.workspace
+        ? collectAutoContext({
+            workspace: backend.workspace,
+            recentEdits: this.recentEdits,
+            symbolFocus,
+            enabled: contextEnabled,
+          })
+        : Promise.resolve({ items: [], blocks: [] }),
+    ])
     const manifest = buildManifest({
       workspace: backend.workspace,
       workspaceInfo: this.workspaceInfo(),
@@ -949,6 +964,20 @@ export class ChatView implements vscode.WebviewViewProvider {
       attachments,
       mentionBytes: mentionResult.bytes,
     })
+    // Merge automatic collector items into the manifest. The auto-context
+    // builder already classified them by source / status / priority.
+    manifest.items.push(...auto.items)
+    for (const item of auto.items) {
+      if (item.status === "included") manifest.totals.includedItems += 1
+      if (item.status === "truncated") {
+        manifest.totals.includedItems += 1
+        manifest.totals.truncatedItems += 1
+      }
+      if (item.status === "skipped") manifest.totals.skippedItems += 1
+      if (item.bytes && (item.status === "included" || item.status === "truncated")) {
+        manifest.totals.includedBytes += item.bytes
+      }
+    }
     // Tag capped/failed mentions explicitly so the manifest shows them.
     for (const rel of mentionResult.capped) {
       manifest.items.push({
@@ -991,7 +1020,10 @@ export class ChatView implements vscode.WebviewViewProvider {
         })
       }
     }
-    parts.push({ type: "text", text: buildPrompt(text, ctx, mentionResult.block, backend.workspace) })
+    parts.push({
+      type: "text",
+      text: buildPrompt(text, ctx, mentionResult.block, backend.workspace, auto.blocks),
+    })
     type PromptBody = NonNullable<Parameters<typeof backend.client.session.prompt>[0]["body"]>
     const body: PromptBody = {
       parts: parts as PromptBody["parts"],
@@ -1342,6 +1374,21 @@ export class ChatView implements vscode.WebviewViewProvider {
     html = html.replace("<head>", `<head><meta http-equiv="Content-Security-Policy" content="${csp}">`)
     return html
   }
+}
+
+function collectSymbolFocus(activeRel: string | undefined, mentions: string[] | undefined): string[] {
+  const out: string[] = []
+  const seen = new Set<string>()
+  const push = (p: string | undefined) => {
+    if (!p) return
+    if (path.isAbsolute(p)) return
+    if (seen.has(p)) return
+    seen.add(p)
+    out.push(p)
+  }
+  push(activeRel)
+  for (const m of mentions ?? []) push(m)
+  return out
 }
 
 function appendText(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,16 +5,20 @@ import { ChatView } from "./chat/view"
 import { InlineEdit } from "./inline/edit"
 import { Preferences } from "./preferences"
 import { Picker } from "./picker"
+import { RecentEditsTracker } from "./workspace-context/recent-edits"
 import { getOutputChannel, log } from "./output"
 
 let servers: ServerManager | undefined
+let recentEdits: RecentEditsTracker | undefined
 
 export async function activate(context: vscode.ExtensionContext) {
   log("activating OpenCode Panel")
   servers = new ServerManager(context)
+  recentEdits = new RecentEditsTracker()
+  context.subscriptions.push({ dispose: () => recentEdits?.dispose() })
   const prefs = new Preferences(context.globalState)
   const status = new StatusBar(context, prefs)
-  const chat = new ChatView(context, servers, prefs)
+  const chat = new ChatView(context, servers, prefs, recentEdits)
   const inline = new InlineEdit(servers, prefs)
   const picker = new Picker(servers, prefs)
 

--- a/src/workspace-context/collector.ts
+++ b/src/workspace-context/collector.ts
@@ -1,0 +1,50 @@
+import type { WorkspaceRoot } from "../workspace-root"
+import { log } from "../output"
+import { collectOpenTabs } from "./open-tabs"
+import { collectDiagnostics } from "./diagnostics"
+import { collectGitDiff } from "./git"
+import { RecentEditsTracker } from "./recent-edits"
+import { collectDocs } from "./docs"
+import { collectSymbols } from "./symbols"
+import type { CollectorOutput } from "./types"
+
+export type AutoContext = CollectorOutput
+
+export type CollectInputs = {
+  workspace: WorkspaceRoot
+  recentEdits: RecentEditsTracker
+  /** Paths to query for symbol outlines: active editor + mentions. */
+  symbolFocus: string[]
+  enabled: boolean
+}
+
+/**
+ * Run every workspace-bound automatic collector in parallel, merge their
+ * items + blocks. Collectors are independent and failure-isolated — if one
+ * throws, the others still contribute and we log the failure.
+ *
+ * Phase 4 will wrap this with a budget pass that drops blocks until the
+ * total fits a configured cap.
+ */
+export async function collectAutoContext(input: CollectInputs): Promise<AutoContext> {
+  if (!input.enabled) return { items: [], blocks: [] }
+  const settled = await Promise.allSettled([
+    Promise.resolve(collectDiagnostics(input.workspace)),
+    collectOpenTabs(input.workspace),
+    collectGitDiff(input.workspace),
+    input.recentEdits.collect(input.workspace),
+    collectDocs(input.workspace),
+    collectSymbols(input.workspace, input.symbolFocus),
+  ])
+  const items: AutoContext["items"] = []
+  const blocks: AutoContext["blocks"] = []
+  for (const r of settled) {
+    if (r.status === "fulfilled") {
+      items.push(...r.value.items)
+      blocks.push(...r.value.blocks)
+    } else {
+      log("auto context: collector failed", r.reason)
+    }
+  }
+  return { items, blocks }
+}

--- a/src/workspace-context/diagnostics.ts
+++ b/src/workspace-context/diagnostics.ts
@@ -1,0 +1,77 @@
+import * as vscode from "vscode"
+import { isInsideRoot, relativeToRoot, type WorkspaceRoot } from "../workspace-root"
+import type { CollectorOutput } from "./types"
+
+const MAX_DIAGS = 30
+
+type Diag = {
+  relativePath: string
+  line: number
+  severity: vscode.DiagnosticSeverity
+  source?: string
+  message: string
+  code?: string
+}
+
+/**
+ * Collect VS Code diagnostics (errors + warnings) for files inside the
+ * workspace. Errors come first, then warnings; capped at `MAX_DIAGS` so a
+ * project with a sea of warnings doesn't blow the prompt budget. Info /
+ * hint severities are dropped — they rarely matter to an LLM and add noise.
+ */
+export function collectDiagnostics(workspace: WorkspaceRoot): CollectorOutput {
+  const errors: Diag[] = []
+  const warnings: Diag[] = []
+  for (const [uri, diags] of vscode.languages.getDiagnostics()) {
+    if (uri.scheme !== "file") continue
+    if (!isInsideRoot(workspace, uri.fsPath)) continue
+    const rel = relativeToRoot(workspace, uri.fsPath)
+    for (const d of diags) {
+      const entry: Diag = {
+        relativePath: rel,
+        line: d.range.start.line + 1,
+        severity: d.severity,
+        source: d.source,
+        message: d.message,
+        code: typeof d.code === "object" ? String((d.code as { value?: unknown }).value ?? "") : String(d.code ?? ""),
+      }
+      if (d.severity === vscode.DiagnosticSeverity.Error) errors.push(entry)
+      else if (d.severity === vscode.DiagnosticSeverity.Warning) warnings.push(entry)
+    }
+  }
+  const trimmed = [...errors, ...warnings].slice(0, MAX_DIAGS)
+  if (trimmed.length === 0) return { items: [], blocks: [] }
+  const lines = trimmed.map((d) => {
+    const sev = d.severity === vscode.DiagnosticSeverity.Error ? "error" : "warning"
+    const src = d.source ? `${d.source}: ` : ""
+    const code = d.code ? `[${d.code}] ` : ""
+    return `- ${d.relativePath}:${d.line} ${sev} ${src}${code}${d.message}`
+  })
+  const content = lines.join("\n")
+  const bytes = Buffer.byteLength(content, "utf8")
+  const id = `diagnostics_${Date.now()}`
+  return {
+    items: [
+      {
+        id,
+        source: "diagnostic",
+        kind: "diagnostic",
+        label: `Diagnostics (${trimmed.length})`,
+        reason: `${errors.length} error${errors.length === 1 ? "" : "s"}, ${warnings.length} warning${warnings.length === 1 ? "" : "s"} in the workspace`,
+        status: "included",
+        bytes,
+        priority: 5,
+      },
+    ],
+    blocks: [
+      {
+        id: `diagnostics_block`,
+        itemID: id,
+        title: "Diagnostics",
+        content,
+        bytes,
+        priority: 5,
+      },
+    ],
+  }
+}

--- a/src/workspace-context/docs.ts
+++ b/src/workspace-context/docs.ts
@@ -1,0 +1,65 @@
+import * as vscode from "vscode"
+import * as path from "path"
+import type { WorkspaceRoot } from "../workspace-root"
+import type { CollectorOutput } from "./types"
+import { log } from "../output"
+
+const KNOWN_DOCS = ["README.md", "CLAUDE.md", "AGENTS.md", "CONTRIBUTING.md"]
+const DOC_SUMMARY_BYTES = 1200
+const MAX_DOCS = 4
+
+/**
+ * Surface short summaries of project-root docs the agent should know about:
+ * README, CLAUDE.md, AGENTS.md, CONTRIBUTING.md. For each one found we emit
+ * the first `DOC_SUMMARY_BYTES` of content — enough for goals/conventions
+ * but not enough to overflow the prompt with a long spec.
+ *
+ * Reads are workspace-root only — Phase 3's auto-context never reaches
+ * outside open folders.
+ */
+export async function collectDocs(workspace: WorkspaceRoot): Promise<CollectorOutput> {
+  const items: CollectorOutput["items"] = []
+  const blocks: CollectorOutput["blocks"] = []
+  let included = 0
+  for (const name of KNOWN_DOCS) {
+    if (included >= MAX_DOCS) break
+    const uri = vscode.Uri.file(path.join(workspace.fsPath, name))
+    try {
+      const buf = await vscode.workspace.fs.readFile(uri)
+      const truncated = buf.byteLength > DOC_SUMMARY_BYTES
+      const slice = truncated ? buf.slice(0, DOC_SUMMARY_BYTES) : buf
+      const content = Buffer.from(slice).toString("utf8")
+      const bytes = slice.byteLength
+      const id = `doc_${name}`
+      items.push({
+        id,
+        source: "doc",
+        kind: "file",
+        label: name,
+        path: name,
+        reason: "Project documentation at the workspace root",
+        status: truncated ? "truncated" : "included",
+        bytes,
+        priority: 9,
+      })
+      blocks.push({
+        id: `doc_block_${name}`,
+        itemID: id,
+        title: name,
+        path: name,
+        language: "md",
+        content,
+        bytes,
+        priority: 9,
+      })
+      included += 1
+    } catch (e) {
+      // Most projects only have README.md — fall through quietly.
+      const code = (e as { code?: string }).code
+      if (code !== "FileNotFound" && code !== "ENOENT" && code !== "EntryNotFound") {
+        log("docs collector: skipping", name, e)
+      }
+    }
+  }
+  return { items, blocks }
+}

--- a/src/workspace-context/git.ts
+++ b/src/workspace-context/git.ts
@@ -1,0 +1,86 @@
+import { execFile } from "child_process"
+import { promisify } from "util"
+import type { WorkspaceRoot } from "../workspace-root"
+import type { CollectorOutput } from "./types"
+import { log } from "../output"
+
+const execFileAsync = promisify(execFile)
+
+const MAX_DIFF_BYTES = 60_000
+const TIMEOUT_MS = 5_000
+
+/**
+ * Collect a compact git diff against the workspace root: `git status --short`
+ * + `git diff --unified=3` for unstaged + `git diff --cached --unified=3` for
+ * staged. Each diff is truncated to `MAX_DIFF_BYTES` so a sweeping refactor
+ * doesn't drown the prompt. Returns empty output when the workspace isn't a
+ * git repo (the usual `fatal: not a git repository` exit code).
+ */
+export async function collectGitDiff(workspace: WorkspaceRoot): Promise<CollectorOutput> {
+  const cwd = workspace.fsPath
+  const [status, unstaged, staged] = await Promise.all([
+    runGit(cwd, ["status", "--short"]),
+    runGit(cwd, ["diff", "--unified=3", "--no-color"]),
+    runGit(cwd, ["diff", "--cached", "--unified=3", "--no-color"]),
+  ])
+  const parts: string[] = []
+  if (status) parts.push(`### Status\n${status}`)
+  if (unstaged) parts.push(`### Unstaged diff\n${truncate(unstaged)}`)
+  if (staged) parts.push(`### Staged diff\n${truncate(staged)}`)
+  if (parts.length === 0) return { items: [], blocks: [] }
+  const content = parts.join("\n\n")
+  const bytes = Buffer.byteLength(content, "utf8")
+  const truncated = unstaged.length > MAX_DIFF_BYTES || staged.length > MAX_DIFF_BYTES
+  const id = `git_${Date.now()}`
+  return {
+    items: [
+      {
+        id,
+        source: "git",
+        kind: "diff",
+        label: "Git changes",
+        reason: "Local git diff against the workspace root",
+        status: truncated ? "truncated" : "included",
+        bytes,
+        priority: 4,
+      },
+    ],
+    blocks: [
+      {
+        id: "git_block",
+        itemID: id,
+        title: "Git Changes",
+        content,
+        bytes,
+        priority: 4,
+      },
+    ],
+  }
+}
+
+function truncate(s: string): string {
+  if (s.length <= MAX_DIFF_BYTES) return s
+  return s.slice(0, MAX_DIFF_BYTES) + `\n… (truncated to ${MAX_DIFF_BYTES} bytes)`
+}
+
+async function runGit(cwd: string, args: string[]): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync("git", args, {
+      cwd,
+      timeout: TIMEOUT_MS,
+      // Cap stdout aggressively — `git diff` on a giant change-set is unbounded
+      // and we already truncate per-output anyway.
+      maxBuffer: 4 * 1024 * 1024,
+      env: { ...process.env, LANG: "C.UTF-8" },
+    })
+    return stdout.trim()
+  } catch (e) {
+    // ENOENT = git not installed, exitCode 128 = not a git repo. Both are
+    // expected; surface them only in the output log, don't fail the collector.
+    const code = (e as NodeJS.ErrnoException).code
+    if (code !== "ENOENT") {
+      log("git collector: command failed", args.join(" "), (e as Error).message)
+    }
+    return ""
+  }
+}

--- a/src/workspace-context/open-tabs.ts
+++ b/src/workspace-context/open-tabs.ts
@@ -1,0 +1,67 @@
+import * as vscode from "vscode"
+import { isInsideRoot, relativeToRoot, type WorkspaceRoot } from "../workspace-root"
+import type { CollectorOutput } from "./types"
+
+const MAX_TABS = 20
+
+/**
+ * Collect workspace-relative paths of files currently open as tabs. Returns
+ * metadata only — file contents are NOT included (the picker, the agent's
+ * tools, and other collectors are responsible for content if needed). This
+ * gives the model a "here are the files the user is looking at" hint without
+ * blowing the prompt budget.
+ *
+ * Active editor first, then tab-group order. Files outside the workspace are
+ * dropped — Phase 3's automatic context is workspace-bound by design.
+ */
+export async function collectOpenTabs(workspace: WorkspaceRoot): Promise<CollectorOutput> {
+  const out: Array<{ relativePath: string; active: boolean }> = []
+  const seen = new Set<string>()
+  const active = vscode.window.activeTextEditor?.document.uri
+  const push = (uri: vscode.Uri, isActive: boolean) => {
+    if (uri.scheme !== "file") return
+    if (!isInsideRoot(workspace, uri.fsPath)) return
+    const rel = relativeToRoot(workspace, uri.fsPath)
+    if (!rel || seen.has(rel)) return
+    seen.add(rel)
+    out.push({ relativePath: rel, active: isActive })
+  }
+  if (active) push(active, true)
+  for (const group of vscode.window.tabGroups.all) {
+    for (const tab of group.tabs) {
+      const input = tab.input
+      if (input && typeof input === "object" && "uri" in input) {
+        push((input as { uri: vscode.Uri }).uri, false)
+      }
+    }
+  }
+  const trimmed = out.slice(0, MAX_TABS)
+  if (trimmed.length === 0) return { items: [], blocks: [] }
+  const lines = trimmed.map((t) => `- ${t.relativePath}${t.active ? "  (active)" : ""}`)
+  const content = lines.join("\n")
+  const bytes = Buffer.byteLength(content, "utf8")
+  return {
+    items: [
+      {
+        id: `open-tabs_${Date.now()}`,
+        source: "openTab",
+        kind: "summary",
+        label: `Open tabs (${trimmed.length})`,
+        reason: "Files currently open in the editor — hints at user focus",
+        status: "included",
+        bytes,
+        priority: 7,
+      },
+    ],
+    blocks: [
+      {
+        id: `open-tabs_block`,
+        itemID: `open-tabs_${Date.now()}`,
+        title: "Open Tabs",
+        content,
+        bytes,
+        priority: 7,
+      },
+    ],
+  }
+}

--- a/src/workspace-context/recent-edits.ts
+++ b/src/workspace-context/recent-edits.ts
@@ -1,0 +1,85 @@
+import * as vscode from "vscode"
+import { isInsideRoot, relativeToRoot, type WorkspaceRoot } from "../workspace-root"
+import type { CollectorOutput } from "./types"
+
+const MAX_MRU = 20
+const MAX_INCLUDED = 10
+
+/**
+ * In-memory MRU of recently-edited workspace files. Subscribes to VS Code's
+ * text/save/create/delete/rename events when constructed; clients call
+ * `list(workspace)` to get the current ordered list.
+ *
+ * Not persisted across reloads — Phase 3's recall is a soft signal; the cost
+ * of cold-start being empty is small and skipping persistence keeps this
+ * collector free of state-management headaches.
+ */
+export class RecentEditsTracker {
+  private mru: string[] = []
+  private disposables: vscode.Disposable[] = []
+
+  constructor() {
+    this.disposables.push(
+      vscode.workspace.onDidChangeTextDocument((e) => this.touch(e.document.uri)),
+      vscode.workspace.onDidSaveTextDocument((doc) => this.touch(doc.uri)),
+      vscode.workspace.onDidCreateFiles((e) => e.files.forEach((u) => this.touch(u))),
+      vscode.workspace.onDidRenameFiles((e) => e.files.forEach((f) => this.touch(f.newUri))),
+      // Deletion: drop the path from the MRU; it can't be recalled later.
+      vscode.workspace.onDidDeleteFiles((e) => {
+        for (const u of e.files) {
+          if (u.scheme !== "file") continue
+          this.mru = this.mru.filter((p) => p !== u.fsPath)
+        }
+      }),
+    )
+  }
+
+  dispose() {
+    for (const d of this.disposables) d.dispose()
+    this.disposables = []
+  }
+
+  private touch(uri: vscode.Uri) {
+    if (uri.scheme !== "file") return
+    const fsPath = uri.fsPath
+    this.mru = [fsPath, ...this.mru.filter((p) => p !== fsPath)]
+    if (this.mru.length > MAX_MRU) this.mru.length = MAX_MRU
+  }
+
+  list(workspace: WorkspaceRoot): string[] {
+    return this.mru.filter((p) => isInsideRoot(workspace, p))
+  }
+
+  async collect(workspace: WorkspaceRoot): Promise<CollectorOutput> {
+    const paths = this.list(workspace).slice(0, MAX_INCLUDED)
+    if (paths.length === 0) return { items: [], blocks: [] }
+    const lines = paths.map((p) => `- ${relativeToRoot(workspace, p)}`)
+    const content = lines.join("\n")
+    const bytes = Buffer.byteLength(content, "utf8")
+    const id = `recent_${Date.now()}`
+    return {
+      items: [
+        {
+          id,
+          source: "recentEdit",
+          kind: "summary",
+          label: `Recent edits (${paths.length})`,
+          reason: "Files touched recently in this VS Code session",
+          status: "included",
+          bytes,
+          priority: 8,
+        },
+      ],
+      blocks: [
+        {
+          id: "recent_block",
+          itemID: id,
+          title: "Recent Edits",
+          content,
+          bytes,
+          priority: 8,
+        },
+      ],
+    }
+  }
+}

--- a/src/workspace-context/symbols.ts
+++ b/src/workspace-context/symbols.ts
@@ -1,0 +1,124 @@
+import * as vscode from "vscode"
+import * as path from "path"
+import { isInsideRoot, relativeToRoot, type WorkspaceRoot } from "../workspace-root"
+import type { CollectorOutput } from "./types"
+import { log } from "../output"
+
+const MAX_FILES = 5
+const MAX_SYMBOLS_PER_FILE = 50
+
+/**
+ * Run VS Code's `executeDocumentSymbolProvider` against the active editor
+ * and the user's mentions to capture an outline of structure (function /
+ * class / type names + line ranges). Symbol bodies are intentionally NOT
+ * included — Phase 3's symbol pass is a navigation hint, not full
+ * substitution for the file. Phase 6's semantic index can layer richer
+ * symbol-aware retrieval on top.
+ */
+export async function collectSymbols(
+  workspace: WorkspaceRoot,
+  focusPaths: string[],
+): Promise<CollectorOutput> {
+  const seen = new Set<string>()
+  const files = focusPaths
+    .map((rel) => path.join(workspace.fsPath, rel))
+    .filter((abs) => {
+      if (seen.has(abs)) return false
+      seen.add(abs)
+      return isInsideRoot(workspace, abs)
+    })
+    .slice(0, MAX_FILES)
+
+  const items: CollectorOutput["items"] = []
+  const blocks: CollectorOutput["blocks"] = []
+  for (const abs of files) {
+    const rel = relativeToRoot(workspace, abs)
+    const uri = vscode.Uri.file(abs)
+    let symbols: vscode.DocumentSymbol[] | undefined
+    try {
+      symbols = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+        "vscode.executeDocumentSymbolProvider",
+        uri,
+      )
+    } catch (e) {
+      log("symbols collector: provider failed for", rel, e)
+      continue
+    }
+    if (!symbols || symbols.length === 0) continue
+    const flat = flatten(symbols).slice(0, MAX_SYMBOLS_PER_FILE)
+    const lines = flat.map((s) => `- ${s.kind} ${s.name} (L${s.line})`)
+    const content = `${rel}\n${lines.join("\n")}`
+    const bytes = Buffer.byteLength(content, "utf8")
+    const id = `symbols_${rel.replace(/[^a-zA-Z0-9]/g, "_")}`
+    items.push({
+      id,
+      source: "symbol",
+      kind: "symbol",
+      label: `${rel} (${flat.length} symbol${flat.length === 1 ? "" : "s"})`,
+      path: rel,
+      reason: "Document outline for a focused file",
+      status: "included",
+      bytes,
+      priority: 10,
+    })
+    blocks.push({
+      id: `symbols_block_${rel}`,
+      itemID: id,
+      title: `Symbols — ${rel}`,
+      path: rel,
+      content,
+      bytes,
+      priority: 10,
+    })
+  }
+  return { items, blocks }
+}
+
+type FlatSymbol = { name: string; kind: string; line: number }
+
+function flatten(symbols: vscode.DocumentSymbol[], depth = 0): FlatSymbol[] {
+  const out: FlatSymbol[] = []
+  for (const s of symbols) {
+    out.push({
+      name: s.name,
+      kind: kindName(s.kind),
+      line: s.range.start.line + 1,
+    })
+    if (s.children && s.children.length > 0 && depth < 2) {
+      out.push(...flatten(s.children, depth + 1))
+    }
+  }
+  return out
+}
+
+function kindName(kind: vscode.SymbolKind): string {
+  const map: Record<number, string> = {
+    0: "file",
+    1: "module",
+    2: "namespace",
+    3: "package",
+    4: "class",
+    5: "method",
+    6: "property",
+    7: "field",
+    8: "constructor",
+    9: "enum",
+    10: "interface",
+    11: "function",
+    12: "variable",
+    13: "constant",
+    14: "string",
+    15: "number",
+    16: "boolean",
+    17: "array",
+    18: "object",
+    19: "key",
+    20: "null",
+    21: "enumMember",
+    22: "struct",
+    23: "event",
+    24: "operator",
+    25: "typeParameter",
+  }
+  return map[kind] ?? "symbol"
+}

--- a/src/workspace-context/types.ts
+++ b/src/workspace-context/types.ts
@@ -1,0 +1,33 @@
+import type { PromptContextManifestItem } from "../protocol"
+import type { WorkspaceRoot } from "../workspace-root"
+
+/**
+ * A single chunk of context the host plans to include in the prompt. The
+ * builder (`buildPrompt`) splices these into the final string under one
+ * `## <title>` heading per block.
+ */
+export type PromptContextBlock = {
+  id: string
+  /** Manifest item this block corresponds to — for budget/skip bookkeeping. */
+  itemID: string
+  title: string
+  /** Optional path used by some block renderers (diagnostics, docs). */
+  path?: string
+  /** Optional language hint for ```<lang> fences. */
+  language?: string
+  content: string
+  bytes: number
+  /** Lower priority = higher preference for inclusion when budgets bite. */
+  priority: number
+}
+
+export type CollectorOutput = {
+  items: PromptContextManifestItem[]
+  blocks: PromptContextBlock[]
+}
+
+export type CollectorInput = {
+  workspace: WorkspaceRoot
+}
+
+export type Collector = (input: CollectorInput) => Promise<CollectorOutput>

--- a/test/host/collectors.test.ts
+++ b/test/host/collectors.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import * as vscode from "vscode"
+import { collectOpenTabs } from "../../src/workspace-context/open-tabs"
+import { collectDiagnostics } from "../../src/workspace-context/diagnostics"
+import { collectGitDiff } from "../../src/workspace-context/git"
+import { RecentEditsTracker } from "../../src/workspace-context/recent-edits"
+import { collectDocs } from "../../src/workspace-context/docs"
+import { collectSymbols } from "../../src/workspace-context/symbols"
+import type { WorkspaceRoot } from "../../src/workspace-root"
+
+const WORKSPACE: WorkspaceRoot = {
+  uri: { fsPath: "/workspace", scheme: "file" } as unknown as vscode.Uri,
+  fsPath: "/workspace",
+  name: "workspace",
+  index: 0,
+  isDefault: true,
+}
+
+type MutableWindow = {
+  activeTextEditor?: { document: { uri: { fsPath: string; scheme: string } } }
+  tabGroups: { all: Array<{ tabs: Array<{ input?: unknown }> }> }
+}
+const win = vscode.window as unknown as MutableWindow
+
+function setTabs(paths: string[]) {
+  win.tabGroups = {
+    all: [
+      {
+        tabs: paths.map((p) => ({
+          input: { uri: { fsPath: p, scheme: "file" } as unknown as vscode.Uri },
+        })),
+      },
+    ],
+  }
+}
+
+function setActive(p: string | undefined) {
+  win.activeTextEditor = p
+    ? { document: { uri: { fsPath: p, scheme: "file" } } }
+    : undefined
+}
+
+describe("collectOpenTabs", () => {
+  beforeEach(() => {
+    win.tabGroups = { all: [] }
+    setActive(undefined)
+  })
+
+  it("returns empty output when no tabs are open", async () => {
+    const out = await collectOpenTabs(WORKSPACE)
+    expect(out.items).toEqual([])
+    expect(out.blocks).toEqual([])
+  })
+
+  it("lists workspace tabs and marks the active one", async () => {
+    setTabs(["/workspace/a.ts", "/workspace/b.ts"])
+    setActive("/workspace/b.ts")
+    const out = await collectOpenTabs(WORKSPACE)
+    expect(out.items).toHaveLength(1)
+    expect(out.blocks[0].content).toContain("- b.ts  (active)")
+    expect(out.blocks[0].content).toContain("- a.ts")
+  })
+
+  it("filters out external tabs", async () => {
+    setTabs(["/workspace/a.ts", "/elsewhere/b.ts"])
+    const out = await collectOpenTabs(WORKSPACE)
+    expect(out.blocks[0].content).toContain("a.ts")
+    expect(out.blocks[0].content).not.toContain("b.ts")
+  })
+})
+
+describe("collectDiagnostics", () => {
+  beforeEach(() => {
+    vi.mocked(vscode.languages.getDiagnostics).mockReset()
+    vi.mocked(vscode.languages.getDiagnostics).mockReturnValue([])
+  })
+
+  it("returns empty output when there are no diagnostics", () => {
+    const out = collectDiagnostics(WORKSPACE)
+    expect(out.items).toEqual([])
+  })
+
+  it("orders errors before warnings", () => {
+    vi.mocked(vscode.languages.getDiagnostics).mockReturnValue([
+      [
+        { fsPath: "/workspace/a.ts", scheme: "file" } as unknown as vscode.Uri,
+        [
+          {
+            range: { start: { line: 4 } } as unknown as vscode.Range,
+            severity: vscode.DiagnosticSeverity.Warning,
+            message: "warn here",
+            source: "eslint",
+          } as unknown as vscode.Diagnostic,
+          {
+            range: { start: { line: 1 } } as unknown as vscode.Range,
+            severity: vscode.DiagnosticSeverity.Error,
+            message: "type error",
+            source: "ts",
+            code: "TS2345",
+          } as unknown as vscode.Diagnostic,
+        ],
+      ],
+    ])
+    const out = collectDiagnostics(WORKSPACE)
+    expect(out.blocks).toHaveLength(1)
+    const lines = out.blocks[0].content.split("\n")
+    expect(lines[0]).toContain("error")
+    expect(lines[0]).toContain("TS2345")
+    expect(lines[1]).toContain("warning")
+  })
+
+  it("drops diagnostics from outside the workspace", () => {
+    vi.mocked(vscode.languages.getDiagnostics).mockReturnValue([
+      [
+        { fsPath: "/elsewhere/file.ts", scheme: "file" } as unknown as vscode.Uri,
+        [
+          {
+            range: { start: { line: 1 } } as unknown as vscode.Range,
+            severity: vscode.DiagnosticSeverity.Error,
+            message: "no",
+          } as unknown as vscode.Diagnostic,
+        ],
+      ],
+    ])
+    const out = collectDiagnostics(WORKSPACE)
+    expect(out.items).toEqual([])
+  })
+})
+
+describe("collectGitDiff", () => {
+  it("returns empty output for a non-git directory", async () => {
+    const out = await collectGitDiff({ ...WORKSPACE, fsPath: "/tmp/definitely-not-a-repo-xyzzy" })
+    expect(out.items).toEqual([])
+    expect(out.blocks).toEqual([])
+  })
+})
+
+describe("RecentEditsTracker", () => {
+  it("starts empty and trims items outside the workspace", async () => {
+    const t = new RecentEditsTracker()
+    expect(t.list(WORKSPACE)).toEqual([])
+    const out = await t.collect(WORKSPACE)
+    expect(out.items).toEqual([])
+    t.dispose()
+  })
+})
+
+describe("collectDocs", () => {
+  beforeEach(() => {
+    vi.mocked(vscode.workspace.fs.readFile).mockReset()
+  })
+
+  it("emits items for each known doc that exists", async () => {
+    const readme = new TextEncoder().encode("# Project\n\nDescribes the project.")
+    const claude = new TextEncoder().encode("# Claude rules")
+    vi.mocked(vscode.workspace.fs.readFile)
+      .mockResolvedValueOnce(readme) // README.md
+      .mockResolvedValueOnce(claude) // CLAUDE.md
+      .mockRejectedValueOnce({ code: "ENOENT" }) // AGENTS.md
+      .mockRejectedValueOnce({ code: "ENOENT" }) // CONTRIBUTING.md
+    const out = await collectDocs(WORKSPACE)
+    const labels = out.items.map((i) => i.label)
+    expect(labels).toEqual(["README.md", "CLAUDE.md"])
+  })
+
+  it("returns empty output when no docs exist", async () => {
+    vi.mocked(vscode.workspace.fs.readFile).mockRejectedValue({ code: "ENOENT" })
+    const out = await collectDocs(WORKSPACE)
+    expect(out.items).toEqual([])
+  })
+})
+
+describe("collectSymbols", () => {
+  beforeEach(() => {
+    vi.mocked(vscode.commands.executeCommand).mockReset()
+  })
+
+  it("emits one item per focus file when symbols are present", async () => {
+    vi.mocked(vscode.commands.executeCommand).mockResolvedValueOnce([
+      {
+        name: "Foo",
+        kind: vscode.SymbolKind.Class,
+        range: { start: { line: 2 } } as unknown as vscode.Range,
+        children: [
+          {
+            name: "bar",
+            kind: vscode.SymbolKind.Method,
+            range: { start: { line: 5 } } as unknown as vscode.Range,
+            children: [],
+          },
+        ],
+      },
+    ] as unknown as vscode.DocumentSymbol[])
+    const out = await collectSymbols(WORKSPACE, ["src/foo.ts"])
+    expect(out.items).toHaveLength(1)
+    expect(out.blocks[0].content).toContain("class Foo")
+    expect(out.blocks[0].content).toContain("method bar")
+  })
+
+  it("returns empty when the symbol provider yields nothing", async () => {
+    vi.mocked(vscode.commands.executeCommand).mockResolvedValueOnce(undefined)
+    const out = await collectSymbols(WORKSPACE, ["src/foo.ts"])
+    expect(out.items).toEqual([])
+  })
+})

--- a/test/host/setup.ts
+++ b/test/host/setup.ts
@@ -92,6 +92,12 @@ vi.mock("vscode", () => {
         stat: vi.fn().mockResolvedValue({}),
         readFile: vi.fn().mockResolvedValue(new Uint8Array()),
       },
+      onDidChangeTextDocument: vi.fn(() => ({ dispose: vi.fn() })),
+      onDidSaveTextDocument: vi.fn(() => ({ dispose: vi.fn() })),
+      onDidCreateFiles: vi.fn(() => ({ dispose: vi.fn() })),
+      onDidDeleteFiles: vi.fn(() => ({ dispose: vi.fn() })),
+      onDidRenameFiles: vi.fn(() => ({ dispose: vi.fn() })),
+      onDidChangeWorkspaceFolders: vi.fn(() => ({ dispose: vi.fn() })),
     },
     window: {
       activeTextEditor: undefined,
@@ -125,6 +131,15 @@ vi.mock("vscode", () => {
     },
     languages: {
       registerCodeLensProvider: vi.fn(() => ({ dispose: vi.fn() })),
+      getDiagnostics: vi.fn(() => [] as Array<[Uri, unknown[]]>),
+    },
+    DiagnosticSeverity: { Error: 0, Warning: 1, Information: 2, Hint: 3 },
+    SymbolKind: {
+      File: 0, Module: 1, Namespace: 2, Package: 3, Class: 4, Method: 5,
+      Property: 6, Field: 7, Constructor: 8, Enum: 9, Interface: 10,
+      Function: 11, Variable: 12, Constant: 13, String: 14, Number: 15,
+      Boolean: 16, Array: 17, Object: 18, Key: 19, Null: 20, EnumMember: 21,
+      Struct: 22, Event: 23, Operator: 24, TypeParameter: 25,
     },
   }
   return {


### PR DESCRIPTION
Closes #121 — part of #117.

Implements **Phase 3** of [`docs/workspace-context-and-indexing.md`](docs/workspace-context-and-indexing.md). With Phase 2's manifest in place, each prompt now carries deterministic high-signal context the user shouldn't have to type out manually.

## Summary

All collectors are **workspace-bound** — Phase 3's auto-context never reaches outside open folders.

| File | What it collects | Notes |
| --- | --- | --- |
| `open-tabs.ts` | Workspace-relative paths of open tabs, active first | Metadata only, no file contents |
| `diagnostics.ts` | Errors + warnings from `vscode.languages.getDiagnostics()` | Errors first, capped at 30 |
| `git.ts` | `git status --short` + unstaged + staged diffs against the workspace root | Tolerates non-git dirs and missing `git`; per-diff cap 60 KB |
| `recent-edits.ts` | In-memory MRU subscribed to text/save/create/delete/rename events | Survives across sends via `extension.ts` |
| `docs.ts` | Short summaries (≤ 1.2 KB) of `README.md`, `CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md` | Workspace-root only |
| `symbols.ts` | `vscode.executeDocumentSymbolProvider` outline for active editor + mentions | Symbol names + line ranges; not bodies |
| `collector.ts` | Orchestrator running everything in parallel with `Promise.allSettled` | Failure-isolated |

## Wiring

- `src/chat/prompt-builder.ts` — `buildPrompt` accepts `autoBlocks`; each block lands as a `## <title>` section, ordered by priority.
- `src/chat/view.ts` — `handleSend` runs `collectAutoContext` in parallel with `readMentions`, merges items into the Phase 2 manifest, and passes blocks to `buildPrompt`. Skipped when no workspace or when `opencui.context.enabled` is false.
- `src/extension.ts` — holds the `RecentEditsTracker` for the extension lifetime; disposes it on teardown.
- `package.json` — adds `opencui.context.enabled` (default `true`).

## Test plan

- [x] `bun run test` — 554/554, with 17 new collector cases.
- [x] `bun run check-types` — host clean.
- [ ] Manual: send a prompt in a git repo and confirm the manifest expands to show "Git changes / Diagnostics / Open tabs / Docs / Symbols" sections; toggle `opencui.context.enabled: false` and confirm only the manual mentions land in the prompt.

## Out of scope

- Budget enforcement (currently every collector self-caps) — Phase 4 (#122).
- OMO / semantic-source labeling — Phase 5 (#123).
- Semantic index — Phase 6 (#124).