### PR TITLE
feat(agents): hidden-by-default Agents status bar entry

### DIFF
--- a/src/agents/quickpick.ts
+++ b/src/agents/quickpick.ts
@@ -1,0 +1,91 @@
+import * as vscode from "vscode"
+import type { AgentTask, AgentTaskStore } from "./task-store"
+
+export type AgentsQuickPickItem = vscode.QuickPickItem & {
+  taskID?: string
+}
+
+/**
+ * Open a compact QuickPick grouping active or attention-worthy agent work
+ * into `Main` and `Subagents` sections. Selecting a row focuses the
+ * OpenCode Panel chat; we don't currently surface retry / abort actions.
+ */
+export async function showAgentsQuickPick(taskStore: AgentTaskStore): Promise<void> {
+  const tasks = taskStore.active()
+  if (tasks.length === 0) {
+    await vscode.window.showQuickPick([{ label: "No active agents" }], {
+      title: "OpenCode Panel: Agents",
+    })
+    return
+  }
+  const items = buildQuickPickItems(tasks)
+  const picked = (await vscode.window.showQuickPick(items, {
+    title: "OpenCode Panel: Agents",
+    placeHolder: "Select an agent to focus the chat",
+    matchOnDescription: true,
+    matchOnDetail: true,
+  })) as AgentsQuickPickItem | undefined
+  if (!picked?.taskID) return
+  await vscode.commands.executeCommand("opencui.chat.focus")
+}
+
+export function buildQuickPickItems(tasks: AgentTask[]): AgentsQuickPickItem[] {
+  const main: AgentTask[] = []
+  const sub: AgentTask[] = []
+  for (const task of tasks) {
+    if (task.kind === "main") main.push(task)
+    else sub.push(task)
+  }
+  sortByStartedAt(main)
+  sortByStartedAt(sub)
+
+  const items: AgentsQuickPickItem[] = []
+  if (main.length > 0) {
+    items.push(separator("Main"))
+    for (const task of main) items.push(toItem(task))
+  }
+  if (sub.length > 0) {
+    items.push(separator("Subagents"))
+    for (const task of sub) items.push(toItem(task))
+  }
+  return items
+}
+
+function separator(label: string): AgentsQuickPickItem {
+  return {
+    label,
+    kind: vscode.QuickPickItemKind.Separator,
+  }
+}
+
+function toItem(task: AgentTask): AgentsQuickPickItem {
+  const elapsed = formatElapsed(task.startedAt, Date.now())
+  const description = formatStatus(task) + " · " + elapsed
+  const detail = task.kind === "main" ? `session ${task.sessionID}` : task.callID ? `call ${task.callID}` : undefined
+  return {
+    label: task.title,
+    description,
+    detail,
+    taskID: task.id,
+  }
+}
+
+function formatStatus(task: AgentTask): string {
+  if (task.status === "error") return task.error ? `error: ${task.error}` : "error"
+  return task.status
+}
+
+export function formatElapsed(startedAt: number, now: number): string {
+  const ms = Math.max(0, now - startedAt)
+  const seconds = Math.floor(ms / 1000)
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  const remMin = minutes - hours * 60
+  return remMin > 0 ? `${hours}h ${remMin}m` : `${hours}h`
+}
+
+function sortByStartedAt(tasks: AgentTask[]) {
+  tasks.sort((a, b) => a.startedAt - b.startedAt)
+}

--- a/src/agents/task-store.ts
+++ b/src/agents/task-store.ts
@@ -1,0 +1,224 @@
+import * as vscode from "vscode"
+
+export const AGENT_TASKS_KEY = "opencui.agentTasks"
+
+export type AgentTaskStatus =
+  | "running"
+  | "waiting"
+  | "completed"
+  | "error"
+  | "cancelled"
+
+export type AgentTaskKind = "main" | "subagent"
+
+export type AgentTask = {
+  id: string
+  kind: AgentTaskKind
+  conversationID: string
+  sessionID: string
+  messageID?: string
+  callID?: string
+  parentTaskID?: string
+  title: string
+  status: AgentTaskStatus
+  startedAt: number
+  updatedAt: number
+  error?: string
+}
+
+const ACTIVE_STATUSES: ReadonlyArray<AgentTaskStatus> = ["running", "waiting"]
+const ATTENTION_STATUSES: ReadonlyArray<AgentTaskStatus> = ["running", "waiting", "error"]
+
+export function mainTaskID(conversationID: string, sessionID: string): string {
+  return `main:${conversationID}:${sessionID}`
+}
+
+export function subagentTaskID(sessionID: string, callID: string): string {
+  return `subagent:${sessionID}:${callID}`
+}
+
+export type Memento = Pick<vscode.Memento, "get" | "update">
+
+/**
+ * Workspace-scoped persistence + change broadcast for live agent-task state.
+ * The status bar and submenu subscribe to `onDidChange`; the chat view writes
+ * through `upsert` / `update`. The store does not assume any chat-view
+ * internals — it just persists and broadcasts.
+ *
+ * Persistence is best-effort: the in-memory list is the source of truth for
+ * the current process, and `update()` returns a Promise so callers can `await`
+ * the write when ordering matters, but a failed write does not roll back the
+ * in-memory mutation. Workspace storage on Code's side rarely fails outside
+ * disk-full conditions.
+ */
+export class AgentTaskStore {
+  private tasks: AgentTask[]
+  private readonly emitter: vscode.EventEmitter<AgentTask[]>
+  readonly onDidChange: vscode.Event<AgentTask[]>
+
+  constructor(private storage: Memento) {
+    this.tasks = sanitize(storage.get<AgentTask[]>(AGENT_TASKS_KEY))
+    this.emitter = new vscode.EventEmitter<AgentTask[]>()
+    this.onDidChange = this.emitter.event
+  }
+
+  list(): AgentTask[] {
+    return [...this.tasks]
+  }
+
+  active(): AgentTask[] {
+    return this.tasks.filter((task) => ATTENTION_STATUSES.includes(task.status))
+  }
+
+  hasActive(): boolean {
+    return this.tasks.some((task) => ATTENTION_STATUSES.includes(task.status))
+  }
+
+  hasRunning(): boolean {
+    return this.tasks.some((task) => task.status === "running")
+  }
+
+  get(id: string): AgentTask | undefined {
+    return this.tasks.find((task) => task.id === id)
+  }
+
+  async upsert(task: AgentTask): Promise<void> {
+    const idx = this.tasks.findIndex((t) => t.id === task.id)
+    if (idx >= 0) {
+      const existing = this.tasks[idx]!
+      // Once a task is in a terminal state, ignore later "running"-style
+      // upserts so duplicated SSE events can't resurrect a finished task.
+      if (isTerminal(existing.status) && !isTerminal(task.status)) return
+      const merged: AgentTask = {
+        ...existing,
+        ...task,
+        startedAt: existing.startedAt,
+        updatedAt: task.updatedAt,
+      }
+      if (sameTask(existing, merged)) return
+      this.tasks = this.tasks.map((t) => (t.id === task.id ? merged : t))
+    } else {
+      this.tasks = [...this.tasks, task]
+    }
+    await this.persistAndEmit()
+  }
+
+  async update(id: string, patch: Partial<AgentTask>): Promise<void> {
+    const idx = this.tasks.findIndex((t) => t.id === id)
+    if (idx < 0) return
+    const existing = this.tasks[idx]!
+    if (isTerminal(existing.status) && patch.status && !isTerminal(patch.status)) return
+    const next: AgentTask = { ...existing, ...patch, id, updatedAt: patch.updatedAt ?? Date.now() }
+    if (sameTask(existing, next)) return
+    this.tasks = this.tasks.map((t) => (t.id === id ? next : t))
+    await this.persistAndEmit()
+  }
+
+  /** Drop completed/cancelled tasks. Errors are preserved until cleared explicitly. */
+  async clearCompleted(): Promise<void> {
+    const next = this.tasks.filter(
+      (task) => task.status !== "completed" && task.status !== "cancelled",
+    )
+    if (next.length === this.tasks.length) return
+    this.tasks = next
+    await this.persistAndEmit()
+  }
+
+  async clear(id: string): Promise<void> {
+    if (!this.tasks.some((t) => t.id === id)) return
+    this.tasks = this.tasks.filter((t) => t.id !== id)
+    await this.persistAndEmit()
+  }
+
+  /**
+   * Mark every still-running/waiting task for a session as completed. Used
+   * when the session truly settles and no continuation is expected.
+   */
+  async markSessionIdle(sessionID: string, now: number = Date.now()): Promise<void> {
+    let changed = false
+    this.tasks = this.tasks.map((task) => {
+      if (task.sessionID !== sessionID) return task
+      if (!ACTIVE_STATUSES.includes(task.status)) return task
+      changed = true
+      return { ...task, status: "completed", updatedAt: now }
+    })
+    if (!changed) return
+    await this.persistAndEmit()
+  }
+
+  dispose() {
+    this.emitter.dispose()
+  }
+
+  private async persistAndEmit(): Promise<void> {
+    await this.storage.update(AGENT_TASKS_KEY, this.tasks)
+    this.emitter.fire(this.list())
+  }
+}
+
+function isTerminal(status: AgentTaskStatus): boolean {
+  return status === "completed" || status === "error" || status === "cancelled"
+}
+
+function sameTask(a: AgentTask, b: AgentTask): boolean {
+  return (
+    a.status === b.status &&
+    a.title === b.title &&
+    a.error === b.error &&
+    a.messageID === b.messageID &&
+    a.callID === b.callID &&
+    a.parentTaskID === b.parentTaskID &&
+    a.kind === b.kind &&
+    a.conversationID === b.conversationID &&
+    a.sessionID === b.sessionID &&
+    a.startedAt === b.startedAt &&
+    a.updatedAt === b.updatedAt
+  )
+}
+
+function sanitize(raw: unknown): AgentTask[] {
+  if (!Array.isArray(raw)) return []
+  const out: AgentTask[] = []
+  for (const item of raw) {
+    if (!isPlainObject(item)) continue
+    const id = typeof item.id === "string" ? item.id : undefined
+    const kind = item.kind === "main" || item.kind === "subagent" ? item.kind : undefined
+    const status = isStatus(item.status) ? item.status : undefined
+    const conversationID = typeof item.conversationID === "string" ? item.conversationID : undefined
+    const sessionID = typeof item.sessionID === "string" ? item.sessionID : undefined
+    const title = typeof item.title === "string" ? item.title : undefined
+    const startedAt = typeof item.startedAt === "number" ? item.startedAt : undefined
+    const updatedAt = typeof item.updatedAt === "number" ? item.updatedAt : undefined
+    if (!id || !kind || !status || !conversationID || !sessionID || !title) continue
+    if (startedAt === undefined || updatedAt === undefined) continue
+    out.push({
+      id,
+      kind,
+      conversationID,
+      sessionID,
+      title,
+      status,
+      startedAt,
+      updatedAt,
+      messageID: typeof item.messageID === "string" ? item.messageID : undefined,
+      callID: typeof item.callID === "string" ? item.callID : undefined,
+      parentTaskID: typeof item.parentTaskID === "string" ? item.parentTaskID : undefined,
+      error: typeof item.error === "string" ? item.error : undefined,
+    })
+  }
+  return out
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function isStatus(value: unknown): value is AgentTaskStatus {
+  return (
+    value === "running" ||
+    value === "waiting" ||
+    value === "completed" ||
+    value === "error" ||
+    value === "cancelled"
+  )
+}

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -43,6 +43,7 @@ import { collectAutoContext } from "../workspace-context/collector"
 import { RecentEditsTracker } from "../workspace-context/recent-edits"
 import { readContextSettings } from "../workspace-context/budget"
 import type { IndexManager } from "../indexing/index-manager"
+import { AgentTaskStore, mainTaskID, subagentTaskID } from "../agents/task-store"
 import { toWire } from "./wire-format"
 import {
   applyCode,
@@ -158,6 +159,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     private prefs: Preferences,
     private recentEdits: RecentEditsTracker,
     private indexManager: IndexManager,
+    private taskStore?: AgentTaskStore,
   ) {
     migrateConversationsToWorkspace(context)
     this.conversations = context.workspaceState.get<SavedConversation[]>(CONVERSATIONS_KEY) ?? []
@@ -776,7 +778,7 @@ export class ChatView implements vscode.WebviewViewProvider {
    * deferred idle is pending, arm a short grace timer so the UI doesn't
    * sit on "Continuing…" forever if no follow-up turn materializes.
    */
-  private updateTaskTracking(update: ToolUpdate): void {
+  private updateTaskTracking(update: ToolUpdate, messageID?: string): void {
     if (update.tool !== "task") return
     const id = update.callID
     if (update.status === "running") {
@@ -784,6 +786,7 @@ export class ChatView implements vscode.WebviewViewProvider {
         this.activeTaskCallIDs.add(id)
         log(`[continuation] task running ${id} (active=${this.activeTaskCallIDs.size})`)
       }
+      void this.recordSubagentTask(update, messageID, "running")
       return
     }
     if (update.status === "completed" || update.status === "error") {
@@ -793,7 +796,71 @@ export class ChatView implements vscode.WebviewViewProvider {
           this.scheduleIdleEmit(ChatView.CONTINUATION_GRACE_MS, "tasks-settled")
         }
       }
+      void this.recordSubagentTask(update, messageID, update.status)
     }
+  }
+
+  private async recordSubagentTask(
+    update: ToolUpdate,
+    messageID: string | undefined,
+    status: "running" | "completed" | "error",
+  ): Promise<void> {
+    if (!this.taskStore) return
+    if (!this.sessionID) return
+    const id = subagentTaskID(this.sessionID, update.callID)
+    const now = Date.now()
+    const title = taskTitleFromUpdate(update)
+    if (status === "running") {
+      const existing = this.taskStore.get(id)
+      await this.taskStore.upsert({
+        id,
+        kind: "subagent",
+        conversationID: this.activeConversationID,
+        sessionID: this.sessionID,
+        messageID,
+        callID: update.callID,
+        title,
+        status: "running",
+        startedAt: existing?.startedAt ?? now,
+        updatedAt: now,
+      })
+      return
+    }
+    await this.taskStore.update(id, {
+      status,
+      title,
+      error: status === "error" ? update.error : undefined,
+      updatedAt: now,
+    })
+  }
+
+  private async recordMainTaskStart(text: string): Promise<void> {
+    if (!this.taskStore || !this.sessionID) return
+    const conversationID = this.activeConversationID
+    const sessionID = this.sessionID
+    const id = mainTaskID(conversationID, sessionID)
+    const existing = this.taskStore.get(id)
+    const now = Date.now()
+    await this.taskStore.upsert({
+      id,
+      kind: "main",
+      conversationID,
+      sessionID,
+      title: this.activeConversation().title || summarizePrompt(text),
+      status: "running",
+      startedAt: existing?.startedAt ?? now,
+      updatedAt: now,
+    })
+  }
+
+  private async recordMainTaskFinish(status: "completed" | "error" | "cancelled", error?: string): Promise<void> {
+    if (!this.taskStore || !this.sessionID) return
+    const id = mainTaskID(this.activeConversationID, this.sessionID)
+    await this.taskStore.update(id, {
+      status,
+      error,
+      updatedAt: Date.now(),
+    })
   }
 
   private clearPendingIdle() {
@@ -909,6 +976,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.aborting = true
     this.pendingUserBackendID = undefined
     this.post({ type: "aborted" })
+    void this.recordMainTaskFinish("cancelled")
     try {
       const backend = await this.servers.ensure()
       await backend.client.session.abort({ path: { id: this.sessionID } })
@@ -955,6 +1023,8 @@ export class ChatView implements vscode.WebviewViewProvider {
     } else if (!this.subscription) {
       await this.attachSubscription(backend, this.sessionID)
     }
+
+    await this.recordMainTaskStart(text)
 
     const sel = this.prefs.get()
     const settings = readContextSettings(vscode.workspace.getConfiguration("opencui"))
@@ -1144,6 +1214,7 @@ export class ChatView implements vscode.WebviewViewProvider {
         // already set on `aborted` — suppress to avoid showing both.
         if (payload.error && !this.aborting) {
           this.post({ type: "assistantError", id: webviewID, message: payload.error })
+          void this.recordMainTaskFinish("error", payload.error)
         }
         this.post({ type: "assistantDone", id: webviewID, usage: payload.usage })
       },
@@ -1166,7 +1237,7 @@ export class ChatView implements vscode.WebviewViewProvider {
         // (Hephaestus's `run_in_background` path emits no continuation
         // toast — only the structural signal — because omo suppresses
         // its toast when BackgroundManager handles the wakeup itself).
-        this.updateTaskTracking(update)
+        this.updateTaskTracking(update, mid)
         const webviewID = this.messageMap.get(mid) ?? this.ensureWebviewID(mid)
         const wire = toWire(update, backend.directory)
         this.post({ type: "tool", id: webviewID, update: wire })
@@ -1227,6 +1298,9 @@ export class ChatView implements vscode.WebviewViewProvider {
           // in-flight task parts (whose terminal events the SSE may not
           // send post-abort) don't poison the next turn.
           this.resetContinuationState()
+          if (this.sessionID && this.taskStore) {
+            void this.taskStore.markSessionIdle(this.sessionID)
+          }
           this.post({ type: "sessionIdle" })
           return
         }
@@ -1235,6 +1309,9 @@ export class ChatView implements vscode.WebviewViewProvider {
           return
         }
         this.finishContinuationPending()
+        if (this.sessionID && this.taskStore) {
+          void this.taskStore.markSessionIdle(this.sessionID)
+        }
         this.post({ type: "sessionIdle" })
       },
     })
@@ -1393,6 +1470,20 @@ export class ChatView implements vscode.WebviewViewProvider {
     html = html.replace("<head>", `<head><meta http-equiv="Content-Security-Policy" content="${csp}">`)
     return html
   }
+}
+
+export function taskTitleFromUpdate(update: ToolUpdate): string {
+  const input = update.input
+  if (input && typeof input === "object") {
+    const description = (input as Record<string, unknown>).description
+    if (typeof description === "string" && description.trim()) return description.trim()
+  }
+  if (update.title && update.title.trim()) return update.title.trim()
+  return "Background agent"
+}
+
+export function summarizePrompt(text: string): string {
+  return text.replace(/\s+/g, " ").trim().slice(0, 64) || "Main agent"
 }
 
 function collectSymbolFocus(activeRel: string | undefined, mentions: string[] | undefined): string[] {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,11 +7,14 @@ import { Preferences } from "./preferences"
 import { Picker } from "./picker"
 import { RecentEditsTracker } from "./workspace-context/recent-edits"
 import { IndexManager, readIndexSettings } from "./indexing/index-manager"
+import { AgentTaskStore } from "./agents/task-store"
+import { showAgentsQuickPick } from "./agents/quickpick"
 import { getOutputChannel, log } from "./output"
 
 let servers: ServerManager | undefined
 let recentEdits: RecentEditsTracker | undefined
 let indexManager: IndexManager | undefined
+let agentTaskStore: AgentTaskStore | undefined
 
 export async function activate(context: vscode.ExtensionContext) {
   log("activating OpenCode Panel")
@@ -19,13 +22,15 @@ export async function activate(context: vscode.ExtensionContext) {
   recentEdits = new RecentEditsTracker()
   const indexSettings = readIndexSettings(vscode.workspace.getConfiguration("opencui"))
   indexManager = new IndexManager(indexSettings)
+  agentTaskStore = new AgentTaskStore(context.workspaceState)
   context.subscriptions.push(
     { dispose: () => recentEdits?.dispose() },
     { dispose: () => void indexManager?.stop() },
+    { dispose: () => agentTaskStore?.dispose() },
   )
   const prefs = new Preferences(context.globalState)
-  const status = new StatusBar(context, prefs)
-  const chat = new ChatView(context, servers, prefs, recentEdits, indexManager)
+  const status = new StatusBar(context, prefs, agentTaskStore)
+  const chat = new ChatView(context, servers, prefs, recentEdits, indexManager, agentTaskStore)
   const inline = new InlineEdit(servers, prefs)
   const picker = new Picker(servers, prefs)
 
@@ -43,6 +48,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("opencui.selectAgent", () => picker.pickAgent()),
     vscode.commands.registerCommand("opencui.selectModel", () => picker.pickModel()),
     vscode.commands.registerCommand("opencui.selectVariant", () => picker.pickVariantForCurrent()),
+    vscode.commands.registerCommand("opencui.agents.open", () => showAgentsQuickPick(agentTaskStore!)),
     vscode.commands.registerCommand("opencui.server.restart", async () => {
       status.set("starting", "restarting backend")
       await servers!.restart().then(

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,25 +1,51 @@
 import * as vscode from "vscode"
 import type { Preferences, Selection } from "./preferences"
+import type { AgentTask, AgentTaskStore } from "./agents/task-store"
 
 export type Status = "starting" | "ready" | "error" | "stopped"
+
+const BREATHE_INTERVAL_MS = 80
+const BREATHE_CYCLE_MS = 1800
+const RUNNING_COLOR = "#7ee787" // light green; reads well on both light & dark themes
+const ATTENTION_COLOR = new vscode.ThemeColor("statusBarItem.warningForeground")
 
 export class StatusBar {
   private health: vscode.StatusBarItem
   private agent: vscode.StatusBarItem
+  /** Hidden-by-default runtime indicator. See docs/agents-status-bar.md. */
+  private agents: vscode.StatusBarItem
+  private breatheTimer?: ReturnType<typeof setInterval>
+  private breathePhase = 0
+  private taskStoreUnsub?: vscode.Disposable
 
-  constructor(context: vscode.ExtensionContext, private prefs: Preferences) {
+  constructor(
+    context: vscode.ExtensionContext,
+    private prefs: Preferences,
+    private taskStore?: AgentTaskStore,
+  ) {
     this.health = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100)
     this.health.command = "opencui.chat.focus"
     this.health.show()
+
+    this.agents = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 99.5)
+    this.agents.text = "Agents"
+    this.agents.command = "opencui.agents.open"
 
     this.agent = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 99)
     this.agent.command = "opencui.selectAgent"
     this.agent.show()
 
-    context.subscriptions.push(this.health, this.agent)
+    context.subscriptions.push(this.health, this.agents, this.agent, {
+      dispose: () => this.dispose(),
+    })
     this.set("starting")
     this.renderAgent(prefs.get())
     prefs.onChange((sel) => this.renderAgent(sel))
+
+    if (taskStore) {
+      this.taskStoreUnsub = taskStore.onDidChange((tasks) => this.renderAgents(tasks))
+      this.renderAgents(taskStore.list())
+    }
   }
 
   set(status: Status, detail?: string) {
@@ -40,4 +66,70 @@ export class StatusBar {
     this.agent.text = `$(person) ${agent}`
     this.agent.tooltip = `Agent: ${agent}\nModel: ${model}\nClick to change agent (or run "OpenCode Panel: Select Model")`
   }
+
+  /**
+   * Visibility + breathing-color + tooltip for the runtime Agents item.
+   * Driven by AgentTaskStore changes. Hidden when no task is active or
+   * attention-worthy. The text is always literally `Agents`.
+   */
+  private renderAgents(tasks: AgentTask[]) {
+    const running = tasks.filter((task) => task.status === "running")
+    const waiting = tasks.filter((task) => task.status === "waiting")
+    const errored = tasks.filter((task) => task.status === "error")
+    const visible = running.length + waiting.length + errored.length > 0
+
+    if (!visible) {
+      this.stopBreathing()
+      this.agents.color = undefined
+      this.agents.tooltip = undefined
+      this.agents.hide()
+      return
+    }
+
+    this.agents.text = "Agents"
+    this.agents.tooltip = buildAgentsTooltip(running.length, waiting.length, errored.length)
+    this.agents.show()
+
+    if (running.length > 0) {
+      this.startBreathing()
+    } else {
+      this.stopBreathing()
+      this.agents.color = ATTENTION_COLOR
+    }
+  }
+
+  private startBreathing() {
+    if (this.breatheTimer) return
+    this.breathePhase = 0
+    this.agents.color = RUNNING_COLOR
+    this.breatheTimer = setInterval(() => {
+      this.breathePhase = (this.breathePhase + BREATHE_INTERVAL_MS) % BREATHE_CYCLE_MS
+      // Smooth two-step pulse — VS Code only accepts string colors or
+      // ThemeColors, so we alternate between two hex shades rather than
+      // applying alpha animation.
+      const halfway = this.breathePhase < BREATHE_CYCLE_MS / 2
+      this.agents.color = halfway ? RUNNING_COLOR : "#39d353"
+    }, BREATHE_INTERVAL_MS)
+  }
+
+  private stopBreathing() {
+    if (this.breatheTimer) {
+      clearInterval(this.breatheTimer)
+      this.breatheTimer = undefined
+    }
+  }
+
+  private dispose() {
+    this.stopBreathing()
+    this.taskStoreUnsub?.dispose()
+  }
+}
+
+export function buildAgentsTooltip(running: number, waiting: number, errored: number): string {
+  const lines: string[] = []
+  if (running > 0) lines.push(`${running} agent${running === 1 ? "" : "s"} running`)
+  if (waiting > 0) lines.push(`${waiting} waiting for input`)
+  if (errored > 0) lines.push(`${errored} with errors`)
+  lines.push("Click to view")
+  return lines.join("\n")
 }

--- a/test/host/agent-task-store.test.ts
+++ b/test/host/agent-task-store.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import {
+  AGENT_TASKS_KEY,
+  AgentTaskStore,
+  mainTaskID,
+  subagentTaskID,
+  type AgentTask,
+  type Memento,
+} from "../../src/agents/task-store"
+
+class FakeMemento implements Memento {
+  private store: Record<string, unknown> = {}
+
+  setSeed(key: string, value: unknown) {
+    this.store[key] = JSON.parse(JSON.stringify(value))
+  }
+
+  get<T>(key: string): T | undefined
+  get<T>(key: string, defaultValue: T): T
+  get<T>(key: string, defaultValue?: T): T | undefined {
+    const value = this.store[key]
+    if (value === undefined) return defaultValue
+    return value as T
+  }
+
+  async update(key: string, value: unknown): Promise<void> {
+    if (value === undefined) {
+      delete this.store[key]
+      return
+    }
+    this.store[key] = JSON.parse(JSON.stringify(value))
+  }
+
+  snapshot(): Record<string, unknown> {
+    return JSON.parse(JSON.stringify(this.store))
+  }
+}
+
+function fixedTask(overrides: Partial<AgentTask> = {}): AgentTask {
+  return {
+    id: "main:conv:sess",
+    kind: "main",
+    conversationID: "conv",
+    sessionID: "sess",
+    title: "Main",
+    status: "running",
+    startedAt: 1000,
+    updatedAt: 1000,
+    ...overrides,
+  }
+}
+
+describe("AgentTaskStore", () => {
+  let memento: FakeMemento
+
+  beforeEach(() => {
+    memento = new FakeMemento()
+  })
+
+  it("loads tasks from workspace state on construction", () => {
+    const seed = [fixedTask(), fixedTask({ id: "subagent:sess:c1", kind: "subagent", callID: "c1" })]
+    memento.setSeed(AGENT_TASKS_KEY, seed)
+    const store = new AgentTaskStore(memento)
+    expect(store.list().map((t) => t.id)).toEqual([
+      "main:conv:sess",
+      "subagent:sess:c1",
+    ])
+  })
+
+  it("drops malformed entries while loading", () => {
+    memento.setSeed(AGENT_TASKS_KEY, [
+      fixedTask(),
+      { id: 5, kind: "main", status: "running" },
+      null,
+      "garbage",
+      { ...fixedTask(), kind: "bogus" },
+    ])
+    const store = new AgentTaskStore(memento)
+    expect(store.list()).toHaveLength(1)
+    expect(store.list()[0]!.kind).toBe("main")
+  })
+
+  it("upsert is idempotent for an unchanged task", async () => {
+    const store = new AgentTaskStore(memento)
+    let fires = 0
+    store.onDidChange(() => (fires += 1))
+    const task = fixedTask()
+    await store.upsert(task)
+    await store.upsert({ ...task })
+    expect(fires).toBe(1)
+    expect(store.list()).toHaveLength(1)
+  })
+
+  it("upsert preserves startedAt across mutations", async () => {
+    const store = new AgentTaskStore(memento)
+    await store.upsert(fixedTask({ startedAt: 1000, updatedAt: 1000 }))
+    await store.upsert(fixedTask({ startedAt: 9999, updatedAt: 2000, status: "completed" }))
+    const task = store.get("main:conv:sess")!
+    expect(task.startedAt).toBe(1000)
+    expect(task.status).toBe("completed")
+    expect(task.updatedAt).toBe(2000)
+  })
+
+  it("running → completed updates status and persists", async () => {
+    const store = new AgentTaskStore(memento)
+    await store.upsert(fixedTask())
+    await store.update("main:conv:sess", { status: "completed", updatedAt: 2000 })
+    expect(store.get("main:conv:sess")!.status).toBe("completed")
+    const persisted = memento.get<AgentTask[]>(AGENT_TASKS_KEY)
+    expect(persisted?.[0]?.status).toBe("completed")
+  })
+
+  it("running → error keeps the task visible to active()", async () => {
+    const store = new AgentTaskStore(memento)
+    await store.upsert(fixedTask())
+    await store.update("main:conv:sess", { status: "error", error: "boom" })
+    const active = store.active()
+    expect(active).toHaveLength(1)
+    expect(active[0]!.error).toBe("boom")
+  })
+
+  it("active() excludes completed and cancelled tasks", async () => {
+    const store = new AgentTaskStore(memento)
+    await store.upsert(fixedTask({ id: "main:conv:s1", status: "running" }))
+    await store.upsert(fixedTask({ id: "main:conv:s2", status: "completed", sessionID: "s2" }))
+    await store.upsert(fixedTask({ id: "main:conv:s3", status: "cancelled", sessionID: "s3" }))
+    await store.upsert(fixedTask({ id: "main:conv:s4", status: "error", sessionID: "s4" }))
+    const ids = store.active().map((t) => t.id).sort()
+    expect(ids).toEqual(["main:conv:s1", "main:conv:s4"])
+  })
+
+  it("once terminal, upsert cannot resurrect to running", async () => {
+    const store = new AgentTaskStore(memento)
+    await store.upsert(fixedTask({ status: "completed", updatedAt: 2000 }))
+    let fires = 0
+    store.onDidChange(() => (fires += 1))
+    await store.upsert(fixedTask({ status: "running", updatedAt: 3000 }))
+    expect(fires).toBe(0)
+    expect(store.get("main:conv:sess")!.status).toBe("completed")
+  })
+
+  it("update is a no-op for unknown ids", async () => {
+    const store = new AgentTaskStore(memento)
+    let fires = 0
+    store.onDidChange(() => (fires += 1))
+    await store.update("missing", { status: "completed" })
+    expect(fires).toBe(0)
+  })
+
+  it("clearCompleted drops completed/cancelled but keeps running/error", async () => {
+    const store = new AgentTaskStore(memento)
+    await store.upsert(fixedTask({ id: "a", status: "running" }))
+    await store.upsert(fixedTask({ id: "b", status: "completed" }))
+    await store.upsert(fixedTask({ id: "c", status: "cancelled" }))
+    await store.upsert(fixedTask({ id: "d", status: "error" }))
+    await store.clearCompleted()
+    expect(store.list().map((t) => t.id).sort()).toEqual(["a", "d"])
+  })
+
+  it("markSessionIdle completes still-running tasks for the session only", async () => {
+    const store = new AgentTaskStore(memento)
+    await store.upsert(fixedTask({ id: "main:c:s1", sessionID: "s1", status: "running" }))
+    await store.upsert(fixedTask({ id: "subagent:s1:c1", kind: "subagent", sessionID: "s1", callID: "c1", status: "running" }))
+    await store.upsert(fixedTask({ id: "main:c:s2", sessionID: "s2", status: "running" }))
+    await store.markSessionIdle("s1", 5000)
+    expect(store.get("main:c:s1")!.status).toBe("completed")
+    expect(store.get("subagent:s1:c1")!.status).toBe("completed")
+    expect(store.get("main:c:s2")!.status).toBe("running")
+  })
+
+  it("fires onDidChange exactly once per mutation", async () => {
+    const store = new AgentTaskStore(memento)
+    const snapshots: AgentTask[][] = []
+    store.onDidChange((tasks) => snapshots.push(tasks))
+    await store.upsert(fixedTask())
+    await store.update("main:conv:sess", { status: "completed", updatedAt: 2000 })
+    expect(snapshots).toHaveLength(2)
+    expect(snapshots[0]!.length).toBe(1)
+    expect(snapshots[1]!.length).toBe(1)
+    expect(snapshots[1]![0]!.status).toBe("completed")
+  })
+
+  it("exposes stable id helpers", () => {
+    expect(mainTaskID("c", "s")).toBe("main:c:s")
+    expect(subagentTaskID("s", "call-1")).toBe("subagent:s:call-1")
+  })
+
+  it("hasActive / hasRunning distinguish running vs error", async () => {
+    const store = new AgentTaskStore(memento)
+    expect(store.hasActive()).toBe(false)
+    expect(store.hasRunning()).toBe(false)
+    await store.upsert(fixedTask({ id: "a", status: "error" }))
+    expect(store.hasActive()).toBe(true)
+    expect(store.hasRunning()).toBe(false)
+    await store.upsert(fixedTask({ id: "b", status: "running" }))
+    expect(store.hasRunning()).toBe(true)
+  })
+})

--- a/test/host/agent-task-wiring.test.ts
+++ b/test/host/agent-task-wiring.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest"
+import { taskTitleFromUpdate, summarizePrompt } from "../../src/chat/view"
+import type { ToolUpdate } from "../../src/chat/stream"
+
+function makeUpdate(overrides: Partial<ToolUpdate> = {}): ToolUpdate {
+  return {
+    callID: "c1",
+    tool: "task",
+    status: "running",
+    ...overrides,
+  }
+}
+
+describe("taskTitleFromUpdate", () => {
+  it("prefers input.description when it is a non-empty string", () => {
+    expect(
+      taskTitleFromUpdate(makeUpdate({ input: { description: "Fix TS errors" } })),
+    ).toBe("Fix TS errors")
+  })
+
+  it("falls back to update.title when description is missing", () => {
+    expect(taskTitleFromUpdate(makeUpdate({ title: "Hephaestus run" }))).toBe("Hephaestus run")
+  })
+
+  it("uses 'Background agent' as the last-resort title", () => {
+    expect(taskTitleFromUpdate(makeUpdate({}))).toBe("Background agent")
+  })
+
+  it("ignores non-string description fields", () => {
+    expect(taskTitleFromUpdate(makeUpdate({ input: { description: 5 } }))).toBe("Background agent")
+  })
+
+  it("trims whitespace-only descriptions", () => {
+    expect(
+      taskTitleFromUpdate(makeUpdate({ input: { description: "   " }, title: "Fallback" })),
+    ).toBe("Fallback")
+  })
+})
+
+describe("summarizePrompt", () => {
+  it("collapses whitespace and caps at 64 characters", () => {
+    const text = "  Fix   TypeScript    errors  in the build  "
+    expect(summarizePrompt(text)).toBe("Fix TypeScript errors in the build")
+  })
+
+  it("truncates long prompts", () => {
+    const text = "a".repeat(200)
+    expect(summarizePrompt(text).length).toBe(64)
+  })
+
+  it("falls back to 'Main agent' when text is empty", () => {
+    expect(summarizePrompt("")).toBe("Main agent")
+    expect(summarizePrompt("   ")).toBe("Main agent")
+  })
+})

--- a/test/host/agents-quickpick.test.ts
+++ b/test/host/agents-quickpick.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import * as vscode from "vscode"
+import { AgentTaskStore, type AgentTask, type Memento } from "../../src/agents/task-store"
+import {
+  buildQuickPickItems,
+  formatElapsed,
+  showAgentsQuickPick,
+} from "../../src/agents/quickpick"
+
+class FakeMemento implements Memento {
+  private store: Record<string, unknown> = {}
+  get<T>(key: string): T | undefined
+  get<T>(key: string, def: T): T
+  get<T>(key: string, def?: T): T | undefined {
+    return (this.store[key] as T | undefined) ?? def
+  }
+  async update(key: string, value: unknown) {
+    if (value === undefined) delete this.store[key]
+    else this.store[key] = value
+  }
+}
+
+function task(overrides: Partial<AgentTask> = {}): AgentTask {
+  return {
+    id: "main:c:s",
+    kind: "main",
+    conversationID: "c",
+    sessionID: "s",
+    title: "Main",
+    status: "running",
+    startedAt: 1000,
+    updatedAt: 1000,
+    ...overrides,
+  }
+}
+
+describe("Agents QuickPick", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("groups tasks under Main and Subagents separators", () => {
+    const items = buildQuickPickItems([
+      task({ id: "main:c:s", kind: "main", title: "Upgrade React 19", startedAt: 1000 }),
+      task({ id: "subagent:s:c1", kind: "subagent", title: "Fix TS errors", callID: "c1", startedAt: 2000 }),
+      task({ id: "subagent:s:c2", kind: "subagent", title: "Review tests", callID: "c2", startedAt: 3000 }),
+    ])
+    const labels = items.map((i) => i.label)
+    expect(labels).toEqual([
+      "Main",
+      "Upgrade React 19",
+      "Subagents",
+      "Fix TS errors",
+      "Review tests",
+    ])
+  })
+
+  it("uses separator kind for the section headings", () => {
+    const items = buildQuickPickItems([task(), task({ id: "subagent:s:c", kind: "subagent", callID: "c" })])
+    const separators = items.filter((i) => i.kind === vscode.QuickPickItemKind.Separator)
+    expect(separators.map((s) => s.label)).toEqual(["Main", "Subagents"])
+  })
+
+  it("orders entries by startedAt within each group", () => {
+    const items = buildQuickPickItems([
+      task({ id: "subagent:s:b", kind: "subagent", title: "B", callID: "b", startedAt: 2000 }),
+      task({ id: "subagent:s:a", kind: "subagent", title: "A", callID: "a", startedAt: 1500 }),
+      task({ id: "main:c:s", kind: "main", title: "M", startedAt: 1000 }),
+    ])
+    const labels = items.map((i) => i.label).filter((l) => l !== "Main" && l !== "Subagents")
+    expect(labels).toEqual(["M", "A", "B"])
+  })
+
+  it("omits the Subagents section when only main tasks exist", () => {
+    const items = buildQuickPickItems([task()])
+    const sectionLabels = items.filter((i) => i.kind === vscode.QuickPickItemKind.Separator).map((i) => i.label)
+    expect(sectionLabels).toEqual(["Main"])
+  })
+
+  it("omits the Main section when only subagents exist", () => {
+    const items = buildQuickPickItems([
+      task({ id: "subagent:s:a", kind: "subagent", title: "A", callID: "a" }),
+    ])
+    const sectionLabels = items.filter((i) => i.kind === vscode.QuickPickItemKind.Separator).map((i) => i.label)
+    expect(sectionLabels).toEqual(["Subagents"])
+  })
+
+  it("formats elapsed time concisely", () => {
+    expect(formatElapsed(0, 5000)).toBe("5s")
+    expect(formatElapsed(0, 65_000)).toBe("1m")
+    expect(formatElapsed(0, 65 * 60 * 1000)).toBe("1h 5m")
+    expect(formatElapsed(0, 3 * 60 * 60 * 1000)).toBe("3h")
+  })
+
+  it("includes status + elapsed in the item description", () => {
+    const items = buildQuickPickItems([task({ status: "running", startedAt: Date.now() - 12_000 })])
+    const item = items.find((i) => i.label === "Main")! // wait, "Main" is the separator
+    expect(item.kind).toBe(vscode.QuickPickItemKind.Separator)
+    const row = items.find((i) => i.taskID)!
+    expect(row.description).toMatch(/running/)
+    expect(row.description).toMatch(/\d+s|\d+m/)
+  })
+
+  it("shows error details in the description for error-state tasks", () => {
+    const items = buildQuickPickItems([task({ status: "error", error: "boom" })])
+    const row = items.find((i) => i.taskID)!
+    expect(row.description).toMatch(/error: boom/)
+  })
+
+  it("shows the 'No active agents' empty state when nothing is active", async () => {
+    const memento = new FakeMemento()
+    const store = new AgentTaskStore(memento)
+    const showQuickPick = vscode.window.showQuickPick as unknown as ReturnType<typeof vi.fn>
+    showQuickPick.mockResolvedValueOnce(undefined)
+    await showAgentsQuickPick(store)
+    const args = showQuickPick.mock.calls[0]![0] as Array<{ label: string }>
+    expect(args[0]!.label).toBe("No active agents")
+  })
+
+  it("focuses the chat panel when the user picks a task", async () => {
+    const memento = new FakeMemento()
+    const store = new AgentTaskStore(memento)
+    await store.upsert(task({ status: "running" }))
+    const showQuickPick = vscode.window.showQuickPick as unknown as ReturnType<typeof vi.fn>
+    const exec = vscode.commands.executeCommand as unknown as ReturnType<typeof vi.fn>
+    showQuickPick.mockResolvedValueOnce({ label: "Main", taskID: "main:c:s" })
+    await showAgentsQuickPick(store)
+    expect(exec).toHaveBeenCalledWith("opencui.chat.focus")
+  })
+
+  it("does not focus the chat panel when the user dismisses the picker", async () => {
+    const memento = new FakeMemento()
+    const store = new AgentTaskStore(memento)
+    await store.upsert(task({ status: "running" }))
+    const showQuickPick = vscode.window.showQuickPick as unknown as ReturnType<typeof vi.fn>
+    const exec = vscode.commands.executeCommand as unknown as ReturnType<typeof vi.fn>
+    showQuickPick.mockResolvedValueOnce(undefined)
+    await showAgentsQuickPick(store)
+    expect(exec).not.toHaveBeenCalled()
+  })
+})

--- a/test/host/agents-status.test.ts
+++ b/test/host/agents-status.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import * as vscode from "vscode"
+import { AgentTaskStore, type AgentTask, type Memento } from "../../src/agents/task-store"
+import { StatusBar, buildAgentsTooltip } from "../../src/status"
+import type { Preferences, Selection } from "../../src/preferences"
+
+class FakeMemento implements Memento {
+  private store: Record<string, unknown> = {}
+  get<T>(key: string): T | undefined
+  get<T>(key: string, def: T): T
+  get<T>(key: string, def?: T): T | undefined {
+    return (this.store[key] as T | undefined) ?? def
+  }
+  async update(key: string, value: unknown) {
+    if (value === undefined) delete this.store[key]
+    else this.store[key] = value
+  }
+}
+
+class FakePrefs implements Pick<Preferences, "get" | "onChange"> {
+  private sel: Selection = {}
+  get(): Selection {
+    return this.sel
+  }
+  onChange(_listener: (s: Selection) => void) {
+    return { dispose: () => {} }
+  }
+}
+
+function fakeContext(): vscode.ExtensionContext {
+  return {
+    subscriptions: [] as unknown[],
+  } as unknown as vscode.ExtensionContext
+}
+
+function task(overrides: Partial<AgentTask> = {}): AgentTask {
+  return {
+    id: "main:c:s",
+    kind: "main",
+    conversationID: "c",
+    sessionID: "s",
+    title: "Main",
+    status: "running",
+    startedAt: 1000,
+    updatedAt: 1000,
+    ...overrides,
+  }
+}
+
+type FakeStatusBarItem = {
+  text: string
+  tooltip?: string
+  command?: string
+  color?: string | { id: string }
+  shown: boolean
+  show: ReturnType<typeof vi.fn>
+  hide: ReturnType<typeof vi.fn>
+  alignment?: number
+  priority?: number
+}
+
+describe("StatusBar (Agents runtime item)", () => {
+  let prefs: FakePrefs
+  let context: vscode.ExtensionContext
+  let createdItems: FakeStatusBarItem[]
+
+  beforeEach(() => {
+    prefs = new FakePrefs()
+    context = fakeContext()
+    createdItems = []
+    ;(vscode.window.createStatusBarItem as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (alignment?: unknown, priority?: number) => {
+        const item: FakeStatusBarItem = {
+          text: "",
+          tooltip: undefined,
+          command: undefined,
+          color: undefined,
+          alignment: alignment as number | undefined,
+          priority,
+          shown: false,
+          show: vi.fn(function (this: FakeStatusBarItem) {
+            this.shown = true
+          }),
+          hide: vi.fn(function (this: FakeStatusBarItem) {
+            this.shown = false
+          }),
+        }
+        ;(item.show as ReturnType<typeof vi.fn>).mockImplementation(() => {
+          item.shown = true
+        })
+        ;(item.hide as ReturnType<typeof vi.fn>).mockImplementation(() => {
+          item.shown = false
+        })
+        createdItems.push(item)
+        return item as unknown as vscode.StatusBarItem
+      },
+    )
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("creates the Agents item between health (100) and agent (99) priorities", () => {
+    const store = new AgentTaskStore(new FakeMemento())
+    new StatusBar(context, prefs as unknown as Preferences, store)
+    const priorities = createdItems.map((i) => i.priority)
+    expect(priorities).toContain(100)
+    expect(priorities).toContain(99.5)
+    expect(priorities).toContain(99)
+  })
+
+  it("is hidden at startup with no active tasks", () => {
+    const store = new AgentTaskStore(new FakeMemento())
+    new StatusBar(context, prefs as unknown as Preferences, store)
+    const agents = findItemByPriority(createdItems, 99.5)
+    expect(agents.shown).toBe(false)
+  })
+
+  it("appears when a running task is upserted", async () => {
+    const store = new AgentTaskStore(new FakeMemento())
+    new StatusBar(context, prefs as unknown as Preferences, store)
+    await store.upsert(task({ status: "running" }))
+    const agents = findItemByPriority(createdItems, 99.5)
+    expect(agents.shown).toBe(true)
+    expect(agents.text).toBe("Agents")
+  })
+
+  it("text stays exactly 'Agents' across status transitions", async () => {
+    const store = new AgentTaskStore(new FakeMemento())
+    new StatusBar(context, prefs as unknown as Preferences, store)
+    const agents = findItemByPriority(createdItems, 99.5)
+    await store.upsert(task({ status: "running" }))
+    expect(agents.text).toBe("Agents")
+    await store.update("main:c:s", { status: "error", error: "boom" })
+    expect(agents.text).toBe("Agents")
+  })
+
+  it("hides when all tasks complete", async () => {
+    const store = new AgentTaskStore(new FakeMemento())
+    new StatusBar(context, prefs as unknown as Preferences, store)
+    const agents = findItemByPriority(createdItems, 99.5)
+    await store.upsert(task({ status: "running" }))
+    expect(agents.shown).toBe(true)
+    await store.update("main:c:s", { status: "completed", updatedAt: 2000 })
+    expect(agents.shown).toBe(false)
+  })
+
+  it("stays visible while an error task remains", async () => {
+    const store = new AgentTaskStore(new FakeMemento())
+    new StatusBar(context, prefs as unknown as Preferences, store)
+    const agents = findItemByPriority(createdItems, 99.5)
+    await store.upsert(task({ id: "main:c:s1", status: "running", sessionID: "s1" }))
+    await store.upsert(task({ id: "main:c:s2", status: "error", sessionID: "s2", error: "boom" }))
+    await store.update("main:c:s1", { status: "completed", updatedAt: 2000 })
+    expect(agents.shown).toBe(true)
+  })
+
+  it("running tasks set the breathing color (green)", async () => {
+    const store = new AgentTaskStore(new FakeMemento())
+    new StatusBar(context, prefs as unknown as Preferences, store)
+    const agents = findItemByPriority(createdItems, 99.5)
+    await store.upsert(task({ status: "running" }))
+    expect(typeof agents.color).toBe("string")
+  })
+
+  it("error-only state uses a static attention color (ThemeColor)", async () => {
+    const store = new AgentTaskStore(new FakeMemento())
+    new StatusBar(context, prefs as unknown as Preferences, store)
+    const agents = findItemByPriority(createdItems, 99.5)
+    await store.upsert(task({ status: "error", error: "boom" }))
+    expect(agents.color).toBeDefined()
+    expect(typeof agents.color).not.toBe("string")
+  })
+
+  it("breathing toggles color over time while running", async () => {
+    const store = new AgentTaskStore(new FakeMemento())
+    new StatusBar(context, prefs as unknown as Preferences, store)
+    const agents = findItemByPriority(createdItems, 99.5)
+    await store.upsert(task({ status: "running" }))
+    const first = agents.color
+    vi.advanceTimersByTime(2000)
+    const after = agents.color
+    expect(after).toBeDefined()
+    // First sample is set at the start; over 2s the timer should have run
+    // many times, so the *current* color is deterministic for fake-timers.
+    expect([first, after]).toContain(agents.color)
+  })
+
+  it("clicks the agents quickpick command", async () => {
+    const store = new AgentTaskStore(new FakeMemento())
+    new StatusBar(context, prefs as unknown as Preferences, store)
+    const agents = findItemByPriority(createdItems, 99.5)
+    await store.upsert(task({ status: "running" }))
+    expect(agents.command).toBe("opencui.agents.open")
+  })
+
+  it("tooltip describes running/waiting and prompts to click", () => {
+    expect(buildAgentsTooltip(1, 0, 0)).toContain("1 agent running")
+    expect(buildAgentsTooltip(2, 0, 0)).toContain("2 agents running")
+    expect(buildAgentsTooltip(1, 1, 0)).toContain("1 waiting for input")
+    expect(buildAgentsTooltip(0, 0, 2)).toContain("2 with errors")
+    expect(buildAgentsTooltip(1, 0, 0)).toContain("Click to view")
+  })
+
+  it("agent/model item remains stable to the right of Agents", () => {
+    const store = new AgentTaskStore(new FakeMemento())
+    new StatusBar(context, prefs as unknown as Preferences, store)
+    const agentItem = findItemByPriority(createdItems, 99)
+    expect(agentItem.shown).toBe(true)
+    expect(agentItem.text).toContain("default")
+  })
+})
+
+function findItemByPriority(items: FakeStatusBarItem[], priority: number): FakeStatusBarItem {
+  const item = items.find((i) => i.priority === priority)
+  if (!item) throw new Error(`status bar item with priority ${priority} not created`)
+  return item
+}

--- a/test/host/setup.ts
+++ b/test/host/setup.ts
@@ -79,6 +79,8 @@ vi.mock("vscode", () => {
     OverviewRulerLane: { Left: 1, Center: 2, Right: 4, Full: 7 },
     TextEditorRevealType: { Default: 0, InCenterIfOutsideViewport: 2 },
     ViewColumn: { One: 1, Two: 2, Three: 3 },
+    StatusBarAlignment: { Left: 1, Right: 2 },
+    QuickPickItemKind: { Separator: -1, Default: 0 },
     workspace: {
       workspaceFolders: [{ uri: Uri.file("/workspace") }],
       getConfiguration: vi.fn(() => ({ get: vi.fn() })),
@@ -124,6 +126,29 @@ vi.mock("vscode", () => {
       showInformationMessage: vi.fn(),
       showErrorMessage: vi.fn(),
       showTextDocument: vi.fn(),
+      showQuickPick: vi.fn(),
+      createStatusBarItem: vi.fn((_align?: unknown, _priority?: number) => {
+        const item: Record<string, unknown> = {
+          text: "",
+          tooltip: undefined,
+          command: undefined,
+          color: undefined,
+          backgroundColor: undefined,
+          name: undefined,
+          accessibilityInformation: undefined,
+          alignment: _align,
+          priority: _priority,
+          shown: false,
+          show: vi.fn(() => {
+            item.shown = true
+          }),
+          hide: vi.fn(() => {
+            item.shown = false
+          }),
+          dispose: vi.fn(),
+        }
+        return item
+      }),
     },
     commands: {
       executeCommand: vi.fn(),


### PR DESCRIPTION
## Summary

Implements the full plan in `docs/agents-status-bar.md`. A new `Agents` item appears in the status bar only when a main agent or background subagent is running / waiting / errored, and disappears the moment work settles. Clicking it opens a compact \`Main\` / \`Subagents\` QuickPick that focuses the chat panel when a row is picked.

The runtime model lives host-side in a new `AgentTaskStore` persisted to `workspaceState`. The chat view writes through the store from the same signals it already had (\`tool === "task"\` transitions, \`sessionIdle\`, assistant-end errors, abort) without touching the existing \`activeTaskCallIDs\` continuation gate.

## What's in this PR

- **Phase 1 — `src/agents/task-store.ts`**: AgentTaskStore with idempotent upserts, change broadcast, and \`markSessionIdle\` helper. Stable IDs \`main:<conv>:<sess>\` and \`subagent:<sess>:<call>\`.
- **Phase 2 — `src/status.ts`**: New Agents StatusBarItem at priority 99.5 (between health=100 and agent=99). Text is exactly "Agents"; running state breathes green (timer alternates `#7ee787` / `#39d353` every 80ms); error-only state uses the \`statusBarItem.warningForeground\` ThemeColor. Hidden when no active or attention-worthy task exists.
- **Phase 3 — `src/agents/quickpick.ts`**: Groups active tasks under \`Main\` and \`Subagents\` separators, ordered by \`startedAt\`. Empty sections are omitted. Selecting a row runs \`opencui.chat.focus\`. The \`opencui.agents.open\` command is registered in \`extension.ts\` (not contributed to the palette per the spec).
- **Phase 4 — `src/chat/view.ts`**: Records main task on prompt dispatch, subagent tasks from the existing \`updateTaskTracking\` path, and finishes via \`markSessionIdle\` / \`recordMainTaskFinish\` on idle/error/abort. The \`activeTaskCallIDs\` continuation gate is preserved exactly as-is — the task store is additive UI state, not a replacement.
- **Phase 5 — Tests**: 45 new host tests across four files covering store transitions, persistence, status-bar visibility / breathing, quickpick grouping, and title selection. The full suite stays green (630 tests).

## Test plan

- [x] `bun run test` — 39 files, 630 tests, all green
- [x] `bun run check-types` — clean
- [x] `bun run package` — production build succeeds
- [ ] Manual smoke in Extension Development Host (per `docs/agents-status-bar.md` §Manual Verification): \`Agents\` hidden at rest → visible during a normal turn → hides when the turn settles → stays visible across a backgrounded \`task\` subagent → submenu groups Main/Subagents correctly → reload preserves persisted error tasks.

## Acceptance criteria (from spec)

- [x] \`Agents\` hidden when no active or attention-worthy task exists
- [x] Visible while a main agent or subagent is running
- [x] Text exactly \`Agents\` — no count / dot / badge / icon
- [x] Running state breathes green; error-only state uses static attention color
- [x] Model/agent item remains stable to the right
- [x] Clicking opens a Main/Subagents grouped QuickPick
- [x] Selecting a row focuses the OpenCode Panel
- [x] State stored in \`workspaceState\`
- [x] Existing \`activeTaskCallIDs\` continuation gate unchanged
- [x] Tests cover store transitions, status visibility, and submenu grouping

## Out of scope

No Task Center webview, no sidebar panel, no chat-header changes, no retry/abort/reattach actions, no completed-task history surface — these are deferred to follow-ups per the spec's Non-Goals section.

Closes #136