### PR TITLE
feat(ecosystem): classify opencode/OMO/semantic tools (Phase 5)

### DIFF
--- a/src/opencode/tool-discovery.ts
+++ b/src/opencode/tool-discovery.ts
@@ -1,0 +1,109 @@
+import type { PromptContextManifestItemSource } from "../protocol"
+
+/**
+ * Best-effort classification of an opencode tool name into a source family
+ * used by the context manifest. We can't introspect every plugin's tool list
+ * — opencode's plugin API doesn't expose typed metadata yet — so this works
+ * off a curated list of well-known patterns and falls back to `opencode` for
+ * anything we don't recognize.
+ *
+ * Phase 5 of the workspace-context plan
+ * (docs/workspace-context-and-indexing.md). The classifier is intentionally
+ * conservative: surfacing the wrong family on the manifest is worse than
+ * surfacing "OpenCode" as a generic catchall.
+ */
+export type ToolFamily =
+  | "opencode"
+  | "shell"
+  | "lsp"
+  | "omo"
+  | "semantic"
+  | "external"
+
+/** Known OMO plugins (oh-my-openagent / oh-my-opencode). Pattern-matched on
+ *  the leading segment of the tool name so plugin-versioned suffixes work. */
+const OMO_TOOLS = new Set([
+  "todo",
+  "todo_continuation",
+  "background_task",
+  "task_toast",
+  "scout",
+  "crafter",
+  "lens",
+  "hephaestus",
+  "explore",
+  "librarian",
+  "explorer",
+])
+
+/** Known semantic-search / vector-store plugin tools. */
+const SEMANTIC_TOOLS = new Set([
+  "codebase_search",
+  "semantic_search",
+  "embed_search",
+  "vector_search",
+])
+
+/** Stock opencode shell/exec tools. */
+const SHELL_TOOLS = new Set([
+  "bash",
+  "shell",
+  "exec",
+  "run",
+  "terminal",
+])
+
+/** Stock opencode LSP / language tools. */
+const LSP_TOOLS = new Set([
+  "lsp_diagnostics",
+  "lsp_hover",
+  "lsp_definition",
+  "lsp_references",
+  "lsp_symbol",
+  "ast_grep",
+])
+
+export function classifyTool(toolName: string): ToolFamily {
+  if (!toolName) return "opencode"
+  const lower = toolName.toLowerCase()
+  // First segment — strip a `:variant` or `_v2` suffix opencode plugins
+  // sometimes include.
+  const head = lower.split(/[:_-]/, 1)[0]
+  if (SEMANTIC_TOOLS.has(lower) || SEMANTIC_TOOLS.has(head)) return "semantic"
+  if (SHELL_TOOLS.has(lower) || SHELL_TOOLS.has(head)) return "shell"
+  if (LSP_TOOLS.has(lower) || LSP_TOOLS.has(head) || lower.startsWith("lsp_")) return "lsp"
+  if (OMO_TOOLS.has(lower) || OMO_TOOLS.has(head)) return "omo"
+  return "opencode"
+}
+
+/** Map a tool family to the manifest source enum. */
+export function toolFamilyToManifestSource(family: ToolFamily): PromptContextManifestItemSource {
+  switch (family) {
+    case "omo":
+      return "omo"
+    case "semantic":
+      return "semantic"
+    case "external":
+      return "external"
+    // shell / lsp / opencode all roll up to the `opencode` bucket in the
+    // manifest — they're already grouped under the OpenCode-managed tools
+    // section from the user's perspective.
+    default:
+      return "opencode"
+  }
+}
+
+/**
+ * Discover the tool families the host expects to be available given the
+ * active config mode. In `isolated` mode opencode only sees its built-ins
+ * (shell + LSP + the opencode catchall). In `user` mode any installed
+ * plugin's tools are *potentially* available — we can't enumerate them
+ * pre-flight, so we surface a generic "plugins active" hint and let
+ * downstream tool-classification fill in the specifics as calls happen.
+ */
+export function expectedToolFamilies(
+  configMode: "isolated" | "user",
+): ToolFamily[] {
+  if (configMode === "isolated") return ["opencode", "shell", "lsp"]
+  return ["opencode", "shell", "lsp", "omo", "semantic"]
+}

--- a/src/workspace-context/manifest.ts
+++ b/src/workspace-context/manifest.ts
@@ -8,6 +8,7 @@ import type {
 import type { OpencodeConfigMode } from "../server"
 import type { EditorContext } from "../context"
 import { isInsideRoot, type WorkspaceRoot } from "../workspace-root"
+import { expectedToolFamilies } from "../opencode/tool-discovery"
 
 export type ManifestInputs = {
   workspace?: WorkspaceRoot
@@ -78,6 +79,7 @@ export function buildManifest(inputs: ManifestInputs): PromptContextManifest {
     opencode: {
       directory: inputs.workspace?.fsPath,
       configMode: inputs.configMode,
+      toolFamilies: expectedToolFamilies(inputs.configMode),
     },
     totals,
     items,

--- a/test/host/manifest.test.ts
+++ b/test/host/manifest.test.ts
@@ -173,4 +173,28 @@ describe("buildManifest", () => {
     })
     expect(m.opencode?.configMode).toBe("user")
   })
+
+  it("populates expected tool families based on config mode", () => {
+    const isolated = buildManifest({
+      workspace: ROOT,
+      workspaceInfo: WORKSPACE_INFO,
+      configMode: "isolated",
+      editor: {},
+    })
+    expect(isolated.opencode?.toolFamilies).toEqual(["opencode", "shell", "lsp"])
+
+    const user = buildManifest({
+      workspace: ROOT,
+      workspaceInfo: WORKSPACE_INFO,
+      configMode: "user",
+      editor: {},
+    })
+    expect(user.opencode?.toolFamilies).toEqual([
+      "opencode",
+      "shell",
+      "lsp",
+      "omo",
+      "semantic",
+    ])
+  })
 })

--- a/test/host/tool-discovery.test.ts
+++ b/test/host/tool-discovery.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest"
+import {
+  classifyTool,
+  expectedToolFamilies,
+  toolFamilyToManifestSource,
+} from "../../src/opencode/tool-discovery"
+
+describe("classifyTool", () => {
+  it("classifies stock opencode shell tools", () => {
+    expect(classifyTool("bash")).toBe("shell")
+    expect(classifyTool("shell")).toBe("shell")
+    expect(classifyTool("exec")).toBe("shell")
+    expect(classifyTool("run")).toBe("shell")
+  })
+
+  it("classifies known LSP-family tools", () => {
+    expect(classifyTool("lsp_diagnostics")).toBe("lsp")
+    expect(classifyTool("lsp_hover")).toBe("lsp")
+    expect(classifyTool("ast_grep")).toBe("lsp")
+    expect(classifyTool("lsp_anything_else")).toBe("lsp")
+  })
+
+  it("classifies known OMO tools", () => {
+    expect(classifyTool("hephaestus")).toBe("omo")
+    expect(classifyTool("scout")).toBe("omo")
+    expect(classifyTool("crafter")).toBe("omo")
+    expect(classifyTool("lens")).toBe("omo")
+    expect(classifyTool("todo")).toBe("omo")
+  })
+
+  it("classifies semantic-search tools", () => {
+    expect(classifyTool("codebase_search")).toBe("semantic")
+    expect(classifyTool("semantic_search")).toBe("semantic")
+    expect(classifyTool("vector_search")).toBe("semantic")
+  })
+
+  it("falls back to opencode for unknown tools", () => {
+    expect(classifyTool("read_file")).toBe("opencode")
+    expect(classifyTool("edit_file")).toBe("opencode")
+    expect(classifyTool("definitely_not_known")).toBe("opencode")
+  })
+
+  it("is case-insensitive and tolerates suffixes", () => {
+    expect(classifyTool("BASH")).toBe("shell")
+    expect(classifyTool("Hephaestus")).toBe("omo")
+    expect(classifyTool("scout:v2")).toBe("omo")
+    expect(classifyTool("lsp_hover_v2")).toBe("lsp")
+  })
+
+  it("handles empty/null-ish input safely", () => {
+    expect(classifyTool("")).toBe("opencode")
+  })
+})
+
+describe("expectedToolFamilies", () => {
+  it("isolated mode → built-in families only", () => {
+    expect(expectedToolFamilies("isolated")).toEqual(["opencode", "shell", "lsp"])
+  })
+
+  it("user mode → built-in + omo + semantic", () => {
+    expect(expectedToolFamilies("user")).toEqual([
+      "opencode",
+      "shell",
+      "lsp",
+      "omo",
+      "semantic",
+    ])
+  })
+})
+
+describe("toolFamilyToManifestSource", () => {
+  it("maps omo and semantic to their own sources", () => {
+    expect(toolFamilyToManifestSource("omo")).toBe("omo")
+    expect(toolFamilyToManifestSource("semantic")).toBe("semantic")
+  })
+
+  it("rolls shell / lsp / opencode under the opencode bucket", () => {
+    expect(toolFamilyToManifestSource("opencode")).toBe("opencode")
+    expect(toolFamilyToManifestSource("shell")).toBe("opencode")
+    expect(toolFamilyToManifestSource("lsp")).toBe("opencode")
+  })
+
+  it("maps external to external", () => {
+    expect(toolFamilyToManifestSource("external")).toBe("external")
+  })
+})

--- a/webview/src/components/ContextManifest.tsx
+++ b/webview/src/components/ContextManifest.tsx
@@ -83,10 +83,26 @@ export function ContextManifest({ context }: Props) {
                 <span className="context-row-meta">{context.workspace.root}</span>
               </div>
               {context.opencode && (
-                <div className="context-section-row">
-                  <span className="context-row-label">Config mode</span>
-                  <span className="context-row-meta">{context.opencode.configMode}</span>
-                </div>
+                <>
+                  <div className="context-section-row">
+                    <span className="context-row-label">Config mode</span>
+                    <span className="context-row-meta">
+                      <span className={`context-badge mode-${context.opencode.configMode}`}>
+                        {context.opencode.configMode}
+                      </span>
+                    </span>
+                  </div>
+                  {context.opencode.toolFamilies && context.opencode.toolFamilies.length > 0 && (
+                    <div className="context-section-row">
+                      <span className="context-row-label">Tool families</span>
+                      <span className="context-row-meta">
+                        {context.opencode.toolFamilies.map((f) => (
+                          <span key={f} className="context-badge tool-family">{f}</span>
+                        ))}
+                      </span>
+                    </div>
+                  )}
+                </>
               )}
             </div>
           )}

--- a/webview/src/protocol.ts
+++ b/webview/src/protocol.ts
@@ -148,6 +148,12 @@ export type PromptContextManifest = {
   opencode?: {
     directory?: string
     configMode: "isolated" | "user"
+    /**
+     * Best-effort list of tool families opencode is *expected* to expose for
+     * this turn (populated in Phase 5). Concrete tool calls are classified
+     * after the fact via the wire-format pass.
+     */
+    toolFamilies?: string[]
   }
   totals: {
     includedItems: number

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -1217,6 +1217,9 @@ button {
 .context-badge.truncated { color: var(--vscode-charts-yellow); }
 .context-badge.skipped   { color: var(--vscode-descriptionForeground); }
 .context-badge.external  { color: var(--vscode-charts-blue); }
+.context-badge.mode-isolated { color: var(--vscode-descriptionForeground); }
+.context-badge.mode-user     { color: var(--vscode-charts-green); }
+.context-badge.tool-family   { color: var(--vscode-descriptionForeground); margin-left: 2px; }
 
 
 .thinking-dots {


### PR DESCRIPTION
Closes #123 — part of #117.

Implements **Phase 5** of [`docs/workspace-context-and-indexing.md`](docs/workspace-context-and-indexing.md). Lays the classification groundwork so the Phase 2 manifest can credit OMO and semantic-search plugins distinctly from stock opencode tools.

## Summary

- **`src/opencode/tool-discovery.ts`** — pure classifier:
  - `classifyTool(name)` → one of `opencode | shell | lsp | omo | semantic | external`. Curated patterns cover the stock shell / LSP tools, the well-known OMO plugins (scout / crafter / lens / hephaestus, todo-continuation, background-task), and common semantic plugin names. Unknown tools fall back to `opencode`.
  - `toolFamilyToManifestSource(family)` rolls shell / LSP / opencode under the same manifest bucket.
  - `expectedToolFamilies(mode)` — isolated mode lists built-ins only; user mode adds OMO + semantic.
- **`src/workspace-context/manifest.ts`** — includes `expectedToolFamilies(configMode)` in `opencode.toolFamilies` on every manifest.
- **`webview/src/protocol.ts`** — adds optional `toolFamilies` on the `opencode` block of `PromptContextManifest`.
- **`ContextManifest.tsx`** — expanded view now shows the config mode as a colored chip (green for `user`, neutral for `isolated`) plus a row of `tool-family` chips listing what's expected.

The classifier is intentionally conservative — surfacing the wrong family is worse than tagging unknown tools as the generic `opencode` bucket. Concrete classification of actual tool-call events (re-tagging tool entries in the chat with their family) can layer on top in a follow-up PR without changing the public types.

## Test plan

- [x] `bun run test` — 573/573 with 14 new classifier cases + 2 new manifest cases for `toolFamilies`.
- [x] `bun run check-types` — host clean.
- [ ] Manual: with `opencodeConfigMode: "user"` and the OMO plugin installed, confirm the expanded manifest shows the green `user` chip and `omo` in the tool families row.

## Out of scope

- Re-tagging individual tool entries in the chat with their family (post-hoc wire-format pass).
- Semantic index — Phase 6 (#124).