### PR TITLE
feat(context-budget): prompt budget manager (Phase 4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,26 @@
           "type": "boolean",
           "default": true,
           "description": "Attach automatic workspace context (open tabs, diagnostics, git diff, recent edits, docs, symbols) to each prompt. Disable to send only the user's text + mentions."
+        },
+        "opencui.context.maxBytes": {
+          "type": "number",
+          "default": 300000,
+          "description": "Approximate cap (UTF-8 bytes) on the total context attached to a single prompt. The manifest reports this as `budgetBytes`."
+        },
+        "opencui.context.maxAutoBytes": {
+          "type": "number",
+          "default": 120000,
+          "description": "Cap on automatic-context bytes (open tabs, diagnostics, git diff, recent edits, docs, symbols). Lower-priority blocks are dropped first when the budget bites."
+        },
+        "opencui.context.maxMentionBytes": {
+          "type": "number",
+          "default": 200000,
+          "description": "Cap on bytes read from manual @-file mentions. Files past this cap are skipped and shown as 'skipped' in the manifest."
+        },
+        "opencui.context.showManifest": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show the context-manifest pill under each user message in the chat panel."
         }
       }
     }

--- a/src/chat/prompt-builder.ts
+++ b/src/chat/prompt-builder.ts
@@ -5,7 +5,7 @@ import type { WorkspaceRoot } from "../workspace-root"
 import type { PromptContextBlock } from "../workspace-context/types"
 import { log } from "../output"
 
-const MENTION_MAX_BYTES = 200_000
+export const DEFAULT_MENTION_MAX_BYTES = 200_000
 const MENTION_MAX_FILES = 20
 
 export function buildPrompt(
@@ -73,7 +73,10 @@ export type MentionReadResult = {
   failed: string[]
 }
 
-export async function readMentions(mentions?: string[]): Promise<MentionReadResult> {
+export async function readMentions(
+  mentions?: string[],
+  maxBytes: number = DEFAULT_MENTION_MAX_BYTES,
+): Promise<MentionReadResult> {
   if (!mentions || mentions.length === 0) {
     return { bytes: {}, capped: [], failed: [] }
   }
@@ -95,7 +98,7 @@ export async function readMentions(mentions?: string[]): Promise<MentionReadResu
     const uri = path.isAbsolute(rel) ? vscode.Uri.file(rel) : vscode.Uri.joinPath(folder.uri, rel)
     try {
       const buf = await vscode.workspace.fs.readFile(uri)
-      const remaining = MENTION_MAX_BYTES - totalBytes
+      const remaining = maxBytes - totalBytes
       if (remaining <= 0) {
         capped.push(rel)
         continue

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -41,6 +41,7 @@ import { buildPrompt, readMentions } from "./prompt-builder"
 import { buildManifest } from "../workspace-context/manifest"
 import { collectAutoContext } from "../workspace-context/collector"
 import { RecentEditsTracker } from "../workspace-context/recent-edits"
+import { readContextSettings } from "../workspace-context/budget"
 import { toWire } from "./wire-format"
 import {
   applyCode,
@@ -942,16 +943,17 @@ export class ChatView implements vscode.WebviewViewProvider {
     }
 
     const sel = this.prefs.get()
-    const contextEnabled = vscode.workspace.getConfiguration("opencui").get<boolean>("context.enabled") ?? true
+    const settings = readContextSettings(vscode.workspace.getConfiguration("opencui"))
     const symbolFocus = collectSymbolFocus(ctx.relativePath, mentions)
     const [mentionResult, auto] = await Promise.all([
-      readMentions(mentions),
+      readMentions(mentions, settings.maxMentionBytes),
       backend.workspace
         ? collectAutoContext({
             workspace: backend.workspace,
             recentEdits: this.recentEdits,
             symbolFocus,
-            enabled: contextEnabled,
+            enabled: settings.enabled,
+            maxAutoBytes: settings.maxAutoBytes,
           })
         : Promise.resolve({ items: [], blocks: [] }),
     ])
@@ -1003,7 +1005,10 @@ export class ChatView implements vscode.WebviewViewProvider {
       })
       manifest.totals.skippedItems += 1
     }
-    this.post({ type: "userMessageContext", id: userMessageID, context: manifest })
+    manifest.totals.budgetBytes = settings.maxBytes
+    if (settings.showManifest) {
+      this.post({ type: "userMessageContext", id: userMessageID, context: manifest })
+    }
     const parts: Array<Record<string, unknown>> = []
     if (attachments) {
       for (const a of attachments) {

--- a/src/workspace-context/budget.ts
+++ b/src/workspace-context/budget.ts
@@ -1,0 +1,91 @@
+import type { PromptContextManifestItem } from "../protocol"
+import type { PromptContextBlock } from "./types"
+
+export type BudgetOptions = {
+  /** Cap on the sum of `block.bytes` for automatic-context blocks. */
+  maxAutoBytes: number
+}
+
+export type AppliedBudget = {
+  blocks: PromptContextBlock[]
+  items: PromptContextManifestItem[]
+  droppedBytes: number
+}
+
+/**
+ * Trim automatic-context blocks down to `maxAutoBytes`. Lowest-priority-number
+ * (= most important) blocks stay; we drop from the high-priority tail until
+ * the total fits. Items whose blocks were dropped flip to status `skipped`
+ * with an explanatory reason; items without a corresponding block (manifest
+ * summaries) pass through untouched.
+ *
+ * The cap is intentionally a **soft** budget: collectors self-cap already, so
+ * this routine is the final guardrail — it doesn't try to slice individual
+ * blocks because doing so destroys diff and symbol-table structure. Phase 4's
+ * design accepts that "skip an entire block" is easier to explain in the
+ * manifest than "truncated to N bytes mid-block".
+ */
+export function applyAutoContextBudget(
+  blocks: PromptContextBlock[],
+  items: PromptContextManifestItem[],
+  options: BudgetOptions,
+): AppliedBudget {
+  const { maxAutoBytes } = options
+  const sorted = [...blocks].sort((a, b) => a.priority - b.priority)
+  const kept: PromptContextBlock[] = []
+  const droppedIds = new Set<string>()
+  let used = 0
+  for (const block of sorted) {
+    if (used + block.bytes <= maxAutoBytes) {
+      kept.push(block)
+      used += block.bytes
+    } else {
+      droppedIds.add(block.itemID)
+    }
+  }
+  // Preserve the original block order for prompt rendering (buildPrompt
+  // re-sorts by priority anyway, but we keep determinism here).
+  const keptIds = new Set(kept.map((b) => b.id))
+  const orderedKept = blocks.filter((b) => keptIds.has(b.id))
+  const updatedItems = items.map((item) => {
+    if (!droppedIds.has(item.id)) return item
+    return {
+      ...item,
+      status: "skipped" as const,
+      reason: `Skipped: over per-prompt auto-context budget (${maxAutoBytes} bytes)`,
+    }
+  })
+  const droppedBytes = blocks.reduce((acc, b) => acc + b.bytes, 0) - used
+  return { blocks: orderedKept, items: updatedItems, droppedBytes }
+}
+
+export type ContextSettings = {
+  enabled: boolean
+  maxBytes: number
+  maxAutoBytes: number
+  maxMentionBytes: number
+  showManifest: boolean
+}
+
+export const DEFAULT_CONTEXT_SETTINGS: ContextSettings = {
+  enabled: true,
+  maxBytes: 300_000,
+  maxAutoBytes: 120_000,
+  maxMentionBytes: 200_000,
+  showManifest: true,
+}
+
+export function readContextSettings(
+  config: { get<T>(key: string): T | undefined },
+): ContextSettings {
+  return {
+    enabled: config.get<boolean>("context.enabled") ?? DEFAULT_CONTEXT_SETTINGS.enabled,
+    maxBytes: config.get<number>("context.maxBytes") ?? DEFAULT_CONTEXT_SETTINGS.maxBytes,
+    maxAutoBytes:
+      config.get<number>("context.maxAutoBytes") ?? DEFAULT_CONTEXT_SETTINGS.maxAutoBytes,
+    maxMentionBytes:
+      config.get<number>("context.maxMentionBytes") ?? DEFAULT_CONTEXT_SETTINGS.maxMentionBytes,
+    showManifest:
+      config.get<boolean>("context.showManifest") ?? DEFAULT_CONTEXT_SETTINGS.showManifest,
+  }
+}

--- a/src/workspace-context/collector.ts
+++ b/src/workspace-context/collector.ts
@@ -7,6 +7,7 @@ import { RecentEditsTracker } from "./recent-edits"
 import { collectDocs } from "./docs"
 import { collectSymbols } from "./symbols"
 import type { CollectorOutput } from "./types"
+import { applyAutoContextBudget } from "./budget"
 
 export type AutoContext = CollectorOutput
 
@@ -16,6 +17,7 @@ export type CollectInputs = {
   /** Paths to query for symbol outlines: active editor + mentions. */
   symbolFocus: string[]
   enabled: boolean
+  maxAutoBytes: number
 }
 
 /**
@@ -46,5 +48,9 @@ export async function collectAutoContext(input: CollectInputs): Promise<AutoCont
       log("auto context: collector failed", r.reason)
     }
   }
-  return { items, blocks }
+  const budgeted = applyAutoContextBudget(blocks, items, { maxAutoBytes: input.maxAutoBytes })
+  if (budgeted.droppedBytes > 0) {
+    log("auto context: dropped", budgeted.droppedBytes, "bytes over budget", input.maxAutoBytes)
+  }
+  return { items: budgeted.items, blocks: budgeted.blocks }
 }

--- a/test/host/budget.test.ts
+++ b/test/host/budget.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest"
+import {
+  applyAutoContextBudget,
+  readContextSettings,
+  DEFAULT_CONTEXT_SETTINGS,
+} from "../../src/workspace-context/budget"
+import type { PromptContextBlock } from "../../src/workspace-context/types"
+import type { PromptContextManifestItem } from "../../src/protocol"
+
+function block(id: string, itemID: string, bytes: number, priority: number): PromptContextBlock {
+  return {
+    id,
+    itemID,
+    title: id,
+    content: "x".repeat(bytes),
+    bytes,
+    priority,
+  }
+}
+
+function item(id: string, priority: number, bytes: number): PromptContextManifestItem {
+  return {
+    id,
+    source: "openTab",
+    kind: "summary",
+    label: id,
+    reason: "Test",
+    status: "included",
+    bytes,
+    priority,
+  }
+}
+
+describe("applyAutoContextBudget", () => {
+  it("returns everything when the total fits the budget", () => {
+    const blocks = [block("a", "i1", 100, 1), block("b", "i2", 100, 2)]
+    const items = [item("i1", 1, 100), item("i2", 2, 100)]
+    const out = applyAutoContextBudget(blocks, items, { maxAutoBytes: 500 })
+    expect(out.blocks).toHaveLength(2)
+    expect(out.droppedBytes).toBe(0)
+    expect(out.items.every((i) => i.status === "included")).toBe(true)
+  })
+
+  it("drops lower-priority blocks first and marks their items skipped", () => {
+    const blocks = [
+      block("a", "i1", 100, 1), // highest priority (smallest number)
+      block("b", "i2", 200, 5),
+      block("c", "i3", 200, 9), // lowest priority — drops first
+    ]
+    const items = [item("i1", 1, 100), item("i2", 5, 200), item("i3", 9, 200)]
+    const out = applyAutoContextBudget(blocks, items, { maxAutoBytes: 350 })
+    expect(out.blocks.map((b) => b.id)).toEqual(["a", "b"])
+    expect(out.droppedBytes).toBe(200)
+    const dropped = out.items.find((i) => i.id === "i3")
+    expect(dropped?.status).toBe("skipped")
+    expect(dropped?.reason).toContain("over per-prompt auto-context budget")
+  })
+
+  it("does not slice individual blocks", () => {
+    const blocks = [block("a", "i1", 200, 1)]
+    const items = [item("i1", 1, 200)]
+    const out = applyAutoContextBudget(blocks, items, { maxAutoBytes: 100 })
+    // Block too big for the budget → fully dropped, not partially included.
+    expect(out.blocks).toEqual([])
+    expect(out.items[0].status).toBe("skipped")
+  })
+
+  it("preserves the original block array order in the result", () => {
+    const blocks = [
+      block("a", "i1", 100, 5), // input order: a, b, c
+      block("b", "i2", 100, 1),
+      block("c", "i3", 100, 3),
+    ]
+    const items = [item("i1", 5, 100), item("i2", 1, 100), item("i3", 3, 100)]
+    const out = applyAutoContextBudget(blocks, items, { maxAutoBytes: 500 })
+    expect(out.blocks.map((b) => b.id)).toEqual(["a", "b", "c"])
+  })
+})
+
+describe("readContextSettings", () => {
+  it("falls back to defaults when nothing is set", () => {
+    const cfg = { get: <T>(_k: string): T | undefined => undefined }
+    expect(readContextSettings(cfg)).toEqual(DEFAULT_CONTEXT_SETTINGS)
+  })
+
+  it("returns explicit overrides", () => {
+    const cfg = {
+      get<T>(key: string): T | undefined {
+        if (key === "context.enabled") return false as unknown as T
+        if (key === "context.maxBytes") return 50000 as unknown as T
+        if (key === "context.maxAutoBytes") return 25000 as unknown as T
+        if (key === "context.maxMentionBytes") return 10000 as unknown as T
+        if (key === "context.showManifest") return false as unknown as T
+        return undefined
+      },
+    }
+    expect(readContextSettings(cfg)).toEqual({
+      enabled: false,
+      maxBytes: 50000,
+      maxAutoBytes: 25000,
+      maxMentionBytes: 10000,
+      showManifest: false,
+    })
+  })
+})


### PR DESCRIPTION
Closes #122 — part of #117.

Implements **Phase 4** of [`docs/workspace-context-and-indexing.md`](docs/workspace-context-and-indexing.md). With Phase 3's collectors emitting more material than will always fit, this PR centralizes the "how much context fits" decision and reports the result honestly in the Phase 2 manifest.

## Summary

- **`src/workspace-context/budget.ts`**
  - `applyAutoContextBudget(blocks, items, { maxAutoBytes })` keeps highest-priority blocks (lowest priority number wins) and drops the tail until the total fits. Manifest items for dropped blocks flip to `skipped` with the over-budget reason. Blocks are **not sliced** — preserving diff and symbol-table structure beats squeezing a few extra bytes.
  - `readContextSettings(config)` returns the canonical settings shape with safe defaults — usable in tests without spinning up the full vscode mock.
- **`src/workspace-context/collector.ts`** — applies the budget after collectors run; logs dropped bytes for debugging.
- **`src/chat/prompt-builder.ts`** — `readMentions(mentions, maxBytes = DEFAULT_MENTION_MAX_BYTES)` now takes a configurable cap.
- **`src/chat/view.ts`** — pulls all four context settings via `readContextSettings`, threads them to the collector and `readMentions`, sets `manifest.totals.budgetBytes`, and respects `context.showManifest` (host still builds the manifest for logging; webview only sees it when the setting is on).
- **`package.json`** — `opencui.context.maxBytes` (300 KB), `maxAutoBytes` (120 KB), `maxMentionBytes` (200 KB), `showManifest` (true).

## Budget rules (from the plan)

- Manual mentions get the largest budget share via `maxMentionBytes`.
- Automatic context never evicts mentions — independent cap.
- Truncation and skipping are recorded on each manifest item with the reason.
- Budgets are computed in UTF-8 bytes (`Buffer.byteLength`) to match the rest of the host.

## Test plan

- [x] `bun run test` — 560/560 with 6 new budget cases (in-budget, partial drop, oversized single block, order preservation, default settings, override settings).
- [x] `bun run check-types` — host clean.
- [ ] Manual: with a giant git diff, confirm the manifest pill shows the dropped collector items as `skipped` with the budget reason; lower `opencui.context.maxAutoBytes` to 20 KB and confirm only the smallest blocks survive.

## Out of scope

- Source classification for OMO / semantic plugins — Phase 5 (#123).
- Semantic index — Phase 6 (#124).