### PR TITLE
feat(agents): inline popover scoped to current chat

### DIFF
--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -44,7 +44,7 @@ import { RecentEditsTracker } from "../workspace-context/recent-edits"
 import { readContextSettings } from "../workspace-context/budget"
 import type { IndexManager } from "../indexing/index-manager"
 import { AgentTaskStore, mainTaskID, subagentTaskID, type AgentTask } from "../agents/task-store"
-import type { AgentsStatusInfo } from "../protocol"
+import type { AgentsStatusInfo, AgentsTaskInfo } from "../protocol"
 import { toWire } from "./wire-format"
 import {
   applyCode,
@@ -178,7 +178,7 @@ export class ChatView implements vscode.WebviewViewProvider {
   }
 
   private postAgentsStatus(tasks: AgentTask[]) {
-    const status = summarizeAgentTasks(tasks)
+    const status = summarizeAgentTasks(tasks, this.activeConversationID)
     this.post({ type: "agentsStatus", status })
   }
 
@@ -240,6 +240,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.reviewHunks = {}
     await this.persistConversations()
     this.sendConversationState()
+    if (this.taskStore) this.postAgentsStatus(this.taskStore.list())
   }
 
   async pickConversation() {
@@ -327,6 +328,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.restoreActiveState()
     await this.persistConversations()
     this.sendConversationState()
+    if (this.taskStore) this.postAgentsStatus(this.taskStore.list())
   }
 
   private async renameConversation(id: string, title: string) {
@@ -705,9 +707,6 @@ export class ChatView implements vscode.WebviewViewProvider {
         return
       case "stopIndex":
         void this.indexManager.stop()
-        return
-      case "openAgents":
-        await vscode.commands.executeCommand("opencui.agents.open")
         return
     }
   }
@@ -1496,16 +1495,35 @@ export class ChatView implements vscode.WebviewViewProvider {
   }
 }
 
-export function summarizeAgentTasks(tasks: AgentTask[]): AgentsStatusInfo {
+export function summarizeAgentTasks(
+  tasks: AgentTask[],
+  conversationID?: string,
+): AgentsStatusInfo {
+  const items: AgentsTaskInfo[] = []
   let running = 0
   let waiting = 0
   let error = 0
   for (const task of tasks) {
+    if (conversationID && task.conversationID !== conversationID) continue
     if (task.status === "running") running += 1
     else if (task.status === "waiting") waiting += 1
     else if (task.status === "error") error += 1
+    else continue
+    items.push({
+      id: task.id,
+      kind: task.kind,
+      title: task.title,
+      status: task.status,
+      error: task.error,
+      startedAt: task.startedAt,
+    })
   }
-  return { running, waiting, error, total: running + waiting + error }
+  // Stable order: main tasks first, then subagents, then by startedAt asc.
+  items.sort((a, b) => {
+    if (a.kind !== b.kind) return a.kind === "main" ? -1 : 1
+    return a.startedAt - b.startedAt
+  })
+  return { running, waiting, error, total: running + waiting + error, tasks: items }
 }
 
 export function taskTitleFromUpdate(update: ToolUpdate): string {

--- a/test/host/agent-task-wiring.test.ts
+++ b/test/host/agent-task-wiring.test.ts
@@ -54,27 +54,81 @@ function task(overrides: Partial<AgentTask> = {}): AgentTask {
 
 describe("summarizeAgentTasks", () => {
   it("returns zeros for an empty list", () => {
-    expect(summarizeAgentTasks([])).toEqual({ running: 0, waiting: 0, error: 0, total: 0 })
+    expect(summarizeAgentTasks([])).toEqual({
+      running: 0,
+      waiting: 0,
+      error: 0,
+      total: 0,
+      tasks: [],
+    })
   })
 
   it("counts running / waiting / error states", () => {
-    expect(
-      summarizeAgentTasks([
-        task({ id: "a", status: "running" }),
-        task({ id: "b", status: "running" }),
-        task({ id: "c", status: "waiting" }),
-        task({ id: "d", status: "error" }),
-      ]),
-    ).toEqual({ running: 2, waiting: 1, error: 1, total: 4 })
+    const result = summarizeAgentTasks([
+      task({ id: "a", status: "running" }),
+      task({ id: "b", status: "running" }),
+      task({ id: "c", status: "waiting" }),
+      task({ id: "d", status: "error" }),
+    ])
+    expect(result.running).toBe(2)
+    expect(result.waiting).toBe(1)
+    expect(result.error).toBe(1)
+    expect(result.total).toBe(4)
+    expect(result.tasks.map((t) => t.id).sort()).toEqual(["a", "b", "c", "d"])
   })
 
   it("ignores completed and cancelled tasks", () => {
-    expect(
-      summarizeAgentTasks([
-        task({ id: "a", status: "completed" }),
-        task({ id: "b", status: "cancelled" }),
-      ]),
-    ).toEqual({ running: 0, waiting: 0, error: 0, total: 0 })
+    const result = summarizeAgentTasks([
+      task({ id: "a", status: "completed" }),
+      task({ id: "b", status: "cancelled" }),
+    ])
+    expect(result.tasks).toEqual([])
+    expect(result.total).toBe(0)
+  })
+
+  it("filters by conversationID when provided", () => {
+    const result = summarizeAgentTasks(
+      [
+        task({ id: "x", conversationID: "convA", status: "running" }),
+        task({ id: "y", conversationID: "convB", status: "running" }),
+        task({ id: "z", conversationID: "convA", kind: "subagent", status: "error" }),
+      ],
+      "convA",
+    )
+    expect(result.running).toBe(1)
+    expect(result.error).toBe(1)
+    expect(result.total).toBe(2)
+    expect(result.tasks.map((t) => t.id)).toEqual(["x", "z"])
+  })
+
+  it("orders Main first, then Subagents, both by startedAt ascending", () => {
+    const result = summarizeAgentTasks([
+      task({ id: "sub-late", kind: "subagent", status: "running", startedAt: 3000 }),
+      task({ id: "sub-early", kind: "subagent", status: "running", startedAt: 2000 }),
+      task({ id: "main", kind: "main", status: "running", startedAt: 5000 }),
+    ])
+    expect(result.tasks.map((t) => t.id)).toEqual(["main", "sub-early", "sub-late"])
+  })
+
+  it("strips host-only fields and keeps only the wire shape", () => {
+    const result = summarizeAgentTasks([
+      task({
+        id: "a",
+        kind: "main",
+        title: "Refactor",
+        status: "running",
+        startedAt: 1000,
+        error: undefined,
+      }),
+    ])
+    expect(result.tasks[0]).toEqual({
+      id: "a",
+      kind: "main",
+      title: "Refactor",
+      status: "running",
+      error: undefined,
+      startedAt: 1000,
+    })
   })
 })
 

--- a/test/webview/statusbar.test.tsx
+++ b/test/webview/statusbar.test.tsx
@@ -20,7 +20,6 @@ const baseProps = {
   onOpenConversation: vi.fn(),
   onRenameConversation: vi.fn(),
   onDeleteConversation: vi.fn(),
-  onOpenAgents: vi.fn(),
 }
 
 describe("StatusBar", () => {
@@ -258,7 +257,23 @@ describe("StatusBar: history popover", () => {
   })
 })
 
-describe("AgentsPill (StatusBar inline)", () => {
+describe("AgentsMenu (StatusBar inline popover)", () => {
+  const baseStatus = {
+    running: 1,
+    waiting: 0,
+    error: 0,
+    total: 1,
+    tasks: [
+      {
+        id: "main:c:s",
+        kind: "main" as const,
+        title: "Explain this file",
+        status: "running" as const,
+        startedAt: Date.now() - 12_000,
+      },
+    ],
+  }
+
   it("is hidden when no agentsStatus is set", () => {
     render(<StatusBar {...baseProps} />)
     expect(screen.queryByText("Agents")).not.toBeInTheDocument()
@@ -266,29 +281,21 @@ describe("AgentsPill (StatusBar inline)", () => {
 
   it("is hidden when total === 0", () => {
     render(
-      <StatusBar {...baseProps} agentsStatus={{ running: 0, waiting: 0, error: 0, total: 0 }} />,
+      <StatusBar
+        {...baseProps}
+        agentsStatus={{ running: 0, waiting: 0, error: 0, total: 0, tasks: [] }}
+      />,
     )
     expect(screen.queryByText("Agents")).not.toBeInTheDocument()
   })
 
-  it("renders 'Agents' between the dot and the selector when a task is running", () => {
-    render(
-      <StatusBar
-        {...baseProps}
-        selection={{ model: "openai/gpt-5", agent: "deep-agent" }}
-        agentsStatus={{ running: 1, waiting: 0, error: 0, total: 1 }}
-      />,
-    )
+  it("renders 'Agents' when a task is running in this chat", () => {
+    render(<StatusBar {...baseProps} agentsStatus={baseStatus} />)
     expect(screen.getByText("Agents")).toBeInTheDocument()
   })
 
   it("applies is-running class so the breathing animation can trigger", () => {
-    render(
-      <StatusBar
-        {...baseProps}
-        agentsStatus={{ running: 2, waiting: 0, error: 0, total: 2 }}
-      />,
-    )
+    render(<StatusBar {...baseProps} agentsStatus={baseStatus} />)
     const pill = screen.getByText("Agents")
     expect(pill.className).toContain("agents-pill")
     expect(pill.className).toContain("is-running")
@@ -298,7 +305,22 @@ describe("AgentsPill (StatusBar inline)", () => {
     render(
       <StatusBar
         {...baseProps}
-        agentsStatus={{ running: 0, waiting: 0, error: 1, total: 1 }}
+        agentsStatus={{
+          running: 0,
+          waiting: 0,
+          error: 1,
+          total: 1,
+          tasks: [
+            {
+              id: "main:c:s",
+              kind: "main",
+              title: "Failed",
+              status: "error",
+              error: "boom",
+              startedAt: 0,
+            },
+          ],
+        }}
       />,
     )
     const pill = screen.getByText("Agents")
@@ -306,37 +328,85 @@ describe("AgentsPill (StatusBar inline)", () => {
     expect(pill.className).not.toContain("is-running")
   })
 
-  it("uses static is-waiting class for waiting-only state", () => {
+  it("opens an inline popover on click and lists tasks", async () => {
+    const user = userEvent.setup()
     render(
       <StatusBar
         {...baseProps}
-        agentsStatus={{ running: 0, waiting: 1, error: 0, total: 1 }}
+        agentsStatus={{
+          ...baseStatus,
+          running: 2,
+          total: 2,
+          tasks: [
+            {
+              id: "main:c:s",
+              kind: "main",
+              title: "Refactor module",
+              status: "running",
+              startedAt: Date.now() - 5_000,
+            },
+            {
+              id: "subagent:s:c1",
+              kind: "subagent",
+              title: "Fix lint errors",
+              status: "running",
+              startedAt: Date.now() - 2_000,
+            },
+          ],
+        }}
       />,
     )
-    const pill = screen.getByText("Agents")
-    expect(pill.className).toContain("is-waiting")
-    expect(pill.className).not.toContain("is-running")
+    expect(screen.queryByText("Refactor module")).not.toBeInTheDocument()
+    await user.click(screen.getByText("Agents"))
+    expect(screen.getByText("Refactor module")).toBeInTheDocument()
+    expect(screen.getByText("Fix lint errors")).toBeInTheDocument()
+    expect(screen.getByText("Main")).toBeInTheDocument()
+    expect(screen.getByText("Subagents")).toBeInTheDocument()
   })
 
-  it("calls onOpenAgents when clicked", async () => {
+  it("groups separators are omitted when only one kind is present", async () => {
     const user = userEvent.setup()
-    const onOpenAgents = vi.fn()
-    render(
+    render(<StatusBar {...baseProps} agentsStatus={baseStatus} />)
+    await user.click(screen.getByText("Agents"))
+    expect(screen.getByText("Main")).toBeInTheDocument()
+    expect(screen.queryByText("Subagents")).not.toBeInTheDocument()
+  })
+
+  it("closes the popover when the chat goes idle (total → 0)", async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(<StatusBar {...baseProps} agentsStatus={baseStatus} />)
+    await user.click(screen.getByText("Agents"))
+    expect(screen.getByText("Explain this file")).toBeInTheDocument()
+    rerender(
       <StatusBar
         {...baseProps}
-        onOpenAgents={onOpenAgents}
-        agentsStatus={{ running: 1, waiting: 0, error: 0, total: 1 }}
+        agentsStatus={{ running: 0, waiting: 0, error: 0, total: 0, tasks: [] }}
       />,
     )
+    expect(screen.queryByText("Explain this file")).not.toBeInTheDocument()
+    expect(screen.queryByText("Agents")).not.toBeInTheDocument()
+  })
+
+  it("closes the popover when Escape is pressed", async () => {
+    const user = userEvent.setup()
+    render(<StatusBar {...baseProps} agentsStatus={baseStatus} />)
     await user.click(screen.getByText("Agents"))
-    expect(onOpenAgents).toHaveBeenCalledTimes(1)
+    expect(screen.getByText("Explain this file")).toBeInTheDocument()
+    await user.keyboard("{Escape}")
+    expect(screen.queryByText("Explain this file")).not.toBeInTheDocument()
   })
 
   it("shows a tooltip summarizing the counts", () => {
     render(
       <StatusBar
         {...baseProps}
-        agentsStatus={{ running: 2, waiting: 1, error: 0, total: 3 }}
+        agentsStatus={{
+          running: 2,
+          waiting: 1,
+          error: 0,
+          total: 3,
+          tasks: [],
+        }}
       />,
     )
     const pill = screen.getByText("Agents")

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -32,7 +32,6 @@ export default function App() {
     attachFile,
     startIndex,
     stopIndex,
-    openAgents,
   } = useChatState()
   const scrollRef = useRef<HTMLDivElement>(null)
   const stickToBottom = useRef(true)
@@ -138,7 +137,6 @@ export default function App() {
         onOpenConversation={openConversation}
         onRenameConversation={renameConversation}
         onDeleteConversation={deleteConversation}
-        onOpenAgents={openAgents}
       />
       {state.indexStatus && state.indexStatus.state !== "disabled" && (
         <div className="index-status-wrap">

--- a/webview/src/components/StatusBar.tsx
+++ b/webview/src/components/StatusBar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react"
-import type { AgentsStatusInfo, ConversationSummary, Selection } from "../protocol"
+import type { AgentsStatusInfo, AgentsTaskInfo, ConversationSummary, Selection } from "../protocol"
 import { StatusIndicator, type StatusIndicatorKind } from "./StatusIndicator"
 
 type Props = {
@@ -17,7 +17,6 @@ type Props = {
   onOpenConversation: (id: string) => void
   onRenameConversation: (id: string, title: string) => void
   onDeleteConversation: (id: string) => void
-  onOpenAgents: () => void
 }
 
 export function StatusBar({
@@ -35,7 +34,6 @@ export function StatusBar({
   onOpenConversation,
   onRenameConversation,
   onDeleteConversation,
-  onOpenAgents,
 }: Props) {
   const agent = selection.agent ?? "default"
   const model = selection.model ?? "default"
@@ -71,7 +69,7 @@ export function StatusBar({
         label={showStatus ? statusLabel : undefined}
         title={statusTitle}
       />
-      <AgentsPill status={agentsStatus} onOpen={onOpenAgents} />
+      <AgentsMenu status={agentsStatus} />
       <div className="spacer" />
       <SelectorMenu
         agent={agent}
@@ -296,35 +294,103 @@ function ChatHistoryMenu({
 }
 
 /**
- * Hidden-by-default `Agents` pill rendered between the connection dot and the
- * model/agent selector. Visibility tracks the host-side AgentTaskStore counts
- * — hidden when total === 0, shown while any task is running/waiting/errored.
- * Running state breathes via CSS animation (`.agents-pill.is-running`).
+ * Hidden-by-default `Agents` menu rendered between the connection dot and the
+ * model/agent selector. The host scopes the snapshot to the active
+ * conversation, so `tasks` only contains work for THIS chat. Clicking the
+ * pill toggles an inline popover (matching the SelectorMenu pattern) that
+ * lists tasks grouped by Main / Subagents.
  */
-function AgentsPill({
-  status,
-  onOpen,
-}: {
-  status?: AgentsStatusInfo
-  onOpen: () => void
-}) {
+function AgentsMenu({ status }: { status?: AgentsStatusInfo }) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (event: PointerEvent) => {
+      if (ref.current?.contains(event.target as Node)) return
+      setOpen(false)
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false)
+    }
+    window.addEventListener("pointerdown", onPointerDown)
+    window.addEventListener("keydown", onKeyDown)
+    return () => {
+      window.removeEventListener("pointerdown", onPointerDown)
+      window.removeEventListener("keydown", onKeyDown)
+    }
+  }, [open])
+
+  // Close the popover automatically when the chat goes idle so the menu
+  // doesn't sit open after the last task it was showing terminates.
+  useEffect(() => {
+    if (status && status.total === 0) setOpen(false)
+  }, [status?.total])
+
   if (!status || status.total === 0) return null
   const running = status.running > 0
   const className =
     "agents-pill" +
+    (open ? " is-open" : "") +
     (running ? " is-running" : "") +
     (!running && status.error > 0 ? " is-error" : "") +
     (!running && status.waiting > 0 ? " is-waiting" : "")
+  const main = status.tasks.filter((t) => t.kind === "main")
+  const sub = status.tasks.filter((t) => t.kind === "subagent")
   return (
-    <button
-      type="button"
-      className={className}
-      onClick={onOpen}
-      title={buildAgentsTitle(status)}
-      aria-label="Open agents"
-    >
-      Agents
-    </button>
+    <div className="agents-menu" ref={ref}>
+      <button
+        type="button"
+        className={className}
+        onClick={() => setOpen((value) => !value)}
+        title={buildAgentsTitle(status)}
+        aria-label="Open agents for this chat"
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        Agents
+      </button>
+      {open && (
+        <div className="agents-popover" role="menu">
+          <div className="agents-popover-title">Agents in this chat</div>
+          {main.length > 0 && (
+            <>
+              <div className="agents-popover-section">Main</div>
+              {main.map((task) => (
+                <AgentsRow key={task.id} task={task} />
+              ))}
+            </>
+          )}
+          {sub.length > 0 && (
+            <>
+              <div className="agents-popover-section">Subagents</div>
+              {sub.map((task) => (
+                <AgentsRow key={task.id} task={task} />
+              ))}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function AgentsRow({ task }: { task: AgentsTaskInfo }) {
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    if (task.status !== "running" && task.status !== "waiting") return
+    const handle = window.setInterval(() => setNow(Date.now()), 1000)
+    return () => window.clearInterval(handle)
+  }, [task.status])
+  const elapsed = formatElapsed(now - task.startedAt)
+  const statusText = task.status === "error" && task.error
+    ? `error · ${task.error}`
+    : task.status
+  return (
+    <div className={`agents-row agents-row-${task.status}`} title={`${task.title} · ${statusText} · ${elapsed}`}>
+      <span className="agents-row-title">{task.title}</span>
+      <span className="agents-row-meta">{statusText} · {elapsed}</span>
+    </div>
   )
 }
 
@@ -336,6 +402,16 @@ export function buildAgentsTitle(status: AgentsStatusInfo): string {
   if (status.error > 0) lines.push(`${status.error} with errors`)
   lines.push("Click to view")
   return lines.join("\n")
+}
+
+export function formatElapsed(ms: number): string {
+  const seconds = Math.max(0, Math.floor(ms / 1000))
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  const remMin = minutes - hours * 60
+  return remMin > 0 ? `${hours}h ${remMin}m` : `${hours}h`
 }
 
 export function formatUpdated(updatedAt: number) {

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -437,8 +437,5 @@ export function useChatState() {
     stopIndex() {
       vscode.post({ type: "stopIndex" })
     },
-    openAgents() {
-      vscode.post({ type: "openAgents" })
-    },
   }
 }

--- a/webview/src/protocol.ts
+++ b/webview/src/protocol.ts
@@ -148,15 +148,33 @@ export type IndexStatusInfo = {
 }
 
 /**
- * Snapshot of live main-agent + subagent activity, driven by the host-side
- * AgentTaskStore. The webview header renders an `Agents` pill that is
- * hidden when total === 0 and breathes green while `running > 0`.
+ * One agent task as seen by the webview popover. The host strips
+ * conversationID / sessionID / messageID / parentTaskID / callID before
+ * sending because the popover only needs to render — it doesn't action
+ * on those fields.
+ */
+export type AgentsTaskInfo = {
+  id: string
+  kind: "main" | "subagent"
+  title: string
+  status: "running" | "waiting" | "error"
+  error?: string
+  startedAt: number
+}
+
+/**
+ * Snapshot of live main-agent + subagent activity for the currently-active
+ * conversation, driven by the host-side AgentTaskStore. The webview header
+ * renders an `Agents` pill that is hidden when `total === 0` and breathes
+ * green while `running > 0`. Clicking the pill opens a popover that lists
+ * `tasks` grouped by kind.
  */
 export type AgentsStatusInfo = {
   running: number
   waiting: number
   error: number
   total: number
+  tasks: AgentsTaskInfo[]
 }
 
 /**
@@ -324,4 +342,3 @@ export type Inbound =
   | { type: "questionReject"; id: string }
   | { type: "startIndex" }
   | { type: "stopIndex" }
-  | { type: "openAgents" }

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -169,12 +169,19 @@ button {
   white-space: nowrap;
 }
 
-/* ===== AgentsPill =====
+/* ===== AgentsMenu =====
    Hidden-by-default text-only pill that surfaces live main-agent + subagent
    activity. Sits between the connection dot and the model/agent selector.
    While at least one task is running, the text breathes via a 1.6s opacity +
    green color animation. Waiting / error states use a steady amber / red
-   foreground without animation. */
+   foreground without animation. Clicking opens an inline popover scoped to
+   the current chat (`.agents-popover`). */
+.agents-menu {
+  position: relative;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+}
 .agents-pill {
   flex: 0 0 auto;
   background: transparent;
@@ -189,7 +196,8 @@ button {
   line-height: 1;
   white-space: nowrap;
 }
-.agents-pill:hover {
+.agents-pill:hover,
+.agents-pill.is-open {
   text-decoration: underline;
 }
 .agents-pill.is-running {
@@ -209,6 +217,60 @@ button {
 @media (prefers-reduced-motion: reduce) {
   .agents-pill.is-running { animation: none; }
 }
+
+.agents-popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: -4px;
+  min-width: 260px;
+  max-width: 360px;
+  background: var(--vscode-dropdown-background, var(--vscode-editorWidget-background));
+  color: var(--vscode-foreground);
+  border: 1px solid var(--vscode-dropdown-border, var(--vscode-panel-border));
+  border-radius: 4px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.32);
+  padding: 8px 0;
+  z-index: 50;
+  font-size: 12px;
+}
+.agents-popover-title {
+  padding: 0 12px 6px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.7;
+}
+.agents-popover-section {
+  padding: 6px 12px 2px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  opacity: 0.55;
+}
+.agents-row {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 4px 12px;
+  white-space: nowrap;
+  overflow: hidden;
+}
+.agents-row-title {
+  font-weight: 500;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+.agents-row-meta {
+  opacity: 0.65;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+.agents-row-running .agents-row-title { color: #7ee787; }
+.agents-row-error .agents-row-meta { color: var(--vscode-errorForeground, #f85149); }
+.agents-row-waiting .agents-row-meta { color: var(--vscode-notificationsWarningIcon-foreground, #d29922); }
 
 .selector-menu {
   flex: 0 1 auto;


### PR DESCRIPTION
## Summary

The \`Agents\` pill from #139 dispatched an Inbound that opened VS Code's QuickPick — a separate popup that listed agents *workspace-wide*. This PR turns the click into an in-webview popover (same pattern as the Model / Agent selector right next to it) and scopes the contents to the currently-open chat.

## What changes

- \`AgentsStatusInfo\` gains a \`tasks: AgentsTaskInfo[]\` array. The host scopes the snapshot to \`activeConversationID\` before sending, so the webview only ever sees tasks for the current chat.
- ChatView re-posts the snapshot on \`selectConversation\` and \`createConversation\` so switching chats immediately updates the pill + popover.
- The \`openAgents\` Inbound is dropped. The pill is now a self-contained \`AgentsMenu\` (toggle button + popover, click-outside / Escape close, auto-closes when the chat goes idle).
- Popover groups tasks under \`Main\` and \`Subagents\` separators (skipped when empty), each row shows title + status + live-updating elapsed time.
- Host-side \`opencui.agents.open\` command + QuickPick are left in place for command-palette users who want a workspace-wide view.

## Test plan

- [x] \`bun run test\` — 38 files, 634 tests green (+5 from new cases: popover open/close, Escape, idle-auto-close, summarizer conversation filter + ordering).
- [x] \`bun run check-types\` — host clean. Pre-existing webview tsc errors unchanged (per CLAUDE.md).
- [x] \`bun run package\` — production build succeeds.
- [ ] Manual smoke in EDH: pill click opens an inline popover next to the dot (no separate VS Code popup); popover lists only the active chat's tasks under Main / Subagents; switching conversations updates the pill + popover instantly; popover closes on Escape, click-outside, and when work settles.

## Acceptance criteria

- [x] Pill click opens an in-webview popover styled like the Model / Agent menu
- [x] Only tasks belonging to the currently-open conversation appear
- [x] Switching to a different conversation updates the popover and pill
- [x] Click-outside or Escape closes the popover
- [x] Counts continue to drive pill visibility + breathing
- [x] Host-side command + QuickPick preserved as a command-palette fallback

Closes #140