### PR TITLE
feat(agents): always-on pill, centered layout, in-turn subagent history

### DIFF
--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -1536,21 +1536,45 @@ export function summarizeAgentTasks(
   tasks: AgentTask[],
   conversationID?: string,
 ): AgentsStatusInfo {
+  const scoped = conversationID
+    ? tasks.filter((task) => task.conversationID === conversationID)
+    : tasks
+
+  // Sessions whose parent main task is still alive ("turn ongoing"). While
+  // any such session exists, we keep ALL of its subagents visible — even
+  // ones that have already completed — so the user can see what the
+  // currently-active turn dispatched, not just the agents racing at the
+  // millisecond of inspection. Without this, Hephaestus-style runs where a
+  // subagent finishes seconds before the parent finishes the prose leave
+  // the popover showing only the main entry.
+  const liveSessions = new Set(
+    scoped
+      .filter((t) => t.kind === "main" && (t.status === "running" || t.status === "waiting"))
+      .map((t) => t.sessionID),
+  )
+
   const items: AgentsTaskInfo[] = []
   let running = 0
   let waiting = 0
   let error = 0
-  for (const task of tasks) {
-    if (conversationID && task.conversationID !== conversationID) continue
+  for (const task of scoped) {
+    const liveStatus =
+      task.status === "running" || task.status === "waiting" || task.status === "error"
+    const parentAlive = task.kind === "subagent" && liveSessions.has(task.sessionID)
+    if (task.kind === "main" && !liveStatus) continue
+    if (task.kind === "subagent" && !liveStatus && !parentAlive) continue
+    if (task.kind === "subagent" && task.status === "cancelled") continue
     if (task.status === "running") running += 1
     else if (task.status === "waiting") waiting += 1
     else if (task.status === "error") error += 1
-    else continue
+    const wireStatus: AgentsTaskInfo["status"] = liveStatus
+      ? (task.status as "running" | "waiting" | "error")
+      : "completed"
     items.push({
       id: task.id,
       kind: task.kind,
       title: task.title,
-      status: task.status,
+      status: wireStatus,
       error: task.error,
       startedAt: task.startedAt,
     })

--- a/test/host/agent-task-wiring.test.ts
+++ b/test/host/agent-task-wiring.test.ts
@@ -106,6 +106,37 @@ describe("summarizeAgentTasks", () => {
     expect(result.tasks.map((t) => t.id)).toEqual(["x", "z"])
   })
 
+  it("keeps completed subagents in the list while the parent main task is still alive", () => {
+    const result = summarizeAgentTasks([
+      task({ id: "main:c:s", kind: "main", status: "running" }),
+      task({ id: "subagent:s:c1", kind: "subagent", status: "completed", startedAt: 100 }),
+      task({ id: "subagent:s:c2", kind: "subagent", status: "running", startedAt: 200 }),
+    ])
+    // Counts only reflect live work — the completed subagent doesn't bump
+    // running, but it remains visible in the task list.
+    expect(result.running).toBe(2)
+    expect(result.total).toBe(2)
+    expect(result.tasks.map((t) => t.id)).toEqual(["main:c:s", "subagent:s:c1", "subagent:s:c2"])
+    expect(result.tasks.find((t) => t.id === "subagent:s:c1")!.status).toBe("completed")
+  })
+
+  it("drops completed subagents once the parent main task settles", () => {
+    const result = summarizeAgentTasks([
+      task({ id: "main:c:s", kind: "main", status: "completed" }),
+      task({ id: "subagent:s:c1", kind: "subagent", status: "completed" }),
+    ])
+    expect(result.total).toBe(0)
+    expect(result.tasks).toEqual([])
+  })
+
+  it("does NOT keep cancelled subagents visible even when parent is alive", () => {
+    const result = summarizeAgentTasks([
+      task({ id: "main:c:s", kind: "main", status: "running" }),
+      task({ id: "subagent:s:c1", kind: "subagent", status: "cancelled" }),
+    ])
+    expect(result.tasks.map((t) => t.id)).toEqual(["main:c:s"])
+  })
+
   it("orders Main first, then Subagents, both by startedAt ascending", () => {
     const result = summarizeAgentTasks([
       task({ id: "sub-late", kind: "subagent", status: "running", startedAt: 3000 }),

--- a/test/webview/statusbar.test.tsx
+++ b/test/webview/statusbar.test.tsx
@@ -274,19 +274,30 @@ describe("AgentsMenu (StatusBar inline popover)", () => {
     ],
   }
 
-  it("is hidden when no agentsStatus is set", () => {
+  it("renders 'Agents' even when no agentsStatus has been sent yet", () => {
     render(<StatusBar {...baseProps} />)
-    expect(screen.queryByText("Agents")).not.toBeInTheDocument()
+    expect(screen.getByText("Agents")).toBeInTheDocument()
+    expect(screen.getByText("Agents").className).toContain("is-idle")
   })
 
-  it("is hidden when total === 0", () => {
+  it("renders 'Agents' with is-idle when total === 0", () => {
     render(
       <StatusBar
         {...baseProps}
         agentsStatus={{ running: 0, waiting: 0, error: 0, total: 0, tasks: [] }}
       />,
     )
-    expect(screen.queryByText("Agents")).not.toBeInTheDocument()
+    const pill = screen.getByText("Agents")
+    expect(pill).toBeInTheDocument()
+    expect(pill.className).toContain("is-idle")
+    expect(pill.className).not.toContain("is-running")
+  })
+
+  it("opens an empty-state popover when there are no tasks", async () => {
+    const user = userEvent.setup()
+    render(<StatusBar {...baseProps} />)
+    await user.click(screen.getByText("Agents"))
+    expect(screen.getByText("No agents in this chat")).toBeInTheDocument()
   })
 
   it("renders 'Agents' when a task is running in this chat", () => {
@@ -372,19 +383,38 @@ describe("AgentsMenu (StatusBar inline popover)", () => {
     expect(screen.queryByText("Subagents")).not.toBeInTheDocument()
   })
 
-  it("closes the popover when the chat goes idle (total → 0)", async () => {
+  it("shows completed subagent rows while the parent is still alive", async () => {
     const user = userEvent.setup()
-    const { rerender } = render(<StatusBar {...baseProps} agentsStatus={baseStatus} />)
-    await user.click(screen.getByText("Agents"))
-    expect(screen.getByText("Explain this file")).toBeInTheDocument()
-    rerender(
+    render(
       <StatusBar
         {...baseProps}
-        agentsStatus={{ running: 0, waiting: 0, error: 0, total: 0, tasks: [] }}
+        agentsStatus={{
+          running: 1,
+          waiting: 0,
+          error: 0,
+          total: 1,
+          tasks: [
+            {
+              id: "main:c:s",
+              kind: "main",
+              title: "Explain this file",
+              status: "running",
+              startedAt: Date.now() - 12_000,
+            },
+            {
+              id: "subagent:s:c1",
+              kind: "subagent",
+              title: "Explore codebase patterns",
+              status: "completed",
+              startedAt: Date.now() - 10_000,
+            },
+          ],
+        }}
       />,
     )
-    expect(screen.queryByText("Explain this file")).not.toBeInTheDocument()
-    expect(screen.queryByText("Agents")).not.toBeInTheDocument()
+    await user.click(screen.getByText("Agents"))
+    expect(screen.getByText("Explore codebase patterns")).toBeInTheDocument()
+    expect(screen.getByText("Subagents")).toBeInTheDocument()
   })
 
   it("closes the popover when Escape is pressed", async () => {

--- a/webview/src/components/StatusBar.tsx
+++ b/webview/src/components/StatusBar.tsx
@@ -69,6 +69,7 @@ export function StatusBar({
         label={showStatus ? statusLabel : undefined}
         title={statusTitle}
       />
+      <div className="spacer" />
       <AgentsMenu status={agentsStatus} />
       <div className="spacer" />
       <SelectorMenu
@@ -294,11 +295,14 @@ function ChatHistoryMenu({
 }
 
 /**
- * Hidden-by-default `Agents` menu rendered between the connection dot and the
- * model/agent selector. The host scopes the snapshot to the active
- * conversation, so `tasks` only contains work for THIS chat. Clicking the
- * pill toggles an inline popover (matching the SelectorMenu pattern) that
- * lists tasks grouped by Main / Subagents.
+ * Always-visible `Agents` menu centered in the chat header. The host scopes
+ * the snapshot to the active conversation, so `tasks` only contains work for
+ * THIS chat. Clicking the pill toggles an inline popover (matching the
+ * SelectorMenu pattern) that lists tasks grouped by Main / Subagents.
+ *
+ * The pill text never changes (always literally `Agents`); state is signalled
+ * by color — muted when idle, breathing green while running, attention red
+ * for error, amber for waiting.
  */
 function AgentsMenu({ status }: { status?: AgentsStatusInfo }) {
   const [open, setOpen] = useState(false)
@@ -321,22 +325,22 @@ function AgentsMenu({ status }: { status?: AgentsStatusInfo }) {
     }
   }, [open])
 
-  // Close the popover automatically when the chat goes idle so the menu
-  // doesn't sit open after the last task it was showing terminates.
-  useEffect(() => {
-    if (status && status.total === 0) setOpen(false)
-  }, [status?.total])
-
-  if (!status || status.total === 0) return null
-  const running = status.running > 0
+  const running = (status?.running ?? 0) > 0
+  const errorOnly = !running && (status?.error ?? 0) > 0
+  const waitingOnly = !running && !errorOnly && (status?.waiting ?? 0) > 0
+  const idle = !running && !errorOnly && !waitingOnly
   const className =
     "agents-pill" +
     (open ? " is-open" : "") +
     (running ? " is-running" : "") +
-    (!running && status.error > 0 ? " is-error" : "") +
-    (!running && status.waiting > 0 ? " is-waiting" : "")
-  const main = status.tasks.filter((t) => t.kind === "main")
-  const sub = status.tasks.filter((t) => t.kind === "subagent")
+    (errorOnly ? " is-error" : "") +
+    (waitingOnly ? " is-waiting" : "") +
+    (idle ? " is-idle" : "")
+  const tasks = status?.tasks ?? []
+  const main = tasks.filter((t) => t.kind === "main")
+  const sub = tasks.filter((t) => t.kind === "subagent")
+  const empty = tasks.length === 0
+
   return (
     <div className="agents-menu" ref={ref}>
       <button
@@ -353,6 +357,7 @@ function AgentsMenu({ status }: { status?: AgentsStatusInfo }) {
       {open && (
         <div className="agents-popover" role="menu">
           <div className="agents-popover-title">Agents in this chat</div>
+          {empty && <div className="agents-popover-empty">No agents in this chat</div>}
           {main.length > 0 && (
             <>
               <div className="agents-popover-section">Main</div>
@@ -394,7 +399,10 @@ function AgentsRow({ task }: { task: AgentsTaskInfo }) {
   )
 }
 
-export function buildAgentsTitle(status: AgentsStatusInfo): string {
+export function buildAgentsTitle(status?: AgentsStatusInfo): string {
+  if (!status || status.total === 0) {
+    return "No agents in this chat\nClick to view"
+  }
   const lines: string[] = []
   if (status.running > 0)
     lines.push(`${status.running} agent${status.running === 1 ? "" : "s"} running`)

--- a/webview/src/protocol.ts
+++ b/webview/src/protocol.ts
@@ -157,7 +157,14 @@ export type AgentsTaskInfo = {
   id: string
   kind: "main" | "subagent"
   title: string
-  status: "running" | "waiting" | "error"
+  /**
+   * `completed` is included so the popover can show subagents from the
+   * current turn that finished BEFORE the parent's prose finished. The
+   * counts (`running` / `waiting` / `error` in the parent
+   * `AgentsStatusInfo`) still only reflect live work — `completed`
+   * subagents do not bump those numbers.
+   */
+  status: "running" | "waiting" | "error" | "completed"
   error?: string
   startedAt: number
 }

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -200,6 +200,10 @@ button {
 .agents-pill.is-open {
   text-decoration: underline;
 }
+.agents-pill.is-idle {
+  color: var(--vscode-foreground);
+  opacity: 0.55;
+}
 .agents-pill.is-running {
   color: #7ee787;
   animation: agents-breathe 1.6s ease-in-out infinite;
@@ -271,6 +275,14 @@ button {
 .agents-row-running .agents-row-title { color: #7ee787; }
 .agents-row-error .agents-row-meta { color: var(--vscode-errorForeground, #f85149); }
 .agents-row-waiting .agents-row-meta { color: var(--vscode-notificationsWarningIcon-foreground, #d29922); }
+.agents-row-completed {
+  opacity: 0.6;
+}
+.agents-popover-empty {
+  padding: 6px 12px;
+  opacity: 0.6;
+  font-style: italic;
+}
 
 .selector-menu {
   flex: 0 1 auto;


### PR DESCRIPTION
## Summary

Two follow-ups on PR #143 driven by direct user feedback:

1. **Layout** — pill is now always visible in the chat header, **centered** between the connection dot and the model/agent selector (left+right flex spacers around it). Text stays exactly \`Agents\`; muted when idle, breathing green when running, amber/red for waiting/error. Clicking it with nothing active shows \"No agents in this chat\" in the popover.
2. **Subagent visibility** — subagents that finished *during the current turn* now stay listed in the popover for as long as the parent main task is still \`running\` / \`waiting\`. Previously, a Hephaestus turn that dispatched an \`Investigated\` task and then kept generating text would show only the main entry, because the subagent's status had already moved to \`completed\` by the time the user opened the popover. Cancelled subagents are never kept.

The pill's color and count badges still reflect only **live** work — completed subagents don't bump the running/waiting/error counters, only their rows are rendered (in a muted style).

## Test plan

- [x] \`bun run test\` — 642 tests green (+7 from new cases)
- [x] \`bun run check-types\` — host clean
- [x] \`bun run package\` — production build succeeds
- [ ] Manual smoke: send \"Explain this file using subagent\" to Hephaestus / GPT-5.5; verify the \`Agents\` pill is always visible (idle when no work, green-breathing when running), centered between the dot and the model selector; the subagent's row appears under \`Subagents\` while it runs and STAYS visible (muted) while the parent finishes its text; rows clear when the whole turn settles.

## Acceptance criteria

- [x] Pill is always rendered in the chat header
- [x] Pill is centered between dot and selector
- [x] Idle state uses a muted color; running pulses green
- [x] Empty popover state reads \"No agents in this chat\"
- [x] Completed subagents stay visible while their parent main task is alive
- [x] Cancelled subagents never appear
- [x] Counts on the pill still reflect only live work

Closes #144