### PR TITLE
fix(agents): track subagent lifecycle per child session

### DIFF
--- a/src/agents/subagent-tracker.ts
+++ b/src/agents/subagent-tracker.ts
@@ -372,6 +372,40 @@ export class SubagentTracker {
     this.dispatches.clear()
   }
 
+  /**
+   * Tear down every subagent the tracker holds for `parentSessionID`:
+   *
+   *   - Unregister each child sessionID from the SSE subscription so
+   *     late events (a child whose `session.error` arrived after we
+   *     locally settled the row) stop being routed.
+   *   - Forget the corresponding callIDs in `dispatches` so a fresh
+   *     dispatch with a reused callID can register cleanly.
+   *   - Delegate the actual status mutation to
+   *     `AgentTaskStore.cancelSessionTasks`, which handles both the
+   *     subagent rows we just cleaned up AND any main row for the
+   *     session (`recordMainTaskFinish` in `abortCurrent` usually
+   *     beats us here, but doing it again is idempotent).
+   *
+   * Returns the list of child sessionIDs that were active at the
+   * moment of teardown so the caller can issue HTTP aborts in
+   * parallel — important because opencode's `session.abort` only
+   * acts on the targeted session, and propagation to children isn't
+   * guaranteed across plugin / version combinations.
+   */
+  async cancelForSession(parentSessionID: string): Promise<string[]> {
+    const active = this.store.activeSubagentsForSession(parentSessionID)
+    const childSessionIDs: string[] = []
+    for (const task of active) {
+      if (task.childSessionID) {
+        this.subscription.removeChildSession(task.childSessionID)
+        childSessionIDs.push(task.childSessionID)
+      }
+      this.forgetCallIDsFor(task.id)
+    }
+    await this.store.cancelSessionTasks(parentSessionID)
+    return childSessionIDs
+  }
+
   private async promoteToChildSessionIdentity(
     dispatch: DispatchState,
     childSessionID: string,

--- a/src/agents/subagent-tracker.ts
+++ b/src/agents/subagent-tracker.ts
@@ -387,10 +387,12 @@ export class SubagentTracker {
    *     beats us here, but doing it again is idempotent).
    *
    * Returns the list of child sessionIDs that were active at the
-   * moment of teardown so the caller can issue HTTP aborts in
-   * parallel — important because opencode's `session.abort` only
-   * acts on the targeted session, and propagation to children isn't
-   * guaranteed across plugin / version combinations.
+   * moment of teardown. Informational only — callers should rely on
+   * opencode's `session.abort` propagating down the parent's "wait
+   * on tool" to settle the children atomically. Issuing explicit
+   * child aborts in parallel introduced a race that left the parent
+   * visibly continuing after Stop; see the comment in
+   * `ChatView.abortCurrent` for the full story.
    */
   async cancelForSession(parentSessionID: string): Promise<string[]> {
     const active = this.store.activeSubagentsForSession(parentSessionID)

--- a/src/agents/subagent-tracker.ts
+++ b/src/agents/subagent-tracker.ts
@@ -1,0 +1,512 @@
+import { log } from "../output"
+import type { Backend } from "../server"
+import type { ChildSessionEvent, ToolUpdate } from "../chat/stream"
+import {
+  type AgentTask,
+  type AgentTaskModel,
+  type AgentTaskStore,
+  classifyTerminal,
+  subagentTaskID,
+  subagentTaskIDByChildSession,
+} from "./task-store"
+
+/**
+ * Set of tool names that count as "dispatching a subagent". Mirrors
+ * `TARGET_TOOLS2` in oh-my-opencode source. Kept in sync with
+ * `SUBAGENT_TOOLS` in `chat/view.ts` — the export there is the public
+ * spelling used by tests; this internal copy avoids a circular import
+ * between view.ts and this file.
+ */
+const SUBAGENT_DISPATCH_TOOLS: ReadonlySet<string> = new Set([
+  "task",
+  "Task",
+  "task_tool",
+  "delegate_task",
+  "call_omo_agent",
+  "background_task",
+])
+
+export type SubagentSubscription = {
+  addChildSession: (sessionID: string) => void
+  removeChildSession: (sessionID: string) => void
+}
+
+export type SubagentTrackerDeps = {
+  store: AgentTaskStore
+  /**
+   * Reads the conversationID + parent sessionID at the moment of
+   * mutation. Pulled lazily because both can change while a tracker
+   * instance is alive (the user can switch conversations); a stale
+   * snapshot here is what causes ghost rows in the popover.
+   */
+  getActiveConversationID: () => string
+  /** May be `undefined` between session creation and first tool dispatch. */
+  getParentSessionID: () => string | undefined
+  /**
+   * The stream subscription's child-session registration mutators.
+   * Decoupled from `stream.Subscription` so unit tests can pass a tiny
+   * stub instead of standing up a full SSE pipeline.
+   */
+  subscription: SubagentSubscription
+}
+
+/**
+ * Per-callID memory of what we've already learned about a subagent
+ * dispatch. Required because opencode emits multiple `tool.part.updated`
+ * events for the same callID (initial `running`, post-metadata
+ * `running`, terminal `completed`); we need to know whether we already
+ * have a child sessionID so we don't keep re-registering it with the
+ * subscription on every event.
+ */
+type DispatchState = {
+  callID: string
+  taskID: string
+  childSessionID?: string
+}
+
+/**
+ * Per-conversation subagent state machine. Decoupled from `ChatView` so
+ * we can test the state transitions in isolation without spinning up
+ * the whole webview-host wiring.
+ *
+ * Lifecycle (Hephaestus / Sisyphus background-dispatch is the
+ * worst case, so the comment walks through that):
+ *
+ *   1. Parent's `task` tool part flips to `running` →
+ *      `handleToolUpdate` upserts an AgentTask keyed by callID with
+ *      status `running`. We don't know the child sessionID yet.
+ *   2. omo's `publishToolMetadata` causes a second `tool.part.updated`
+ *      whose `state.metadata` carries `sessionId` / `backgroundTaskId`
+ *      / `agent` / `model` / `run_in_background`. We re-key the task
+ *      to `subagent:child:<childSessionID>`, copy the metadata onto
+ *      the record, and `addChildSession()` so the SSE router starts
+ *      forwarding the child's events.
+ *   3. Child session starts emitting `message.updated` /
+ *      `message.part.*` events → `handleChildSessionEvent` keeps the
+ *      task on `running` (refreshes `updatedAt`).
+ *   4. Parent's `task` tool part flips to `completed` →
+ *      `handleToolUpdate` IGNORES the terminal status when we have a
+ *      live child sessionID (background tasks return their task_id
+ *      immediately even though the child is still working). Without
+ *      a child sessionID — i.e. opencode without omo, or a
+ *      foreground call that didn't publish metadata — we honor the
+ *      parent's terminal status as before.
+ *   5. Child session emits `session.idle` →
+ *      `handleChildSessionEvent` marks the task `completed` and
+ *      `removeChildSession()` drops it from the interest set.
+ *
+ * Reconciliation (`reconcile()`) handles the dropped-VS-Code-instance
+ * case: any task left in `running`/`waiting` from a prior session is
+ * checked against `/session/status` and either resumed (added back to
+ * the interest set) or settled.
+ */
+export class SubagentTracker {
+  private readonly store: AgentTaskStore
+  private readonly subscription: SubagentSubscription
+  private readonly getConversationID: () => string
+  private readonly getParentSessionID: () => string | undefined
+  private readonly dispatches = new Map<string, DispatchState>()
+
+  constructor(deps: SubagentTrackerDeps) {
+    this.store = deps.store
+    this.subscription = deps.subscription
+    this.getConversationID = deps.getActiveConversationID
+    this.getParentSessionID = deps.getParentSessionID
+  }
+
+  static isSubagentDispatchTool(toolName: string): boolean {
+    return SUBAGENT_DISPATCH_TOOLS.has(toolName)
+  }
+
+  /**
+   * Called from `ChatView.onTool` for every tool transition. Filters
+   * to dispatch tools and updates the AgentTask accordingly.
+   */
+  async handleToolUpdate(update: ToolUpdate, messageID?: string): Promise<void> {
+    if (!SUBAGENT_DISPATCH_TOOLS.has(update.tool)) return
+    const parentSessionID = this.getParentSessionID()
+    if (!parentSessionID) {
+      log(`[subagent-tracker] skip ${update.tool}:${update.callID} — no parent sessionID yet`)
+      return
+    }
+    const conversationID = this.getConversationID()
+    const meta = readMetadata(update.metadata)
+
+    let dispatch = this.dispatches.get(update.callID)
+    if (!dispatch) {
+      // First sighting of this callID — pre-register with the callID-based
+      // identity. The promote step below moves it to the child-session
+      // identity once metadata arrives.
+      dispatch = {
+        callID: update.callID,
+        taskID: subagentTaskID(parentSessionID, update.callID),
+      }
+      this.dispatches.set(update.callID, dispatch)
+    }
+
+    if (meta.childSessionID && !dispatch.childSessionID) {
+      dispatch = await this.promoteToChildSessionIdentity(dispatch, meta.childSessionID, parentSessionID)
+    }
+
+    const now = Date.now()
+    const existing = this.store.get(dispatch.taskID)
+    const merged = mergeMetadata(existing, meta)
+
+    if (update.status === "running" || update.status === "pending") {
+      const next: AgentTask = {
+        id: dispatch.taskID,
+        kind: "subagent",
+        conversationID,
+        sessionID: parentSessionID,
+        messageID,
+        callID: update.callID,
+        childSessionID: dispatch.childSessionID,
+        backgroundTaskID: merged.backgroundTaskID,
+        subagent: merged.subagent,
+        category: merged.category,
+        model: merged.model,
+        runInBackground: merged.runInBackground,
+        title: titleForDispatch(update, merged),
+        status: "running",
+        startedAt: existing?.startedAt ?? now,
+        updatedAt: now,
+      }
+      await this.store.upsert(next)
+      log(
+        `[subagent-tracker] running ${dispatch.taskID} child=${dispatch.childSessionID ?? "(unknown)"} bg=${merged.runInBackground ?? false} agent=${merged.subagent ?? "?"}`,
+      )
+      return
+    }
+
+    if (update.status === "completed" || update.status === "error") {
+      // Background dispatches (omo's `background_task`, or `call_omo_agent`
+      // with `run_in_background: true`) return their task_id immediately
+      // while the child keeps working — the parent's terminal status is
+      // NOT authoritative there, and we must wait on the child's own
+      // `session.idle` (via handleChildSessionEvent).
+      //
+      // Foreground dispatches (opencode's built-in `task`, `call_omo_agent`
+      // for deep agents like Hephaestus → Sisyphus) only flip to
+      // terminal AFTER the subagent has finished producing its result —
+      // the parent's terminal status IS authoritative. The earlier
+      // "any childSessionID" gate was leaving these stuck on `running`
+      // forever (the foreground child's `session.idle` may have fired
+      // before we registered the child sessionID, or never fired at all
+      // when omo keeps the session warm for resume).
+      const isBackground =
+        merged.runInBackground === true || update.tool === "background_task"
+      if (dispatch.childSessionID && isBackground) {
+        // Still refresh metadata + agent/model in case the terminal
+        // event carries fresher values, but keep status running.
+        await this.store.update(dispatch.taskID, {
+          backgroundTaskID: merged.backgroundTaskID,
+          subagent: merged.subagent,
+          category: merged.category,
+          model: merged.model,
+          runInBackground: merged.runInBackground,
+          title: titleForDispatch(update, merged),
+          updatedAt: now,
+        })
+        log(
+          `[subagent-tracker] parent dispatch ${dispatch.taskID} terminal=${update.status} ignored (background child ${dispatch.childSessionID} owns lifecycle)`,
+        )
+        return
+      }
+
+      const classified =
+        update.status === "error"
+          ? classifyTerminal(update.error)
+          : { status: "completed" as const, error: undefined }
+      await this.store.update(dispatch.taskID, {
+        status: classified.status,
+        error: classified.error,
+        updatedAt: now,
+      })
+      // If we had registered the child session with the SSE subscription,
+      // drop it now — the parent has signalled the subagent is done, and
+      // any late child events are stale.
+      if (dispatch.childSessionID) {
+        this.subscription.removeChildSession(dispatch.childSessionID)
+      }
+      this.dispatches.delete(update.callID)
+      log(
+        `[subagent-tracker] ${dispatch.taskID} settled ${classified.status} via parent terminal (child=${dispatch.childSessionID ?? "none"})`,
+      )
+    }
+  }
+
+  /**
+   * Forwarded by `ChatView`'s subscription `onChildSessionEvent`. Maps
+   * a child session lifecycle event onto the corresponding AgentTask.
+   */
+  async handleChildSessionEvent(event: ChildSessionEvent): Promise<void> {
+    const taskID = subagentTaskIDByChildSession(event.sessionID)
+    const existing = this.store.get(taskID)
+    if (!existing) {
+      // We may receive child events before the parent's tool update
+      // metadata has been processed (rare; SSE order is best-effort).
+      // Drop silently — the parent tool update will create the record
+      // and the next child event will land on it.
+      log(`[subagent-tracker] child event ${event.type} for unknown ${event.sessionID}`)
+      return
+    }
+    const now = Date.now()
+    switch (event.type) {
+      case "busy":
+        // Refresh updatedAt but don't bounce a terminal task back to
+        // running — once errored/completed, a stray busy is ignored.
+        if (existing.status === "error" || existing.status === "completed" || existing.status === "cancelled") {
+          return
+        }
+        await this.store.update(taskID, { status: "running", updatedAt: now })
+        return
+      case "idle":
+        // Final state. Drop the child session from the interest set so
+        // the subscription doesn't keep routing its future events
+        // (some plugins keep sessions warm for resume).
+        if (existing.status === "completed" || existing.status === "error" || existing.status === "cancelled") {
+          return
+        }
+        await this.store.update(taskID, { status: "completed", updatedAt: now })
+        this.subscription.removeChildSession(event.sessionID)
+        this.forgetCallIDsFor(taskID)
+        log(`[subagent-tracker] ${taskID} child idle → completed`)
+        return
+      case "error": {
+        const classified = classifyTerminal(event.message)
+        await this.store.update(taskID, {
+          status: classified.status,
+          error: classified.error,
+          updatedAt: now,
+        })
+        this.subscription.removeChildSession(event.sessionID)
+        this.forgetCallIDsFor(taskID)
+        log(`[subagent-tracker] ${taskID} child error → ${classified.status} (${event.message ?? "no message"})`)
+        return
+      }
+      case "assistantEnd":
+        if (event.error) {
+          const classified = classifyTerminal(event.error)
+          await this.store.update(taskID, {
+            status: classified.status,
+            error: classified.error,
+            updatedAt: now,
+          })
+          this.subscription.removeChildSession(event.sessionID)
+          this.forgetCallIDsFor(taskID)
+        } else if (event.usage?.model && !existing.model) {
+          // Backfill model from the assistant message when omo's
+          // metadata didn't carry one (defensive — every omo path I
+          // traced does publish `model`, but opencode's built-in
+          // `task` tool may not).
+          const [providerID, modelID] = event.usage.model.split("/")
+          if (providerID && modelID) {
+            await this.store.update(taskID, {
+              model: { providerID, modelID },
+              updatedAt: now,
+            })
+          }
+        }
+        return
+    }
+  }
+
+  /**
+   * Walk the store at attach time to settle stale rows and re-register
+   * still-alive child sessions with the new subscription. Called once
+   * per `attachSubscription` in `ChatView` so a reload doesn't leave
+   * subagent rows stuck on "running" forever.
+   *
+   * The reconcile call doesn't fail loudly — `/session/status` is
+   * best-effort, and stale rows are better than wrongly-completed
+   * rows. Failures are logged and the tracker proceeds.
+   */
+  async reconcile(backend: Backend, parentSessionID: string): Promise<void> {
+    const conversationID = this.getConversationID()
+    const candidates = this.store
+      .list()
+      .filter(
+        (t) =>
+          t.kind === "subagent" &&
+          t.conversationID === conversationID &&
+          t.sessionID === parentSessionID &&
+          (t.status === "running" || t.status === "waiting") &&
+          t.childSessionID,
+      )
+    if (candidates.length === 0) return
+    let statuses: Record<string, { type?: string } | undefined> = {}
+    try {
+      const res = await backend.client.session.status({
+        query: { directory: backend.directory },
+      })
+      statuses = (res?.data ?? {}) as Record<string, { type?: string } | undefined>
+    } catch (e) {
+      log("[subagent-tracker] reconcile session.status failed", e)
+      return
+    }
+    const now = Date.now()
+    for (const task of candidates) {
+      const childSid = task.childSessionID!
+      const childStatus = statuses[childSid]
+      if (!childStatus) {
+        // Server has no record of this session — it ended (or was
+        // never visible to this directory). Treat as completed.
+        await this.store.update(task.id, { status: "completed", updatedAt: now })
+        log(`[subagent-tracker] reconcile ${task.id} child ${childSid} not present → completed`)
+        continue
+      }
+      if (childStatus.type === "idle") {
+        await this.store.update(task.id, { status: "completed", updatedAt: now })
+        log(`[subagent-tracker] reconcile ${task.id} child ${childSid} idle → completed`)
+        continue
+      }
+      // Child is still busy — register it with the new subscription so
+      // we resume tracking it from here on.
+      this.subscription.addChildSession(childSid)
+      log(`[subagent-tracker] reconcile ${task.id} child ${childSid} still ${childStatus.type ?? "?"} — resumed tracking`)
+    }
+  }
+
+  /** Drop in-memory dispatch state — called on conversation switch. */
+  reset(): void {
+    this.dispatches.clear()
+  }
+
+  private async promoteToChildSessionIdentity(
+    dispatch: DispatchState,
+    childSessionID: string,
+    parentSessionID: string,
+  ): Promise<DispatchState> {
+    const oldID = dispatch.taskID
+    const newID = subagentTaskIDByChildSession(childSessionID)
+    if (oldID === newID) {
+      dispatch.childSessionID = childSessionID
+      this.subscription.addChildSession(childSessionID)
+      return dispatch
+    }
+    const oldTask = this.store.get(oldID)
+    // If a row already exists under the child-session id (task_id
+    // reuse: Hephaestus resumed an existing subagent), we merge into
+    // it rather than creating a duplicate.
+    const existingChildTask = this.store.get(newID)
+    if (oldTask) {
+      if (existingChildTask) {
+        // Both rows exist — the old (callID-based) row is the new
+        // duplicate; carry forward its messageID/callID and drop the
+        // old key. We do this by clearing the old row.
+        await this.store.clear(oldID)
+        // existingChildTask gets a fresh updatedAt + messageID on the
+        // next upsert through handleToolUpdate (called shortly after
+        // by the same SSE event chain).
+      } else {
+        // Atomically re-key: write the new id, then drop the old.
+        // (AgentTaskStore has no rename API; clear+upsert is the
+        // smallest surface change.)
+        const next: AgentTask = {
+          ...oldTask,
+          id: newID,
+          childSessionID,
+          sessionID: parentSessionID,
+        }
+        await this.store.upsert(next)
+        await this.store.clear(oldID)
+      }
+    }
+    dispatch.taskID = newID
+    dispatch.childSessionID = childSessionID
+    this.subscription.addChildSession(childSessionID)
+    return dispatch
+  }
+
+  private forgetCallIDsFor(taskID: string): void {
+    for (const [callID, state] of this.dispatches) {
+      if (state.taskID === taskID) this.dispatches.delete(callID)
+    }
+  }
+}
+
+type ReadMetadata = {
+  childSessionID?: string
+  backgroundTaskID?: string
+  subagent?: string
+  category?: string
+  model?: AgentTaskModel
+  runInBackground?: boolean
+  description?: string
+}
+
+export function readMetadata(metadata: Record<string, unknown> | undefined): ReadMetadata {
+  if (!metadata) return {}
+  // omo writes both `sessionId` and `taskId`; opencode itself uses
+  // camelCase too. We accept any common spelling so this works even if
+  // a future omo refactor renames fields.
+  const childSessionID = readStr(metadata.sessionId) ?? readStr(metadata.sessionID) ?? readStr(metadata.session_id) ?? readStr(metadata.taskId) ?? readStr(metadata.taskID) ?? readStr(metadata.task_id)
+  const backgroundTaskID = readStr(metadata.backgroundTaskId) ?? readStr(metadata.backgroundTaskID) ?? readStr(metadata.background_task_id)
+  const subagent = readStr(metadata.agent) ?? readStr(metadata.subagent) ?? readStr(metadata.subagent_type)
+  const category = readStr(metadata.category)
+  const description = readStr(metadata.description)
+  const runInBackgroundRaw = metadata.run_in_background ?? metadata.runInBackground
+  const runInBackground = typeof runInBackgroundRaw === "boolean" ? runInBackgroundRaw : undefined
+  return {
+    childSessionID,
+    backgroundTaskID,
+    subagent,
+    category,
+    description,
+    runInBackground,
+    model: readModel(metadata.model),
+  }
+}
+
+function readStr(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  return trimmed ? trimmed : undefined
+}
+
+function readModel(value: unknown): AgentTaskModel | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
+  const obj = value as Record<string, unknown>
+  const providerID = readStr(obj.providerID) ?? readStr(obj.providerId) ?? readStr(obj.provider_id)
+  const modelID = readStr(obj.modelID) ?? readStr(obj.modelId) ?? readStr(obj.model_id)
+  if (!providerID || !modelID) return undefined
+  return { providerID, modelID }
+}
+
+type Merged = {
+  backgroundTaskID?: string
+  subagent?: string
+  category?: string
+  model?: AgentTaskModel
+  runInBackground?: boolean
+  description?: string
+}
+
+function mergeMetadata(existing: AgentTask | undefined, meta: ReadMetadata): Merged {
+  // "Fresh wins" for every scalar field — the metadata stream evolves
+  // (omo can publish multiple times during execution to add things
+  // like fallback model swaps), but `existing` is the previous truth
+  // for fields we haven't re-learned in this event.
+  return {
+    backgroundTaskID: meta.backgroundTaskID ?? existing?.backgroundTaskID,
+    subagent: meta.subagent ?? existing?.subagent,
+    category: meta.category ?? existing?.category,
+    model: meta.model ?? existing?.model,
+    runInBackground: meta.runInBackground ?? existing?.runInBackground,
+    description: meta.description,
+  }
+}
+
+function titleForDispatch(update: ToolUpdate, merged: Merged): string {
+  // Same precedence as the legacy `taskTitleFromUpdate`: explicit
+  // description (from input or metadata) → tool's own title → fallback.
+  const input = update.input
+  if (input && typeof input === "object") {
+    const desc = (input as Record<string, unknown>).description
+    if (typeof desc === "string" && desc.trim()) return desc.trim()
+  }
+  if (merged.description) return merged.description
+  if (update.title && update.title.trim()) return update.title.trim()
+  if (merged.subagent) return `Subagent: ${merged.subagent}`
+  return "Background agent"
+}

--- a/src/agents/task-store.ts
+++ b/src/agents/task-store.ts
@@ -196,9 +196,14 @@ export class AgentTaskStore {
     const idx = this.tasks.findIndex((t) => t.id === task.id)
     if (idx >= 0) {
       const existing = this.tasks[idx]!
-      // Once a task is in a terminal state, ignore later "running"-style
-      // upserts so duplicated SSE events can't resurrect a finished task.
-      if (isTerminal(existing.status) && !isTerminal(task.status)) return
+      // Once a task is in a terminal state, freeze its status: ignore
+      // late upserts that would either resurrect it (terminal → active)
+      // OR flip it between terminal states. The second case shows up
+      // when a user-initiated abort settles a subagent as `cancelled`
+      // and a stray child `session.error` arrives afterwards — without
+      // this guard the row flips to `error`, overriding the user's
+      // explicit Stop. Same-status upserts still merge other fields.
+      if (isTerminal(existing.status) && task.status !== existing.status) return
       const merged: AgentTask = {
         ...existing,
         ...task,
@@ -217,7 +222,11 @@ export class AgentTaskStore {
     const idx = this.tasks.findIndex((t) => t.id === id)
     if (idx < 0) return
     const existing = this.tasks[idx]!
-    if (isTerminal(existing.status) && patch.status && !isTerminal(patch.status)) return
+    // Same strict rule as `upsert`: once terminal, status is frozen.
+    // A patch without `status` is always allowed (e.g. backfilling
+    // model / metadata on a settled row); a patch that would change
+    // status is rejected. See `upsert` for the abort-race motivation.
+    if (isTerminal(existing.status) && patch.status && patch.status !== existing.status) return
     const next: AgentTask = { ...existing, ...patch, id, updatedAt: patch.updatedAt ?? Date.now() }
     if (sameTask(existing, next)) return
     this.tasks = this.tasks.map((t) => (t.id === id ? next : t))

--- a/src/agents/task-store.ts
+++ b/src/agents/task-store.ts
@@ -11,14 +11,56 @@ export type AgentTaskStatus =
 
 export type AgentTaskKind = "main" | "subagent"
 
+/**
+ * Subset of opencode/omo metadata we mirror onto a task record so the
+ * Agents popover can show *what kind* of subagent is running and on
+ * which model. All fields are best-effort — opencode's built-in `task`
+ * tool may not populate every field, and third-party plugins might
+ * write nothing at all. Consumers MUST treat each field as optional.
+ */
+export type AgentTaskModel = {
+  providerID: string
+  modelID: string
+}
+
 export type AgentTask = {
   id: string
   kind: AgentTaskKind
   conversationID: string
+  /**
+   * For a `main` task: the parent opencode sessionID.
+   * For a `subagent` task: the parent sessionID (kept so we can scope by
+   *   conversation). The subagent's *own* sessionID lives in
+   *   `childSessionID` and is populated as soon as omo's tool metadata
+   *   surfaces it (one or two SSE frames after the tool dispatch).
+   */
   sessionID: string
   messageID?: string
   callID?: string
   parentTaskID?: string
+  /**
+   * The opencode sessionID of the subagent's own session. Populated from
+   * `update.metadata.sessionId` (omo writes both `sessionId` and `taskId`
+   * to the same value). Used as the canonical identity once known — the
+   * task is re-keyed from `subagent:<parent>:<callID>` to
+   * `subagent:child:<childSessionID>` to survive task_id-reuse follow-ups.
+   */
+  childSessionID?: string
+  /**
+   * omo's internal BackgroundManager task id. Distinct from the
+   * opencode sessionID. We keep it so the QuickPick / popover can
+   * show it for debugging and so future "cancel background task"
+   * actions have a handle.
+   */
+  backgroundTaskID?: string
+  /** Subagent slug like `explore`, `librarian`, `oracle`, `hephaestus`. */
+  subagent?: string
+  /** Category slug like `deep`, `quick`, `ultrabrain`. */
+  category?: string
+  /** Resolved model used for this subagent's session. */
+  model?: AgentTaskModel
+  /** True when omo dispatched this task with `run_in_background=true`. */
+  runInBackground?: boolean
   title: string
   status: AgentTaskStatus
   startedAt: number
@@ -29,12 +71,53 @@ export type AgentTask = {
 const ACTIVE_STATUSES: ReadonlyArray<AgentTaskStatus> = ["running", "waiting"]
 const ATTENTION_STATUSES: ReadonlyArray<AgentTaskStatus> = ["running", "waiting", "error"]
 
-export function mainTaskID(conversationID: string, sessionID: string): string {
-  return `main:${conversationID}:${sessionID}`
+/**
+ * One main task per user turn. `turnID` is minted by ChatView at prompt
+ * submit time so a second message in the same conversation gets its own
+ * row instead of trying to resurrect the previous (terminal) one. The
+ * terminal-guard in `upsert` blocks revival by design, so we sidestep it
+ * by issuing a fresh identity.
+ */
+export function mainTaskID(conversationID: string, sessionID: string, turnID: string): string {
+  return `main:${conversationID}:${sessionID}:${turnID}`
 }
 
+/**
+ * Pre-metadata identity for a subagent: we know which parent + callID
+ * dispatched it but not yet the child session. The tracker promotes the
+ * record to `subagentTaskIDByChildSession` once metadata arrives.
+ */
 export function subagentTaskID(sessionID: string, callID: string): string {
   return `subagent:${sessionID}:${callID}`
+}
+
+/**
+ * Canonical identity once the child opencode sessionID is known.
+ * Keyed off the child session so task_id-reuse follow-ups (Hephaestus
+ * reuses task_id by design to save 70%+ tokens) collapse into a single
+ * record instead of accumulating a new row per resume.
+ */
+export function subagentTaskIDByChildSession(childSessionID: string): string {
+  return `subagent:child:${childSessionID}`
+}
+
+/**
+ * Decide whether a terminal error message represents a real failure or
+ * an abort signal. opencode/omo emit the literal string "Aborted" when
+ * a session is cancelled — either user-initiated (Stop button) or
+ * internal (parent agent giving up on a subagent and pivoting). The
+ * chat-bubble path already maps `/^aborted$/i` to a "Stopped" badge
+ * rather than a red error block (see CLAUDE.md); this helper extends
+ * the same convention to the popover so abort signals settle as
+ * `cancelled` (filtered out of the active-only popover) instead of
+ * painting the row red.
+ */
+export function classifyTerminal(message: string | undefined): {
+  status: "cancelled" | "error"
+  error?: string
+} {
+  if (message && /^aborted$/i.test(message.trim())) return { status: "cancelled" }
+  return { status: "error", error: message }
 }
 
 export type Memento = Pick<vscode.Memento, "get" | "update">
@@ -80,6 +163,33 @@ export class AgentTaskStore {
 
   get(id: string): AgentTask | undefined {
     return this.tasks.find((task) => task.id === id)
+  }
+
+  /** Look up a subagent by its child opencode sessionID, if known. */
+  getByChildSession(childSessionID: string): AgentTask | undefined {
+    return this.tasks.find(
+      (task) => task.kind === "subagent" && task.childSessionID === childSessionID,
+    )
+  }
+
+  /**
+   * Active (running/waiting) subagent tasks belonging to the given
+   * parent session. Used by ChatView as the structural continuation gate:
+   * while any of these are alive, a `session.idle` event on the parent
+   * must NOT clear the busy state — the parent is just waiting on its
+   * subagents to finish.
+   */
+  activeSubagentsForSession(parentSessionID: string): AgentTask[] {
+    return this.tasks.filter(
+      (task) =>
+        task.kind === "subagent" &&
+        task.sessionID === parentSessionID &&
+        ACTIVE_STATUSES.includes(task.status),
+    )
+  }
+
+  hasActiveSubagentsForSession(parentSessionID: string): boolean {
+    return this.activeSubagentsForSession(parentSessionID).length > 0
   }
 
   async upsert(task: AgentTask): Promise<void> {
@@ -131,16 +241,53 @@ export class AgentTaskStore {
   }
 
   /**
-   * Mark every still-running/waiting task for a session as completed. Used
-   * when the session truly settles and no continuation is expected.
+   * Drop every task — live or historical — belonging to a conversation.
+   * Called from ChatView when the user deletes the conversation, so the
+   * popover history is bounded by conversation lifetime rather than
+   * accumulating forever in `workspaceState`.
+   */
+  async clearForConversation(conversationID: string): Promise<void> {
+    const next = this.tasks.filter((t) => t.conversationID !== conversationID)
+    if (next.length === this.tasks.length) return
+    this.tasks = next
+    await this.persistAndEmit()
+  }
+
+  /**
+   * Mark every still-running/waiting *main* task for a session as completed.
+   * Subagent tasks are NOT touched: their lifecycle is owned by the child
+   * session's own SSE events (via SubagentTracker) — completing them here
+   * would race against a background subagent that's still working after
+   * the parent's LLM is done. Stale subagent rows are cleaned up by
+   * `SubagentTracker.reconcile` on the next attach, by user-initiated
+   * abort (which propagates to children), or by conversation switch.
    */
   async markSessionIdle(sessionID: string, now: number = Date.now()): Promise<void> {
     let changed = false
     this.tasks = this.tasks.map((task) => {
       if (task.sessionID !== sessionID) return task
+      if (task.kind !== "main") return task
       if (!ACTIVE_STATUSES.includes(task.status)) return task
       changed = true
       return { ...task, status: "completed", updatedAt: now }
+    })
+    if (!changed) return
+    await this.persistAndEmit()
+  }
+
+  /**
+   * Force every still-active task for a session to settle — used for
+   * user-initiated abort, which opencode propagates to child sessions
+   * too. Unlike `markSessionIdle`, this DOES include subagents because
+   * the user explicitly cancelled the entire turn.
+   */
+  async cancelSessionTasks(sessionID: string, now: number = Date.now()): Promise<void> {
+    let changed = false
+    this.tasks = this.tasks.map((task) => {
+      if (task.sessionID !== sessionID) return task
+      if (!ACTIVE_STATUSES.includes(task.status)) return task
+      changed = true
+      return { ...task, status: "cancelled", updatedAt: now }
     })
     if (!changed) return
     await this.persistAndEmit()
@@ -168,12 +315,24 @@ function sameTask(a: AgentTask, b: AgentTask): boolean {
     a.messageID === b.messageID &&
     a.callID === b.callID &&
     a.parentTaskID === b.parentTaskID &&
+    a.childSessionID === b.childSessionID &&
+    a.backgroundTaskID === b.backgroundTaskID &&
+    a.subagent === b.subagent &&
+    a.category === b.category &&
+    a.runInBackground === b.runInBackground &&
+    sameModel(a.model, b.model) &&
     a.kind === b.kind &&
     a.conversationID === b.conversationID &&
     a.sessionID === b.sessionID &&
     a.startedAt === b.startedAt &&
     a.updatedAt === b.updatedAt
   )
+}
+
+function sameModel(a: AgentTaskModel | undefined, b: AgentTaskModel | undefined): boolean {
+  if (a === b) return true
+  if (!a || !b) return false
+  return a.providerID === b.providerID && a.modelID === b.modelID
 }
 
 function sanitize(raw: unknown): AgentTask[] {
@@ -203,6 +362,14 @@ function sanitize(raw: unknown): AgentTask[] {
       messageID: typeof item.messageID === "string" ? item.messageID : undefined,
       callID: typeof item.callID === "string" ? item.callID : undefined,
       parentTaskID: typeof item.parentTaskID === "string" ? item.parentTaskID : undefined,
+      childSessionID: typeof item.childSessionID === "string" ? item.childSessionID : undefined,
+      backgroundTaskID: typeof item.backgroundTaskID === "string" ? item.backgroundTaskID : undefined,
+      subagent: typeof item.subagent === "string" ? item.subagent : undefined,
+      category: typeof item.category === "string" ? item.category : undefined,
+      model: isPlainObject(item.model) && typeof item.model.providerID === "string" && typeof item.model.modelID === "string"
+        ? { providerID: item.model.providerID, modelID: item.model.modelID }
+        : undefined,
+      runInBackground: typeof item.runInBackground === "boolean" ? item.runInBackground : undefined,
       error: typeof item.error === "string" ? item.error : undefined,
     })
   }

--- a/src/chat/stream.ts
+++ b/src/chat/stream.ts
@@ -85,11 +85,54 @@ export type StreamHandlers = {
   onSessionError?: (message: string) => void
   onSessionIdle?: () => void
   onSessionBusy?: () => void
+  /**
+   * Optional second routing branch for child (subagent) sessions. The
+   * SSE stream is process-wide (`client.global.event()` returns every
+   * session's events), so we can listen for child-session lifecycle
+   * without opening a second connection — subscribers register child
+   * sessionIDs via `Subscription.addChildSession()` and the events
+   * arrive here. `messageInfo` only flows for assistant-role
+   * `message.updated` events; the rest are pure lifecycle signals.
+   */
+  onChildSessionEvent?: (event: ChildSessionEvent) => void
 }
+
+/**
+ * Events surfaced to `onChildSessionEvent` for sessions registered via
+ * `Subscription.addChildSession()`. Modeled after the minimum the
+ * subagent tracker needs to mirror a child session's lifecycle onto an
+ * AgentTask:
+ *   - `busy` — first sign the child session has started executing
+ *   - `idle` — child session reports it has nothing in flight
+ *   - `error` — child session reported an opencode-side session error
+ *   - `assistantEnd` — final assistant message with optional usage
+ *     (so the tracker can pick up model + token usage on completion)
+ */
+export type ChildSessionEvent =
+  | { type: "busy"; sessionID: string }
+  | { type: "idle"; sessionID: string }
+  | { type: "error"; sessionID: string; message: string }
+  | {
+      type: "assistantEnd"
+      sessionID: string
+      messageID: string
+      finish?: string
+      usage?: MessageUsage
+      error?: string
+    }
 
 export type Subscription = {
   ready: Promise<void>
   abort: () => void
+  /**
+   * Register a child sessionID we want lifecycle events for. Re-adding
+   * the same id is a no-op. Use `removeChildSession()` once the
+   * tracker is done with it; staying subscribed past completion is
+   * harmless (the child session simply stops emitting), but the
+   * tracker uses removal to bound its internal map.
+   */
+  addChildSession: (sessionID: string) => void
+  removeChildSession: (sessionID: string) => void
 }
 
 export type SubscriptionOptions = {
@@ -132,6 +175,15 @@ export function subscribeSession(
   const assistantFinished = new Set<string>()
   const toolStatus = new Map<string, string>()
   const seenPatches = new Set<string>()
+  /**
+   * Sessions we additionally route lifecycle events for (subagent
+   * children). Distinct from the parent `sessionID` because parent
+   * routing has rich per-message handlers; child routing only needs
+   * the small `ChildSessionEvent` surface.
+   */
+  const childSessions = new Set<string>()
+  /** assistantEnd dedup for child sessions (parent has its own set). */
+  const childAssistantFinished = new Set<string>()
 
   // messageID → set of tool part IDs that are still pending/running.
   // Used to defer per-message `assistantEnd` until all tool calls terminate:
@@ -173,6 +225,11 @@ export function subscribeSession(
 
   function route(type: string, props: any) {
     log(`[sse] ${type}`)
+    // First, fan child-session events off to the subagent tracker (if
+    // any registered). We do this BEFORE the parent-session switch so
+    // events for sessions in both sets (unlikely, but possible) are
+    // observed by both branches.
+    routeChildSessionEvent(type, props)
     switch (type) {
       case "message.updated":
         onMessageUpdated(props?.info)
@@ -207,7 +264,7 @@ export function subscribeSession(
       case "tui.toast.show":
         return onToast(props)
       case "session.error":
-        return onSessionError(props?.error)
+        return onSessionError(props?.error, props?.sessionID)
       case "session.idle":
         if (props?.sessionID === sessionID) markIdle()
         return
@@ -221,6 +278,79 @@ export function subscribeSession(
         }
         return
     }
+  }
+
+  function routeChildSessionEvent(type: string, props: any) {
+    const childCb = handlers.onChildSessionEvent
+    if (!childCb || childSessions.size === 0) return
+    const childSid = extractSessionID(type, props)
+    if (!childSid || !childSessions.has(childSid)) return
+    switch (type) {
+      case "session.idle":
+        childCb({ type: "idle", sessionID: childSid })
+        return
+      case "session.status":
+        if (props?.status?.type === "idle") {
+          childCb({ type: "idle", sessionID: childSid })
+        } else if (props?.status?.type) {
+          childCb({ type: "busy", sessionID: childSid })
+        }
+        return
+      case "session.error":
+        childCb({
+          type: "error",
+          sessionID: childSid,
+          message: props?.error?.data?.message ?? props?.error?.name ?? "session error",
+        })
+        return
+      case "message.updated":
+        // A child assistant message that just finished — surface usage
+        // and any terminal error to the tracker. Also doubles as a
+        // "subagent is alive" signal for busy detection.
+        if (props?.info?.role === "assistant") {
+          childCb({ type: "busy", sessionID: childSid })
+          const mid = props.info.id as string | undefined
+          if (!mid) return
+          const dedupKey = `${childSid}|${mid}`
+          if (props.info.error && !childAssistantFinished.has(dedupKey)) {
+            childAssistantFinished.add(dedupKey)
+            const err = props.info.error as { name?: string; data?: { message?: string } }
+            childCb({
+              type: "assistantEnd",
+              sessionID: childSid,
+              messageID: mid,
+              error: err.data?.message ?? err.name ?? "unknown error",
+              finish: props.info.finish,
+            })
+            return
+          }
+          if (props.info.finish && isTerminalFinish(props.info.finish) && !childAssistantFinished.has(dedupKey)) {
+            childAssistantFinished.add(dedupKey)
+            childCb({
+              type: "assistantEnd",
+              sessionID: childSid,
+              messageID: mid,
+              finish: props.info.finish,
+              usage: extractUsage(props.info),
+            })
+          }
+        }
+        return
+      case "message.part.updated":
+      case "message.part.delta":
+        // Any activity on the child means it is busy. Cheap "still
+        // alive" signal that complements `session.idle` for tracker
+        // hysteresis.
+        childCb({ type: "busy", sessionID: childSid })
+        return
+    }
+  }
+
+  function extractSessionID(type: string, props: any): string | undefined {
+    if (!props || typeof props !== "object") return undefined
+    if (type === "message.updated") return props?.info?.sessionID
+    if (type === "message.part.updated") return props?.part?.sessionID
+    return props?.sessionID
   }
 
   function markActivity(eventSessionID: string | undefined) {
@@ -463,7 +593,10 @@ export function subscribeSession(
     })
   }
 
-  function onSessionError(err: any) {
+  function onSessionError(err: any, eventSessionID?: string) {
+    // session.error is global — only surface ones for our parent session
+    // (child-session errors are already routed to onChildSessionEvent).
+    if (eventSessionID && eventSessionID !== sessionID) return
     const msg = err?.data?.message ?? err?.name ?? "session error"
     handlers.onSessionError?.(msg)
   }
@@ -474,6 +607,12 @@ export function subscribeSession(
       stopped = true
       clearWatchdog()
       controller.abort()
+    },
+    addChildSession: (id: string) => {
+      childSessions.add(id)
+    },
+    removeChildSession: (id: string) => {
+      childSessions.delete(id)
     },
   }
 }

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -43,7 +43,8 @@ import { collectAutoContext } from "../workspace-context/collector"
 import { RecentEditsTracker } from "../workspace-context/recent-edits"
 import { readContextSettings } from "../workspace-context/budget"
 import type { IndexManager } from "../indexing/index-manager"
-import { AgentTaskStore, mainTaskID, subagentTaskID, type AgentTask } from "../agents/task-store"
+import { AgentTaskStore, classifyTerminal, mainTaskID, type AgentTask } from "../agents/task-store"
+import { SubagentTracker } from "../agents/subagent-tracker"
 import type { AgentsStatusInfo, AgentsTaskInfo } from "../protocol"
 import { toWire } from "./wire-format"
 import {
@@ -95,28 +96,14 @@ export class ChatView implements vscode.WebviewViewProvider {
   private static readonly TOAST_DEDUP_MS = 3000
   /**
    * Timestamp of the most recent *toast-style* signal that a continuation is
-   * imminent (see `isContinuationToast`). When `session.idle` arrives within
-   * `CONTINUATION_SIGNAL_TTL_MS` of this timestamp, the busy clear is
-   * deferred. This complements the structural check on `activeTaskCallIDs`.
+   * imminent (see `isContinuationToast`). Used as a defensive fallback gate
+   * — if a plugin emits a continuation toast but never produces a
+   * recognizable subagent dispatch tool, we still defer `sessionIdle` for
+   * a bounded window. The PRIMARY gate is structural (live subagent tasks
+   * in the store, tracked by `SubagentTracker`).
    */
   private lastContinuationSignalAt = 0
   private pendingIdleTimer?: ReturnType<typeof setTimeout>
-  /**
-   * Call IDs of subagent-launching tool parts currently in `running` state —
-   * i.e. live subagents on this parent session. Maintained from `onTool`
-   * updates that match `SUBAGENT_TOOLS` (`task` + `call_omo_agent` + name
-   * variants).
-   *
-   * Used as the primary "do not mark parent done" gate: opencode emits
-   * `session.idle` on the parent while a backgrounded subagent child is
-   * still executing (the parent's LLM has genuinely finished its tool
-   * call), and omo's TodoContinuationEnforcer *suppresses* its own
-   * continuation toast when BackgroundManager knows there are running
-   * background tasks. So toast-based detection alone misses the
-   * Hephaestus / Sisyphus deep-agent paths — structural tracking is
-   * required.
-   */
-  private activeTaskCallIDs = new Set<string>()
   /**
    * True between `continuationPending: true` and either the deferred
    * `sessionIdle` firing, or a new `sessionBusy` / `assistantStart` /
@@ -125,19 +112,19 @@ export class ChatView implements vscode.WebviewViewProvider {
   private idleDeferActive = false
   private static readonly CONTINUATION_SIGNAL_TTL_MS = 30_000
   /**
-   * Max wait for a *toast-only* continuation (no active task parts) to
-   * materialize before declaring idle. Bumped from 30 s to 120 s because
-   * deep-agent runs can stretch the gap between parent idle and the omo
-   * plugin injecting the continuation toast. The structural variant
-   * (active task parts) has no fixed cap — it waits for the task parts
+   * Max wait for a *toast-only* continuation (no active subagent tasks
+   * in the store) to materialize before declaring idle. Long enough to
+   * absorb the lag between a parent's idle and an omo plugin injecting
+   * its continuation toast. The structural variant (live subagent
+   * tasks) has no fixed cap — it waits for the child sessions
    * themselves to terminate.
    */
   private static readonly CONTINUATION_DEFER_MS = 120_000
   /**
-   * After the last running `task` tool part terminates while we were
-   * deferring, wait this long for a continuation toast / new turn to
-   * arrive before clearing busy. Most omo / opencode wakeups fire within
-   * a couple of seconds.
+   * After the last running subagent task settles while we were deferring,
+   * wait this long for a continuation toast / new turn to arrive before
+   * clearing busy. Most omo / opencode wakeups fire within a couple of
+   * seconds.
    */
   private static readonly CONTINUATION_GRACE_MS = 10_000
   /** opencode messageID → webview-side id used in UI */
@@ -156,6 +143,22 @@ export class ChatView implements vscode.WebviewViewProvider {
    */
   private aborting = false
   private taskStoreUnsub?: vscode.Disposable
+  /**
+   * Full task-store ID of the main task for the turn currently in flight.
+   * Minted at `recordMainTaskStart` and used by `recordMainTaskFinish` so a
+   * follow-up turn in the same session doesn't try to mutate the previous
+   * turn's terminal main row. Cleared by `markSessionIdle`/`cancelSessionTasks`
+   * paths in `onSessionIdle`.
+   */
+  private currentMainTaskID?: string
+  /**
+   * Single per-conversation subagent state machine. Reset on
+   * `createConversation` / `selectConversation` / `dispose`. Constructed
+   * lazily inside `attachSubscription` because the SSE subscription's
+   * `addChildSession` / `removeChildSession` are the wiring it depends
+   * on — both don't exist until we have a session to subscribe to.
+   */
+  private subagentTracker?: SubagentTracker
 
   constructor(
     private context: vscode.ExtensionContext,
@@ -237,6 +240,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.subscription?.abort()
     this.subscription = undefined
     this.sessionID = undefined
+    this.currentMainTaskID = undefined
     this.messageMap.clear()
     this.activePermissions.clear(); this.activeQuestions.clear()
     const conversation = this.addConversation("New conversation")
@@ -272,6 +276,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.resetContinuationState()
     this.subscription?.abort()
     this.subscription = undefined
+    this.currentMainTaskID = undefined
     this.taskStoreUnsub?.dispose()
     this.taskStoreUnsub = undefined
   }
@@ -327,6 +332,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.resetContinuationState()
     this.subscription?.abort()
     this.subscription = undefined
+    this.currentMainTaskID = undefined
     this.messageMap.clear()
     this.activePermissions.clear(); this.activeQuestions.clear()
     this.activeConversationID = id
@@ -353,6 +359,12 @@ export class ChatView implements vscode.WebviewViewProvider {
   private async deleteConversation(id: string) {
     this.conversations = this.conversations.filter((conversation) => conversation.id !== id)
     if (!this.conversations.length) this.addConversation("New conversation")
+    // Drop the deleted conversation's task history so the popover
+    // doesn't carry forward rows the user can no longer trace back to
+    // anything. Best-effort; failures here aren't fatal.
+    if (this.taskStore) {
+      void this.taskStore.clearForConversation(id)
+    }
     if (this.activeConversationID === id) {
       this.resetContinuationState()
       this.subscription?.abort()
@@ -773,12 +785,12 @@ export class ChatView implements vscode.WebviewViewProvider {
   private markContinuationSignal(source: string) {
     this.lastContinuationSignalAt = Date.now()
     log(`[continuation] signal observed (${source})`)
-    // If we're already in a *toast-only* defer (no active task parts) and
+    // If we're already in a *toast-only* defer (no active subagents) and
     // its cap timer is running, restart the cap so a fresh signal extends
     // the wait. With omo, a Background-task-complete toast can arrive
     // late into a Todo-Continuation wait — we want to honour the newer
     // signal rather than time out on the older one.
-    if (this.idleDeferActive && this.activeTaskCallIDs.size === 0 && this.pendingIdleTimer) {
+    if (this.idleDeferActive && this.activeSubagentCount() === 0 && this.pendingIdleTimer) {
       this.scheduleIdleEmit(ChatView.CONTINUATION_DEFER_MS, "signal-re-arm")
     }
   }
@@ -788,84 +800,42 @@ export class ChatView implements vscode.WebviewViewProvider {
   }
 
   private hasContinuationGate(): boolean {
-    return this.activeTaskCallIDs.size > 0 || this.hasRecentContinuationSignal()
+    return this.activeSubagentCount() > 0 || this.hasRecentContinuationSignal()
   }
 
   /**
-   * Update the running-subagent set from a subagent-launching tool's state
-   * transition. Adds on `running`, removes on terminal (`completed` / `error`).
-   * When the last running subagent settles while a deferred idle is pending,
-   * arm a short grace timer so the UI doesn't sit on "Continuing…" forever
-   * if no follow-up turn materializes.
+   * Bridge from the SSE `onTool` callback to the SubagentTracker. The
+   * tracker is the single source of truth for subagent records — view.ts
+   * only owns the main-task lifecycle. We also keep `lastContinuationSignal`
+   * armed off subagent activity as a second-source defense: if anything
+   * else clears `idleDeferActive`'s timer, the structural store check
+   * below in `onSessionIdle` will re-defer.
    *
-   * Tracked tools — see oh-my-opencode dist/index.js `TASK_TOOLS` and
-   * `TARGET_TOOLS2`:
-   *   - `task` — opencode's built-in subagent dispatcher.
-   *   - `Task` / `task_tool` — name variants that omo also treats as the
-   *     same family (defensive).
-   *   - `call_omo_agent` — omo's parallel subagent dispatcher used by
-   *     Hephaestus / Sisyphus / Prometheus deep agents. Without this we
-   *     never see Hephaestus's background work and the popover lists only
-   *     the main turn.
+   * Tracked tools live in `SubagentTracker.isSubagentDispatchTool()` —
+   * see the omo source notes there.
    */
-  private updateTaskTracking(update: ToolUpdate, messageID?: string): void {
+  private async forwardToolForSubagentTracking(
+    update: ToolUpdate,
+    messageID: string | undefined,
+  ): Promise<void> {
+    if (!this.subagentTracker) return
+    if (!SubagentTracker.isSubagentDispatchTool(update.tool)) return
     log(
       `[agents-status] tool event tool=${update.tool} status=${update.status} callID=${update.callID}`,
     )
-    if (!SUBAGENT_TOOLS.has(update.tool)) return
-    const id = update.callID
-    if (update.status === "running") {
-      if (!this.activeTaskCallIDs.has(id)) {
-        this.activeTaskCallIDs.add(id)
-        log(`[continuation] subagent running ${update.tool}:${id} (active=${this.activeTaskCallIDs.size})`)
-      }
-      void this.recordSubagentTask(update, messageID, "running")
-      return
-    }
-    if (update.status === "completed" || update.status === "error") {
-      if (this.activeTaskCallIDs.delete(id)) {
-        log(`[continuation] subagent ${update.status} ${update.tool}:${id} (active=${this.activeTaskCallIDs.size})`)
-        if (this.idleDeferActive && this.activeTaskCallIDs.size === 0) {
-          this.scheduleIdleEmit(ChatView.CONTINUATION_GRACE_MS, "tasks-settled")
-        }
-      }
-      void this.recordSubagentTask(update, messageID, update.status)
+    await this.subagentTracker.handleToolUpdate(update, messageID)
+    // When a subagent settles while a continuation defer is open,
+    // collapse the defer down to the short post-settle grace window
+    // so the UI doesn't sit at "Continuing…" forever waiting on a
+    // follow-up that never comes.
+    if (this.idleDeferActive && this.activeSubagentCount() === 0) {
+      this.scheduleIdleEmit(ChatView.CONTINUATION_GRACE_MS, "subagents-settled")
     }
   }
 
-  private async recordSubagentTask(
-    update: ToolUpdate,
-    messageID: string | undefined,
-    status: "running" | "completed" | "error",
-  ): Promise<void> {
-    if (!this.taskStore) return
-    if (!this.sessionID) return
-    const id = subagentTaskID(this.sessionID, update.callID)
-    const now = Date.now()
-    const title = taskTitleFromUpdate(update)
-    log(`[agents-status] recordSubagentTask ${id} status=${status} title="${title}"`)
-    if (status === "running") {
-      const existing = this.taskStore.get(id)
-      await this.taskStore.upsert({
-        id,
-        kind: "subagent",
-        conversationID: this.activeConversationID,
-        sessionID: this.sessionID,
-        messageID,
-        callID: update.callID,
-        title,
-        status: "running",
-        startedAt: existing?.startedAt ?? now,
-        updatedAt: now,
-      })
-      return
-    }
-    await this.taskStore.update(id, {
-      status,
-      title,
-      error: status === "error" ? update.error : undefined,
-      updatedAt: now,
-    })
+  private activeSubagentCount(): number {
+    if (!this.taskStore || !this.sessionID) return 0
+    return this.taskStore.activeSubagentsForSession(this.sessionID).length
   }
 
   private async recordMainTaskStart(text: string): Promise<void> {
@@ -879,25 +849,28 @@ export class ChatView implements vscode.WebviewViewProvider {
     }
     const conversationID = this.activeConversationID
     const sessionID = this.sessionID
-    const id = mainTaskID(conversationID, sessionID)
-    const existing = this.taskStore.get(id)
+    const turnID = crypto.randomUUID()
+    const id = mainTaskID(conversationID, sessionID, turnID)
     const now = Date.now()
+    this.currentMainTaskID = id
     log(`[agents-status] recordMainTaskStart ${id}`)
     await this.taskStore.upsert({
       id,
       kind: "main",
       conversationID,
       sessionID,
-      title: this.activeConversation().title || summarizePrompt(text),
+      title: summarizePrompt(text),
       status: "running",
-      startedAt: existing?.startedAt ?? now,
+      startedAt: now,
       updatedAt: now,
     })
   }
 
   private async recordMainTaskFinish(status: "completed" | "error" | "cancelled", error?: string): Promise<void> {
-    if (!this.taskStore || !this.sessionID) return
-    const id = mainTaskID(this.activeConversationID, this.sessionID)
+    if (!this.taskStore) return
+    const id = this.currentMainTaskID
+    if (!id) return
+    this.currentMainTaskID = undefined
     await this.taskStore.update(id, {
       status,
       error,
@@ -927,8 +900,9 @@ export class ChatView implements vscode.WebviewViewProvider {
   }
 
   /**
-   * Open a continuation defer. While `activeTaskCallIDs` is non-empty,
-   * no timer runs — we wait for task-terminal events to drive the close.
+   * Open a continuation defer. While there are any active subagent tasks
+   * for the parent session, no timer runs — we wait for child-session
+   * idle events (routed through the SubagentTracker) to drive the close.
    * Otherwise (toast-only signal), a cap timer prevents an indefinite
    * wait if no continuation actually arrives.
    */
@@ -939,24 +913,24 @@ export class ChatView implements vscode.WebviewViewProvider {
       this.post({ type: "continuationPending", pending: true })
     }
     log(
-      `[continuation] deferring sessionIdle (${source}, tasks=${this.activeTaskCallIDs.size}, signal=${this.hasRecentContinuationSignal()})`,
+      `[continuation] deferring sessionIdle (${source}, subagents=${this.activeSubagentCount()}, signal=${this.hasRecentContinuationSignal()})`,
     )
-    if (this.activeTaskCallIDs.size > 0) return
+    if (this.activeSubagentCount() > 0) return
     this.scheduleIdleEmit(ChatView.CONTINUATION_DEFER_MS, "toast-cap")
   }
 
   /**
    * Schedule the emission of `sessionIdle` after `delay`. Used both for
-   * the post-task grace window and the toast-only cap. On fire, if any
-   * task part has spun up again, the timer no-ops — task tracking will
-   * re-schedule when those parts settle.
+   * the post-subagent grace window and the toast-only cap. On fire, if a
+   * subagent has spun up again (or never settled), the timer no-ops —
+   * tracker callbacks will re-schedule when subagents settle.
    */
   private scheduleIdleEmit(delay: number, source: string) {
     this.clearPendingIdle()
     this.pendingIdleTimer = setTimeout(() => {
       this.pendingIdleTimer = undefined
-      if (this.activeTaskCallIDs.size > 0) {
-        log(`[continuation] timer (${source}) fired but tasks still active; staying deferred`)
+      if (this.activeSubagentCount() > 0) {
+        log(`[continuation] timer (${source}) fired but subagents still active; staying deferred`)
         return
       }
       log(`[continuation] timer (${source}) resolved; emitting sessionIdle`)
@@ -970,8 +944,8 @@ export class ChatView implements vscode.WebviewViewProvider {
   private resetContinuationState() {
     this.clearPendingIdle()
     this.idleDeferActive = false
-    this.activeTaskCallIDs.clear()
     this.lastContinuationSignalAt = 0
+    this.subagentTracker?.reset()
   }
 
   private surfaceToast(toast: Toast) {
@@ -1231,7 +1205,7 @@ export class ChatView implements vscode.WebviewViewProvider {
 
   private async attachSubscription(backend: Backend, sessionID: string) {
     this.subscription?.abort()
-    this.subscription = subscribeSession(backend, sessionID, {
+    const subscription = subscribeSession(backend, sessionID, {
       onUserMessage: (mid) => {
         const targetID = this.pendingUserBackendID
         if (!targetID) return
@@ -1255,8 +1229,14 @@ export class ChatView implements vscode.WebviewViewProvider {
         // "Aborted"-style error. That's redundant with the Stopped badge we
         // already set on `aborted` — suppress to avoid showing both.
         if (payload.error && !this.aborting) {
+          // Server-side abort (no local Stop) arrives here as
+          // `error: "Aborted"`. classifyTerminal routes that to
+          // `cancelled` so the popover doesn't flash red on what is
+          // really a quiet stop. The chat bubble's own /^aborted$/i
+          // mapping keeps the UI consistent.
+          const classified = classifyTerminal(payload.error)
           this.post({ type: "assistantError", id: webviewID, message: payload.error })
-          void this.recordMainTaskFinish("error", payload.error)
+          void this.recordMainTaskFinish(classified.status, classified.error)
         }
         this.post({ type: "assistantDone", id: webviewID, usage: payload.usage })
       },
@@ -1272,14 +1252,12 @@ export class ChatView implements vscode.WebviewViewProvider {
       },
       onTool: (mid, update) => {
         if (this.aborting) return
-        // Structural subagent tracking: every `task` tool part on the
-        // parent gets added/removed from `activeTaskCallIDs` as it
-        // transitions running → completed/error. This is the primary
-        // gate against marking the parent done while a subagent is alive
-        // (Hephaestus's `run_in_background` path emits no continuation
-        // toast — only the structural signal — because omo suppresses
-        // its toast when BackgroundManager handles the wakeup itself).
-        this.updateTaskTracking(update, mid)
+        // Forward to the subagent tracker FIRST so the store is
+        // up-to-date before any downstream consumer (continuation gate,
+        // popover snapshot) reads from it. `forwardToolForSubagentTracking`
+        // is responsible for filtering to subagent-dispatch tools and for
+        // re-keying the task once metadata surfaces the child sessionID.
+        void this.forwardToolForSubagentTracking(update, mid)
         const webviewID = this.messageMap.get(mid) ?? this.ensureWebviewID(mid)
         const wire = toWire(update, backend.directory)
         this.post({ type: "tool", id: webviewID, update: wire })
@@ -1338,11 +1316,14 @@ export class ChatView implements vscode.WebviewViewProvider {
           // User-initiated abort bypasses the continuation defer — Stop
           // means stop now. Clear all continuation tracking so any
           // in-flight task parts (whose terminal events the SSE may not
-          // send post-abort) don't poison the next turn.
+          // send post-abort) don't poison the next turn. opencode's
+          // session.abort propagates to child sessions too, so we
+          // settle the entire subagent tree as cancelled.
           this.resetContinuationState()
           if (this.sessionID && this.taskStore) {
-            void this.taskStore.markSessionIdle(this.sessionID)
+            void this.taskStore.cancelSessionTasks(this.sessionID)
           }
+          this.currentMainTaskID = undefined
           this.post({ type: "sessionIdle" })
           return
         }
@@ -1354,11 +1335,39 @@ export class ChatView implements vscode.WebviewViewProvider {
         if (this.sessionID && this.taskStore) {
           void this.taskStore.markSessionIdle(this.sessionID)
         }
+        this.currentMainTaskID = undefined
         this.post({ type: "sessionIdle" })
       },
+      onChildSessionEvent: (event) => {
+        if (!this.subagentTracker) return
+        void this.subagentTracker.handleChildSessionEvent(event).then(() => {
+          // After any child terminal event, if we were deferring an
+          // idle waiting on subagents and the store is now empty,
+          // arm the short grace timer.
+          if (this.idleDeferActive && this.activeSubagentCount() === 0) {
+            this.scheduleIdleEmit(ChatView.CONTINUATION_GRACE_MS, "child-settled")
+          }
+        })
+      },
     })
+    this.subscription = subscription
+    if (this.taskStore) {
+      this.subagentTracker = new SubagentTracker({
+        store: this.taskStore,
+        getActiveConversationID: () => this.activeConversationID,
+        getParentSessionID: () => this.sessionID,
+        subscription: {
+          addChildSession: (id) => subscription.addChildSession(id),
+          removeChildSession: (id) => subscription.removeChildSession(id),
+        },
+      })
+      // Reconcile any rows that survived a VS Code reload. Best-effort —
+      // failures fall through and stale rows simply linger until the
+      // user clears them.
+      void this.subagentTracker.reconcile(backend, sessionID)
+    }
     try {
-      await this.subscription.ready
+      await subscription.ready
     } catch {
       // error already surfaced via handler
     }
@@ -1515,17 +1524,26 @@ export class ChatView implements vscode.WebviewViewProvider {
 }
 
 /**
- * Tool names that represent dispatching a subagent. Includes opencode's
- * built-in `task` (plus defensive name variants) and omo's `call_omo_agent`,
- * which Hephaestus / Sisyphus / Prometheus deep agents use for parallel
- * background subagents. Mirrors `TASK_TOOLS` + `TARGET_TOOLS2` from
- * oh-my-opencode's source.
+ * Tool names that represent dispatching a subagent. Mirrors
+ * `TASK_TOOLS` + `TARGET_TOOLS2` from oh-my-opencode's source plus the
+ * omo background-task and delegate-task families:
+ *   - `task` / `Task` / `task_tool` — opencode's built-in task tool (and
+ *     omo's `delegateTask` which is registered under the name `task`).
+ *   - `delegate_task` — defensive: if a future omo version re-registers
+ *     this with its lowercase name we still catch it.
+ *   - `call_omo_agent` — omo's parallel subagent dispatcher used by the
+ *     deep-agent stack (Hephaestus / Sisyphus / Prometheus).
+ *   - `background_task` — omo's pure background dispatcher, used by
+ *     Hephaestus prompts for fire-and-forget worker tasks.
+ * Kept in sync with the internal set in `src/agents/subagent-tracker.ts`.
  */
 export const SUBAGENT_TOOLS: ReadonlySet<string> = new Set([
   "task",
   "Task",
   "task_tool",
+  "delegate_task",
   "call_omo_agent",
+  "background_task",
 ])
 
 export function isSubagentTool(toolName: string): boolean {
@@ -1540,46 +1558,37 @@ export function summarizeAgentTasks(
     ? tasks.filter((task) => task.conversationID === conversationID)
     : tasks
 
-  // Sessions whose parent main task is still alive ("turn ongoing"). While
-  // any such session exists, we keep ALL of its subagents visible — even
-  // ones that have already completed — so the user can see what the
-  // currently-active turn dispatched, not just the agents racing at the
-  // millisecond of inspection. Without this, Hephaestus-style runs where a
-  // subagent finishes seconds before the parent finishes the prose leave
-  // the popover showing only the main entry.
-  const liveSessions = new Set(
-    scoped
-      .filter((t) => t.kind === "main" && (t.status === "running" || t.status === "waiting"))
-      .map((t) => t.sessionID),
-  )
-
+  // The popover shows ONLY currently-active work — the latest main task
+  // and any subagents that are still running / waiting / errored. We drop
+  // `completed` and `cancelled` rows so the popover reflects "what's
+  // happening right now," not a per-chat history. A second user prompt
+  // gets its own main row (see mainTaskID's per-turn keying); the prior
+  // turn's row is settled and filtered out.
   const items: AgentsTaskInfo[] = []
   let running = 0
   let waiting = 0
   let error = 0
   for (const task of scoped) {
-    const liveStatus =
-      task.status === "running" || task.status === "waiting" || task.status === "error"
-    const parentAlive = task.kind === "subagent" && liveSessions.has(task.sessionID)
-    if (task.kind === "main" && !liveStatus) continue
-    if (task.kind === "subagent" && !liveStatus && !parentAlive) continue
-    if (task.kind === "subagent" && task.status === "cancelled") continue
     if (task.status === "running") running += 1
     else if (task.status === "waiting") waiting += 1
     else if (task.status === "error") error += 1
-    const wireStatus: AgentsTaskInfo["status"] = liveStatus
-      ? (task.status as "running" | "waiting" | "error")
-      : "completed"
+    else continue
     items.push({
       id: task.id,
       kind: task.kind,
       title: task.title,
-      status: wireStatus,
+      status: task.status,
       error: task.error,
       startedAt: task.startedAt,
+      updatedAt: task.updatedAt,
+      subagent: task.kind === "subagent" ? task.subagent : undefined,
+      category: task.kind === "subagent" ? task.category : undefined,
+      model: task.kind === "subagent" ? task.model : undefined,
     })
   }
-  // Stable order: main tasks first, then subagents, then by startedAt asc.
+  // Stable order: main tasks first (the user's prompt anchor), then
+  // subagents by startedAt asc. Within each kind, chronological order
+  // is what makes "scrolling back through the turn" make sense.
   items.sort((a, b) => {
     if (a.kind !== b.kind) return a.kind === "main" ? -1 : 1
     return a.startedAt - b.startedAt

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -995,43 +995,39 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.post({ type: "aborted" })
     void this.recordMainTaskFinish("cancelled")
 
-    // Tear down the tracker's view of the session BEFORE issuing HTTP
-    // aborts. Two reasons:
+    // Tear down the tracker's local view of the subagent tree first.
+    // Two reasons:
     //   1. The store mutation runs in-process and is fast; doing it
     //      first means the popover settles immediately instead of
     //      waiting on the network round-trip.
     //   2. With the store's strict terminal guard, marking tasks
-    //      `cancelled` now makes the user's intent sticky — late
-    //      child error events (rate-limit / token-expired races
+    //      `cancelled` now makes the user's Stop sticky — a late
+    //      child error event (rate-limit / token-expired races
     //      arriving after the abort propagation) can no longer flip
     //      a cancelled row to `error`.
-    // `cancelForSession` returns the child sessionIDs that were live
-    // at the snapshot moment so we can HTTP-abort each one explicitly.
-    let childSessionIDs: string[] = []
     if (this.subagentTracker) {
-      childSessionIDs = await this.subagentTracker.cancelForSession(sessionID)
+      await this.subagentTracker.cancelForSession(sessionID)
     } else if (this.taskStore) {
       await this.taskStore.cancelSessionTasks(sessionID)
     }
 
     try {
       const backend = await this.servers.ensure()
-      // Parent + every live child in parallel. opencode's
-      // `session.abort` only targets the named session; propagation
-      // to subagent children isn't guaranteed across plugin / version
-      // combinations, so we issue each child abort explicitly. Each
-      // call is independent — a failure on one shouldn't block the
-      // others, hence `allSettled` + per-call `.catch`.
-      await Promise.allSettled([
-        backend.client.session.abort({ path: { id: sessionID } }),
-        ...childSessionIDs.map((childID) =>
-          backend.client.session
-            .abort({ path: { id: childID } })
-            .catch((e) => {
-              log(`session.abort failed for child ${childID}`, e)
-            }),
-        ),
-      ])
+      // Abort ONLY the parent. opencode's `session.abort` propagates
+      // down to the parent's "wait on tool" (the in-flight tool call
+      // dispatched to the child session), so cancelling the parent
+      // also cancels the children atomically.
+      //
+      // Earlier we issued explicit aborts for parent + each child in
+      // parallel as a "belt and suspenders" measure. That introduced
+      // a race: the child's abort processed first, the child's tool
+      // result returned to the parent with a cancel error, the parent
+      // started a NEW LLM call to process that result, and the
+      // parent's own abort then arrived *after* the new call started
+      // — leaving the parent visibly continuing. The user had to
+      // press Stop a second time to abort the new LLM call. Trusting
+      // opencode's propagation avoids the race entirely.
+      await backend.client.session.abort({ path: { id: sessionID } })
     } catch (e) {
       log("session.abort failed", e)
     }

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -989,13 +989,49 @@ export class ChatView implements vscode.WebviewViewProvider {
 
   private async abortCurrent() {
     if (!this.sessionID) return
+    const sessionID = this.sessionID
     this.aborting = true
     this.pendingUserBackendID = undefined
     this.post({ type: "aborted" })
     void this.recordMainTaskFinish("cancelled")
+
+    // Tear down the tracker's view of the session BEFORE issuing HTTP
+    // aborts. Two reasons:
+    //   1. The store mutation runs in-process and is fast; doing it
+    //      first means the popover settles immediately instead of
+    //      waiting on the network round-trip.
+    //   2. With the store's strict terminal guard, marking tasks
+    //      `cancelled` now makes the user's intent sticky — late
+    //      child error events (rate-limit / token-expired races
+    //      arriving after the abort propagation) can no longer flip
+    //      a cancelled row to `error`.
+    // `cancelForSession` returns the child sessionIDs that were live
+    // at the snapshot moment so we can HTTP-abort each one explicitly.
+    let childSessionIDs: string[] = []
+    if (this.subagentTracker) {
+      childSessionIDs = await this.subagentTracker.cancelForSession(sessionID)
+    } else if (this.taskStore) {
+      await this.taskStore.cancelSessionTasks(sessionID)
+    }
+
     try {
       const backend = await this.servers.ensure()
-      await backend.client.session.abort({ path: { id: this.sessionID } })
+      // Parent + every live child in parallel. opencode's
+      // `session.abort` only targets the named session; propagation
+      // to subagent children isn't guaranteed across plugin / version
+      // combinations, so we issue each child abort explicitly. Each
+      // call is independent — a failure on one shouldn't block the
+      // others, hence `allSettled` + per-call `.catch`.
+      await Promise.allSettled([
+        backend.client.session.abort({ path: { id: sessionID } }),
+        ...childSessionIDs.map((childID) =>
+          backend.client.session
+            .abort({ path: { id: childID } })
+            .catch((e) => {
+              log(`session.abort failed for child ${childID}`, e)
+            }),
+        ),
+      ])
     } catch (e) {
       log("session.abort failed", e)
     }
@@ -1316,12 +1352,17 @@ export class ChatView implements vscode.WebviewViewProvider {
           // User-initiated abort bypasses the continuation defer — Stop
           // means stop now. Clear all continuation tracking so any
           // in-flight task parts (whose terminal events the SSE may not
-          // send post-abort) don't poison the next turn. opencode's
-          // session.abort propagates to child sessions too, so we
-          // settle the entire subagent tree as cancelled.
+          // send post-abort) don't poison the next turn. `abortCurrent`
+          // already ran `cancelForSession` proactively; this is the
+          // catch-all that covers any dispatch that snuck in between
+          // the snapshot there and the session.idle arriving here.
           this.resetContinuationState()
-          if (this.sessionID && this.taskStore) {
-            void this.taskStore.cancelSessionTasks(this.sessionID)
+          if (this.sessionID) {
+            if (this.subagentTracker) {
+              void this.subagentTracker.cancelForSession(this.sessionID)
+            } else if (this.taskStore) {
+              void this.taskStore.cancelSessionTasks(this.sessionID)
+            }
           }
           this.currentMainTaskID = undefined
           this.post({ type: "sessionIdle" })

--- a/test/host/agent-task-store.test.ts
+++ b/test/host/agent-task-store.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect, beforeEach } from "vitest"
 import {
   AGENT_TASKS_KEY,
   AgentTaskStore,
+  classifyTerminal,
   mainTaskID,
   subagentTaskID,
+  subagentTaskIDByChildSession,
   type AgentTask,
   type Memento,
 } from "../../src/agents/task-store"
@@ -147,6 +149,24 @@ describe("AgentTaskStore", () => {
     expect(fires).toBe(0)
   })
 
+  it("clearForConversation drops every task — live or historical — for that conversation only", async () => {
+    const store = new AgentTaskStore(memento)
+    await store.upsert(fixedTask({ id: "main:c1:s1", conversationID: "c1", sessionID: "s1", status: "running" }))
+    await store.upsert(
+      fixedTask({
+        id: "subagent:c1:done",
+        conversationID: "c1",
+        sessionID: "s1",
+        kind: "subagent",
+        callID: "x",
+        status: "completed",
+      }),
+    )
+    await store.upsert(fixedTask({ id: "main:c2:s2", conversationID: "c2", sessionID: "s2", status: "running" }))
+    await store.clearForConversation("c1")
+    expect(store.list().map((t) => t.id)).toEqual(["main:c2:s2"])
+  })
+
   it("clearCompleted drops completed/cancelled but keeps running/error", async () => {
     const store = new AgentTaskStore(memento)
     await store.upsert(fixedTask({ id: "a", status: "running" }))
@@ -157,14 +177,33 @@ describe("AgentTaskStore", () => {
     expect(store.list().map((t) => t.id).sort()).toEqual(["a", "d"])
   })
 
-  it("markSessionIdle completes still-running tasks for the session only", async () => {
+  it("markSessionIdle completes only the MAIN task — subagents are owned by SubagentTracker", async () => {
     const store = new AgentTaskStore(memento)
     await store.upsert(fixedTask({ id: "main:c:s1", sessionID: "s1", status: "running" }))
-    await store.upsert(fixedTask({ id: "subagent:s1:c1", kind: "subagent", sessionID: "s1", callID: "c1", status: "running" }))
+    await store.upsert(
+      fixedTask({ id: "subagent:s1:c1", kind: "subagent", sessionID: "s1", callID: "c1", status: "running" }),
+    )
     await store.upsert(fixedTask({ id: "main:c:s2", sessionID: "s2", status: "running" }))
     await store.markSessionIdle("s1", 5000)
     expect(store.get("main:c:s1")!.status).toBe("completed")
-    expect(store.get("subagent:s1:c1")!.status).toBe("completed")
+    // Subagents must NOT be auto-completed when the parent goes idle:
+    // omo's `run_in_background=true` subagents keep working long after
+    // the parent's last assistant message lands. The child session's
+    // own idle event (routed via SubagentTracker) settles them.
+    expect(store.get("subagent:s1:c1")!.status).toBe("running")
+    expect(store.get("main:c:s2")!.status).toBe("running")
+  })
+
+  it("cancelSessionTasks settles every active task for the session (used by user-initiated abort)", async () => {
+    const store = new AgentTaskStore(memento)
+    await store.upsert(fixedTask({ id: "main:c:s1", sessionID: "s1", status: "running" }))
+    await store.upsert(
+      fixedTask({ id: "subagent:s1:c1", kind: "subagent", sessionID: "s1", callID: "c1", status: "running" }),
+    )
+    await store.upsert(fixedTask({ id: "main:c:s2", sessionID: "s2", status: "running" }))
+    await store.cancelSessionTasks("s1", 5000)
+    expect(store.get("main:c:s1")!.status).toBe("cancelled")
+    expect(store.get("subagent:s1:c1")!.status).toBe("cancelled")
     expect(store.get("main:c:s2")!.status).toBe("running")
   })
 
@@ -181,8 +220,108 @@ describe("AgentTaskStore", () => {
   })
 
   it("exposes stable id helpers", () => {
-    expect(mainTaskID("c", "s")).toBe("main:c:s")
+    expect(mainTaskID("c", "s", "turn-1")).toBe("main:c:s:turn-1")
     expect(subagentTaskID("s", "call-1")).toBe("subagent:s:call-1")
+    expect(subagentTaskIDByChildSession("ses_child_1")).toBe("subagent:child:ses_child_1")
+  })
+
+  it("main tasks are keyed per turn: a follow-up message creates a new row, prior row stays completed", async () => {
+    // Simulates two sequential user prompts in the same conversation /
+    // session. Each turn gets its own main task ID (ChatView mints a
+    // fresh turnID at recordMainTaskStart) so the popover shows BOTH
+    // rows — the prior one as completed history, the new one as live.
+    const store = new AgentTaskStore(memento)
+    const turn1 = mainTaskID("c", "s", "turn-1")
+    const turn2 = mainTaskID("c", "s", "turn-2")
+    await store.upsert(
+      fixedTask({ id: turn1, conversationID: "c", sessionID: "s", status: "running", startedAt: 1000, updatedAt: 1000 }),
+    )
+    await store.markSessionIdle("s", 2000)
+    expect(store.get(turn1)!.status).toBe("completed")
+    await store.upsert(
+      fixedTask({ id: turn2, conversationID: "c", sessionID: "s", status: "running", startedAt: 3000, updatedAt: 3000 }),
+    )
+    expect(store.get(turn1)!.status).toBe("completed")
+    expect(store.get(turn2)!.status).toBe("running")
+    expect(store.list().map((t) => t.id)).toEqual([turn1, turn2])
+  })
+
+  it("getByChildSession looks up a subagent by its child opencode sessionID", async () => {
+    const store = new AgentTaskStore(memento)
+    await store.upsert(
+      fixedTask({
+        id: subagentTaskIDByChildSession("ses_child_42"),
+        kind: "subagent",
+        sessionID: "ses_parent",
+        callID: "c1",
+        childSessionID: "ses_child_42",
+      }),
+    )
+    const found = store.getByChildSession("ses_child_42")
+    expect(found?.id).toBe("subagent:child:ses_child_42")
+    expect(store.getByChildSession("ses_missing")).toBeUndefined()
+  })
+
+  it("activeSubagentsForSession scopes by parent session and active status", async () => {
+    const store = new AgentTaskStore(memento)
+    await store.upsert(fixedTask({ id: "main:c:s1", kind: "main", sessionID: "s1" }))
+    await store.upsert(
+      fixedTask({
+        id: "subagent:child:a",
+        kind: "subagent",
+        sessionID: "s1",
+        childSessionID: "a",
+        status: "running",
+      }),
+    )
+    await store.upsert(
+      fixedTask({
+        id: "subagent:child:b",
+        kind: "subagent",
+        sessionID: "s1",
+        childSessionID: "b",
+        status: "completed",
+      }),
+    )
+    await store.upsert(
+      fixedTask({
+        id: "subagent:child:c",
+        kind: "subagent",
+        sessionID: "s2",
+        childSessionID: "c",
+        status: "running",
+      }),
+    )
+    const active = store.activeSubagentsForSession("s1")
+    expect(active.map((t) => t.id)).toEqual(["subagent:child:a"])
+    expect(store.hasActiveSubagentsForSession("s1")).toBe(true)
+    expect(store.hasActiveSubagentsForSession("s_unknown")).toBe(false)
+  })
+
+  it("round-trips the new metadata fields (childSessionID, model, subagent, category, runInBackground)", async () => {
+    const seed: AgentTask = {
+      ...fixedTask({
+        id: "subagent:child:ses_x",
+        kind: "subagent",
+        callID: "c1",
+        sessionID: "ses_parent",
+      }),
+      childSessionID: "ses_x",
+      backgroundTaskID: "bg_42",
+      subagent: "explore",
+      category: "deep",
+      model: { providerID: "github-copilot", modelID: "claude-opus-4.5" },
+      runInBackground: true,
+    }
+    memento.setSeed(AGENT_TASKS_KEY, [seed])
+    const store = new AgentTaskStore(memento)
+    const got = store.get("subagent:child:ses_x")!
+    expect(got.childSessionID).toBe("ses_x")
+    expect(got.backgroundTaskID).toBe("bg_42")
+    expect(got.subagent).toBe("explore")
+    expect(got.category).toBe("deep")
+    expect(got.model).toEqual({ providerID: "github-copilot", modelID: "claude-opus-4.5" })
+    expect(got.runInBackground).toBe(true)
   })
 
   it("hasActive / hasRunning distinguish running vs error", async () => {
@@ -194,5 +333,32 @@ describe("AgentTaskStore", () => {
     expect(store.hasRunning()).toBe(false)
     await store.upsert(fixedTask({ id: "b", status: "running" }))
     expect(store.hasRunning()).toBe(true)
+  })
+})
+
+describe("classifyTerminal", () => {
+  it("maps the literal 'Aborted' message to cancelled with no error string", () => {
+    expect(classifyTerminal("Aborted")).toEqual({ status: "cancelled" })
+  })
+
+  it("matches case-insensitively and tolerates surrounding whitespace", () => {
+    expect(classifyTerminal("aborted")).toEqual({ status: "cancelled" })
+    expect(classifyTerminal("ABORTED")).toEqual({ status: "cancelled" })
+    expect(classifyTerminal("  Aborted  ")).toEqual({ status: "cancelled" })
+  })
+
+  it("keeps real failure messages as error and preserves the message", () => {
+    expect(classifyTerminal("rate limit exceeded")).toEqual({
+      status: "error",
+      error: "rate limit exceeded",
+    })
+    expect(classifyTerminal("Aborted: rate limit")).toEqual({
+      status: "error",
+      error: "Aborted: rate limit",
+    })
+  })
+
+  it("treats an undefined message as error with no body", () => {
+    expect(classifyTerminal(undefined)).toEqual({ status: "error", error: undefined })
   })
 })

--- a/test/host/agent-task-store.test.ts
+++ b/test/host/agent-task-store.test.ts
@@ -141,6 +141,57 @@ describe("AgentTaskStore", () => {
     expect(store.get("main:conv:sess")!.status).toBe("completed")
   })
 
+  it("once cancelled, update cannot flip to error (preserves user-initiated Stop)", async () => {
+    // Regression: a stray child `session.error` arriving after the user
+    // aborted would have flipped the row from `cancelled` to `error`,
+    // overriding the user's explicit Stop.
+    const store = new AgentTaskStore(memento)
+    await store.upsert(fixedTask({ status: "cancelled", updatedAt: 2000 }))
+    let fires = 0
+    store.onDidChange(() => (fires += 1))
+    await store.update("main:conv:sess", { status: "error", error: "rate limit", updatedAt: 3000 })
+    expect(fires).toBe(0)
+    expect(store.get("main:conv:sess")!.status).toBe("cancelled")
+    expect(store.get("main:conv:sess")!.error).toBeUndefined()
+  })
+
+  it("rejects every other terminal→other-terminal status flip", async () => {
+    const store = new AgentTaskStore(memento)
+    await store.upsert(fixedTask({ id: "a", status: "completed", updatedAt: 1000 }))
+    await store.upsert(fixedTask({ id: "b", status: "error", updatedAt: 1000 }))
+    await store.update("a", { status: "cancelled", updatedAt: 2000 })
+    await store.update("a", { status: "error", error: "x", updatedAt: 2000 })
+    await store.update("b", { status: "cancelled", updatedAt: 2000 })
+    await store.update("b", { status: "completed", updatedAt: 2000 })
+    expect(store.get("a")!.status).toBe("completed")
+    expect(store.get("b")!.status).toBe("error")
+  })
+
+  it("allows metadata refresh on terminal rows when the patch omits status", async () => {
+    // The strict guard only freezes `status` — other fields (model
+    // backfill, error message refresh on same status) still apply so
+    // late `assistantEnd` events can enrich settled rows.
+    const store = new AgentTaskStore(memento)
+    await store.upsert(
+      fixedTask({
+        id: "sub",
+        kind: "subagent",
+        status: "completed",
+        startedAt: 1000,
+        updatedAt: 2000,
+      }),
+    )
+    await store.update("sub", {
+      model: { providerID: "github-copilot", modelID: "claude-opus-4.5" },
+      updatedAt: 3000,
+    })
+    expect(store.get("sub")!.status).toBe("completed")
+    expect(store.get("sub")!.model).toEqual({
+      providerID: "github-copilot",
+      modelID: "claude-opus-4.5",
+    })
+  })
+
   it("update is a no-op for unknown ids", async () => {
     const store = new AgentTaskStore(memento)
     let fires = 0

--- a/test/host/agent-task-wiring.test.ts
+++ b/test/host/agent-task-wiring.test.ts
@@ -82,13 +82,22 @@ describe("summarizeAgentTasks", () => {
     expect(result.tasks.map((t) => t.id).sort()).toEqual(["a", "b", "c", "d"])
   })
 
-  it("ignores completed and cancelled tasks", () => {
+  it("drops completed tasks — the popover shows only what's currently active", () => {
     const result = summarizeAgentTasks([
-      task({ id: "a", status: "completed" }),
-      task({ id: "b", status: "cancelled" }),
+      task({ id: "a", status: "completed", startedAt: 1000, updatedAt: 5000 }),
     ])
     expect(result.tasks).toEqual([])
+    expect(result.running).toBe(0)
     expect(result.total).toBe(0)
+  })
+
+  it("drops cancelled tasks (user-initiated aborts) and completed tasks", () => {
+    const result = summarizeAgentTasks([
+      task({ id: "a", status: "cancelled" }),
+      task({ id: "b", status: "completed" }),
+      task({ id: "c", status: "running" }),
+    ])
+    expect(result.tasks.map((t) => t.id)).toEqual(["c"])
   })
 
   it("filters by conversationID when provided", () => {
@@ -106,30 +115,29 @@ describe("summarizeAgentTasks", () => {
     expect(result.tasks.map((t) => t.id)).toEqual(["x", "z"])
   })
 
-  it("keeps completed subagents in the list while the parent main task is still alive", () => {
+  it("drops completed subagents even while the parent main task is still alive", () => {
     const result = summarizeAgentTasks([
       task({ id: "main:c:s", kind: "main", status: "running" }),
       task({ id: "subagent:s:c1", kind: "subagent", status: "completed", startedAt: 100 }),
       task({ id: "subagent:s:c2", kind: "subagent", status: "running", startedAt: 200 }),
     ])
-    // Counts only reflect live work — the completed subagent doesn't bump
-    // running, but it remains visible in the task list.
     expect(result.running).toBe(2)
     expect(result.total).toBe(2)
-    expect(result.tasks.map((t) => t.id)).toEqual(["main:c:s", "subagent:s:c1", "subagent:s:c2"])
-    expect(result.tasks.find((t) => t.id === "subagent:s:c1")!.status).toBe("completed")
+    expect(result.tasks.map((t) => t.id)).toEqual(["main:c:s", "subagent:s:c2"])
   })
 
-  it("drops completed subagents once the parent main task settles", () => {
+  it("empties the popover after every task settles — no per-chat history", () => {
     const result = summarizeAgentTasks([
-      task({ id: "main:c:s", kind: "main", status: "completed" }),
-      task({ id: "subagent:s:c1", kind: "subagent", status: "completed" }),
+      task({ id: "main:c:s", kind: "main", status: "completed", startedAt: 0, updatedAt: 9000 }),
+      task({ id: "subagent:s:c1", kind: "subagent", status: "completed", startedAt: 100, updatedAt: 5000 }),
+      task({ id: "subagent:s:c2", kind: "subagent", status: "completed", startedAt: 200, updatedAt: 7000 }),
     ])
-    expect(result.total).toBe(0)
     expect(result.tasks).toEqual([])
+    expect(result.running).toBe(0)
+    expect(result.total).toBe(0)
   })
 
-  it("does NOT keep cancelled subagents visible even when parent is alive", () => {
+  it("drops cancelled subagents — even when the parent is alive (user-initiated abort = noise)", () => {
     const result = summarizeAgentTasks([
       task({ id: "main:c:s", kind: "main", status: "running" }),
       task({ id: "subagent:s:c1", kind: "subagent", status: "cancelled" }),
@@ -154,6 +162,7 @@ describe("summarizeAgentTasks", () => {
         title: "Refactor",
         status: "running",
         startedAt: 1000,
+        updatedAt: 1500,
         error: undefined,
       }),
     ])
@@ -164,7 +173,62 @@ describe("summarizeAgentTasks", () => {
       status: "running",
       error: undefined,
       startedAt: 1000,
+      updatedAt: 1500,
+      subagent: undefined,
+      category: undefined,
+      model: undefined,
     })
+  })
+
+  it("forwards updatedAt so error rows can render a frozen total runtime", () => {
+    const result = summarizeAgentTasks([
+      task({ id: "a", status: "error", error: "boom", startedAt: 1000, updatedAt: 4500 }),
+    ])
+    expect(result.tasks[0]!.updatedAt).toBe(4500)
+  })
+
+  it("passes through subagent/category/model on subagent rows", () => {
+    const result = summarizeAgentTasks([
+      task({
+        id: "main:c:s",
+        kind: "main",
+        sessionID: "s",
+        status: "running",
+      }),
+      task({
+        id: "subagent:child:ses_x",
+        kind: "subagent",
+        sessionID: "s",
+        callID: "c1",
+        childSessionID: "ses_x",
+        subagent: "explore",
+        category: "deep",
+        model: { providerID: "github-copilot", modelID: "claude-opus-4.5" },
+        runInBackground: true,
+        status: "running",
+      }),
+    ])
+    const subRow = result.tasks.find((t) => t.kind === "subagent")!
+    expect(subRow.subagent).toBe("explore")
+    expect(subRow.category).toBe("deep")
+    expect(subRow.model).toEqual({ providerID: "github-copilot", modelID: "claude-opus-4.5" })
+  })
+
+  it("does NOT carry subagent metadata on main rows", () => {
+    const result = summarizeAgentTasks([
+      task({
+        id: "main:c:s",
+        kind: "main",
+        sessionID: "s",
+        status: "running",
+        subagent: "hephaestus",
+        model: { providerID: "github-copilot", modelID: "gpt-5.5" },
+      }),
+    ])
+    const mainRow = result.tasks[0]!
+    expect(mainRow.subagent).toBeUndefined()
+    expect(mainRow.category).toBeUndefined()
+    expect(mainRow.model).toBeUndefined()
   })
 })
 
@@ -175,6 +239,14 @@ describe("isSubagentTool", () => {
 
   it("matches omo's `call_omo_agent` used by Hephaestus / Sisyphus subagents", () => {
     expect(isSubagentTool("call_omo_agent")).toBe(true)
+  })
+
+  it("matches omo's `background_task` (Hephaestus fire-and-forget pattern)", () => {
+    expect(isSubagentTool("background_task")).toBe(true)
+  })
+
+  it("matches `delegate_task` defensively (in case omo re-registers under its lowercase name)", () => {
+    expect(isSubagentTool("delegate_task")).toBe(true)
   })
 
   it("matches defensive name variants (Task, task_tool)", () => {

--- a/test/host/e2e-mock-opencode.test.ts
+++ b/test/host/e2e-mock-opencode.test.ts
@@ -259,3 +259,137 @@ describe("E2E (mock opencode): subscribeSession streaming", () => {
     expect(patches[0]?.files).toEqual(["A new.ts", "M existing.ts"])
   })
 })
+
+describe("E2E (mock opencode): child session routing", () => {
+  it("does NOT call onChildSessionEvent for unregistered child sessions", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const events: { type: string; sessionID: string }[] = []
+    const subscription = subscribeSession({ url: server.url, client, directory: "/tmp" }, "ses_test", {
+      onAssistantStart: () => {},
+      onTextDelta: () => {},
+      onChildSessionEvent: (e) => events.push({ type: e.type, sessionID: e.sessionID }),
+    })
+    await subscription.ready
+    await server.awaitClient()
+    server.push({ type: "session.idle", sessionID: "ses_unknown_child" })
+    await new Promise((r) => setTimeout(r, 50))
+    subscription.abort()
+    expect(events).toEqual([])
+  })
+
+  it("routes session.idle on a REGISTERED child to onChildSessionEvent", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const events: { type: string; sessionID: string }[] = []
+    const subscription = subscribeSession({ url: server.url, client, directory: "/tmp" }, "ses_test", {
+      onAssistantStart: () => {},
+      onTextDelta: () => {},
+      onChildSessionEvent: (e) => events.push({ type: e.type, sessionID: e.sessionID }),
+    })
+    await subscription.ready
+    await server.awaitClient()
+    subscription.addChildSession("ses_child_1")
+    server.push({ type: "session.idle", sessionID: "ses_child_1" })
+    await new Promise((r) => setTimeout(r, 50))
+    subscription.abort()
+    expect(events).toEqual([{ type: "idle", sessionID: "ses_child_1" }])
+  })
+
+  it("stops routing after removeChildSession", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const events: { type: string; sessionID: string }[] = []
+    const subscription = subscribeSession({ url: server.url, client, directory: "/tmp" }, "ses_test", {
+      onAssistantStart: () => {},
+      onTextDelta: () => {},
+      onChildSessionEvent: (e) => events.push({ type: e.type, sessionID: e.sessionID }),
+    })
+    await subscription.ready
+    await server.awaitClient()
+    subscription.addChildSession("ses_child_1")
+    subscription.removeChildSession("ses_child_1")
+    server.push({ type: "session.idle", sessionID: "ses_child_1" })
+    await new Promise((r) => setTimeout(r, 50))
+    subscription.abort()
+    expect(events).toEqual([])
+  })
+
+  it("treats message.part.updated for a registered child as a busy signal", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const events: { type: string; sessionID: string }[] = []
+    const subscription = subscribeSession({ url: server.url, client, directory: "/tmp" }, "ses_test", {
+      onAssistantStart: () => {},
+      onTextDelta: () => {},
+      onChildSessionEvent: (e) => events.push({ type: e.type, sessionID: e.sessionID }),
+    })
+    await subscription.ready
+    await server.awaitClient()
+    subscription.addChildSession("ses_child_busy")
+    server.push({
+      type: "message.part.updated",
+      part: {
+        id: "p1",
+        messageID: "m1",
+        sessionID: "ses_child_busy",
+        type: "text",
+        text: "thinking",
+      },
+    })
+    await new Promise((r) => setTimeout(r, 50))
+    subscription.abort()
+    expect(events).toContainEqual({ type: "busy", sessionID: "ses_child_busy" })
+  })
+
+  it("forwards a terminal assistantEnd with usage from the child session", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const ends: { sessionID: string; usage?: { model?: string } }[] = []
+    const subscription = subscribeSession({ url: server.url, client, directory: "/tmp" }, "ses_test", {
+      onAssistantStart: () => {},
+      onTextDelta: () => {},
+      onChildSessionEvent: (e) => {
+        if (e.type === "assistantEnd") ends.push({ sessionID: e.sessionID, usage: e.usage })
+      },
+    })
+    await subscription.ready
+    await server.awaitClient()
+    subscription.addChildSession("ses_child_end")
+    server.push({
+      type: "message.updated",
+      info: {
+        id: "msg_child_a",
+        role: "assistant",
+        sessionID: "ses_child_end",
+        finish: "stop",
+        providerID: "github-copilot",
+        modelID: "claude-opus-4.5",
+        tokens: { input: 10, output: 20, reasoning: 5 },
+      },
+    })
+    await new Promise((r) => setTimeout(r, 50))
+    subscription.abort()
+    expect(ends).toHaveLength(1)
+    expect(ends[0]?.sessionID).toBe("ses_child_end")
+    expect(ends[0]?.usage?.model).toBe("github-copilot/claude-opus-4.5")
+  })
+
+  it("does NOT call the parent's onSessionIdle when a child session goes idle", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    let parentIdleCount = 0
+    const subscription = subscribeSession({ url: server.url, client, directory: "/tmp" }, "ses_test", {
+      onAssistantStart: () => {},
+      onTextDelta: () => {},
+      onSessionIdle: () => {
+        parentIdleCount += 1
+      },
+      onChildSessionEvent: () => {},
+    })
+    await subscription.ready
+    await server.awaitClient()
+    subscription.addChildSession("ses_child")
+    server.push({ type: "session.idle", sessionID: "ses_child" })
+    await new Promise((r) => setTimeout(r, 50))
+    subscription.abort()
+    // Critical isolation: a child going idle must not be confused with
+    // the parent going idle, otherwise the busy spinner clears too early
+    // when Hephaestus is mid-fanout.
+    expect(parentIdleCount).toBe(0)
+  })
+})

--- a/test/host/subagent-tracker.test.ts
+++ b/test/host/subagent-tracker.test.ts
@@ -1,0 +1,562 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import {
+  SubagentTracker,
+  readMetadata,
+  type SubagentSubscription,
+} from "../../src/agents/subagent-tracker"
+import {
+  AgentTaskStore,
+  subagentTaskID,
+  subagentTaskIDByChildSession,
+  type AgentTask,
+  type Memento,
+} from "../../src/agents/task-store"
+import type { ToolUpdate } from "../../src/chat/stream"
+
+class FakeMemento implements Memento {
+  private store: Record<string, unknown> = {}
+  get<T>(key: string): T | undefined
+  get<T>(key: string, def: T): T
+  get<T>(key: string, def?: T): T | undefined {
+    const v = this.store[key]
+    return v === undefined ? def : (v as T)
+  }
+  async update(key: string, value: unknown) {
+    if (value === undefined) delete this.store[key]
+    else this.store[key] = JSON.parse(JSON.stringify(value))
+  }
+}
+
+class FakeSubscription implements SubagentSubscription {
+  added: string[] = []
+  removed: string[] = []
+  addChildSession(id: string) {
+    this.added.push(id)
+  }
+  removeChildSession(id: string) {
+    this.removed.push(id)
+  }
+}
+
+function makeUpdate(overrides: Partial<ToolUpdate> = {}): ToolUpdate {
+  return {
+    callID: "c1",
+    tool: "task",
+    status: "running",
+    ...overrides,
+  }
+}
+
+function setupTracker(opts?: { sessionID?: string; conversationID?: string }) {
+  const memento = new FakeMemento()
+  const store = new AgentTaskStore(memento)
+  const subscription = new FakeSubscription()
+  const tracker = new SubagentTracker({
+    store,
+    getActiveConversationID: () => opts?.conversationID ?? "conv1",
+    getParentSessionID: () => opts?.sessionID ?? "ses_parent",
+    subscription,
+  })
+  return { tracker, store, subscription }
+}
+
+describe("readMetadata", () => {
+  it("returns an empty object when metadata is undefined", () => {
+    expect(readMetadata(undefined)).toEqual({})
+  })
+
+  it("extracts omo's standard payload (camelCase sessionId/taskId/backgroundTaskId)", () => {
+    const meta = readMetadata({
+      sessionId: "ses_child_1",
+      taskId: "ses_child_1",
+      backgroundTaskId: "bg_42",
+      agent: "explore",
+      category: "deep",
+      run_in_background: true,
+      model: { providerID: "github-copilot", modelID: "claude-opus-4.5" },
+      description: "Find auth patterns",
+    })
+    expect(meta.childSessionID).toBe("ses_child_1")
+    expect(meta.backgroundTaskID).toBe("bg_42")
+    expect(meta.subagent).toBe("explore")
+    expect(meta.category).toBe("deep")
+    expect(meta.runInBackground).toBe(true)
+    expect(meta.model).toEqual({ providerID: "github-copilot", modelID: "claude-opus-4.5" })
+    expect(meta.description).toBe("Find auth patterns")
+  })
+
+  it("accepts snake_case fallbacks for forward-compat with future omo renames", () => {
+    const meta = readMetadata({
+      session_id: "ses_x",
+      background_task_id: "bg_x",
+      subagent_type: "librarian",
+      model: { provider_id: "openai", model_id: "gpt-5.5" },
+    })
+    expect(meta.childSessionID).toBe("ses_x")
+    expect(meta.backgroundTaskID).toBe("bg_x")
+    expect(meta.subagent).toBe("librarian")
+    expect(meta.model).toEqual({ providerID: "openai", modelID: "gpt-5.5" })
+  })
+
+  it("ignores empty/whitespace string fields", () => {
+    const meta = readMetadata({ sessionId: "   ", agent: "", category: "  " })
+    expect(meta.childSessionID).toBeUndefined()
+    expect(meta.subagent).toBeUndefined()
+    expect(meta.category).toBeUndefined()
+  })
+
+  it("returns no model when either providerID or modelID is missing", () => {
+    expect(readMetadata({ model: { providerID: "x" } }).model).toBeUndefined()
+    expect(readMetadata({ model: { modelID: "y" } }).model).toBeUndefined()
+  })
+})
+
+describe("SubagentTracker.handleToolUpdate", () => {
+  it("creates a callID-keyed task on first running event when no metadata is present yet", async () => {
+    const { tracker, store, subscription } = setupTracker()
+    await tracker.handleToolUpdate(makeUpdate({ callID: "c1", status: "running" }), "msg_1")
+    const task = store.get(subagentTaskID("ses_parent", "c1"))!
+    expect(task).toBeDefined()
+    expect(task.kind).toBe("subagent")
+    expect(task.status).toBe("running")
+    expect(task.childSessionID).toBeUndefined()
+    expect(subscription.added).toEqual([])
+  })
+
+  it("promotes to child-session identity once metadata.sessionId arrives", async () => {
+    const { tracker, store, subscription } = setupTracker()
+    await tracker.handleToolUpdate(makeUpdate({ callID: "c1", status: "running" }))
+    await tracker.handleToolUpdate(
+      makeUpdate({
+        callID: "c1",
+        status: "running",
+        metadata: {
+          sessionId: "ses_child_1",
+          backgroundTaskId: "bg_1",
+          agent: "explore",
+          model: { providerID: "github-copilot", modelID: "claude-opus-4.5" },
+          run_in_background: true,
+        },
+      }),
+    )
+    expect(store.get(subagentTaskID("ses_parent", "c1"))).toBeUndefined()
+    const promoted = store.get(subagentTaskIDByChildSession("ses_child_1"))!
+    expect(promoted.childSessionID).toBe("ses_child_1")
+    expect(promoted.backgroundTaskID).toBe("bg_1")
+    expect(promoted.subagent).toBe("explore")
+    expect(promoted.model).toEqual({ providerID: "github-copilot", modelID: "claude-opus-4.5" })
+    expect(promoted.runInBackground).toBe(true)
+    expect(subscription.added).toContain("ses_child_1")
+  })
+
+  it("preserves startedAt across promotion (no clock reset)", async () => {
+    const { tracker, store } = setupTracker()
+    await tracker.handleToolUpdate(makeUpdate({ callID: "c1", status: "running" }))
+    const initial = store.get(subagentTaskID("ses_parent", "c1"))!
+    await new Promise((r) => setTimeout(r, 10))
+    await tracker.handleToolUpdate(
+      makeUpdate({
+        callID: "c1",
+        status: "running",
+        metadata: { sessionId: "ses_child_1" },
+      }),
+    )
+    const promoted = store.get(subagentTaskIDByChildSession("ses_child_1"))!
+    expect(promoted.startedAt).toBe(initial.startedAt)
+  })
+
+  it("IGNORES parent's terminal status when a child session is known (background dispatch)", async () => {
+    const { tracker, store } = setupTracker()
+    await tracker.handleToolUpdate(
+      makeUpdate({
+        callID: "c1",
+        status: "running",
+        metadata: { sessionId: "ses_child_1", run_in_background: true },
+      }),
+    )
+    await tracker.handleToolUpdate(
+      makeUpdate({
+        callID: "c1",
+        status: "completed",
+        metadata: { sessionId: "ses_child_1", run_in_background: true },
+      }),
+    )
+    // Background dispatch returns task_id quickly; the parent's tool
+    // part going completed must NOT settle the subagent — the child is
+    // still working in the background.
+    expect(store.get(subagentTaskIDByChildSession("ses_child_1"))!.status).toBe("running")
+  })
+
+  it("HONORS parent's terminal status for FOREGROUND call_omo_agent even when a child session is known", async () => {
+    // Regression: Hephaestus dispatched Sisyphus via `call_omo_agent`
+    // (foreground), tool.completed arrived with the subagent's result,
+    // but our gate ignored the parent terminal — subagent stuck on
+    // "running" forever, blocking continuation defer indefinitely.
+    const { tracker, store, subscription } = setupTracker()
+    await tracker.handleToolUpdate(
+      makeUpdate({
+        tool: "call_omo_agent",
+        callID: "c1",
+        status: "running",
+        metadata: { sessionId: "ses_child_1", agent: "Sisyphus", category: "quick" },
+      }),
+    )
+    expect(subscription.added).toContain("ses_child_1")
+    await tracker.handleToolUpdate(
+      makeUpdate({
+        tool: "call_omo_agent",
+        callID: "c1",
+        status: "completed",
+        metadata: { sessionId: "ses_child_1", agent: "Sisyphus", category: "quick" },
+      }),
+    )
+    expect(store.get(subagentTaskIDByChildSession("ses_child_1"))!.status).toBe("completed")
+    // Subscription cleanup: late child events would otherwise reopen the row.
+    expect(subscription.removed).toContain("ses_child_1")
+  })
+
+  it("HONORS parent's terminal status when run_in_background is explicitly false", async () => {
+    const { tracker, store } = setupTracker()
+    await tracker.handleToolUpdate(
+      makeUpdate({
+        callID: "c1",
+        status: "running",
+        metadata: { sessionId: "ses_child_2", run_in_background: false },
+      }),
+    )
+    await tracker.handleToolUpdate(
+      makeUpdate({
+        callID: "c1",
+        status: "completed",
+        metadata: { sessionId: "ses_child_2", run_in_background: false },
+      }),
+    )
+    expect(store.get(subagentTaskIDByChildSession("ses_child_2"))!.status).toBe("completed")
+  })
+
+  it("treats the `background_task` tool as background even when no run_in_background metadata is set", async () => {
+    // background_task is omo's pure background dispatcher — always
+    // background by name, regardless of metadata. Parent's tool.completed
+    // returns the task_id immediately while the child keeps working.
+    const { tracker, store } = setupTracker()
+    await tracker.handleToolUpdate(
+      makeUpdate({
+        tool: "background_task",
+        callID: "c1",
+        status: "running",
+        metadata: { sessionId: "ses_child_bg" },
+      }),
+    )
+    await tracker.handleToolUpdate(
+      makeUpdate({
+        tool: "background_task",
+        callID: "c1",
+        status: "completed",
+        metadata: { sessionId: "ses_child_bg" },
+      }),
+    )
+    expect(store.get(subagentTaskIDByChildSession("ses_child_bg"))!.status).toBe("running")
+  })
+
+  it("HONORS parent's terminal status when no child session was ever known", async () => {
+    const { tracker, store } = setupTracker()
+    await tracker.handleToolUpdate(makeUpdate({ callID: "c1", status: "running" }))
+    await tracker.handleToolUpdate(makeUpdate({ callID: "c1", status: "completed" }))
+    // No metadata ever arrived — fall back to legacy behavior so opencode
+    // without omo (or third-party tools that don't publish metadata)
+    // still see their subagents complete.
+    expect(store.get(subagentTaskID("ses_parent", "c1"))!.status).toBe("completed")
+  })
+
+  it("HONORS parent error when no child session known and copies the error message", async () => {
+    const { tracker, store } = setupTracker()
+    await tracker.handleToolUpdate(makeUpdate({ callID: "c1", status: "running" }))
+    await tracker.handleToolUpdate(
+      makeUpdate({ callID: "c1", status: "error", error: "permission denied" }),
+    )
+    const task = store.get(subagentTaskID("ses_parent", "c1"))!
+    expect(task.status).toBe("error")
+    expect(task.error).toBe("permission denied")
+  })
+
+  it("maps an Aborted parent error to cancelled so the popover doesn't flash red on an internal abort", async () => {
+    const { tracker, store } = setupTracker()
+    await tracker.handleToolUpdate(makeUpdate({ callID: "c1", status: "running" }))
+    await tracker.handleToolUpdate(
+      makeUpdate({ callID: "c1", status: "error", error: "Aborted" }),
+    )
+    const task = store.get(subagentTaskID("ses_parent", "c1"))!
+    expect(task.status).toBe("cancelled")
+    expect(task.error).toBeUndefined()
+  })
+
+  it("merges task_id reuse into a single row instead of accumulating dupes", async () => {
+    const { tracker, store, subscription } = setupTracker()
+    // First dispatch — Hephaestus's background-resume pattern: tool flips
+    // to completed quickly while the child keeps working, then the child
+    // emits idle when actually finished.
+    await tracker.handleToolUpdate(
+      makeUpdate({
+        callID: "c1",
+        status: "running",
+        metadata: { sessionId: "ses_child_x", run_in_background: true },
+      }),
+    )
+    await tracker.handleToolUpdate(
+      makeUpdate({
+        callID: "c1",
+        status: "completed",
+        metadata: { sessionId: "ses_child_x", run_in_background: true },
+      }),
+    )
+    // Background dispatch: parent terminal is ignored; the child's own
+    // idle is what settles the task.
+    await tracker.handleChildSessionEvent({ type: "idle", sessionID: "ses_child_x" })
+    expect(store.get(subagentTaskIDByChildSession("ses_child_x"))!.status).toBe("completed")
+    // Second dispatch reuses task_id (Hephaestus pattern) under a NEW callID.
+    await tracker.handleToolUpdate(
+      makeUpdate({
+        callID: "c2",
+        status: "running",
+        metadata: { sessionId: "ses_child_x", run_in_background: true },
+      }),
+    )
+    // Same canonical id; the previous completion is *not* resurrected
+    // (terminal status sticks per AgentTaskStore guard), so we end up
+    // with at most one row per child session. The terminal guard means
+    // the row remains `completed` — which is acceptable: it means we
+    // tracked the resume but stopped counting it as active. The far
+    // worse failure mode was N ghost duplicates per resume.
+    const childTasks = store.list().filter((t) => t.childSessionID === "ses_child_x")
+    expect(childTasks).toHaveLength(1)
+    expect(subscription.added.filter((s) => s === "ses_child_x").length).toBeGreaterThanOrEqual(1)
+  })
+})
+
+describe("SubagentTracker.handleChildSessionEvent", () => {
+  async function bootstrapPromoted(sessionID = "ses_parent") {
+    const { tracker, store, subscription } = setupTracker({ sessionID })
+    await tracker.handleToolUpdate(
+      makeUpdate({
+        callID: "c1",
+        status: "running",
+        metadata: {
+          sessionId: "ses_child_1",
+          agent: "oracle",
+          run_in_background: false,
+        },
+      }),
+    )
+    return { tracker, store, subscription }
+  }
+
+  it("a child `idle` event marks the subagent completed and unregisters the session", async () => {
+    const { tracker, store, subscription } = await bootstrapPromoted()
+    await tracker.handleChildSessionEvent({ type: "idle", sessionID: "ses_child_1" })
+    expect(store.get(subagentTaskIDByChildSession("ses_child_1"))!.status).toBe("completed")
+    expect(subscription.removed).toContain("ses_child_1")
+  })
+
+  it("a child `error` event marks the subagent errored with the message preserved", async () => {
+    const { tracker, store, subscription } = await bootstrapPromoted()
+    await tracker.handleChildSessionEvent({
+      type: "error",
+      sessionID: "ses_child_1",
+      message: "rate limit exceeded",
+    })
+    const task = store.get(subagentTaskIDByChildSession("ses_child_1"))!
+    expect(task.status).toBe("error")
+    expect(task.error).toBe("rate limit exceeded")
+    expect(subscription.removed).toContain("ses_child_1")
+  })
+
+  it("a child `error` event with message 'Aborted' maps to cancelled, not error", async () => {
+    const { tracker, store, subscription } = await bootstrapPromoted()
+    await tracker.handleChildSessionEvent({
+      type: "error",
+      sessionID: "ses_child_1",
+      message: "Aborted",
+    })
+    const task = store.get(subagentTaskIDByChildSession("ses_child_1"))!
+    expect(task.status).toBe("cancelled")
+    expect(task.error).toBeUndefined()
+    expect(subscription.removed).toContain("ses_child_1")
+  })
+
+  it("a child `assistantEnd` carrying an 'Aborted' error also maps to cancelled", async () => {
+    const { tracker, store, subscription } = await bootstrapPromoted()
+    await tracker.handleChildSessionEvent({
+      type: "assistantEnd",
+      sessionID: "ses_child_1",
+      messageID: "msg_1",
+      error: "Aborted",
+    })
+    const task = store.get(subagentTaskIDByChildSession("ses_child_1"))!
+    expect(task.status).toBe("cancelled")
+    expect(task.error).toBeUndefined()
+    expect(subscription.removed).toContain("ses_child_1")
+  })
+
+  it("a child `busy` event keeps an active task on running but never resurrects a terminal one", async () => {
+    const { tracker, store } = await bootstrapPromoted()
+    await tracker.handleChildSessionEvent({ type: "idle", sessionID: "ses_child_1" })
+    // Stray late busy event after settlement — must NOT bounce status back.
+    await tracker.handleChildSessionEvent({ type: "busy", sessionID: "ses_child_1" })
+    expect(store.get(subagentTaskIDByChildSession("ses_child_1"))!.status).toBe("completed")
+  })
+
+  it("an `assistantEnd` event backfills the model when omo metadata didn't carry one", async () => {
+    const { tracker, store, subscription } = setupTracker()
+    // Dispatch without model in metadata.
+    await tracker.handleToolUpdate(
+      makeUpdate({
+        callID: "c1",
+        status: "running",
+        metadata: { sessionId: "ses_child_x", agent: "oracle" },
+      }),
+    )
+    expect(store.get(subagentTaskIDByChildSession("ses_child_x"))!.model).toBeUndefined()
+    await tracker.handleChildSessionEvent({
+      type: "assistantEnd",
+      sessionID: "ses_child_x",
+      messageID: "msg_1",
+      usage: { model: "github-copilot/claude-opus-4.5" },
+    })
+    expect(store.get(subagentTaskIDByChildSession("ses_child_x"))!.model).toEqual({
+      providerID: "github-copilot",
+      modelID: "claude-opus-4.5",
+    })
+    expect(subscription.removed).not.toContain("ses_child_x")
+  })
+
+  it("drops the event silently when no AgentTask exists for that child session", async () => {
+    const { tracker, store } = setupTracker()
+    await tracker.handleChildSessionEvent({ type: "idle", sessionID: "ses_ghost" })
+    expect(store.list()).toEqual([])
+  })
+})
+
+describe("SubagentTracker.reconcile", () => {
+  function mockBackend(statuses: Record<string, { type?: string }>) {
+    return {
+      url: "http://test",
+      directory: "/tmp",
+      configMode: "isolated" as const,
+      client: {
+        session: {
+          status: async () => ({ data: statuses }),
+        },
+      },
+    } as unknown as Parameters<SubagentTracker["reconcile"]>[0]
+  }
+
+  it("marks rows complete when opencode reports their child session idle", async () => {
+    const { tracker, store, subscription } = setupTracker()
+    const seed: AgentTask = {
+      id: subagentTaskIDByChildSession("ses_child_done"),
+      kind: "subagent",
+      conversationID: "conv1",
+      sessionID: "ses_parent",
+      callID: "c1",
+      childSessionID: "ses_child_done",
+      title: "old task",
+      status: "running",
+      startedAt: 1,
+      updatedAt: 1,
+    }
+    await store.upsert(seed)
+    await tracker.reconcile(mockBackend({ ses_child_done: { type: "idle" } }), "ses_parent")
+    expect(store.get(seed.id)!.status).toBe("completed")
+    expect(subscription.added).not.toContain("ses_child_done")
+  })
+
+  it("resumes tracking when opencode reports the child still busy", async () => {
+    const { tracker, store, subscription } = setupTracker()
+    const seed: AgentTask = {
+      id: subagentTaskIDByChildSession("ses_child_busy"),
+      kind: "subagent",
+      conversationID: "conv1",
+      sessionID: "ses_parent",
+      callID: "c1",
+      childSessionID: "ses_child_busy",
+      title: "still working",
+      status: "running",
+      startedAt: 1,
+      updatedAt: 1,
+    }
+    await store.upsert(seed)
+    await tracker.reconcile(mockBackend({ ses_child_busy: { type: "busy" } }), "ses_parent")
+    expect(store.get(seed.id)!.status).toBe("running")
+    expect(subscription.added).toContain("ses_child_busy")
+  })
+
+  it("completes rows whose child session is no longer in /session/status (server forgot)", async () => {
+    const { tracker, store } = setupTracker()
+    const seed: AgentTask = {
+      id: subagentTaskIDByChildSession("ses_gone"),
+      kind: "subagent",
+      conversationID: "conv1",
+      sessionID: "ses_parent",
+      callID: "c1",
+      childSessionID: "ses_gone",
+      title: "vanished",
+      status: "running",
+      startedAt: 1,
+      updatedAt: 1,
+    }
+    await store.upsert(seed)
+    await tracker.reconcile(mockBackend({}), "ses_parent")
+    expect(store.get(seed.id)!.status).toBe("completed")
+  })
+
+  it("skips reconcile for rows whose conversationID does NOT match (cross-conversation safety)", async () => {
+    const { tracker, store } = setupTracker({ conversationID: "conv1" })
+    const seed: AgentTask = {
+      id: subagentTaskIDByChildSession("ses_other_conv"),
+      kind: "subagent",
+      conversationID: "other_conv",
+      sessionID: "ses_parent",
+      callID: "c1",
+      childSessionID: "ses_other_conv",
+      title: "not ours",
+      status: "running",
+      startedAt: 1,
+      updatedAt: 1,
+    }
+    await store.upsert(seed)
+    await tracker.reconcile(mockBackend({ ses_other_conv: { type: "idle" } }), "ses_parent")
+    expect(store.get(seed.id)!.status).toBe("running")
+  })
+})
+
+describe("SubagentTracker tool name gate", () => {
+  it("does not touch the store for unrelated tools", async () => {
+    const { tracker, store } = setupTracker()
+    await tracker.handleToolUpdate(makeUpdate({ tool: "read", callID: "c_read" }))
+    await tracker.handleToolUpdate(makeUpdate({ tool: "grep", callID: "c_grep" }))
+    expect(store.list()).toEqual([])
+  })
+
+  it("does not touch the store before a parent sessionID exists", async () => {
+    const memento = new FakeMemento()
+    const store = new AgentTaskStore(memento)
+    const subscription = new FakeSubscription()
+    const tracker = new SubagentTracker({
+      store,
+      getActiveConversationID: () => "conv1",
+      getParentSessionID: () => undefined,
+      subscription,
+    })
+    await tracker.handleToolUpdate(makeUpdate({ callID: "c1" }))
+    expect(store.list()).toEqual([])
+  })
+
+  it("recognizes every dispatch tool name (task, call_omo_agent, background_task, delegate_task, defensives)", () => {
+    for (const tool of ["task", "Task", "task_tool", "delegate_task", "call_omo_agent", "background_task"]) {
+      expect(SubagentTracker.isSubagentDispatchTool(tool)).toBe(true)
+    }
+    for (const tool of ["read", "edit", "tasks", "background_output", "background_cancel"]) {
+      expect(SubagentTracker.isSubagentDispatchTool(tool)).toBe(false)
+    }
+  })
+})

--- a/test/host/subagent-tracker.test.ts
+++ b/test/host/subagent-tracker.test.ts
@@ -529,6 +529,85 @@ describe("SubagentTracker.reconcile", () => {
   })
 })
 
+describe("SubagentTracker.cancelForSession", () => {
+  it("settles every active subagent for the parent, unregisters child sessions, and returns their IDs", async () => {
+    const { tracker, store, subscription } = setupTracker({ sessionID: "ses_parent" })
+    await tracker.handleToolUpdate(
+      makeUpdate({
+        callID: "c1",
+        status: "running",
+        metadata: { sessionId: "ses_child_a" },
+      }),
+    )
+    await tracker.handleToolUpdate(
+      makeUpdate({
+        callID: "c2",
+        status: "running",
+        metadata: { sessionId: "ses_child_b", run_in_background: true },
+      }),
+    )
+    const aborted = await tracker.cancelForSession("ses_parent")
+    expect(aborted.sort()).toEqual(["ses_child_a", "ses_child_b"])
+    expect(store.get(subagentTaskIDByChildSession("ses_child_a"))!.status).toBe("cancelled")
+    expect(store.get(subagentTaskIDByChildSession("ses_child_b"))!.status).toBe("cancelled")
+    expect(subscription.removed.sort()).toEqual(["ses_child_a", "ses_child_b"])
+  })
+
+  it("clears dispatches so a follow-up event with the same callID does not see a stale entry", async () => {
+    const { tracker, store } = setupTracker({ sessionID: "ses_parent" })
+    await tracker.handleToolUpdate(
+      makeUpdate({
+        callID: "c1",
+        status: "running",
+        metadata: { sessionId: "ses_child_a" },
+      }),
+    )
+    await tracker.cancelForSession("ses_parent")
+    // A late tool-completed event with the same callID should NOT find
+    // a live dispatch — it goes through the "no live dispatch" path and
+    // the terminal guard on the cancelled row blocks resurrection.
+    await tracker.handleToolUpdate(
+      makeUpdate({ callID: "c1", status: "completed", metadata: { sessionId: "ses_child_a" } }),
+    )
+    expect(store.get(subagentTaskIDByChildSession("ses_child_a"))!.status).toBe("cancelled")
+  })
+
+  it("returns an empty list and is a no-op when there are no active subagents", async () => {
+    const { tracker, subscription } = setupTracker({ sessionID: "ses_parent" })
+    const aborted = await tracker.cancelForSession("ses_parent")
+    expect(aborted).toEqual([])
+    expect(subscription.removed).toEqual([])
+  })
+
+  it("leaves subagents under OTHER parent sessions alone (single-conversation scope)", async () => {
+    const { tracker, store, subscription } = setupTracker({ sessionID: "ses_parent" })
+    await tracker.handleToolUpdate(
+      makeUpdate({
+        callID: "c1",
+        status: "running",
+        metadata: { sessionId: "ses_child_a" },
+      }),
+    )
+    // Seed a row owned by a DIFFERENT parent session directly via the store
+    // (we don't have a clean tracker entry point for cross-session seeds).
+    await store.upsert({
+      id: subagentTaskIDByChildSession("ses_other_child"),
+      kind: "subagent",
+      conversationID: "conv1",
+      sessionID: "ses_other_parent",
+      childSessionID: "ses_other_child",
+      title: "elsewhere",
+      status: "running",
+      startedAt: 1,
+      updatedAt: 1,
+    })
+    await tracker.cancelForSession("ses_parent")
+    expect(store.get(subagentTaskIDByChildSession("ses_child_a"))!.status).toBe("cancelled")
+    expect(store.get(subagentTaskIDByChildSession("ses_other_child"))!.status).toBe("running")
+    expect(subscription.removed).toEqual(["ses_child_a"])
+  })
+})
+
 describe("SubagentTracker tool name gate", () => {
   it("does not touch the store for unrelated tools", async () => {
     const { tracker, store } = setupTracker()

--- a/test/webview/statusbar.test.tsx
+++ b/test/webview/statusbar.test.tsx
@@ -270,6 +270,7 @@ describe("AgentsMenu (StatusBar inline popover)", () => {
         title: "Explain this file",
         status: "running" as const,
         startedAt: Date.now() - 12_000,
+        updatedAt: Date.now(),
       },
     ],
   }
@@ -329,6 +330,7 @@ describe("AgentsMenu (StatusBar inline popover)", () => {
               status: "error",
               error: "boom",
               startedAt: 0,
+              updatedAt: 1000,
             },
           ],
         }}
@@ -355,6 +357,7 @@ describe("AgentsMenu (StatusBar inline popover)", () => {
               title: "Refactor module",
               status: "running",
               startedAt: Date.now() - 5_000,
+              updatedAt: Date.now(),
             },
             {
               id: "subagent:s:c1",
@@ -362,6 +365,7 @@ describe("AgentsMenu (StatusBar inline popover)", () => {
               title: "Fix lint errors",
               status: "running",
               startedAt: Date.now() - 2_000,
+              updatedAt: Date.now(),
             },
           ],
         }}
@@ -383,7 +387,7 @@ describe("AgentsMenu (StatusBar inline popover)", () => {
     expect(screen.queryByText("Subagents")).not.toBeInTheDocument()
   })
 
-  it("shows completed subagent rows while the parent is still alive", async () => {
+  it("shows errored subagent rows alongside a running parent", async () => {
     const user = userEvent.setup()
     render(
       <StatusBar
@@ -391,8 +395,8 @@ describe("AgentsMenu (StatusBar inline popover)", () => {
         agentsStatus={{
           running: 1,
           waiting: 0,
-          error: 0,
-          total: 1,
+          error: 1,
+          total: 2,
           tasks: [
             {
               id: "main:c:s",
@@ -400,13 +404,16 @@ describe("AgentsMenu (StatusBar inline popover)", () => {
               title: "Explain this file",
               status: "running",
               startedAt: Date.now() - 12_000,
+              updatedAt: Date.now(),
             },
             {
               id: "subagent:s:c1",
               kind: "subagent",
               title: "Explore codebase patterns",
-              status: "completed",
+              status: "error",
+              error: "search timed out",
               startedAt: Date.now() - 10_000,
+              updatedAt: Date.now() - 5_000,
             },
           ],
         }}
@@ -443,5 +450,148 @@ describe("AgentsMenu (StatusBar inline popover)", () => {
     expect(pill.getAttribute("title")).toMatch(/2 agents running/)
     expect(pill.getAttribute("title")).toMatch(/1 waiting for input/)
     expect(pill.getAttribute("title")).toMatch(/Click to view/)
+  })
+
+  it("renders the subagent slug + prettified model on a subagent row", async () => {
+    const user = userEvent.setup()
+    render(
+      <StatusBar
+        {...baseProps}
+        agentsStatus={{
+          running: 1,
+          waiting: 0,
+          error: 0,
+          total: 1,
+          tasks: [
+            {
+              id: "subagent:child:ses_x",
+              kind: "subagent",
+              title: "Explore auth flow",
+              status: "running",
+              startedAt: Date.now() - 4_000,
+              updatedAt: Date.now(),
+              subagent: "explore",
+              model: { providerID: "github-copilot", modelID: "claude-opus-4.5" },
+            },
+          ],
+        }}
+      />,
+    )
+    await user.click(screen.getByText("Agents"))
+    // formatAgent("explore") → "Explore"; formatModel(...) → "Opus 4.5".
+    // The detail string joins them with " · ".
+    expect(screen.getByText(/Explore · Opus 4\.5/)).toBeInTheDocument()
+  })
+
+  it("prefixes a category label when the dispatch went through a category route", async () => {
+    const user = userEvent.setup()
+    render(
+      <StatusBar
+        {...baseProps}
+        agentsStatus={{
+          running: 1,
+          waiting: 0,
+          error: 0,
+          total: 1,
+          tasks: [
+            {
+              id: "subagent:child:ses_y",
+              kind: "subagent",
+              title: "Deep refactor",
+              status: "running",
+              startedAt: Date.now() - 1_000,
+              updatedAt: Date.now(),
+              subagent: "hephaestus",
+              category: "deep",
+              model: { providerID: "github-copilot", modelID: "gpt-5.5" },
+            },
+          ],
+        }}
+      />,
+    )
+    await user.click(screen.getByText("Agents"))
+    expect(screen.getByText(/category: deep/)).toBeInTheDocument()
+    expect(screen.getByText(/Hephaestus/)).toBeInTheDocument()
+  })
+
+  it("does not render the agent/model detail line when neither is set", async () => {
+    const user = userEvent.setup()
+    render(
+      <StatusBar
+        {...baseProps}
+        agentsStatus={{
+          running: 1,
+          waiting: 0,
+          error: 0,
+          total: 1,
+          tasks: [
+            {
+              id: "subagent:child:ses_z",
+              kind: "subagent",
+              title: "Mystery worker",
+              status: "running",
+              startedAt: Date.now() - 1_000,
+              updatedAt: Date.now(),
+            },
+          ],
+        }}
+      />,
+    )
+    await user.click(screen.getByText("Agents"))
+    expect(screen.getByText("Mystery worker")).toBeInTheDocument()
+    expect(screen.queryByText(/category:/)).not.toBeInTheDocument()
+  })
+
+  it("renders the empty state once every task has settled (popover is not chat history)", async () => {
+    const user = userEvent.setup()
+    render(
+      <StatusBar
+        {...baseProps}
+        // Host filters terminal states out of the wire, so a settled
+        // conversation arrives as an empty tasks array — the popover
+        // shows only what's currently active, never history.
+        agentsStatus={{
+          running: 0,
+          waiting: 0,
+          error: 0,
+          total: 0,
+          tasks: [],
+        }}
+      />,
+    )
+    const pill = screen.getByText("Agents")
+    expect(pill.className).toContain("is-idle")
+    await user.click(pill)
+    expect(screen.getByText("No agents in this chat")).toBeInTheDocument()
+  })
+
+  it("freezes the elapsed time on error rows using updatedAt - startedAt", async () => {
+    const user = userEvent.setup()
+    render(
+      <StatusBar
+        {...baseProps}
+        agentsStatus={{
+          running: 0,
+          waiting: 0,
+          error: 1,
+          total: 1,
+          tasks: [
+            {
+              id: "subagent:child:ses_err",
+              kind: "subagent",
+              title: "Failed subagent",
+              status: "error",
+              error: "boom",
+              startedAt: 1_000,
+              updatedAt: 13_000, // 12s elapsed regardless of when the popover renders
+            },
+          ],
+        }}
+      />,
+    )
+    await user.click(screen.getByText("Agents"))
+    // Meta line reads "error · boom · 12s" — the row freezes the
+    // duration so opening the popover later still says "12s".
+    expect(screen.getByText(/error · boom · 12s/)).toBeInTheDocument()
   })
 })

--- a/webview/src/components/StatusBar.tsx
+++ b/webview/src/components/StatusBar.tsx
@@ -70,8 +70,6 @@ export function StatusBar({
         title={statusTitle}
       />
       <div className="spacer" />
-      <AgentsMenu status={agentsStatus} />
-      <div className="spacer" />
       <SelectorMenu
         agent={agent}
         model={model}
@@ -80,6 +78,7 @@ export function StatusBar({
         onSelectModel={onSelectModel}
         onSelectVariant={onSelectVariant}
       />
+      <AgentsMenu status={agentsStatus} />
       <button
         type="button"
         className="new-chat-trigger"
@@ -295,10 +294,11 @@ function ChatHistoryMenu({
 }
 
 /**
- * Always-visible `Agents` menu centered in the chat header. The host scopes
- * the snapshot to the active conversation, so `tasks` only contains work for
- * THIS chat. Clicking the pill toggles an inline popover (matching the
- * SelectorMenu pattern) that lists tasks grouped by Main / Subagents.
+ * Always-visible `Agents` menu in the chat header, sitting between the
+ * Model/Agent selector and the new-chat button. The host scopes the snapshot
+ * to the active conversation, so `tasks` only contains work for THIS chat.
+ * Clicking the pill toggles an inline popover (matching the SelectorMenu
+ * pattern) that lists tasks grouped by Main / Subagents.
  *
  * The pill text never changes (always literally `Agents`); state is signalled
  * by color — muted when idle, breathing green while running, attention red
@@ -358,21 +358,25 @@ function AgentsMenu({ status }: { status?: AgentsStatusInfo }) {
         <div className="agents-popover" role="menu">
           <div className="agents-popover-title">Agents in this chat</div>
           {empty && <div className="agents-popover-empty">No agents in this chat</div>}
-          {main.length > 0 && (
-            <>
-              <div className="agents-popover-section">Main</div>
-              {main.map((task) => (
-                <AgentsRow key={task.id} task={task} />
-              ))}
-            </>
-          )}
-          {sub.length > 0 && (
-            <>
-              <div className="agents-popover-section">Subagents</div>
-              {sub.map((task) => (
-                <AgentsRow key={task.id} task={task} />
-              ))}
-            </>
+          {!empty && (
+            <div className="agents-popover-scroll">
+              {main.length > 0 && (
+                <>
+                  <div className="agents-popover-section">Main</div>
+                  {main.map((task) => (
+                    <AgentsRow key={task.id} task={task} />
+                  ))}
+                </>
+              )}
+              {sub.length > 0 && (
+                <>
+                  <div className="agents-popover-section">Subagents</div>
+                  {sub.map((task) => (
+                    <AgentsRow key={task.id} task={task} />
+                  ))}
+                </>
+              )}
+            </div>
           )}
         </div>
       )}
@@ -381,20 +385,41 @@ function AgentsMenu({ status }: { status?: AgentsStatusInfo }) {
 }
 
 function AgentsRow({ task }: { task: AgentsTaskInfo }) {
+  const isLive = task.status === "running" || task.status === "waiting"
   const [now, setNow] = useState(() => Date.now())
   useEffect(() => {
-    if (task.status !== "running" && task.status !== "waiting") return
+    if (!isLive) return
     const handle = window.setInterval(() => setNow(Date.now()), 1000)
     return () => window.clearInterval(handle)
-  }, [task.status])
-  const elapsed = formatElapsed(now - task.startedAt)
+  }, [isLive])
+  // Live rows tick `now` for a moving stopwatch. Terminal rows freeze
+  // the elapsed at the store's `updatedAt` so a completed subagent
+  // shows its true total runtime, not "minutes since the popover
+  // happened to render".
+  const elapsedMs = isLive ? now - task.startedAt : task.updatedAt - task.startedAt
+  const elapsed = formatElapsed(elapsedMs)
   const statusText = task.status === "error" && task.error
     ? `error · ${task.error}`
     : task.status
+  // Build the per-subagent "agent · model" sublabel from the metadata
+  // omo writes on dispatch (`update.metadata` → AgentTask). Either piece
+  // can be missing — opencode's built-in task tool doesn't publish a
+  // model — so we render whatever subset is present.
+  const subagentLabel = task.subagent ? formatAgent(task.subagent) : undefined
+  const modelLabel = task.model ? formatModel(`${task.model.providerID}/${task.model.modelID}`) : undefined
+  const categoryLabel = task.category && task.category !== task.subagent ? task.category : undefined
+  const detailParts = [
+    categoryLabel ? `category: ${categoryLabel}` : undefined,
+    subagentLabel,
+    modelLabel,
+  ].filter((part): part is string => Boolean(part))
+  const detail = detailParts.length > 0 ? detailParts.join(" · ") : undefined
+  const tooltip = [task.title, statusText, elapsed, detail].filter(Boolean).join(" · ")
   return (
-    <div className={`agents-row agents-row-${task.status}`} title={`${task.title} · ${statusText} · ${elapsed}`}>
+    <div className={`agents-row agents-row-${task.status}`} title={tooltip}>
       <span className="agents-row-title">{task.title}</span>
       <span className="agents-row-meta">{statusText} · {elapsed}</span>
+      {detail && <span className="agents-row-detail">{detail}</span>}
     </div>
   )
 }

--- a/webview/src/protocol.ts
+++ b/webview/src/protocol.ts
@@ -158,15 +158,36 @@ export type AgentsTaskInfo = {
   kind: "main" | "subagent"
   title: string
   /**
-   * `completed` is included so the popover can show subagents from the
-   * current turn that finished BEFORE the parent's prose finished. The
-   * counts (`running` / `waiting` / `error` in the parent
-   * `AgentsStatusInfo`) still only reflect live work — `completed`
-   * subagents do not bump those numbers.
+   * Only currently-active states reach the wire. The host filters out
+   * `completed` / `cancelled` in `summarizeAgentTasks` so the popover
+   * reflects "what's happening right now," not a per-chat history.
+   * `error` is kept because it needs attention until cleared.
    */
-  status: "running" | "waiting" | "error" | "completed"
+  status: "running" | "waiting" | "error"
   error?: string
   startedAt: number
+  /**
+   * Last state-change timestamp. For terminal rows this is the
+   * effective endedAt — the AgentsRow uses `updatedAt - startedAt` to
+   * render a frozen total runtime instead of "X seconds since the row
+   * mounted". For live rows this just keeps refreshing; the live
+   * elapsed display ticks off `Date.now()` instead.
+   */
+  updatedAt: number
+  /**
+   * Subagent slug (`explore` / `librarian` / `oracle` / `hephaestus` /
+   * `prometheus` / …). Set only for subagent rows where omo's tool
+   * metadata surfaced it; main-agent rows leave this undefined because
+   * the StatusBar already displays the user's primary agent next to
+   * the model selector.
+   */
+  subagent?: string
+  /** Category slug like `deep`, `quick`, `ultrabrain` when the
+   * subagent was dispatched via category-based routing. */
+  category?: string
+  /** Resolved model — same shape opencode reports on the assistant
+   * message; the StatusBar will prettify it through `formatModel`. */
+  model?: { providerID: string; modelID: string }
 }
 
 /**

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -170,12 +170,13 @@ button {
 }
 
 /* ===== AgentsMenu =====
-   Hidden-by-default text-only pill that surfaces live main-agent + subagent
-   activity. Sits between the connection dot and the model/agent selector.
-   While at least one task is running, the text breathes via a 1.6s opacity +
-   green color animation. Waiting / error states use a steady amber / red
-   foreground without animation. Clicking opens an inline popover scoped to
-   the current chat (`.agents-popover`). */
+   Always-visible text-only pill that surfaces live main-agent + subagent
+   activity. Sits between the model/agent selector and the new-chat (+)
+   button on the right side of the chat header. While at least one task is
+   running, the text breathes via a 1.6s opacity + green color animation.
+   Waiting / error states use a steady amber / red foreground without
+   animation. Clicking opens an inline popover scoped to the current chat
+   (`.agents-popover`). */
 .agents-menu {
   position: relative;
   flex: 0 0 auto;
@@ -234,7 +235,12 @@ button {
 .agents-popover {
   position: absolute;
   top: calc(100% + 6px);
-  left: -4px;
+  /* Anchor the popover's right edge to the pill so it grows leftward.
+     With the pill sitting next to the new-chat (+) button on the right
+     side of the header, a left-anchored popover (min-width 260px) would
+     overflow the sidebar's right edge — especially in narrow side
+     panels. Growing leftward keeps the popover inside the panel. */
+  right: -4px;
   min-width: 260px;
   max-width: 360px;
   background: var(--vscode-dropdown-background, var(--vscode-editorWidget-background));
@@ -245,6 +251,21 @@ button {
   padding: 8px 0;
   z-index: 50;
   font-size: 12px;
+  /* Cap how tall the popover can grow before scrolling — without this a
+     long-running Hephaestus session can produce 20+ historical
+     subagents and the popover would otherwise stretch off the
+     bottom of the chat view. The header sticks in place; only the
+     list scrolls (see `.agents-popover-scroll` below). */
+  display: flex;
+  flex-direction: column;
+  max-height: min(420px, calc(100vh - 80px));
+  overflow: hidden;
+}
+.agents-popover-scroll {
+  overflow-y: auto;
+  min-height: 0;
+  /* Subtle scrollbar to match VS Code; falls back to system default. */
+  scrollbar-width: thin;
 }
 .agents-popover-title {
   padding: 0 12px 6px;
@@ -280,6 +301,17 @@ button {
   font-size: 11px;
   text-overflow: ellipsis;
   overflow: hidden;
+}
+/* Per-subagent "agent slug · model name" sub-label. Renders only when
+   omo's tool metadata gave us something to show; main-agent rows leave
+   it undefined because the StatusBar already shows the user's primary
+   agent + model next to the selector. */
+.agents-row-detail {
+  opacity: 0.5;
+  font-size: 10.5px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  font-variant-numeric: tabular-nums;
 }
 .agents-row-running .agents-row-title { color: #7ee787; }
 .agents-row-error .agents-row-meta { color: var(--vscode-errorForeground, #f85149); }


### PR DESCRIPTION
## Summary

- Extracts the subagent state machine from `view.ts` into a dedicated
  `SubagentTracker` (`src/agents/subagent-tracker.ts`) that subscribes
  to child-session SSE events and re-keys tasks by child sessionID, so
  Hephaestus's task_id-reuse collapses into one row instead of
  accumulating dupes.
- **The headline bug**: foreground dispatches (opencode's built-in
  `task`, `call_omo_agent` for Hephaestus -> Sisyphus deep agents)
  were getting stuck on `running` forever. `handleToolUpdate` ignored
  the parent's terminal status for *any* dispatch with a known child
  sessionID, even though the comment's intent was background-only.
  Tightening the gate to `runInBackground === true` (or tool ===
  `background_task`) lets the parent's terminal flip authoritatively
  settle foreground subagents — which in turn unblocks the
  continuation defer that had `subagents=1` repeating in the logs.
- Adds `reconcile()` at `attachSubscription` time so subagent rows
  that survive a VS Code reload settle (or resume tracking) against
  `/session/status`, instead of lingering as ghost "running" rows.
- `classifyTerminal()` (shared helper) maps a literal `"Aborted"` to
  `cancelled` at every terminal write site, mirroring the chat-bubble
  convention so internal aborts don't flash the popover red.
- Subscription cleanup: `removeChildSession()` fires on
  parent-terminal settlement so we stop routing stale child events.
- **UI**: relocate the Agents pill to sit between the Model/Agent
  selector and the new-chat (+) button. Popover anchors on the right
  (`right: -4px`) so it grows leftward, keeping it inside the sidebar
  on narrow side panels.

## Test plan

- [x] `bun run test` — 699/699 pass, includes 3 new regression tests
  for the foreground-stuck-running case (`HONORS parent's terminal
  status for FOREGROUND call_omo_agent…`, explicit `run_in_background:
  false` path, and `background_task` tool-name fallback).
- [x] `bun run check-types` — clean.
- [x] `cd webview && bunx tsc --noEmit` — three pre-existing errors
  in `App.tsx` / `MessageView.tsx` only (unchanged from main).
- [ ] Manual: run a Hephaestus -> Sisyphus dispatch in a real workspace
  and confirm the Agents pill / popover settle when the parent's
  response completes.
- [ ] Manual: confirm the Agents pill's popover doesn't overflow the
  side panel after the relocation.

Closes #148