### PR TITLE
fix(context): scope git diff to workspace

### DIFF
--- a/src/workspace-context/git.ts
+++ b/src/workspace-context/git.ts
@@ -6,31 +6,34 @@ import { log } from "../output"
 
 const execFileAsync = promisify(execFile)
 
-const MAX_DIFF_BYTES = 60_000
+const MAX_GIT_CONTEXT_BYTES = 16_000
 const TIMEOUT_MS = 5_000
 
 /**
- * Collect a compact git diff against the workspace root: `git status --short`
- * + `git diff --unified=3` for unstaged + `git diff --cached --unified=3` for
- * staged. Each diff is truncated to `MAX_DIFF_BYTES` so a sweeping refactor
- * doesn't drown the prompt. Returns empty output when the workspace isn't a
- * git repo (the usual `fatal: not a git repository` exit code).
+ * Collect a compact git diff scoped to the VS Code workspace folder.
+ *
+ * Important: Git commands run from a subdirectory still discover the parent
+ * repository. Without a pathspec, `git status` can report sibling projects as
+ * `../other-project/...` when the user opened only one folder inside a larger
+ * repo. The explicit `-- .` keeps automatic context bounded to the opened
+ * workspace.
  */
 export async function collectGitDiff(workspace: WorkspaceRoot): Promise<CollectorOutput> {
   const cwd = workspace.fsPath
   const [status, unstaged, staged] = await Promise.all([
-    runGit(cwd, ["status", "--short"]),
-    runGit(cwd, ["diff", "--unified=3", "--no-color"]),
-    runGit(cwd, ["diff", "--cached", "--unified=3", "--no-color"]),
+    runGit(cwd, ["status", "--short", "--", "."]),
+    runGit(cwd, ["diff", "--unified=3", "--no-color", "--", "."]),
+    runGit(cwd, ["diff", "--cached", "--unified=3", "--no-color", "--", "."]),
   ])
   const parts: string[] = []
   if (status) parts.push(`### Status\n${status}`)
-  if (unstaged) parts.push(`### Unstaged diff\n${truncate(unstaged)}`)
-  if (staged) parts.push(`### Staged diff\n${truncate(staged)}`)
+  if (unstaged) parts.push(`### Unstaged diff\n${unstaged}`)
+  if (staged) parts.push(`### Staged diff\n${staged}`)
   if (parts.length === 0) return { items: [], blocks: [] }
-  const content = parts.join("\n\n")
+  const rawContent = parts.join("\n\n")
+  const content = truncate(rawContent)
   const bytes = Buffer.byteLength(content, "utf8")
-  const truncated = unstaged.length > MAX_DIFF_BYTES || staged.length > MAX_DIFF_BYTES
+  const truncated = Buffer.byteLength(rawContent, "utf8") > MAX_GIT_CONTEXT_BYTES
   const id = `git_${Date.now()}`
   return {
     items: [
@@ -39,7 +42,7 @@ export async function collectGitDiff(workspace: WorkspaceRoot): Promise<Collecto
         source: "git",
         kind: "diff",
         label: "Git changes",
-        reason: "Local git diff against the workspace root",
+        reason: "Local git changes scoped to the opened workspace folder",
         status: truncated ? "truncated" : "included",
         bytes,
         priority: 4,
@@ -59,8 +62,9 @@ export async function collectGitDiff(workspace: WorkspaceRoot): Promise<Collecto
 }
 
 function truncate(s: string): string {
-  if (s.length <= MAX_DIFF_BYTES) return s
-  return s.slice(0, MAX_DIFF_BYTES) + `\n… (truncated to ${MAX_DIFF_BYTES} bytes)`
+  if (Buffer.byteLength(s, "utf8") <= MAX_GIT_CONTEXT_BYTES) return s
+  return Buffer.from(s, "utf8").subarray(0, MAX_GIT_CONTEXT_BYTES).toString("utf8")
+    + `\n... (truncated to ${MAX_GIT_CONTEXT_BYTES} bytes)`
 }
 
 async function runGit(cwd: string, args: string[]): Promise<string> {

--- a/test/host/collectors.test.ts
+++ b/test/host/collectors.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from "vitest"
 import * as vscode from "vscode"
+import * as fs from "fs/promises"
+import * as os from "os"
+import * as path from "path"
+import { execFile } from "child_process"
+import { promisify } from "util"
 import { collectOpenTabs } from "../../src/workspace-context/open-tabs"
 import { collectDiagnostics } from "../../src/workspace-context/diagnostics"
 import { collectGitDiff } from "../../src/workspace-context/git"
@@ -21,6 +26,7 @@ type MutableWindow = {
   tabGroups: { all: Array<{ tabs: Array<{ input?: unknown }> }> }
 }
 const win = vscode.window as unknown as MutableWindow
+const execFileAsync = promisify(execFile)
 
 function setTabs(paths: string[]) {
   win.tabGroups = {
@@ -132,6 +138,41 @@ describe("collectGitDiff", () => {
     const out = await collectGitDiff({ ...WORKSPACE, fsPath: "/tmp/definitely-not-a-repo-xyzzy" })
     expect(out.items).toEqual([])
     expect(out.blocks).toEqual([])
+  })
+
+  it("scopes parent-repo git output to the opened workspace folder", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencui-git-scope-"))
+    const workspace = path.join(root, "test")
+    const sibling = path.join(root, "ExamHelper")
+    await fs.mkdir(workspace)
+    await fs.mkdir(sibling)
+    await fs.writeFile(path.join(workspace, "app.ts"), "export const value = 1\n")
+    await fs.writeFile(path.join(sibling, "app.py"), "print('old')\n")
+
+    await execFileAsync("git", ["init"], { cwd: root })
+    await execFileAsync("git", ["add", "."], { cwd: root })
+    await execFileAsync(
+      "git",
+      ["-c", "user.name=OpenCode Panel", "-c", "user.email=test@example.com", "commit", "-m", "initial"],
+      { cwd: root },
+    )
+
+    await fs.writeFile(path.join(workspace, "app.ts"), "export const value = 2\n")
+    await fs.writeFile(path.join(sibling, "app.py"), "print('new')\n")
+
+    const out = await collectGitDiff({
+      ...WORKSPACE,
+      fsPath: workspace,
+      uri: vscode.Uri.file(workspace),
+      name: "test",
+    })
+
+    expect(out.blocks).toHaveLength(1)
+    expect(out.blocks[0].content).toContain("app.ts")
+    expect(out.blocks[0].content).toContain("value = 2")
+    expect(out.blocks[0].content).not.toContain("ExamHelper")
+    expect(out.blocks[0].content).not.toContain("app.py")
+    expect(out.blocks[0].content).not.toContain("../")
   })
 })
 


### PR DESCRIPTION
Closes #130

## Summary

- Scope automatic Git status and diff collection to the opened VS Code workspace folder with an explicit pathspec.
- Prevent parent-repository sibling project changes from entering prompt context as `../...` paths.
- Lower the automatic Git context cap from a large per-diff payload to a smaller total Git context budget.
- Add a regression test for a parent Git repo containing both workspace and sibling-project changes.

## Test plan

- [x] `bun run check-types`
- [x] `bun run test -- test/host/collectors.test.ts`
- [x] `bun run test`
- [ ] Manual VS Code panel verification with a nested workspace inside a parent Git repo