### PR TITLE
feat(review): trustworthy Review Panel with subagent attribution and safe undo

### DIFF
--- a/src/agents/subagent-tracker.ts
+++ b/src/agents/subagent-tracker.ts
@@ -1,6 +1,6 @@
 import { log } from "../output"
 import type { Backend } from "../server"
-import type { ChildSessionEvent, ToolUpdate } from "../chat/stream"
+import type { ChildSessionEvent, ChildSessionInfo, ToolUpdate } from "../chat/stream"
 import {
   type AgentTask,
   type AgentTaskModel,
@@ -131,8 +131,18 @@ export class SubagentTracker {
     }
     const conversationID = this.getConversationID()
     const meta = readMetadata(update.metadata)
+    // Opencode's built-in `task` tool puts the agent slug into
+    // `input.subagent_type` rather than `metadata.agent`, so fall back to
+    // the input when omo-style metadata is missing.
+    if (!meta.subagent && update.input && typeof update.input === "object") {
+      const input = update.input as Record<string, unknown>
+      const fromInput =
+        readStr(input.subagent_type) ?? readStr(input.subagent) ?? readStr(input.agent)
+      if (fromInput) meta.subagent = fromInput
+    }
 
     let dispatch = this.dispatches.get(update.callID)
+    const isFirstSighting = !dispatch
     if (!dispatch) {
       // First sighting of this callID — pre-register with the callID-based
       // identity. The promote step below moves it to the child-session
@@ -146,6 +156,22 @@ export class SubagentTracker {
 
     if (meta.childSessionID && !dispatch.childSessionID) {
       dispatch = await this.promoteToChildSessionIdentity(dispatch, meta.childSessionID, parentSessionID)
+    }
+
+    // If this is the FIRST tool event for a callID AND we have no
+    // metadata.sessionId yet (opencode's built-in `task` tool path), check
+    // whether `registerChildSession` already created an unclaimed placeholder
+    // for a child whose `parentID` matches us. If exactly one orphan exists,
+    // it MUST belong to this dispatch — opencode dispatches subagents
+    // serially within a single tool call, so a unique unclaimed child plus a
+    // unique fresh dispatch is an unambiguous link. Merging them here
+    // prevents the duplicate row the user reported (one keyed by callID,
+    // one keyed by child sessionID).
+    if (isFirstSighting && !dispatch.childSessionID) {
+      const orphanChildID = this.findOrphanChildSessionID(parentSessionID)
+      if (orphanChildID) {
+        dispatch = await this.promoteToChildSessionIdentity(dispatch, orphanChildID, parentSessionID)
+      }
     }
 
     const now = Date.now()
@@ -309,6 +335,80 @@ export class SubagentTracker {
         }
         return
     }
+  }
+
+  /**
+   * Called when the SSE layer discovered a new child session for our parent
+   * via `session.created` / `session.updated`. Creates a placeholder
+   * AgentTask if we don't already have one for this child — this is the
+   * fallback for cases where the parent's task tool doesn't surface
+   * `metadata.sessionId` (opencode's built-in `task` tool, for one). When
+   * the parent's tool metadata DOES arrive later, the existing record gets
+   * merged with the richer info.
+   */
+  async registerChildSession(info: ChildSessionInfo): Promise<void> {
+    const parentSessionID = this.getParentSessionID()
+    if (!parentSessionID) return
+    if (info.parentID !== parentSessionID) return
+    const conversationID = this.getConversationID()
+    const taskID = subagentTaskIDByChildSession(info.id)
+    const existing = this.store.get(taskID)
+    const now = Date.now()
+    if (existing) {
+      // Already known — refresh updatedAt only.
+      await this.store.update(taskID, { updatedAt: now })
+      return
+    }
+    // If the parent's `task` tool dispatch already created a callID-keyed row
+    // and is sitting waiting on a child sessionID, promote it now rather than
+    // creating a second row. The "exactly one unclaimed dispatch" guard
+    // mirrors `handleToolUpdate`'s claim logic — serial dispatch means a
+    // unique unclaimed dispatch must be this child.
+    const orphanDispatch = this.findOrphanDispatch()
+    if (orphanDispatch) {
+      await this.promoteToChildSessionIdentity(orphanDispatch, info.id, parentSessionID)
+      return
+    }
+    await this.store.upsert({
+      id: taskID,
+      kind: "subagent",
+      conversationID,
+      sessionID: parentSessionID,
+      childSessionID: info.id,
+      title: info.title?.trim() ? info.title.trim() : "Subagent",
+      status: "running",
+      startedAt: now,
+      updatedAt: now,
+    })
+  }
+
+  /**
+   * Find a callID-based dispatch that hasn't been linked to a child session
+   * yet. Returns one only when EXACTLY one orphan exists — ambiguous cases
+   * (parallel subagent fan-out) skip the claim and let the metadata-based
+   * path settle them later when sessionId publishing eventually happens.
+   */
+  private findOrphanDispatch(): DispatchState | undefined {
+    const orphans = [...this.dispatches.values()].filter((d) => !d.childSessionID)
+    return orphans.length === 1 ? orphans[0] : undefined
+  }
+
+  /**
+   * Find a `registerChildSession`-created placeholder task (kind=subagent,
+   * has childSessionID, no callID, still active) belonging to `parentSessionID`.
+   * Used by `handleToolUpdate` to merge with a discovery placeholder rather
+   * than creating a duplicate callID-keyed row.
+   */
+  private findOrphanChildSessionID(parentSessionID: string): string | undefined {
+    const candidates = this.store.list().filter(
+      (t) =>
+        t.kind === "subagent" &&
+        t.sessionID === parentSessionID &&
+        !!t.childSessionID &&
+        !t.callID &&
+        (t.status === "running" || t.status === "waiting"),
+    )
+    return candidates.length === 1 ? candidates[0]!.childSessionID : undefined
   }
 
   /**

--- a/src/chat/diff.ts
+++ b/src/chat/diff.ts
@@ -1,6 +1,6 @@
 import * as path from "path"
 import type { ReviewChange } from "../protocol"
-import { normalizePath, unique } from "./paths"
+import { reviewKey as sharedReviewKey } from "../../webview/src/review-extract"
 
 export type ReviewDiffLine = {
   text: string
@@ -14,6 +14,27 @@ export type ReviewDiffHunk = {
   anchorText: string
   oldText: string
   newText: string
+  /**
+   * 1-based starting line in the ORIGINAL file (`-X,Y` of the hunk header).
+   * `0` for created-file hunks where the original side is empty.
+   */
+  oldStart: number
+  oldCount: number
+  /**
+   * 1-based starting line in the NEW (post-change) file (`+A,B` of the
+   * header). `0` for deleted-file hunks where the new side is empty.
+   */
+  newStart: number
+  newCount: number
+  /** Context lines that precede the +/-/space block, used as a secondary anchor. */
+  leadingContext: string[]
+  /** Context lines that follow the change, used as a secondary anchor. */
+  trailingContext: string[]
+  /**
+   * True when we have enough information to reconstruct the original state.
+   * False for malformed hunks (no @@ header parsed) — the UI hides Undo for
+   * those rather than letting it silently fail.
+   */
   reversible: boolean
 }
 
@@ -39,6 +60,26 @@ export function countDiff(patch: string, prefix: "+" | "-") {
     .length
 }
 
+const HUNK_HEADER_RE = /^@@\s+-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s+@@/
+
+export function parseHunkHeader(header: string): {
+  oldStart: number
+  oldCount: number
+  newStart: number
+  newCount: number
+} | undefined {
+  const match = HUNK_HEADER_RE.exec(header)
+  if (!match) return undefined
+  const oldStart = Number(match[1])
+  const oldCount = match[2] !== undefined ? Number(match[2]) : 1
+  const newStart = Number(match[3])
+  const newCount = match[4] !== undefined ? Number(match[4]) : 1
+  if (Number.isNaN(oldStart) || Number.isNaN(oldCount) || Number.isNaN(newStart) || Number.isNaN(newCount)) {
+    return undefined
+  }
+  return { oldStart, oldCount, newStart, newCount }
+}
+
 export function splitReviewDiff(patch: string): { hunks: ReviewDiffHunk[] } {
   const lines = patch.split("\n")
   const hunks: ReviewDiffHunk[] = []
@@ -59,7 +100,13 @@ export function splitReviewDiff(patch: string): { hunks: ReviewDiffHunk[] } {
       index += 1
     }
 
-    const { oldText, newText, anchorText } = hunkText(hunkLines)
+    const { oldText, newText, anchorText, leadingContext, trailingContext } = hunkText(hunkLines)
+    const headerInfo = parseHunkHeader(hunkHeader) ?? {
+      oldStart: 0,
+      oldCount: 0,
+      newStart: 0,
+      newCount: 0,
+    }
     hunks.push({
       id: `${hunks.length}-${hunkHeader}`,
       header: hunkHeader,
@@ -67,7 +114,13 @@ export function splitReviewDiff(patch: string): { hunks: ReviewDiffHunk[] } {
       anchorText,
       oldText,
       newText,
-      reversible: true,
+      oldStart: headerInfo.oldStart,
+      oldCount: headerInfo.oldCount,
+      newStart: headerInfo.newStart,
+      newCount: headerInfo.newCount,
+      leadingContext,
+      trailingContext,
+      reversible: HUNK_HEADER_RE.test(hunkHeader),
     })
   }
 
@@ -79,6 +132,12 @@ export function splitReviewDiff(patch: string): { hunks: ReviewDiffHunk[] } {
       anchorText: firstReviewAnchor(diffLines(patch), patch),
       oldText: "",
       newText: "",
+      oldStart: 0,
+      oldCount: 0,
+      newStart: 0,
+      newCount: 0,
+      leadingContext: [],
+      trailingContext: [],
       reversible: false,
     })
   }
@@ -89,25 +148,34 @@ export function splitReviewDiff(patch: string): { hunks: ReviewDiffHunk[] } {
 export function hunkText(lines: string[]) {
   const oldLines: string[] = []
   const newLines: string[] = []
+  const leadingContext: string[] = []
+  const trailingContext: string[] = []
+  let sawChange = false
   const diff = diffLines(lines.join("\n"))
   for (const line of lines) {
     if (line.startsWith("\\ No newline")) continue
     if (line.startsWith("+") && !line.startsWith("+++")) {
+      sawChange = true
       newLines.push(line.slice(1))
       continue
     }
     if (line.startsWith("-") && !line.startsWith("---")) {
+      sawChange = true
       oldLines.push(line.slice(1))
       continue
     }
     const text = line.startsWith(" ") ? line.slice(1) : line
     oldLines.push(text)
     newLines.push(text)
+    if (!sawChange) leadingContext.push(text)
+    else trailingContext.push(text)
   }
   return {
     oldText: oldLines.join("\n"),
     newText: newLines.join("\n"),
     anchorText: firstReviewAnchor(diff, newLines.join("\n")),
+    leadingContext,
+    trailingContext,
   }
 }
 
@@ -150,19 +218,98 @@ export function reviewLineText(line: ReviewDiffLine) {
 }
 
 export function reviewKey(change: ReviewChange, hunkID: string) {
-  return `${change.source}:${normalizePath(change.path)}:${hunkID}`
+  // Delegate to the shared helper so host + webview agree byte-for-byte.
+  return sharedReviewKey(change, hunkID)
 }
 
-export function findHunkText(current: string, value: string): { start: number; end: number } | undefined {
-  const candidates = unique([
+/**
+ * Locate where a hunk's `newText` lives in the current file content, returning
+ * `{ start, end }` byte offsets into `current` so the caller can replace it
+ * with `oldText`.
+ *
+ * Strategy, in order of preference:
+ *   1. Line-number anchor from the hunk header (`+A,B`). Defends against the
+ *      repeated-identical-text-block case — every hunk has a distinct line
+ *      number, even if the surrounding text is identical.
+ *   2. Unique substring match. If `newText` appears exactly once in the file
+ *      we trust that location. Multiple occurrences = ambiguous → conflict.
+ *
+ * Returns `undefined` when no safe location can be determined.
+ */
+export function findHunkInFile(
+  current: string,
+  hunk: Pick<ReviewDiffHunk, "newText" | "newStart" | "newCount" | "leadingContext" | "trailingContext">,
+): { start: number; end: number } | undefined {
+  // Primary: line-anchored exact match. We try a few variants because opencode
+  // and the editor may disagree on trailing-newline normalization.
+  if (hunk.newStart > 0) {
+    const startOffset = lineToByteOffset(current, hunk.newStart - 1)
+    for (const candidate of newlineCandidates(hunk.newText)) {
+      if (current.slice(startOffset, startOffset + candidate.length) === candidate) {
+        return { start: startOffset, end: startOffset + candidate.length }
+      }
+    }
+  }
+
+  // Empty value preserves the legacy `findHunkText` semantics.
+  if (hunk.newText === "") {
+    return { start: 0, end: 0 }
+  }
+
+  // Secondary: unique substring match. Multiple occurrences = ambiguous.
+  for (const candidate of newlineCandidates(hunk.newText)) {
+    if (candidate.length === 0) continue
+    const first = current.indexOf(candidate)
+    if (first < 0) continue
+    const second = current.indexOf(candidate, first + 1)
+    if (second >= 0) {
+      // Ambiguous — only safe to act when newStart anchor already nailed it,
+      // which it didn't (we'd have returned above). Give up rather than
+      // mutating the wrong occurrence.
+      return undefined
+    }
+    return { start: first, end: first + candidate.length }
+  }
+  return undefined
+}
+
+function newlineCandidates(value: string): string[] {
+  return uniqueStrings([
     value,
     value.endsWith("\n") ? value.slice(0, -1) : `${value}\n`,
     value.replace(/\r?\n/g, "\r\n"),
-  ]).filter((candidate) => candidate.length > 0)
-  for (const candidate of candidates) {
-    const start = current.indexOf(candidate)
-    if (start >= 0) return { start, end: start + candidate.length }
+  ])
+}
+
+function uniqueStrings(items: string[]): string[] {
+  return [...new Set(items)]
+}
+
+function lineToByteOffset(text: string, lineIndex: number): number {
+  if (lineIndex <= 0) return 0
+  let count = 0
+  let offset = 0
+  while (count < lineIndex) {
+    const idx = text.indexOf("\n", offset)
+    if (idx < 0) return text.length
+    offset = idx + 1
+    count++
   }
-  if (value.length === 0) return { start: 0, end: 0 }
-  return undefined
+  return offset
+}
+
+/**
+ * Legacy entry point — preserves the (current, value) signature used by older
+ * callers and tests. Now adds an ambiguity guard: the old `indexOf`-based
+ * implementation silently picked the first match even when multiple identical
+ * blocks existed, which was the root cause of "Undo mangled the wrong copy."
+ */
+export function findHunkText(current: string, value: string): { start: number; end: number } | undefined {
+  return findHunkInFile(current, {
+    newText: value,
+    newStart: 0,
+    newCount: value === "" ? 0 : value.split("\n").length,
+    leadingContext: [],
+    trailingContext: [],
+  })
 }

--- a/src/chat/fs-ops.ts
+++ b/src/chat/fs-ops.ts
@@ -1,8 +1,8 @@
 import * as vscode from "vscode"
 import * as path from "path"
-import type { ReviewHunkState } from "../protocol"
+import type { ReviewChange, ReviewHunkState } from "../protocol"
 import { stripWorkspaceFolderPrefix, normalizePath } from "./paths"
-import { findHunkText } from "./diff"
+import { findHunkInFile, findHunkText, type ReviewDiffHunk } from "./diff"
 
 const SHELL_LANGS = new Set([
   "bash", "sh", "shell", "shellscript", "zsh", "fish", "powershell", "ps", "ps1", "bat", "cmd",
@@ -36,13 +36,13 @@ export async function applyCode(code: string, language?: string) {
   await vscode.workspace.applyEdit(edit)
 }
 
-export async function openFile(relPath: string) {
-  const doc = await openFileDocument(relPath)
+export async function openFile(relPath: string, root?: string) {
+  const doc = await openFileDocument(relPath, root)
   await vscode.window.showTextDocument(doc)
 }
 
-export async function openFileDocument(relPath: string) {
-  const uri = await workspaceFileUri(relPath)
+export async function openFileDocument(relPath: string, root?: string) {
+  const uri = await workspaceFileUri(relPath, root)
   return vscode.workspace.openTextDocument(uri)
 }
 
@@ -51,15 +51,15 @@ export function visibleReviewDocument(relPath: string) {
   return vscode.window.visibleTextEditors.find((editor) => uris.has(editor.document.uri.toString()))?.document
 }
 
-export async function workspaceFileUri(relPath: string) {
-  const existing = await existingWorkspaceFileUri(relPath)
+export async function workspaceFileUri(relPath: string, root?: string) {
+  const existing = await existingWorkspaceFileUri(relPath, root)
   if (existing) return existing
-  const candidates = workspaceFileUriCandidates(relPath)
+  const candidates = workspaceFileUriCandidates(relPath, root)
   return candidates.find((c) => c.preferIfMissing)?.uri ?? candidates[0]?.uri ?? vscode.Uri.file(relPath)
 }
 
-export async function existingWorkspaceFileUri(relPath: string): Promise<vscode.Uri | undefined> {
-  for (const { uri } of workspaceFileUriCandidates(relPath)) {
+export async function existingWorkspaceFileUri(relPath: string, root?: string): Promise<vscode.Uri | undefined> {
+  for (const { uri } of workspaceFileUriCandidates(relPath, root)) {
     try {
       await vscode.workspace.fs.stat(uri)
       return uri
@@ -70,15 +70,27 @@ export async function existingWorkspaceFileUri(relPath: string): Promise<vscode.
   return undefined
 }
 
-export async function reviewPathExists(relPath: string): Promise<boolean> {
-  return !!(await existingWorkspaceFileUri(relPath))
+export async function reviewPathExists(relPath: string, root?: string): Promise<boolean> {
+  return !!(await existingWorkspaceFileUri(relPath, root))
 }
 
-export function workspaceFileUriCandidates(relPath: string): Array<{ uri: vscode.Uri; preferIfMissing?: boolean }> {
+/**
+ * Resolve `relPath` against either:
+ *   - the explicit `root` hint (when the host has the opencode `backend.directory` —
+ *     ALL changes from one session share this root, so the hint disambiguates
+ *     between VS Code workspace folders that happen to contain identically-named
+ *     files), or
+ *   - every workspace folder, in order, as the fallback.
+ *
+ * Passing `root` is what keeps multi-root setups from accidentally targeting
+ * the wrong copy of `src/index.ts` when both root A and root B have one.
+ */
+export function workspaceFileUriCandidates(
+  relPath: string,
+  root?: string,
+): Array<{ uri: vscode.Uri; preferIfMissing?: boolean }> {
   if (path.isAbsolute(relPath)) return [{ uri: vscode.Uri.file(relPath) }]
   const normalized = normalizePath(relPath)
-  const workspaces = vscode.workspace.workspaceFolders ?? []
-  if (!workspaces.length) return [{ uri: vscode.Uri.file(relPath) }]
   const candidates: Array<{ uri: vscode.Uri; preferIfMissing?: boolean }> = []
   const seen = new Set<string>()
   const add = (uri: vscode.Uri, preferIfMissing = false) => {
@@ -87,11 +99,22 @@ export function workspaceFileUriCandidates(relPath: string): Array<{ uri: vscode
     seen.add(key)
     candidates.push({ uri, preferIfMissing })
   }
+  if (root) {
+    // Anchor to the opencode backend's directory first — this is the
+    // unambiguous answer for any change produced in that session.
+    const rootUri = vscode.Uri.file(root)
+    add(joinUriPath(rootUri, normalized))
+    const stripped = stripWorkspaceFolderPrefix(root, normalized)
+    if (stripped) add(joinUriPath(rootUri, stripped), true)
+  }
+  const workspaces = vscode.workspace.workspaceFolders ?? []
+  if (!workspaces.length && !candidates.length) return [{ uri: vscode.Uri.file(relPath) }]
   for (const ws of workspaces) {
     add(joinUriPath(ws.uri, normalized))
     const stripped = stripWorkspaceFolderPrefix(ws.uri.fsPath, normalized)
     if (stripped) add(joinUriPath(ws.uri, stripped), true)
   }
+  if (!candidates.length) return [{ uri: vscode.Uri.file(relPath) }]
   return candidates
 }
 
@@ -99,37 +122,263 @@ function joinUriPath(base: vscode.Uri, relPath: string) {
   return vscode.Uri.joinPath(base, ...relPath.split("/").filter(Boolean))
 }
 
+export type ReviewHunkOutcome =
+  | { status: "applied" }
+  | { status: "no-op"; reason: string }
+  | { status: "conflict"; reason: string }
+  | { status: "missing"; reason: string }
+  | { status: "unsupported"; reason: string }
+
 /**
- * Apply or revert a single review hunk in `relPath`. For "accepted" we just
- * mark it (no file change — opencode already applied it). For "rejected" we
- * locate `newText` in the current file content and replace it with `oldText`.
+ * Execute Keep or Undo for one hunk of one change. Replaces the old
+ * `reviewHunk(path, action, oldText, newText)` API; callers now hand over the
+ * full `change` + `hunk` so we can:
+ *
+ *   - Distinguish create / delete / move / update kinds and undo each safely
+ *     (creating files come back via fs.delete; deleting come back via fs.write
+ *     with the original content).
+ *   - Anchor undo on the hunk's `+A,B` line numbers, preventing the
+ *     "identical text blocks → wrong occurrence got modified" failure mode
+ *     that the old `current.indexOf(newText)` implementation had.
+ *   - Verify Keep against the expected post-change state — if the file has
+ *     drifted (user edited it, another tool clobbered it) we surface a
+ *     conflict instead of silently accepting and dropping the row from the
+ *     review card.
+ *
+ * Returns a structured outcome. The caller decides whether to record the
+ * hunk as `accepted` / `rejected` only when the action actually landed; on
+ * conflict we leave the row pending and surface a warning so the user can
+ * inspect.
  */
 export async function reviewHunk(
-  relPath: string,
+  change: ReviewChange,
+  hunk: ReviewDiffHunk,
   action: ReviewHunkState,
-  oldText: string,
-  newText: string,
-  silent = false,
-): Promise<boolean> {
-  if (action === "accepted") return true
-  const uri = await workspaceFileUri(relPath)
-  const doc = await vscode.workspace.openTextDocument(uri)
-  const current = doc.getText()
-  const match = findHunkText(current, newText)
-  if (!match) {
-    if (!silent) {
-      vscode.window.showWarningMessage(`OpenCode Panel: could not undo hunk in ${relPath}; the file changed since the diff was generated.`)
-      await vscode.window.showTextDocument(doc)
+  options: { silent?: boolean; root?: string } = {},
+): Promise<ReviewHunkOutcome> {
+  const { silent = false, root } = options
+  if (action === "accepted") return acceptHunk(change, hunk, root, silent)
+  return undoHunk(change, hunk, root, silent)
+}
+
+async function acceptHunk(
+  change: ReviewChange,
+  hunk: ReviewDiffHunk,
+  root: string | undefined,
+  silent: boolean,
+): Promise<ReviewHunkOutcome> {
+  // Keep is a verification: confirm the file is in the expected post-change
+  // state. We don't mutate anything — opencode already applied the change.
+  if (change.kind === "created") {
+    const exists = await reviewPathExists(change.path, root)
+    if (!exists) {
+      return reportConflict(change.path, `${change.path} was created but is no longer present.`, silent)
     }
-    return false
+    return { status: "applied" }
+  }
+  if (change.kind === "deleted") {
+    const exists = await reviewPathExists(change.path, root)
+    if (exists) {
+      return reportConflict(change.path, `${change.path} was deleted but still exists.`, silent)
+    }
+    return { status: "applied" }
+  }
+  const existing = await existingWorkspaceFileUri(change.path, root)
+  if (!existing) {
+    return reportMissing(change.path, `${change.path} is no longer present.`, silent)
+  }
+  // For an update / move, the expected newText should be locatable at the
+  // hunk's anchor line. If it isn't, the file has drifted — surface that
+  // rather than silently marking the hunk accepted.
+  const doc = await vscode.workspace.openTextDocument(existing)
+  const located = findHunkInFile(doc.getText(), hunk)
+  if (!located) {
+    return reportConflict(
+      change.path,
+      `Cannot confirm changes in ${change.path}: the file has been modified since.`,
+      silent,
+    )
+  }
+  return { status: "applied" }
+}
+
+async function undoHunk(
+  change: ReviewChange,
+  hunk: ReviewDiffHunk,
+  root: string | undefined,
+  silent: boolean,
+): Promise<ReviewHunkOutcome> {
+  if (!hunk.reversible) {
+    return reportUnsupported(
+      change.path,
+      `Cannot undo ${change.path}: the diff did not provide a parseable hunk header.`,
+      silent,
+    )
+  }
+  if (change.kind === "created") {
+    return undoCreate(change, root, silent)
+  }
+  if (change.kind === "deleted") {
+    return undoDelete(change, hunk, root, silent)
+  }
+  if (change.kind === "moved") {
+    return undoMove(change, hunk, root, silent)
+  }
+  return undoUpdate(change, hunk, root, silent)
+}
+
+async function undoCreate(
+  change: ReviewChange,
+  root: string | undefined,
+  silent: boolean,
+): Promise<ReviewHunkOutcome> {
+  const existing = await existingWorkspaceFileUri(change.path, root)
+  if (!existing) {
+    // Nothing to undo — file already gone (e.g. user manually removed it).
+    return { status: "no-op", reason: `${change.path} is already absent.` }
+  }
+  try {
+    await vscode.workspace.fs.delete(existing, { useTrash: false })
+    return { status: "applied" }
+  } catch (e) {
+    return reportConflict(
+      change.path,
+      `Could not delete ${change.path}: ${(e as Error).message ?? "unknown error"}.`,
+      silent,
+    )
+  }
+}
+
+async function undoDelete(
+  change: ReviewChange,
+  hunk: ReviewDiffHunk,
+  root: string | undefined,
+  silent: boolean,
+): Promise<ReviewHunkOutcome> {
+  if (!hunk.oldText && !hunk.newText) {
+    return reportUnsupported(
+      change.path,
+      `Cannot restore ${change.path}: original content is not available in the diff.`,
+      silent,
+    )
+  }
+  // If the file is back already, leave it alone — surface conflict instead of
+  // clobbering whatever's there now.
+  const existing = await existingWorkspaceFileUri(change.path, root)
+  if (existing) {
+    return reportConflict(
+      change.path,
+      `Cannot restore ${change.path}: a file at that path already exists.`,
+      silent,
+    )
+  }
+  const uri = await workspaceFileUri(change.path, root)
+  try {
+    const data = new TextEncoder().encode(hunk.oldText)
+    await vscode.workspace.fs.writeFile(uri, data)
+    return { status: "applied" }
+  } catch (e) {
+    return reportConflict(
+      change.path,
+      `Could not restore ${change.path}: ${(e as Error).message ?? "unknown error"}.`,
+      silent,
+    )
+  }
+}
+
+async function undoMove(
+  change: ReviewChange,
+  hunk: ReviewDiffHunk,
+  root: string | undefined,
+  silent: boolean,
+): Promise<ReviewHunkOutcome> {
+  if (!change.oldPath) {
+    return reportUnsupported(
+      change.path,
+      `Cannot undo move of ${change.path}: original path not recorded.`,
+      silent,
+    )
+  }
+  const fromUri = await existingWorkspaceFileUri(change.path, root)
+  if (!fromUri) {
+    return reportMissing(change.path, `${change.path} is no longer present; cannot move back.`, silent)
+  }
+  const toExisting = await existingWorkspaceFileUri(change.oldPath, root)
+  if (toExisting) {
+    return reportConflict(
+      change.oldPath,
+      `Cannot restore move target: ${change.oldPath} already exists.`,
+      silent,
+    )
+  }
+  const toUri = await workspaceFileUri(change.oldPath, root)
+  try {
+    await vscode.workspace.fs.rename(fromUri, toUri, { overwrite: false })
+    // If the move was accompanied by edits, restore the old content too.
+    if (hunk.oldText) {
+      const data = new TextEncoder().encode(hunk.oldText)
+      await vscode.workspace.fs.writeFile(toUri, data)
+    }
+    return { status: "applied" }
+  } catch (e) {
+    return reportConflict(
+      change.path,
+      `Could not undo move of ${change.path}: ${(e as Error).message ?? "unknown error"}.`,
+      silent,
+    )
+  }
+}
+
+async function undoUpdate(
+  change: ReviewChange,
+  hunk: ReviewDiffHunk,
+  root: string | undefined,
+  silent: boolean,
+): Promise<ReviewHunkOutcome> {
+  const existing = await existingWorkspaceFileUri(change.path, root)
+  if (!existing) {
+    return reportMissing(change.path, `${change.path} is no longer present.`, silent)
+  }
+  const doc = await vscode.workspace.openTextDocument(existing)
+  const current = doc.getText()
+  const located = findHunkInFile(current, hunk)
+  if (!located) {
+    return reportConflict(
+      change.path,
+      `Could not undo a hunk in ${change.path}: the file has changed since the edit was produced.`,
+      silent,
+    )
   }
   const edit = new vscode.WorkspaceEdit()
-  edit.replace(uri, new vscode.Range(doc.positionAt(match.start), doc.positionAt(match.end)), oldText)
+  edit.replace(
+    existing,
+    new vscode.Range(doc.positionAt(located.start), doc.positionAt(located.end)),
+    hunk.oldText,
+  )
   const ok = await vscode.workspace.applyEdit(edit)
   if (!ok) {
-    if (!silent) vscode.window.showWarningMessage(`OpenCode Panel: could not undo hunk in ${relPath}`)
-    return false
+    return reportConflict(change.path, `Could not undo hunk in ${change.path}.`, silent)
   }
+  // Reveal the file so the user sees the revert immediately; previous behavior.
   await vscode.window.showTextDocument(doc)
-  return true
+  return { status: "applied" }
 }
+
+function reportConflict(p: string, reason: string, silent: boolean): ReviewHunkOutcome {
+  if (!silent) vscode.window.showWarningMessage(`OpenCode Panel: ${reason}`)
+  return { status: "conflict", reason }
+}
+
+function reportMissing(p: string, reason: string, silent: boolean): ReviewHunkOutcome {
+  if (!silent) vscode.window.showWarningMessage(`OpenCode Panel: ${reason}`)
+  return { status: "missing", reason }
+}
+
+function reportUnsupported(p: string, reason: string, silent: boolean): ReviewHunkOutcome {
+  if (!silent) vscode.window.showWarningMessage(`OpenCode Panel: ${reason}`)
+  return { status: "unsupported", reason }
+}
+
+// Re-export `findHunkText` for any callers that still want the legacy
+// 2-argument signature (notably tests).
+export { findHunkText }

--- a/src/chat/review-changes.ts
+++ b/src/chat/review-changes.ts
@@ -1,153 +1,43 @@
-import * as path from "path"
+/**
+ * Host-side wrapper for the shared review extraction logic. The actual rules
+ * live in `webview/src/review-extract.ts` so host and webview agree on what
+ * "the set of changes in this turn" is — having one side collapse differently
+ * was previously a source of stale review-card rows.
+ */
 import type { ChatMessage, ReviewChange, ToolUpdate as WireToolUpdate } from "../protocol"
-import { isRecord, samePath } from "./paths"
-import { countDiff } from "./diff"
+import {
+  aggregateChanges,
+  createPatchChange,
+  diffChanges,
+  displayPath,
+  extractChanges,
+  patchChanges,
+  patchKind,
+  patchPath,
+  synthesizeCreatePatch,
+  toolChanges as sharedToolChanges,
+  turnChanges,
+} from "../../webview/src/review-extract"
 
-export function reviewChanges(messages: ChatMessage[]) {
-  const changes = messages.flatMap((message) =>
-    message.blocks.flatMap((block, blockIndex) => {
-      const source = `${message.id}:${blockIndex}`
-      if (block.type === "patch" && block.diff) return diffChanges(block.diff, source)
-      if (block.type !== "tool" || block.update.status !== "completed") return []
-      return toolChanges(block.update, block.update.callID || source)
-    }),
-  )
-  return changes.reduce<ReviewChange[]>((acc, change) => {
-    const existing = acc.findIndex((item) => (
-      samePath(item.path, change.path) && (item.source === change.source || item.patch === change.patch)
-    ))
-    if (existing < 0) return [...acc, change]
-    const copy = acc.slice()
-    copy[existing] = change
-    return copy
-  }, [])
+export function reviewChanges(messages: ChatMessage[]): ReviewChange[] {
+  return turnChanges(messages)
 }
 
+// Adapter so legacy callers / tests can still pass an SDK ToolUpdate and an
+// optional actor through. The shared helper signature is identical to the
+// old export's first two parameters.
 export function toolChanges(update: WireToolUpdate, source: string): ReviewChange[] {
-  if (update.tool === "apply_patch") return patchChanges(update.metadata?.files, source)
-  const filediff = isRecord(update.metadata?.filediff) ? update.metadata.filediff : undefined
-  let patch =
-    typeof filediff?.patch === "string"
-      ? filediff.patch
-      : typeof update.metadata?.diff === "string"
-        ? update.metadata.diff
-        : undefined
-  const isCreate =
-    (update.tool === "write" && update.metadata?.exists === false) ||
-    (update.tool === "edit" && update.input?.oldString === "")
-  if (!patch && isCreate) patch = synthesizeCreatePatch(update)
-  if (!patch) return []
-  return [{
-    source,
-    path: displayPath(update, filediff),
-    kind: isCreate ? "created" : "updated",
-    additions: typeof filediff?.additions === "number" ? filediff.additions : countDiff(patch, "+"),
-    deletions: typeof filediff?.deletions === "number" ? filediff.deletions : countDiff(patch, "-"),
-    patch,
-  } satisfies ReviewChange]
+  return sharedToolChanges(update, source)
 }
 
-export function synthesizeCreatePatch(update: WireToolUpdate): string | undefined {
-  const content =
-    update.tool === "write" && typeof update.input?.content === "string"
-      ? update.input.content
-      : update.tool === "edit" && typeof update.input?.newString === "string"
-        ? update.input.newString
-        : undefined
-  if (typeof content !== "string" || content === "") return undefined
-  const lines = content.split("\n")
-  if (lines.length > 1 && lines[lines.length - 1] === "") lines.pop()
-  if (!lines.length) return undefined
-  const body = lines.map((line) => `+${line}`).join("\n")
-  return `@@ -0,0 +1,${lines.length} @@\n${body}`
-}
-
-export function patchChanges(files: unknown, source: string): ReviewChange[] {
-  if (!Array.isArray(files)) return []
-  return files.flatMap((file) => {
-    if (!isRecord(file) || typeof file.relativePath !== "string" || typeof file.patch !== "string") return []
-    return [{
-      source: `${source}:${file.relativePath}`,
-      path: file.relativePath,
-      kind: patchKind(file.type),
-      additions: typeof file.additions === "number" ? file.additions : countDiff(file.patch, "+"),
-      deletions: typeof file.deletions === "number" ? file.deletions : countDiff(file.patch, "-"),
-      patch: file.patch,
-    } satisfies ReviewChange]
-  })
-}
-
-export function diffChanges(diff: string, source: string): ReviewChange[] {
-  const starts = diff.split("\n").reduce<number[]>((acc, line, index) => (
-    line.startsWith("diff --git ") ? [...acc, index] : acc
-  ), [])
-  if (!starts.length) return createPatchChange(diff, source)
-  const lines = diff.split("\n")
-  return starts.map((start, index) => {
-    const chunk = lines.slice(start, starts[index + 1] ?? lines.length).join("\n")
-    const header = lines[start] ?? ""
-    const match = header.match(/^diff --git a\/(.+) b\/(.+)$/)
-    const pathValue = match?.[2] ?? match?.[1] ?? patchPath(chunk)
-    return {
-      source: `${source}:${index}`,
-      path: pathValue,
-      kind: chunk.includes("\nnew file mode ")
-        ? "created"
-        : chunk.includes("\ndeleted file mode ")
-          ? "deleted"
-          : "updated",
-      additions: countDiff(chunk, "+"),
-      deletions: countDiff(chunk, "-"),
-      patch: chunk,
-    } satisfies ReviewChange
-  })
-}
-
-export function createPatchChange(patch: string, source: string): ReviewChange[] {
-  return [{
-    source,
-    path: patchPath(patch),
-    kind: patch.includes("\n--- /dev/null")
-      ? "created"
-      : patch.includes("\n+++ /dev/null")
-        ? "deleted"
-        : "updated",
-    additions: countDiff(patch, "+"),
-    deletions: countDiff(patch, "-"),
-    patch,
-  } satisfies ReviewChange]
-}
-
-export function patchPath(patch: string) {
-  const plus = patch.match(/(?:^|\n)\+\+\+\s+(?:b\/)?(.+)/)?.[1]
-  if (plus && plus !== "/dev/null") return plus
-  const minus = patch.match(/(?:^|\n)---\s+(?:a\/)?(.+)/)?.[1]
-  if (minus && minus !== "/dev/null") return minus
-  const index = patch.match(/^Index:\s+(.+)$/m)?.[1]
-  return index ?? "file"
-}
-
-export function displayPath(
-  update: { title?: string; input?: Record<string, unknown>; metadata?: Record<string, unknown> },
-  filediff?: Record<string, unknown>,
-) {
-  // The absolute filepath opencode resolved is unambiguous; prefer it. The
-  // model's raw input.filePath can be relative to opencode's internal
-  // directory (e.g., the git worktree root) which differs from our VSCode
-  // workspace folder, and persisted conversations may already have the wrong
-  // relative there.
-  const fromMetadata = typeof update.metadata?.filepath === "string" ? update.metadata.filepath : undefined
-  if (fromMetadata && path.isAbsolute(fromMetadata)) return fromMetadata
-  const fromFilediff = typeof filediff?.file === "string" ? filediff.file : undefined
-  if (fromFilediff && path.isAbsolute(fromFilediff)) return fromFilediff
-  if (typeof update.input?.filePath === "string" && update.input.filePath) return update.input.filePath
-  if (typeof update.title === "string" && update.title.trim()) return update.title
-  return fromFilediff ?? "file"
-}
-
-export function patchKind(value: unknown): ReviewChange["kind"] {
-  if (value === "add") return "created"
-  if (value === "delete") return "deleted"
-  if (value === "move") return "moved"
-  return "updated"
+export {
+  aggregateChanges,
+  createPatchChange,
+  diffChanges,
+  displayPath,
+  extractChanges,
+  patchChanges,
+  patchKind,
+  patchPath,
+  synthesizeCreatePatch,
 }

--- a/src/chat/stream.ts
+++ b/src/chat/stream.ts
@@ -95,18 +95,43 @@ export type StreamHandlers = {
    * `message.updated` events; the rest are pure lifecycle signals.
    */
   onChildSessionEvent?: (event: ChildSessionEvent) => void
+  /**
+   * Fired when a `session.created` (or `session.updated`) event arrives
+   * for a session whose `parentID` matches our parent — i.e. a subagent
+   * spawned by our session. Subscribers can `addChildSession(info.id)` so
+   * subsequent tool/patch events get routed to `onChildSessionEvent`.
+   *
+   * Why this exists: opencode's built-in `task` tool dispatches a child
+   * session but doesn't always surface `metadata.sessionId` on the parent's
+   * tool call early enough to register the child via the metadata-based
+   * promotion path in `SubagentTracker`. Listening for `session.created`
+   * with a matching parent is a stricter signal — it fires the moment the
+   * subagent's session record is written, so we never miss its events.
+   */
+  onChildSessionDiscovered?: (info: ChildSessionInfo) => void
+}
+
+export type ChildSessionInfo = {
+  id: string
+  parentID: string
+  title?: string
 }
 
 /**
  * Events surfaced to `onChildSessionEvent` for sessions registered via
  * `Subscription.addChildSession()`. Modeled after the minimum the
- * subagent tracker needs to mirror a child session's lifecycle onto an
- * AgentTask:
+ * subagent tracker + review aggregator need to mirror a child session's
+ * lifecycle and file changes onto the parent's chat record:
  *   - `busy` — first sign the child session has started executing
  *   - `idle` — child session reports it has nothing in flight
  *   - `error` — child session reported an opencode-side session error
  *   - `assistantEnd` — final assistant message with optional usage
  *     (so the tracker can pick up model + token usage on completion)
+ *   - `tool` — terminal tool transition on the child. Carries the full
+ *     ToolUpdate so subagent file edits feed into the Review Panel via
+ *     the same path as parent tool blocks.
+ *   - `patch` — child emitted an `apply_patch`/patch part. Same usage as
+ *     `tool` but for whole-tree diffs.
  */
 export type ChildSessionEvent =
   | { type: "busy"; sessionID: string }
@@ -119,6 +144,19 @@ export type ChildSessionEvent =
       finish?: string
       usage?: MessageUsage
       error?: string
+    }
+  | {
+      type: "tool"
+      sessionID: string
+      messageID: string
+      update: ToolUpdate
+    }
+  | {
+      type: "patch"
+      sessionID: string
+      messageID: string
+      files: string[]
+      diff?: string
     }
 
 export type Subscription = {
@@ -230,6 +268,21 @@ export function subscribeSession(
     // events for sessions in both sets (unlikely, but possible) are
     // observed by both branches.
     routeChildSessionEvent(type, props)
+    // Session-created / -updated with a matching parentID is our cue that
+    // opencode just spawned a subagent. Notify the host so it can register
+    // the child for routing — even if the parent's `task` tool metadata
+    // never publishes the child sessionID, we still capture the child's
+    // tool/patch events.
+    if ((type === "session.created" || type === "session.updated") && handlers.onChildSessionDiscovered) {
+      const info = props?.info
+      if (info && typeof info === "object" && typeof info.id === "string" && info.parentID === sessionID) {
+        handlers.onChildSessionDiscovered({
+          id: info.id,
+          parentID: info.parentID,
+          title: typeof info.title === "string" ? info.title : undefined,
+        })
+      }
+    }
     switch (type) {
       case "message.updated":
         onMessageUpdated(props?.info)
@@ -336,11 +389,48 @@ export function subscribeSession(
           }
         }
         return
-      case "message.part.updated":
-      case "message.part.delta":
+      case "message.part.updated": {
         // Any activity on the child means it is busy. Cheap "still
         // alive" signal that complements `session.idle` for tracker
         // hysteresis.
+        childCb({ type: "busy", sessionID: childSid })
+        const part = props?.part
+        if (!part || typeof part !== "object") return
+        const messageID = typeof part.messageID === "string" ? part.messageID : undefined
+        if (!messageID) return
+        if (part.type === "tool" && part.callID && part.tool && part.state) {
+          const status = part.state.status as ToolUpdate["status"]
+          if (status === "completed" || status === "error") {
+            childCb({
+              type: "tool",
+              sessionID: childSid,
+              messageID,
+              update: {
+                callID: part.callID,
+                tool: part.tool,
+                status,
+                title: part.state.title,
+                input: part.state.input,
+                metadata: part.state.metadata,
+                output: part.state.output,
+                error: part.state.error,
+              },
+            })
+          }
+          return
+        }
+        if (part.type === "patch" && Array.isArray(part.files)) {
+          childCb({
+            type: "patch",
+            sessionID: childSid,
+            messageID,
+            files: part.files,
+            diff: typeof part.diff === "string" ? part.diff : undefined,
+          })
+        }
+        return
+      }
+      case "message.part.delta":
         childCb({ type: "busy", sessionID: childSid })
         return
     }

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -26,6 +26,7 @@ import type {
   ToolUpdate as WireToolUpdate,
   Selection,
   ReviewChange,
+  ReviewChangeActor,
   ReviewHunkState,
 } from "../protocol"
 import {
@@ -491,13 +492,15 @@ export class ChatView implements vscode.WebviewViewProvider {
         this.saveActive()
         return
       case "tool":
-        this.messages = upsertTool(this.messages, msg.id, msg.update)
+        this.messages = upsertTool(this.messages, msg.id, msg.update, msg.actor)
         this.saveActive()
         this.queueReviewDecorationsSync()
         return
       case "patch":
         this.messages = this.messages.map((m) =>
-          m.id === msg.id ? { ...m, blocks: [...m.blocks, { type: "patch", files: msg.files, diff: msg.diff }] } : m,
+          m.id === msg.id
+            ? { ...m, blocks: [...m.blocks, { type: "patch", files: msg.files, diff: msg.diff, actor: msg.actor }] }
+            : m,
         )
         this.saveActive()
         this.queueReviewDecorationsSync()
@@ -673,13 +676,55 @@ export class ChatView implements vscode.WebviewViewProvider {
       case "openReviewChange":
         void this.openReviewChange(msg.change)
         return
-      case "reviewHunk":
+      case "reviewHunk": {
+        // Legacy single-hunk path (review-render.ts standalone HTML). Look up
+        // the matching change + hunk by key so we can run safe undo, then
+        // post a single-hunk state update.
+        const root = this.backendDirectory()
+        const found = this.findReviewHunkByKey(msg.key)
+        if (!found) {
+          // Fall back to the pre-attribution behaviour with the legacy
+          // (path, action, oldText, newText) arguments synthesised into a
+          // throwaway change. Used for hunks we can't locate anymore.
+          const change: ReviewChange = {
+            source: msg.key,
+            path: msg.path,
+            kind: "updated",
+            additions: 0,
+            deletions: 0,
+            patch: "",
+          }
+          const hunk = {
+            id: "0",
+            header: "",
+            lines: [],
+            anchorText: msg.newText,
+            oldText: msg.oldText,
+            newText: msg.newText,
+            oldStart: 0,
+            oldCount: 0,
+            newStart: 0,
+            newCount: msg.newText === "" ? 0 : msg.newText.split("\n").length,
+            leadingContext: [],
+            trailingContext: [],
+            reversible: true,
+          }
+          const outcome = await reviewHunk(change, hunk, msg.action, { root })
+          this.post({
+            type: "reviewHunkState",
+            key: msg.key,
+            state: outcome.status === "applied" || outcome.status === "no-op" ? msg.action : undefined,
+          })
+          return
+        }
+        const outcome = await reviewHunk(found.change, found.hunk, msg.action, { root })
         this.post({
           type: "reviewHunkState",
           key: msg.key,
-          state: await reviewHunk(msg.path, msg.action, msg.oldText, msg.newText) ? msg.action : undefined,
+          state: outcome.status === "applied" || outcome.status === "no-op" ? msg.action : undefined,
         })
         return
+      }
       case "reviewAllInChange":
         await this.handleReviewAllInChange(msg.source, msg.path, msg.action)
         return
@@ -1376,6 +1421,14 @@ export class ChatView implements vscode.WebviewViewProvider {
         this.post({ type: "sessionIdle" })
       },
       onChildSessionEvent: (event) => {
+        if (this.aborting) return
+        // Route tool / patch events through the review-card pipeline FIRST so
+        // the subagent's file changes show up in the panel even if the tracker
+        // then decides to settle the row. The tracker's handleChildSessionEvent
+        // ignores tool/patch variants so this isn't double-handling.
+        if (event.type === "tool" || event.type === "patch") {
+          this.appendSubagentBlock(event, backend.directory)
+        }
         if (!this.subagentTracker) return
         void this.subagentTracker.handleChildSessionEvent(event).then(() => {
           // After any child terminal event, if we were deferring an
@@ -1385,6 +1438,15 @@ export class ChatView implements vscode.WebviewViewProvider {
             this.scheduleIdleEmit(ChatView.CONTINUATION_GRACE_MS, "child-settled")
           }
         })
+      },
+      onChildSessionDiscovered: (info) => {
+        if (this.aborting) return
+        // Register for SSE routing IMMEDIATELY so we don't miss the child's
+        // first tool/patch events while we wait for the parent's task tool
+        // metadata to surface the child sessionID. Cheap idempotent add.
+        subscription.addChildSession(info.id)
+        if (!this.subagentTracker) return
+        void this.subagentTracker.registerChildSession(info)
       },
     })
     this.subscription = subscription
@@ -1419,13 +1481,80 @@ export class ChatView implements vscode.WebviewViewProvider {
     return webviewID
   }
 
+  /**
+   * Route a subagent's tool/patch event into the chat record + Review Panel.
+   *
+   * The parent webview message is located by walking back from the child
+   * session's task (stored under `subagent:child:<childSessionID>` in the
+   * task store, which carries the dispatching parent assistant message ID).
+   * If that lookup fails, fall back to the most-recent assistant message in
+   * the conversation — the user still gets the change in the review card,
+   * just attached one bubble higher than ideal.
+   */
+  private appendSubagentBlock(
+    event:
+      | { type: "tool"; sessionID: string; messageID: string; update: ToolUpdate }
+      | { type: "patch"; sessionID: string; messageID: string; files: string[]; diff?: string },
+    cwd: string,
+  ): void {
+    const actor = this.resolveSubagentActor(event.sessionID)
+    const parentWebviewID = this.locateParentWebviewID(event.sessionID)
+    if (!parentWebviewID) {
+      log(`[review] dropping ${event.type} from child ${event.sessionID} — no parent message in view`)
+      return
+    }
+    if (event.type === "tool") {
+      const wire = toWire(event.update, cwd)
+      this.post({ type: "tool", id: parentWebviewID, update: wire, actor })
+      this.queueReviewDecorationsSync()
+      return
+    }
+    this.post({
+      type: "patch",
+      id: parentWebviewID,
+      files: event.files.map((f) => relativeToCwd(cwd, f)),
+      diff: event.diff,
+      actor,
+    })
+    this.queueReviewDecorationsSync()
+  }
+
+  private resolveSubagentActor(childSessionID: string) {
+    const task = this.taskStore?.getByChildSession(childSessionID)
+    return {
+      kind: "subagent" as const,
+      sessionID: childSessionID,
+      subagent: task?.subagent,
+    }
+  }
+
+  /**
+   * Look up which parent assistant message a child session belongs to. The
+   * AgentTaskStore tracks the dispatching `messageID` per subagent task;
+   * combined with `this.messageMap` (backend → webview ID) we land on the
+   * right bubble. Fallback: the most-recent assistant message in the view.
+   */
+  private locateParentWebviewID(childSessionID: string): string | undefined {
+    const task = this.taskStore?.getByChildSession(childSessionID)
+    if (task?.messageID) {
+      const mapped = this.messageMap.get(task.messageID)
+      if (mapped) return mapped
+    }
+    for (let i = this.messages.length - 1; i >= 0; i--) {
+      const message = this.messages[i]!
+      if (message.role === "assistant") return message.id
+    }
+    return undefined
+  }
+
   private async openReviewChange(change: ReviewChange) {
     if (!isTextReviewPath(change.path)) {
       vscode.window.showWarningMessage(`OpenCode Panel: ${change.path} cannot be reviewed as text.`)
       return
     }
     try {
-      const doc = await openFileDocument(change.path)
+      const root = this.backendDirectory()
+      const doc = await openFileDocument(change.path, root)
       // If the requested file is already the active editor, don't re-show it —
       // showTextDocument would steal focus + flash the editor pane for no
       // reason. (Common when the user just clicked a different row and the
@@ -1446,6 +1575,7 @@ export class ChatView implements vscode.WebviewViewProvider {
 
   private async purgeMissingFileHunks(changes: ReviewChange[]): Promise<void> {
     const seen = new Set<string>()
+    const root = this.backendDirectory()
     for (const change of changes) {
       if (seen.has(change.path)) continue
       seen.add(change.path)
@@ -1453,7 +1583,11 @@ export class ChatView implements vscode.WebviewViewProvider {
       // visible to the VS Code file-system API, or the workspace may not cover
       // the path. Purging here would permanently hide the review card.
       if (change.kind === "created") continue
-      if (await reviewPathExists(change.path)) continue
+      // A `deleted` change is SUPPOSED to leave the file gone — don't purge it
+      // either; that's the desired post-change state and the user might still
+      // want to Undo (restoring it) or Keep (confirming the delete).
+      if (change.kind === "deleted") continue
+      if (await reviewPathExists(change.path, root)) continue
       let purged = 0
       for (const sibling of changes) {
         if (!samePath(sibling.path, change.path)) continue
@@ -1475,57 +1609,73 @@ export class ChatView implements vscode.WebviewViewProvider {
     // (tool block + patch block of the same hunk produce different sources
     // and therefore different reviewKeys). If we only mark the source-matched
     // record's hunks reviewed, the other record's hunks still spawn codelenses
-    // and decorations on the next sync. For reject this is masked because the
-    // file actually changes and the duplicate hunks become unlocatable; for
-    // accept the file is unchanged, so duplicates would linger forever.
+    // and decorations on the next sync.
     const targets = all.filter((c) => samePath(c.path, requestedPath))
     if (!targets.length) {
       log("reviewAllInChange: no matching change", { source, path: requestedPath, available: all.map((c) => ({ source: c.source, path: c.path })) })
       return
     }
-    // If the file no longer exists on disk, neither accept nor reject can
-    // operate on it — silently mark every pending hunk reviewed so the row
-    // drops out of the Review Card and tell the user once.
-    if (!(await reviewPathExists(requestedPath))) {
-      let purged = 0
-      for (const change of targets) {
-        for (const hunk of splitReviewDiff(change.patch).hunks) {
-          const key = reviewKey(change, hunk.id)
-          if (this.reviewHunks[key]) continue
-          this.post({ type: "reviewHunkState", key, state: "rejected" })
-          purged += 1
-        }
-      }
-      vscode.window.showInformationMessage(
-        `OpenCode Panel: ${requestedPath} is no longer present; removed ${purged} pending hunk${purged === 1 ? "" : "s"} from review.`,
-      )
-      await this.syncReviewDecorations()
-      return
-    }
-    let any = false
+    const root = this.backendDirectory()
+    // Files might be intentionally missing (a `deleted` change leaves the file
+    // gone, which is the desired post-change state). Only the `updated` /
+    // `moved` cases require the file present; the helpers handle that.
+    let conflicts = 0
+    let applied = 0
     for (const change of targets) {
       const hunks = splitReviewDiff(change.patch).hunks
+      let firstHunk = true
       for (const hunk of hunks) {
         const key = reviewKey(change, hunk.id)
         if (this.reviewHunks[key]) continue
-        if (action === "rejected" && !hunk.reversible) continue
-        const ok = await reviewHunk(change.path, action, hunk.oldText, hunk.newText, true)
-        if (ok) {
-          this.post({ type: "reviewHunkState", key, state: action })
-          any = true
+        if (action === "rejected" && !hunk.reversible) {
+          conflicts += 1
           continue
         }
-        // For reject, the first change in `targets` may have already reverted
-        // the file — subsequent reviewHunk calls then fail to relocate newText.
-        // Still mark the duplicate hunk as reviewed so its codelens clears.
-        if (action === "rejected") {
+        // For non-update kinds (created / deleted / moved) the action is a
+        // whole-file operation; running it once per hunk would double-act.
+        // Skip all but the first hunk in those cases.
+        if (!firstHunk && change.kind !== "updated") {
+          // Mirror whatever the first hunk produced — it already applied or
+          // conflicted as a whole-file op.
           this.post({ type: "reviewHunkState", key, state: action })
-          any = true
+          continue
         }
+        const outcome = await reviewHunk(change, hunk, action, { silent: true, root })
+        firstHunk = false
+        if (outcome.status === "applied" || outcome.status === "no-op") {
+          this.post({ type: "reviewHunkState", key, state: action })
+          applied += 1
+          continue
+        }
+        // Per requirement: do NOT silently mark a hunk rejected when the undo
+        // couldn't be applied safely — leave the row pending so the user can
+        // see the conflict and decide what to do.
+        conflicts += 1
+        log(`reviewAllInChange: ${outcome.status} on ${change.path}: ${"reason" in outcome ? outcome.reason : ""}`)
       }
     }
-    if (any) await this.syncReviewDecorations()
-    else log("reviewAllInChange: no hunks applied", { source, path: requestedPath, action })
+    if (conflicts > 0) {
+      const verb = action === "accepted" ? "accept" : "undo"
+      vscode.window.showWarningMessage(
+        `OpenCode Panel: couldn't ${verb} ${conflicts} hunk${conflicts === 1 ? "" : "s"} in ${requestedPath} — the file has changed since the diff was produced.`,
+      )
+    }
+    if (applied > 0) await this.syncReviewDecorations()
+    else log("reviewAllInChange: no hunks applied", { source, path: requestedPath, action, conflicts })
+  }
+
+  private backendDirectory(): string | undefined {
+    return this.servers.currentWorkspace()?.fsPath
+  }
+
+  private findReviewHunkByKey(key: string) {
+    const all = reviewChanges(this.messages)
+    for (const change of all) {
+      for (const hunk of splitReviewDiff(change.patch).hunks) {
+        if (reviewKey(change, hunk.id) === key) return { change, hunk }
+      }
+    }
+    return undefined
   }
 
   private queueReviewDecorationsSync() {
@@ -1681,16 +1831,26 @@ function appendText(
   })
 }
 
-function upsertTool(messages: ChatMessage[], id: string, update: WireToolUpdate): ChatMessage[] {
+function upsertTool(
+  messages: ChatMessage[],
+  id: string,
+  update: WireToolUpdate,
+  actor?: ReviewChangeActor,
+): ChatMessage[] {
   return messages.map((message) => {
     if (message.id !== id) return message
     const existing = message.blocks.findIndex((b) => b.type === "tool" && b.update.callID === update.callID)
     if (existing >= 0) {
       const blocks = message.blocks.slice()
-      blocks[existing] = { type: "tool", update }
+      const prev = blocks[existing]
+      blocks[existing] = {
+        type: "tool",
+        update,
+        actor: actor ?? (prev.type === "tool" ? prev.actor : undefined),
+      }
       return { ...message, blocks }
     }
-    return { ...message, blocks: [...message.blocks, { type: "tool", update }] }
+    return { ...message, blocks: [...message.blocks, { type: "tool", update, actor }] }
   })
 }
 

--- a/test/host/child-session-discovery.test.ts
+++ b/test/host/child-session-discovery.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { createOpencodeClient } from "@opencode-ai/sdk"
+import { startMockOpencode, type MockOpencodeServer } from "./mock-opencode-server"
+import { subscribeSession, type ChildSessionInfo } from "../../src/chat/stream"
+
+let server: MockOpencodeServer
+
+beforeEach(async () => {
+  server = await startMockOpencode()
+})
+
+afterEach(async () => {
+  await server.close()
+})
+
+describe("subscribeSession: child-session auto-discovery via session.created", () => {
+  it("fires onChildSessionDiscovered for session.created with our parent ID", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const discovered: ChildSessionInfo[] = []
+    const subscription = subscribeSession({ url: server.url, client, directory: "/tmp" }, "ses_parent", {
+      onAssistantStart: () => {},
+      onTextDelta: () => {},
+      onChildSessionDiscovered: (info) => discovered.push(info),
+    })
+    await subscription.ready
+    await server.awaitClient()
+    server.push({
+      type: "session.created",
+      // @ts-expect-error - mock pass-through allows arbitrary payload shapes
+      info: { id: "ses_child_1", parentID: "ses_parent", title: "delegated work" },
+    })
+    await new Promise((r) => setTimeout(r, 50))
+    subscription.abort()
+    expect(discovered).toEqual([
+      { id: "ses_child_1", parentID: "ses_parent", title: "delegated work" },
+    ])
+  })
+
+  it("ignores session.created events for unrelated parents", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const discovered: ChildSessionInfo[] = []
+    const subscription = subscribeSession({ url: server.url, client, directory: "/tmp" }, "ses_parent", {
+      onAssistantStart: () => {},
+      onTextDelta: () => {},
+      onChildSessionDiscovered: (info) => discovered.push(info),
+    })
+    await subscription.ready
+    await server.awaitClient()
+    server.push({
+      type: "session.created",
+      // @ts-expect-error - mock pass-through allows arbitrary payload shapes
+      info: { id: "ses_other_child", parentID: "ses_other_parent" },
+    })
+    await new Promise((r) => setTimeout(r, 50))
+    subscription.abort()
+    expect(discovered).toEqual([])
+  })
+
+  it("fires for session.updated when parentID becomes known", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const discovered: ChildSessionInfo[] = []
+    const subscription = subscribeSession({ url: server.url, client, directory: "/tmp" }, "ses_parent", {
+      onAssistantStart: () => {},
+      onTextDelta: () => {},
+      onChildSessionDiscovered: (info) => discovered.push(info),
+    })
+    await subscription.ready
+    await server.awaitClient()
+    server.push({
+      type: "session.updated",
+      // @ts-expect-error - mock pass-through allows arbitrary payload shapes
+      info: { id: "ses_late_child", parentID: "ses_parent" },
+    })
+    await new Promise((r) => setTimeout(r, 50))
+    subscription.abort()
+    expect(discovered.map((d) => d.id)).toEqual(["ses_late_child"])
+  })
+
+  it("ignores session.created events that lack a parentID", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const discovered: ChildSessionInfo[] = []
+    const subscription = subscribeSession({ url: server.url, client, directory: "/tmp" }, "ses_parent", {
+      onAssistantStart: () => {},
+      onTextDelta: () => {},
+      onChildSessionDiscovered: (info) => discovered.push(info),
+    })
+    await subscription.ready
+    await server.awaitClient()
+    server.push({
+      type: "session.created",
+      // @ts-expect-error - mock pass-through allows arbitrary payload shapes
+      info: { id: "ses_root", title: "no parent" },
+    })
+    await new Promise((r) => setTimeout(r, 50))
+    subscription.abort()
+    expect(discovered).toEqual([])
+  })
+})

--- a/test/host/child-session-tool-routing.test.ts
+++ b/test/host/child-session-tool-routing.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { createOpencodeClient } from "@opencode-ai/sdk"
+import { startMockOpencode, type MockOpencodeServer } from "./mock-opencode-server"
+import { subscribeSession, type ChildSessionEvent } from "../../src/chat/stream"
+
+let server: MockOpencodeServer
+
+beforeEach(async () => {
+  server = await startMockOpencode()
+})
+
+afterEach(async () => {
+  await server.close()
+})
+
+describe("subscribeSession: child-session tool/patch routing", () => {
+  it("forwards a terminal tool event from a registered child to onChildSessionEvent", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const events: ChildSessionEvent[] = []
+    const subscription = subscribeSession({ url: server.url, client, directory: "/tmp" }, "ses_test", {
+      onAssistantStart: () => {},
+      onTextDelta: () => {},
+      onChildSessionEvent: (e) => events.push(e),
+    })
+    await subscription.ready
+    await server.awaitClient()
+    subscription.addChildSession("ses_child_a")
+    // Push a child tool event that has completed (e.g. an edit tool emitting
+    // its filediff metadata).
+    server.push({
+      type: "message.part.updated",
+      part: {
+        id: "p1",
+        messageID: "msg_child_1",
+        sessionID: "ses_child_a",
+        type: "tool",
+        callID: "call_edit_1",
+        tool: "edit",
+        state: {
+          status: "completed",
+          input: { filePath: "src/sub.ts" },
+          metadata: { filediff: { patch: "@@\n+x", additions: 1, deletions: 0 } },
+        },
+      },
+    } as never)
+    await new Promise((r) => setTimeout(r, 50))
+    subscription.abort()
+    const tool = events.find((e) => e.type === "tool")
+    expect(tool).toBeDefined()
+    if (tool && tool.type === "tool") {
+      expect(tool.sessionID).toBe("ses_child_a")
+      expect(tool.messageID).toBe("msg_child_1")
+      expect(tool.update.callID).toBe("call_edit_1")
+      expect(tool.update.tool).toBe("edit")
+      expect(tool.update.status).toBe("completed")
+      expect((tool.update.metadata?.filediff as Record<string, unknown>)?.patch).toBe("@@\n+x")
+    }
+  })
+
+  it("skips tool events that haven't reached a terminal status yet", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const events: ChildSessionEvent[] = []
+    const subscription = subscribeSession({ url: server.url, client, directory: "/tmp" }, "ses_test", {
+      onAssistantStart: () => {},
+      onTextDelta: () => {},
+      onChildSessionEvent: (e) => events.push(e),
+    })
+    await subscription.ready
+    await server.awaitClient()
+    subscription.addChildSession("ses_child_b")
+    server.push({
+      type: "message.part.updated",
+      part: {
+        id: "p1",
+        messageID: "msg_child_1",
+        sessionID: "ses_child_b",
+        type: "tool",
+        callID: "call_edit_1",
+        tool: "edit",
+        state: { status: "running" },
+      },
+    } as never)
+    await new Promise((r) => setTimeout(r, 50))
+    subscription.abort()
+    const toolEvents = events.filter((e) => e.type === "tool")
+    expect(toolEvents).toHaveLength(0)
+    // But it still counts as busy:
+    expect(events.find((e) => e.type === "busy")).toBeDefined()
+  })
+
+  it("forwards a child patch event with files + diff", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const events: ChildSessionEvent[] = []
+    const subscription = subscribeSession({ url: server.url, client, directory: "/tmp" }, "ses_test", {
+      onAssistantStart: () => {},
+      onTextDelta: () => {},
+      onChildSessionEvent: (e) => events.push(e),
+    })
+    await subscription.ready
+    await server.awaitClient()
+    subscription.addChildSession("ses_child_c")
+    server.push({
+      type: "message.part.updated",
+      part: {
+        id: "p2",
+        messageID: "msg_child_2",
+        sessionID: "ses_child_c",
+        type: "patch",
+        files: ["a.ts", "b.ts"],
+        diff: "diff --git a/a.ts b/a.ts\n@@\n+x",
+      },
+    } as never)
+    await new Promise((r) => setTimeout(r, 50))
+    subscription.abort()
+    const patch = events.find((e) => e.type === "patch")
+    expect(patch).toBeDefined()
+    if (patch && patch.type === "patch") {
+      expect(patch.sessionID).toBe("ses_child_c")
+      expect(patch.messageID).toBe("msg_child_2")
+      expect(patch.files).toEqual(["a.ts", "b.ts"])
+      expect(patch.diff).toContain("diff --git")
+    }
+  })
+
+  it("does NOT forward child tool/patch events for unregistered children", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const events: ChildSessionEvent[] = []
+    const subscription = subscribeSession({ url: server.url, client, directory: "/tmp" }, "ses_test", {
+      onAssistantStart: () => {},
+      onTextDelta: () => {},
+      onChildSessionEvent: (e) => events.push(e),
+    })
+    await subscription.ready
+    await server.awaitClient()
+    // Note: NO addChildSession call
+    server.push({
+      type: "message.part.updated",
+      part: {
+        id: "p_orphan",
+        messageID: "m_orphan",
+        sessionID: "ses_other",
+        type: "tool",
+        callID: "c_orphan",
+        tool: "edit",
+        state: { status: "completed" },
+      },
+    } as never)
+    await new Promise((r) => setTimeout(r, 50))
+    subscription.abort()
+    expect(events.filter((e) => e.type === "tool" || e.type === "patch")).toHaveLength(0)
+  })
+})

--- a/test/host/mock-opencode-server.ts
+++ b/test/host/mock-opencode-server.ts
@@ -14,6 +14,8 @@ export type ScriptedEvent =
   | { type: "message.part.updated"; part: Record<string, unknown> }
   | { type: "session.error"; error: { name?: string; data?: { message?: string } } }
   | { type: "session.status"; sessionID: string; status: { type: string } }
+  | { type: "session.created"; info: Record<string, unknown> }
+  | { type: "session.updated"; info: Record<string, unknown> }
 
 export type MockOpencodeServer = {
   url: string

--- a/test/host/review-actions.test.ts
+++ b/test/host/review-actions.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import * as vscode from "vscode"
+import { reviewHunk } from "../../src/chat/fs-ops"
+import { splitReviewDiff } from "../../src/chat/diff"
+import type { ReviewChange } from "../../webview/src/protocol"
+
+// Treat the in-memory filesystem as the single source of truth for these
+// tests. The vscode mock in test/host/setup.ts stubs `workspace.fs.stat`/
+// `readFile` per-test below.
+
+type FileEntry = { content: string }
+let files: Map<string, FileEntry>
+let edits: Array<{ uri: vscode.Uri; range: vscode.Range; text: string }>
+let writes: Array<{ uri: vscode.Uri; content: string }>
+let deletes: vscode.Uri[]
+let renames: Array<{ from: vscode.Uri; to: vscode.Uri }>
+
+beforeEach(() => {
+  files = new Map()
+  edits = []
+  writes = []
+  deletes = []
+  renames = []
+  ;(vscode.workspace.fs.stat as ReturnType<typeof vi.fn>).mockImplementation(async (uri: vscode.Uri) => {
+    if (!files.has(uri.fsPath)) throw new Error(`stat: ${uri.fsPath} not found`)
+    return {}
+  })
+  ;(vscode.workspace.fs.readFile as ReturnType<typeof vi.fn>).mockImplementation(async (uri: vscode.Uri) => {
+    const entry = files.get(uri.fsPath)
+    if (!entry) throw new Error(`readFile: ${uri.fsPath} not found`)
+    return new TextEncoder().encode(entry.content)
+  })
+  ;(vscode.workspace.fs as unknown as { writeFile: typeof vi.fn }).writeFile = vi.fn(
+    async (uri: vscode.Uri, data: Uint8Array) => {
+      const content = new TextDecoder().decode(data)
+      files.set(uri.fsPath, { content })
+      writes.push({ uri, content })
+    },
+  ) as never
+  ;(vscode.workspace.fs as unknown as { delete: typeof vi.fn }).delete = vi.fn(
+    async (uri: vscode.Uri) => {
+      files.delete(uri.fsPath)
+      deletes.push(uri)
+    },
+  ) as never
+  ;(vscode.workspace.fs as unknown as { rename: typeof vi.fn }).rename = vi.fn(
+    async (from: vscode.Uri, to: vscode.Uri) => {
+      const entry = files.get(from.fsPath)
+      if (!entry) throw new Error(`rename: ${from.fsPath} not found`)
+      files.delete(from.fsPath)
+      files.set(to.fsPath, entry)
+      renames.push({ from, to })
+    },
+  ) as never
+  ;(vscode.workspace.openTextDocument as ReturnType<typeof vi.fn>).mockImplementation(
+    async (uri: vscode.Uri) => {
+      const entry = files.get(uri.fsPath)
+      const text = entry?.content ?? ""
+      return {
+        uri,
+        getText: () => text,
+        positionAt: (offset: number) => {
+          // Crude line/character calculation from byte offset; the actual
+          // VS Code Position is opaque to our code under test.
+          const slice = text.slice(0, offset)
+          const line = (slice.match(/\n/g) ?? []).length
+          const character = slice.length - (slice.lastIndexOf("\n") + 1)
+          return new vscode.Position(line, character)
+        },
+      }
+    },
+  )
+  ;(vscode.workspace.applyEdit as ReturnType<typeof vi.fn>).mockImplementation(
+    async (edit: { size?: () => number }) => {
+      // The stubbed WorkspaceEdit collects edits into its internal array;
+      // we mirror them onto a top-level list via the constructor stub below.
+      void edit
+      return true
+    },
+  )
+  ;(vscode.window.showTextDocument as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
+  ;(vscode.window.showWarningMessage as ReturnType<typeof vi.fn>).mockReturnValue(undefined)
+  ;(vscode.window.showInformationMessage as ReturnType<typeof vi.fn>).mockReturnValue(undefined)
+})
+
+// Build a synthetic ReviewChange + parsed hunk for the cases under test.
+function makeChange(opts: {
+  path: string
+  patch: string
+  kind?: ReviewChange["kind"]
+  oldPath?: string
+}): { change: ReviewChange; hunk: ReturnType<typeof splitReviewDiff>["hunks"][number] } {
+  const change: ReviewChange = {
+    source: "src1",
+    path: opts.path,
+    kind: opts.kind ?? "updated",
+    additions: 0,
+    deletions: 0,
+    patch: opts.patch,
+    oldPath: opts.oldPath,
+  }
+  const hunk = splitReviewDiff(opts.patch).hunks[0]!
+  return { change, hunk }
+}
+
+describe("reviewHunk: created files", () => {
+  it("Undo: deletes the file when it exists", async () => {
+    files.set("/workspace/new.ts", { content: "hello world" })
+    const { change, hunk } = makeChange({
+      path: "new.ts",
+      kind: "created",
+      patch: "@@ -0,0 +1,1 @@\n+hello world",
+    })
+    const outcome = await reviewHunk(change, hunk, "rejected", { silent: true })
+    expect(outcome.status).toBe("applied")
+    expect(deletes.map((u) => u.fsPath)).toContain("/workspace/new.ts")
+  })
+
+  it("Undo: returns no-op when the file is already absent", async () => {
+    const { change, hunk } = makeChange({
+      path: "missing.ts",
+      kind: "created",
+      patch: "@@ -0,0 +1,1 @@\n+hello",
+    })
+    const outcome = await reviewHunk(change, hunk, "rejected", { silent: true })
+    expect(outcome.status).toBe("no-op")
+  })
+
+  it("Keep: returns applied when the file exists", async () => {
+    files.set("/workspace/new.ts", { content: "hello" })
+    const { change, hunk } = makeChange({
+      path: "new.ts",
+      kind: "created",
+      patch: "@@ -0,0 +1,1 @@\n+hello",
+    })
+    const outcome = await reviewHunk(change, hunk, "accepted", { silent: true })
+    expect(outcome.status).toBe("applied")
+  })
+
+  it("Keep: returns conflict when the supposedly-created file is missing", async () => {
+    const { change, hunk } = makeChange({
+      path: "new.ts",
+      kind: "created",
+      patch: "@@ -0,0 +1,1 @@\n+hello",
+    })
+    const outcome = await reviewHunk(change, hunk, "accepted", { silent: true })
+    expect(outcome.status).toBe("conflict")
+  })
+})
+
+describe("reviewHunk: deleted files", () => {
+  it("Undo: recreates the file using oldText from the diff", async () => {
+    const patch = ["@@ -1,2 +0,0 @@", "-line1", "-line2"].join("\n")
+    const { change, hunk } = makeChange({ path: "gone.ts", kind: "deleted", patch })
+    const outcome = await reviewHunk(change, hunk, "rejected", { silent: true })
+    expect(outcome.status).toBe("applied")
+    expect(writes[0]?.content).toBe("line1\nline2")
+  })
+
+  it("Undo: conflicts when a file is already at that path", async () => {
+    files.set("/workspace/gone.ts", { content: "different content already there" })
+    const patch = ["@@ -1,1 +0,0 @@", "-line1"].join("\n")
+    const { change, hunk } = makeChange({ path: "gone.ts", kind: "deleted", patch })
+    const outcome = await reviewHunk(change, hunk, "rejected", { silent: true })
+    expect(outcome.status).toBe("conflict")
+    expect(writes).toHaveLength(0)
+  })
+
+  it("Keep: returns applied when the file is indeed gone", async () => {
+    const patch = "@@ -1,1 +0,0 @@\n-line1"
+    const { change, hunk } = makeChange({ path: "gone.ts", kind: "deleted", patch })
+    const outcome = await reviewHunk(change, hunk, "accepted", { silent: true })
+    expect(outcome.status).toBe("applied")
+  })
+
+  it("Keep: returns conflict when the supposedly-deleted file still exists", async () => {
+    files.set("/workspace/gone.ts", { content: "still here" })
+    const patch = "@@ -1,1 +0,0 @@\n-line1"
+    const { change, hunk } = makeChange({ path: "gone.ts", kind: "deleted", patch })
+    const outcome = await reviewHunk(change, hunk, "accepted", { silent: true })
+    expect(outcome.status).toBe("conflict")
+  })
+})
+
+describe("reviewHunk: updated files (safe undo via line anchor)", () => {
+  it("Undo: returns conflict (not silent rejection) when file is missing", async () => {
+    const patch = "@@ -1,1 +1,1 @@\n-old\n+new"
+    const { change, hunk } = makeChange({ path: "gone.ts", patch })
+    const outcome = await reviewHunk(change, hunk, "rejected", { silent: true })
+    expect(outcome.status).toBe("missing")
+  })
+
+  it("Undo: returns conflict when the new text isn't at the expected location anymore", async () => {
+    files.set("/workspace/f.ts", { content: "completely\ndifferent\ncontent" })
+    const patch = "@@ -1,1 +1,1 @@\n-old\n+new"
+    const { change, hunk } = makeChange({ path: "f.ts", patch })
+    const outcome = await reviewHunk(change, hunk, "rejected", { silent: true })
+    expect(outcome.status).toBe("conflict")
+  })
+})
+
+describe("reviewHunk: Keep verifies file state", () => {
+  it("Keep on an updated file reports conflict if the expected newText isn't present", async () => {
+    files.set("/workspace/f.ts", { content: "the file has drifted" })
+    const patch = "@@ -1,1 +1,1 @@\n-old_line\n+new_line"
+    const { change, hunk } = makeChange({ path: "f.ts", patch })
+    const outcome = await reviewHunk(change, hunk, "accepted", { silent: true })
+    expect(outcome.status).toBe("conflict")
+  })
+
+  it("Keep on an updated file reports missing if file is gone", async () => {
+    const patch = "@@ -1,1 +1,1 @@\n-old\n+new"
+    const { change, hunk } = makeChange({ path: "f.ts", patch })
+    const outcome = await reviewHunk(change, hunk, "accepted", { silent: true })
+    expect(outcome.status).toBe("missing")
+  })
+})
+
+describe("reviewHunk: non-reversible hunks", () => {
+  it("returns unsupported when the diff has no parseable @@ header", async () => {
+    const patch = "no hunk marker here"
+    const { change, hunk } = makeChange({ path: "f.ts", patch })
+    const outcome = await reviewHunk(change, hunk, "rejected", { silent: true })
+    expect(outcome.status).toBe("unsupported")
+  })
+})
+
+describe("reviewHunk: moved files", () => {
+  it("Undo: renames the file back to its original path", async () => {
+    files.set("/workspace/new-name.ts", { content: "after-move content" })
+    const patch = "@@ -1 +1 @@\n-after-move content"
+    const { change, hunk } = makeChange({
+      path: "new-name.ts",
+      kind: "moved",
+      patch,
+      oldPath: "old-name.ts",
+    })
+    const outcome = await reviewHunk(change, hunk, "rejected", { silent: true })
+    expect(outcome.status).toBe("applied")
+    expect(renames[0]?.from.fsPath).toBe("/workspace/new-name.ts")
+    expect(renames[0]?.to.fsPath).toBe("/workspace/old-name.ts")
+  })
+
+  it("Undo: conflicts when the destination already exists", async () => {
+    files.set("/workspace/new-name.ts", { content: "after-move" })
+    files.set("/workspace/old-name.ts", { content: "something else now" })
+    const patch = "@@ -1 +1 @@\n-after-move"
+    const { change, hunk } = makeChange({
+      path: "new-name.ts",
+      kind: "moved",
+      patch,
+      oldPath: "old-name.ts",
+    })
+    const outcome = await reviewHunk(change, hunk, "rejected", { silent: true })
+    expect(outcome.status).toBe("conflict")
+    expect(renames).toHaveLength(0)
+  })
+
+  it("Undo: unsupported when oldPath isn't known", async () => {
+    files.set("/workspace/new-name.ts", { content: "content" })
+    const patch = "@@ -1 +1 @@\n-content"
+    const { change, hunk } = makeChange({ path: "new-name.ts", kind: "moved", patch })
+    const outcome = await reviewHunk(change, hunk, "rejected", { silent: true })
+    expect(outcome.status).toBe("unsupported")
+  })
+})

--- a/test/host/review-attribution.test.ts
+++ b/test/host/review-attribution.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from "vitest"
+import { reviewChanges } from "../../src/chat/review-changes"
+import { turnChanges } from "../../webview/src/review-extract"
+import type { ChatMessage } from "../../webview/src/protocol"
+
+function toolBlock(opts: {
+  callID?: string
+  filePath: string
+  patch: string
+  additions?: number
+  deletions?: number
+  actor?: { kind: "main" | "subagent"; sessionID?: string; subagent?: string }
+}) {
+  return {
+    type: "tool" as const,
+    update: {
+      callID: opts.callID ?? `c-${Math.random().toString(36).slice(2)}`,
+      tool: "edit",
+      status: "completed" as const,
+      input: { filePath: opts.filePath },
+      metadata: {
+        filediff: { patch: opts.patch, additions: opts.additions ?? 1, deletions: opts.deletions ?? 0 },
+      },
+    },
+    actor: opts.actor,
+  }
+}
+
+function assistant(id: string, blocks: ReturnType<typeof toolBlock>[]): ChatMessage {
+  return { id, role: "assistant", blocks: blocks as any } as ChatMessage
+}
+
+describe("ReviewChange attribution: subagent vs main", () => {
+  it("records the actor of a subagent-emitted tool block in the change", () => {
+    const messages = [
+      assistant("m1", [
+        toolBlock({
+          filePath: "src/a.ts",
+          patch: "@@ -1 +1 @@\n+x",
+          actor: { kind: "subagent", sessionID: "ses_child_1", subagent: "explore" },
+        }),
+      ]),
+    ]
+    const changes = reviewChanges(messages)
+    expect(changes).toHaveLength(1)
+    expect(changes[0]!.actors).toEqual([
+      { kind: "subagent", sessionID: "ses_child_1", subagent: "explore" },
+    ])
+  })
+
+  it("merges actors when main and subagent edit the same file", () => {
+    const messages = [
+      assistant("m1", [
+        toolBlock({
+          callID: "c-main",
+          filePath: "src/a.ts",
+          patch: "@@ -1 +1 @@\n+x",
+          actor: { kind: "main" },
+        }),
+        toolBlock({
+          callID: "c-sub",
+          filePath: "src/a.ts",
+          patch: "@@ -2 +2 @@\n+y",
+          actor: { kind: "subagent", sessionID: "ses_child_1", subagent: "hephaestus" },
+        }),
+      ]),
+    ]
+    const changes = reviewChanges(messages)
+    expect(changes).toHaveLength(1)
+    expect(changes[0]!.actors).toEqual(
+      expect.arrayContaining([
+        { kind: "main" },
+        { kind: "subagent", sessionID: "ses_child_1", subagent: "hephaestus" },
+      ]),
+    )
+    // Stats sum across both contributors
+    expect(changes[0]!.additions).toBe(2)
+  })
+
+  it("dedupes identical actors across multiple subagent edits", () => {
+    const messages = [
+      assistant("m1", [
+        toolBlock({
+          callID: "c1",
+          filePath: "src/a.ts",
+          patch: "@@ -1 +1 @@\n+x",
+          actor: { kind: "subagent", sessionID: "ses_child_1", subagent: "explore" },
+        }),
+        toolBlock({
+          callID: "c2",
+          filePath: "src/a.ts",
+          patch: "@@ -3 +3 @@\n+y",
+          actor: { kind: "subagent", sessionID: "ses_child_1", subagent: "explore" },
+        }),
+      ]),
+    ]
+    const changes = reviewChanges(messages)
+    expect(changes).toHaveLength(1)
+    expect(changes[0]!.actors).toHaveLength(1)
+  })
+
+  it("treats a missing actor as main (backward-compatible)", () => {
+    const messages = [
+      assistant("m1", [
+        toolBlock({
+          filePath: "src/a.ts",
+          patch: "@@ -1 +1 @@\n+x",
+          // no actor field
+        }),
+      ]),
+    ]
+    const changes = reviewChanges(messages)
+    expect(changes).toHaveLength(1)
+    expect(changes[0]!.actors).toEqual([{ kind: "main" }])
+  })
+})
+
+describe("Host/webview aggregation consistency", () => {
+  // Run the same input through both pipelines and assert the outputs match.
+  // Webview uses `turnChanges`; host uses `reviewChanges`. They MUST agree
+  // because actions (Keep/Undo by path) cross the boundary.
+  function eqOnPaths(a: { path: string; additions: number; deletions: number }[],
+                    b: { path: string; additions: number; deletions: number }[]) {
+    const norm = (xs: typeof a) =>
+      xs.map((x) => ({ path: x.path, additions: x.additions, deletions: x.deletions }))
+        .sort((p, q) => p.path.localeCompare(q.path))
+    expect(norm(a)).toEqual(norm(b))
+  }
+
+  it("agrees on the per-file row count + sums", () => {
+    const messages: ChatMessage[] = [
+      assistant("m1", [
+        toolBlock({ callID: "c1", filePath: "src/a.ts", patch: "@@\n+x\n+y", additions: 2 }),
+        toolBlock({ callID: "c2", filePath: "src/b.ts", patch: "@@\n+z", additions: 1 }),
+        toolBlock({ callID: "c3", filePath: "src/a.ts", patch: "@@\n-q", additions: 0, deletions: 1 }),
+      ]),
+    ]
+    const host = reviewChanges(messages)
+    const web = turnChanges(messages)
+    eqOnPaths(host, web)
+    // And both should produce two rows: a.ts and b.ts.
+    expect(host).toHaveLength(2)
+    expect(web).toHaveLength(2)
+  })
+
+  it("agrees in the presence of subagent attribution", () => {
+    const messages: ChatMessage[] = [
+      assistant("m1", [
+        toolBlock({
+          callID: "c1",
+          filePath: "src/a.ts",
+          patch: "@@\n+x",
+          actor: { kind: "subagent", sessionID: "ses_child_1", subagent: "explore" },
+        }),
+        toolBlock({
+          callID: "c2",
+          filePath: "src/a.ts",
+          patch: "@@\n+y",
+          actor: { kind: "main" },
+        }),
+      ]),
+    ]
+    const host = reviewChanges(messages)
+    const web = turnChanges(messages)
+    eqOnPaths(host, web)
+    expect(host[0]!.actors!.length).toBe(2)
+    expect(web[0]!.actors!.length).toBe(2)
+  })
+
+  it("agrees for a pure-deletion patch", () => {
+    const patch = ["@@ -1,3 +1,1 @@", " ctx", "-removed1", "-removed2"].join("\n")
+    const messages: ChatMessage[] = [
+      assistant("m1", [
+        toolBlock({ callID: "c1", filePath: "src/a.ts", patch, additions: 0, deletions: 2 }),
+      ]),
+    ]
+    const host = reviewChanges(messages)
+    const web = turnChanges(messages)
+    eqOnPaths(host, web)
+  })
+
+  it("agrees on a created-file row", () => {
+    const messages: ChatMessage[] = [
+      {
+        id: "m1",
+        role: "assistant",
+        blocks: [
+          {
+            type: "tool",
+            update: {
+              callID: "c1",
+              tool: "write",
+              status: "completed",
+              input: { filePath: "new.ts", content: "a\nb" },
+              metadata: { exists: false },
+            },
+          },
+        ],
+      } as ChatMessage,
+    ]
+    const host = reviewChanges(messages)
+    const web = turnChanges(messages)
+    eqOnPaths(host, web)
+    expect(host[0]!.kind).toBe("created")
+    expect(web[0]!.kind).toBe("created")
+  })
+
+  it("agrees that subagent + main edits collapse onto one row, not two", () => {
+    const messages: ChatMessage[] = [
+      assistant("m1", [
+        toolBlock({
+          callID: "c1",
+          filePath: "src/file.ts",
+          patch: "@@\n+main",
+          actor: { kind: "main" },
+        }),
+      ]),
+      assistant("m2", [
+        toolBlock({
+          callID: "c2",
+          filePath: "src/file.ts",
+          patch: "@@\n+sub",
+          actor: { kind: "subagent", sessionID: "ses_child_x", subagent: "explore" },
+        }),
+      ]),
+    ]
+    const host = reviewChanges(messages)
+    const web = turnChanges(messages)
+    expect(host).toHaveLength(1)
+    expect(web).toHaveLength(1)
+    eqOnPaths(host, web)
+  })
+})

--- a/test/host/review-undo.test.ts
+++ b/test/host/review-undo.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from "vitest"
+import {
+  findHunkInFile,
+  parseHunkHeader,
+  splitReviewDiff,
+} from "../../src/chat/diff"
+
+describe("parseHunkHeader", () => {
+  it("parses @@ -X,Y +A,B @@", () => {
+    expect(parseHunkHeader("@@ -3,5 +3,3 @@")).toEqual({
+      oldStart: 3,
+      oldCount: 5,
+      newStart: 3,
+      newCount: 3,
+    })
+  })
+
+  it("defaults missing counts to 1 (per unified diff spec)", () => {
+    expect(parseHunkHeader("@@ -7 +9 @@")).toEqual({
+      oldStart: 7,
+      oldCount: 1,
+      newStart: 9,
+      newCount: 1,
+    })
+  })
+
+  it("parses created-file hunk (@@ -0,0 +1,N @@)", () => {
+    expect(parseHunkHeader("@@ -0,0 +1,3 @@")).toEqual({
+      oldStart: 0,
+      oldCount: 0,
+      newStart: 1,
+      newCount: 3,
+    })
+  })
+
+  it("parses deleted-file hunk (@@ -1,N +0,0 @@)", () => {
+    expect(parseHunkHeader("@@ -1,4 +0,0 @@")).toEqual({
+      oldStart: 1,
+      oldCount: 4,
+      newStart: 0,
+      newCount: 0,
+    })
+  })
+
+  it("returns undefined for malformed headers", () => {
+    expect(parseHunkHeader("@@ broken @@")).toBeUndefined()
+    expect(parseHunkHeader("not a hunk header")).toBeUndefined()
+  })
+})
+
+describe("splitReviewDiff: hunk header line numbers", () => {
+  it("attaches oldStart/oldCount/newStart/newCount per hunk", () => {
+    const patch = [
+      "@@ -1,2 +1,3 @@",
+      " ctx",
+      "+added",
+      " ctx2",
+      "@@ -10,3 +11,4 @@",
+      " ctx3",
+      "+added2",
+      " ctx4",
+      " ctx5",
+    ].join("\n")
+    const hunks = splitReviewDiff(patch).hunks
+    expect(hunks).toHaveLength(2)
+    expect(hunks[0]).toMatchObject({ oldStart: 1, oldCount: 2, newStart: 1, newCount: 3 })
+    expect(hunks[1]).toMatchObject({ oldStart: 10, oldCount: 3, newStart: 11, newCount: 4 })
+  })
+
+  it("flags hunks without a parseable header as non-reversible", () => {
+    const patch = "no @@ here\njust text"
+    const hunks = splitReviewDiff(patch).hunks
+    expect(hunks).toHaveLength(1)
+    expect(hunks[0]!.reversible).toBe(false)
+  })
+
+  it("captures leading + trailing context lines per hunk", () => {
+    const patch = [
+      "@@ -1,5 +1,5 @@",
+      " context_before_1",
+      " context_before_2",
+      "-deleted_line",
+      "+added_line",
+      " context_after_1",
+      " context_after_2",
+    ].join("\n")
+    const hunk = splitReviewDiff(patch).hunks[0]!
+    expect(hunk.leadingContext).toEqual(["context_before_1", "context_before_2"])
+    expect(hunk.trailingContext).toEqual(["context_after_1", "context_after_2"])
+  })
+})
+
+describe("findHunkInFile: safe location for repeated text blocks", () => {
+  it("uses newStart line to disambiguate identical blocks", () => {
+    // Two identical blocks at different line offsets. The hunk header
+    // pinpoints the SECOND occurrence (line 4); the legacy indexOf-based
+    // approach would have located the FIRST.
+    const file = ["alpha", "beta", "gamma", "alpha", "beta", "gamma"].join("\n")
+    const result = findHunkInFile(file, {
+      newText: "alpha\nbeta\ngamma",
+      newStart: 4,
+      newCount: 3,
+      leadingContext: [],
+      trailingContext: [],
+    })
+    expect(result).toBeDefined()
+    expect(result!.start).toBe(file.indexOf("alpha", 1))
+    expect(file.slice(result!.start, result!.end)).toBe("alpha\nbeta\ngamma")
+  })
+
+  it("returns undefined when the same text appears multiple times and newStart cannot anchor", () => {
+    const file = "foo\nbar\nfoo\nbar"
+    const result = findHunkInFile(file, {
+      newText: "foo",
+      newStart: 0, // unknown line — falls through to unique substring
+      newCount: 1,
+      leadingContext: [],
+      trailingContext: [],
+    })
+    expect(result).toBeUndefined()
+  })
+
+  it("locates a single unique block via the substring fallback", () => {
+    const file = "header\nbody1\nbody2\nfooter"
+    const result = findHunkInFile(file, {
+      newText: "body1\nbody2",
+      newStart: 0,
+      newCount: 2,
+      leadingContext: [],
+      trailingContext: [],
+    })
+    expect(result).toBeDefined()
+    expect(file.slice(result!.start, result!.end)).toBe("body1\nbody2")
+  })
+
+  it("returns undefined when the new text isn't present at all", () => {
+    const file = "alpha\nbeta"
+    const result = findHunkInFile(file, {
+      newText: "gamma",
+      newStart: 0,
+      newCount: 1,
+      leadingContext: [],
+      trailingContext: [],
+    })
+    expect(result).toBeUndefined()
+  })
+
+  it("handles a hunk that was just appended at the end of the file", () => {
+    const file = "line1\nline2\nappended"
+    const result = findHunkInFile(file, {
+      newText: "appended",
+      newStart: 3,
+      newCount: 1,
+      leadingContext: [],
+      trailingContext: [],
+    })
+    expect(result).toBeDefined()
+    expect(file.slice(result!.start, result!.end)).toBe("appended")
+  })
+
+  it("is tolerant of trailing-newline drift between diff and file", () => {
+    const file = "line1\nline2\n"
+    const result = findHunkInFile(file, {
+      newText: "line2",
+      newStart: 2,
+      newCount: 1,
+      leadingContext: [],
+      trailingContext: [],
+    })
+    expect(result).toBeDefined()
+  })
+})
+
+describe("splitReviewDiff round-trip with findHunkInFile", () => {
+  it("locates each hunk of a multi-hunk diff at its true offset, not at the FIRST match", () => {
+    // Build a fake file with two adjacent identical-ish sections. Both
+    // sections contain the literal substring "do_thing()" — naive indexOf
+    // would always point at the first one.
+    const file = [
+      "function a() {",
+      "  do_thing()",
+      "}",
+      "",
+      "function b() {",
+      "  do_thing()",
+      "}",
+    ].join("\n")
+    // Diff that targets ONLY the b() copy (line 6 in 1-based numbering).
+    const patch = [
+      "@@ -5,3 +5,3 @@",
+      " function b() {",
+      "-  do_thing()",
+      "+  do_other_thing()",
+      " }",
+    ].join("\n")
+    const hunk = splitReviewDiff(patch).hunks[0]!
+    // Simulate the file AFTER the edit (b's body changed).
+    const afterEdit = [
+      "function a() {",
+      "  do_thing()",
+      "}",
+      "",
+      "function b() {",
+      "  do_other_thing()",
+      "}",
+    ].join("\n")
+    const result = findHunkInFile(afterEdit, hunk)
+    expect(result).toBeDefined()
+    // It must point at the b() copy, not a().
+    expect(afterEdit.slice(result!.start, result!.end)).toBe("function b() {\n  do_other_thing()\n}")
+  })
+})

--- a/test/host/subagent-edit-integration.test.ts
+++ b/test/host/subagent-edit-integration.test.ts
@@ -1,0 +1,289 @@
+/**
+ * End-to-end integration test for the "subagent edits a file" flow.
+ *
+ * This is the test that would have caught the regression the user hit in chat:
+ * subscribeSession discovery worked in isolation, child-session tool routing
+ * worked in isolation, but the host wiring that connects them was missing —
+ * so in production the subagent's `edit` tool never reached the Review Panel.
+ *
+ * The test simulates the SSE sequence opencode emits when the built-in `task`
+ * tool dispatches a subagent that edits a file, then drives the same wiring
+ * ChatView.attachSubscription does (auto-register on discovery, append on
+ * tool). If that wire is missing or broken, the assertion at the end fails.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { createOpencodeClient } from "@opencode-ai/sdk"
+import { startMockOpencode, type MockOpencodeServer } from "./mock-opencode-server"
+import { subscribeSession, type ChildSessionEvent, type ChildSessionInfo } from "../../src/chat/stream"
+import { turnChanges } from "../../webview/src/review-extract"
+import type { ChatBlock, ChatMessage } from "../../webview/src/protocol"
+
+let server: MockOpencodeServer
+
+beforeEach(async () => {
+  server = await startMockOpencode()
+})
+
+afterEach(async () => {
+  await server.close()
+})
+
+describe("Subagent file edit → Review Panel: full integration", () => {
+  it("captures a subagent's edit as a ReviewChange with subagent attribution", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+
+    // Stand in for ChatView.messages — the host's chat record. We'll push
+    // tool/patch blocks here exactly as appendSubagentBlock does in
+    // production.
+    const parentBlocks: ChatBlock[] = []
+    const parentMessage: ChatMessage = {
+      id: "a_parent",
+      role: "assistant",
+      blocks: parentBlocks,
+    }
+    const messages: ChatMessage[] = [parentMessage]
+
+    // Mirror ChatView's handler set so the test exercises the same wiring
+    // path. The key piece: onChildSessionDiscovered must auto-register the
+    // child session — without that, subsequent child tool events fall
+    // through unrouted (this was the user-reported bug).
+    let discoveredChild: ChildSessionInfo | undefined
+    const collectedChildEvents: ChildSessionEvent[] = []
+    const subscription = subscribeSession({ url: server.url, client, directory: "/tmp" }, "ses_parent", {
+      onAssistantStart: () => {},
+      onTextDelta: () => {},
+      onChildSessionDiscovered: (info) => {
+        discoveredChild = info
+        // This is what ChatView.attachSubscription does in production.
+        subscription.addChildSession(info.id)
+      },
+      onChildSessionEvent: (event) => {
+        collectedChildEvents.push(event)
+        if (event.type === "tool") {
+          // Same shape as ChatView.appendSubagentBlock — append the tool
+          // block to the parent message with subagent attribution.
+          parentBlocks.push({
+            type: "tool",
+            update: event.update,
+            actor: {
+              kind: "subagent",
+              sessionID: event.sessionID,
+              subagent: discoveredChild?.title?.includes("Sisyphus") ? "Sisyphus-Junior" : undefined,
+            },
+          })
+        }
+      },
+    })
+    await subscription.ready
+    await server.awaitClient()
+
+    // 1. Parent dispatches the task tool. Note: we deliberately DO NOT
+    //    publish `metadata.sessionId` here — opencode's built-in task tool
+    //    behaviour. This is what made the original code path miss subagent
+    //    edits before session.created auto-discovery was added.
+    server.push({
+      type: "message.part.updated",
+      part: {
+        id: "part_task",
+        messageID: "msg_parent",
+        sessionID: "ses_parent",
+        type: "tool",
+        callID: "call_task",
+        tool: "task",
+        state: {
+          status: "running",
+          input: { description: "Add helper function", subagent_type: "Sisyphus-Junior" },
+        },
+      },
+    })
+
+    // 2. opencode creates the subagent's session. THIS is the event that
+    //    auto-discovers the child via parentID match.
+    server.push({
+      type: "session.created",
+      info: {
+        id: "ses_subagent",
+        parentID: "ses_parent",
+        title: "Add helper function (@Sisyphus-Junior subagent)",
+      },
+    })
+    // Allow the discovery handler to run before the next event arrives.
+    await new Promise((r) => setTimeout(r, 20))
+
+    // 3. The subagent emits its `edit` tool — this is where the file change
+    //    actually happens. Before the fix, this event was silently dropped
+    //    because the child session wasn't registered for routing.
+    server.push({
+      type: "message.part.updated",
+      part: {
+        id: "part_edit",
+        messageID: "msg_subagent_a",
+        sessionID: "ses_subagent",
+        type: "tool",
+        callID: "call_edit",
+        tool: "edit",
+        state: {
+          status: "completed",
+          input: { filePath: "quick_sort_1.py" },
+          metadata: {
+            filediff: {
+              patch: "@@ -1 +1,2 @@\n hello\n+world",
+              additions: 1,
+              deletions: 0,
+            },
+          },
+        },
+      },
+    })
+
+    // 4. Subagent finishes.
+    server.push({ type: "session.idle", sessionID: "ses_subagent" })
+    await new Promise((r) => setTimeout(r, 50))
+    subscription.abort()
+
+    // === Assertions ===
+    // The discovery handler fired.
+    expect(discoveredChild?.id).toBe("ses_subagent")
+    expect(discoveredChild?.parentID).toBe("ses_parent")
+
+    // The child's edit tool reached onChildSessionEvent.
+    const toolEvent = collectedChildEvents.find((e) => e.type === "tool")
+    expect(toolEvent).toBeDefined()
+
+    // The block was appended to the parent's message with subagent attribution.
+    expect(parentBlocks).toHaveLength(1)
+    expect(parentBlocks[0]!.type).toBe("tool")
+    if (parentBlocks[0]!.type === "tool") {
+      expect(parentBlocks[0]!.actor?.kind).toBe("subagent")
+      expect(parentBlocks[0]!.actor?.sessionID).toBe("ses_subagent")
+    }
+
+    // And — critically — turnChanges() now reports the file change WITH
+    // subagent attribution. If this fails, the Review Panel won't show the
+    // subagent's edit (the original bug).
+    const changes = turnChanges(messages)
+    expect(changes).toHaveLength(1)
+    expect(changes[0]!.path).toBe("quick_sort_1.py")
+    expect(changes[0]!.additions).toBe(1)
+    expect(changes[0]!.actors).toEqual([
+      expect.objectContaining({ kind: "subagent", sessionID: "ses_subagent" }),
+    ])
+  })
+
+  it("still works when the parent's task tool DOES publish metadata.sessionId (omo path)", async () => {
+    // The other half of the matrix: when omo is installed and publishes the
+    // child sessionID in metadata, the legacy registration path takes over.
+    // We test that both pathways produce the same end result.
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const parentBlocks: ChatBlock[] = []
+    const messages: ChatMessage[] = [{ id: "a_parent", role: "assistant", blocks: parentBlocks }]
+
+    const collectedChildEvents: ChildSessionEvent[] = []
+    const subscription = subscribeSession({ url: server.url, client, directory: "/tmp" }, "ses_parent", {
+      onAssistantStart: () => {},
+      onTextDelta: () => {},
+      onChildSessionDiscovered: (info) => {
+        subscription.addChildSession(info.id)
+      },
+      onChildSessionEvent: (event) => {
+        collectedChildEvents.push(event)
+        if (event.type === "tool") {
+          parentBlocks.push({
+            type: "tool",
+            update: event.update,
+            actor: { kind: "subagent", sessionID: event.sessionID, subagent: "explore" },
+          })
+        }
+      },
+    })
+    await subscription.ready
+    await server.awaitClient()
+
+    // omo path: parent tool publishes metadata.sessionId before session.created
+    // even arrives. Test that ALSO works via session.created auto-discovery —
+    // the new path is additive, not exclusive.
+    server.push({
+      type: "session.created",
+      info: { id: "ses_omo_child", parentID: "ses_parent", title: "delegated" },
+    })
+    await new Promise((r) => setTimeout(r, 20))
+    server.push({
+      type: "message.part.updated",
+      part: {
+        id: "part_write",
+        messageID: "msg_child",
+        sessionID: "ses_omo_child",
+        type: "tool",
+        callID: "call_write",
+        tool: "write",
+        state: {
+          status: "completed",
+          input: { filePath: "new_file.ts", content: "line1\nline2" },
+          metadata: { exists: false },
+        },
+      },
+    })
+    await new Promise((r) => setTimeout(r, 50))
+    subscription.abort()
+
+    const changes = turnChanges(messages)
+    expect(changes).toHaveLength(1)
+    expect(changes[0]!.kind).toBe("created")
+    expect(changes[0]!.path).toBe("new_file.ts")
+    expect(changes[0]!.actors?.[0]?.kind).toBe("subagent")
+  })
+
+  it("doesn't capture edits from sessions that aren't our subagents", async () => {
+    // Robustness: if some unrelated session in opencode emits edit events,
+    // we MUST NOT attribute them to the current conversation's review card.
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const parentBlocks: ChatBlock[] = []
+    const messages: ChatMessage[] = [{ id: "a_parent", role: "assistant", blocks: parentBlocks }]
+
+    const subscription = subscribeSession({ url: server.url, client, directory: "/tmp" }, "ses_parent", {
+      onAssistantStart: () => {},
+      onTextDelta: () => {},
+      onChildSessionDiscovered: (info) => {
+        subscription.addChildSession(info.id)
+      },
+      onChildSessionEvent: (event) => {
+        if (event.type === "tool") {
+          parentBlocks.push({
+            type: "tool",
+            update: event.update,
+            actor: { kind: "subagent", sessionID: event.sessionID },
+          })
+        }
+      },
+    })
+    await subscription.ready
+    await server.awaitClient()
+
+    // Unrelated session (different parent).
+    server.push({
+      type: "session.created",
+      info: { id: "ses_unrelated", parentID: "ses_some_other_parent" },
+    })
+    await new Promise((r) => setTimeout(r, 20))
+    server.push({
+      type: "message.part.updated",
+      part: {
+        id: "part_edit",
+        messageID: "msg_unrelated",
+        sessionID: "ses_unrelated",
+        type: "tool",
+        callID: "call_edit",
+        tool: "edit",
+        state: {
+          status: "completed",
+          input: { filePath: "should_not_appear.ts" },
+          metadata: { filediff: { patch: "@@\n+x", additions: 1, deletions: 0 } },
+        },
+      },
+    })
+    await new Promise((r) => setTimeout(r, 50))
+    subscription.abort()
+
+    expect(turnChanges(messages)).toHaveLength(0)
+  })
+})

--- a/test/host/subagent-tracker.test.ts
+++ b/test/host/subagent-tracker.test.ts
@@ -608,6 +608,185 @@ describe("SubagentTracker.cancelForSession", () => {
   })
 })
 
+describe("SubagentTracker.registerChildSession", () => {
+  it("creates a placeholder subagent task for an auto-discovered child session", async () => {
+    const { tracker, store } = setupTracker()
+    await tracker.registerChildSession({
+      id: "ses_child_x",
+      parentID: "ses_parent",
+      title: "Investigating logs",
+    })
+    const task = store.get(subagentTaskIDByChildSession("ses_child_x"))
+    expect(task).toBeDefined()
+    expect(task!.kind).toBe("subagent")
+    expect(task!.childSessionID).toBe("ses_child_x")
+    expect(task!.status).toBe("running")
+    expect(task!.title).toBe("Investigating logs")
+  })
+
+  it("uses a generic title when the discovered session has none", async () => {
+    const { tracker, store } = setupTracker()
+    await tracker.registerChildSession({ id: "ses_child_y", parentID: "ses_parent" })
+    const task = store.get(subagentTaskIDByChildSession("ses_child_y"))
+    expect(task!.title).toBe("Subagent")
+  })
+
+  it("ignores discoveries with a parent that isn't ours", async () => {
+    const { tracker, store } = setupTracker({ sessionID: "ses_parent" })
+    await tracker.registerChildSession({ id: "ses_orphan", parentID: "ses_someone_else" })
+    expect(store.get(subagentTaskIDByChildSession("ses_orphan"))).toBeUndefined()
+  })
+
+  it("does not overwrite an existing richer record", async () => {
+    const { tracker, store } = setupTracker()
+    // Pre-populate with a tool-update-style record (richer metadata).
+    await tracker.handleToolUpdate(
+      makeUpdate({
+        callID: "c1",
+        tool: "task",
+        status: "running",
+        metadata: {
+          sessionId: "ses_child_z",
+          agent: "hephaestus",
+        },
+      }),
+      "msg_parent",
+    )
+    const before = store.get(subagentTaskIDByChildSession("ses_child_z"))
+    expect(before!.subagent).toBe("hephaestus")
+    // Now simulate the late-arriving session.created discovery.
+    await tracker.registerChildSession({ id: "ses_child_z", parentID: "ses_parent", title: "fallback title" })
+    const after = store.get(subagentTaskIDByChildSession("ses_child_z"))
+    expect(after!.subagent).toBe("hephaestus") // preserved
+    expect(after!.title).toBe(before!.title) // not overwritten
+  })
+})
+
+describe("SubagentTracker: discovery + tool-dispatch merge", () => {
+  // The user-reported bug: opencode's built-in `task` tool doesn't publish
+  // `metadata.sessionId`, so the parent tool path creates a callID-keyed row
+  // AND `session.created` auto-discovery creates a child-keyed row → two
+  // rows for ONE subagent in the Agents popover. Tests below pin both
+  // orderings down to ONE row.
+
+  it("registerChildSession FIRST, then handleToolUpdate: produces one task (child-keyed)", async () => {
+    const { tracker, store, subscription } = setupTracker()
+    // Discovery arrives first (no parent dispatch processed yet).
+    await tracker.registerChildSession({
+      id: "ses_child_merge",
+      parentID: "ses_parent",
+      title: "Add helper (@Sisyphus-Junior subagent)",
+    })
+    // Sanity: placeholder exists.
+    expect(store.list()).toHaveLength(1)
+    // Parent dispatch arrives WITHOUT metadata.sessionId (built-in task tool).
+    await tracker.handleToolUpdate(
+      makeUpdate({
+        callID: "call_1",
+        tool: "task",
+        status: "running",
+        input: { description: "Add helper", subagent_type: "Sisyphus-Junior" },
+      }),
+      "msg_parent",
+    )
+    const tasks = store.list().filter((t) => t.kind === "subagent")
+    expect(tasks).toHaveLength(1)
+    expect(tasks[0]!.childSessionID).toBe("ses_child_merge")
+    expect(tasks[0]!.callID).toBe("call_1")
+    // Title precedence: parent's `input.description` wins over the verbose
+    // session-info title — that's what the popover should show.
+    expect(tasks[0]!.title).toBe("Add helper")
+    // And the SSE subscription got told to track the child.
+    expect(subscription.added).toContain("ses_child_merge")
+  })
+
+  it("handleToolUpdate FIRST, then registerChildSession: produces one task (child-keyed)", async () => {
+    const { tracker, store, subscription } = setupTracker()
+    await tracker.handleToolUpdate(
+      makeUpdate({
+        callID: "call_1",
+        tool: "task",
+        status: "running",
+        input: { description: "Add helper", subagent_type: "Sisyphus-Junior" },
+      }),
+      "msg_parent",
+    )
+    expect(store.list()).toHaveLength(1)
+    expect(store.list()[0]!.callID).toBe("call_1")
+    expect(store.list()[0]!.childSessionID).toBeUndefined()
+    // Discovery arrives after the parent tool dispatch.
+    await tracker.registerChildSession({
+      id: "ses_child_merge",
+      parentID: "ses_parent",
+      title: "Add helper (@Sisyphus-Junior subagent)",
+    })
+    const tasks = store.list().filter((t) => t.kind === "subagent")
+    expect(tasks).toHaveLength(1)
+    expect(tasks[0]!.childSessionID).toBe("ses_child_merge")
+    expect(tasks[0]!.callID).toBe("call_1")
+    expect(tasks[0]!.title).toBe("Add helper")
+    expect(subscription.added).toContain("ses_child_merge")
+  })
+
+  it("ambiguous parallel dispatch (>1 unclaimed) skips merge and keeps both rows", async () => {
+    // Defensive: when the parent fans out multiple subagents in a single
+    // turn, we can't unambiguously match a session.created event to one
+    // specific callID. Tests that we DON'T mis-merge in that case.
+    const { tracker, store } = setupTracker()
+    await tracker.handleToolUpdate(
+      makeUpdate({ callID: "call_a", tool: "task", status: "running", input: { description: "Task A" } }),
+      "msg_parent",
+    )
+    await tracker.handleToolUpdate(
+      makeUpdate({ callID: "call_b", tool: "task", status: "running", input: { description: "Task B" } }),
+      "msg_parent",
+    )
+    // Two unclaimed dispatches now exist — discovery should NOT claim either,
+    // because we can't tell which one this session.created belongs to.
+    await tracker.registerChildSession({ id: "ses_child_x", parentID: "ses_parent", title: "x" })
+    // We expect 3 rows: two callID-keyed dispatches + one child placeholder.
+    expect(store.list().filter((t) => t.kind === "subagent")).toHaveLength(3)
+  })
+
+  it("metadata.sessionId still merges cleanly when it does arrive (omo path)", async () => {
+    // Sanity check: pre-existing omo flow should NOT regress.
+    const { tracker, store } = setupTracker()
+    await tracker.handleToolUpdate(
+      makeUpdate({
+        callID: "call_1",
+        tool: "call_omo_agent",
+        status: "running",
+        input: { description: "Explore auth" },
+        metadata: { sessionId: "ses_omo_child", agent: "explore" },
+      }),
+      "msg_parent",
+    )
+    const tasks = store.list().filter((t) => t.kind === "subagent")
+    expect(tasks).toHaveLength(1)
+    expect(tasks[0]!.childSessionID).toBe("ses_omo_child")
+    expect(tasks[0]!.subagent).toBe("explore")
+  })
+})
+
+describe("SubagentTracker: input.subagent_type fallback", () => {
+  it("reads the agent slug from input.subagent_type when metadata.agent is missing", async () => {
+    const { tracker, store } = setupTracker()
+    await tracker.handleToolUpdate(
+      makeUpdate({
+        callID: "c1",
+        tool: "task",
+        status: "running",
+        input: { description: "Do a thing", subagent_type: "explore" },
+        // no metadata.agent
+        metadata: { sessionId: "ses_child_q" },
+      }),
+      "msg1",
+    )
+    const task = store.get(subagentTaskIDByChildSession("ses_child_q"))
+    expect(task?.subagent).toBe("explore")
+  })
+})
+
 describe("SubagentTracker tool name gate", () => {
   it("does not touch the store for unrelated tools", async () => {
     const { tracker, store } = setupTracker()

--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -95,18 +95,6 @@ describe("PromptBox", () => {
     expect(onAbort).not.toHaveBeenCalled()
   })
 
-  it("renders contextLabel when provided", () => {
-    render(
-      <PromptBox
-        busy={false}
-        contextLabel="src/foo.ts:5-10"
-        onSend={vi.fn()}
-        onAbort={vi.fn()}
-      />,
-    )
-    expect(screen.getByText("src/foo.ts:5-10")).toBeInTheDocument()
-  })
-
   it("does NOT submit when Enter is pressed during IME composition (Chinese / Japanese / Korean input)", () => {
     const onSend = vi.fn()
     render(<PromptBox busy={false} onSend={onSend} onAbort={vi.fn()} />)

--- a/test/webview/review-attribution-render.test.tsx
+++ b/test/webview/review-attribution-render.test.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, afterEach } from "vitest"
+import { render, cleanup } from "@testing-library/react"
+import { ReviewPanel } from "../../webview/src/components/ReviewPanel"
+import type { Message } from "../../webview/src/hooks/useChatState"
+
+afterEach(cleanup)
+
+function toolBlock(opts: {
+  callID: string
+  filePath: string
+  patch: string
+  additions?: number
+  actor?: { kind: "main" | "subagent"; sessionID?: string; subagent?: string }
+}) {
+  return {
+    type: "tool" as const,
+    update: {
+      callID: opts.callID,
+      tool: "edit",
+      status: "completed" as const,
+      input: { filePath: opts.filePath },
+      metadata: {
+        filediff: { patch: opts.patch, additions: opts.additions ?? 1, deletions: 0 },
+      },
+    },
+    actor: opts.actor,
+  }
+}
+
+function assistant(id: string, blocks: ReturnType<typeof toolBlock>[]): Message {
+  return { id, role: "assistant", blocks: blocks as any } as unknown as Message
+}
+
+// Review row should be filename-only — attribution lives in the row's
+// title tooltip, NEVER as a visible inline label that pushes the file name
+// down or clutters the card.
+describe("ReviewPanel: subagent attribution stays on the tooltip", () => {
+  it("does not render an inline subagent label even when a child session produced the change", () => {
+    const messages = [
+      assistant("m1", [
+        toolBlock({
+          callID: "c-sub",
+          filePath: "src/foo.ts",
+          patch: "@@\n+x",
+          actor: { kind: "subagent", sessionID: "ses_child_1", subagent: "explore" },
+        }),
+      ]),
+    ]
+    const { container } = render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
+    // No `.review-file-actor` element — the old badge is gone.
+    expect(container.querySelector(".review-file-actor")).toBeNull()
+    // The row title tooltip still carries the attribution so power users can hover.
+    const row = container.querySelector(".review-file") as HTMLElement
+    expect(row.title).toContain("Modified by: explore")
+  })
+
+  it("keeps tooltip clean (just the path) for main-agent changes", () => {
+    const messages = [
+      assistant("m1", [
+        toolBlock({
+          callID: "c-main",
+          filePath: "src/foo.ts",
+          patch: "@@\n+x",
+        }),
+      ]),
+    ]
+    const { container } = render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
+    expect(container.querySelector(".review-file-actor")).toBeNull()
+    const row = container.querySelector(".review-file") as HTMLElement
+    expect(row.title).toBe("src/foo.ts")
+  })
+
+  it("lists multiple subagents in the tooltip when more than one touched the file", () => {
+    const messages = [
+      assistant("m1", [
+        toolBlock({
+          callID: "c1",
+          filePath: "src/foo.ts",
+          patch: "@@\n+x",
+          actor: { kind: "subagent", sessionID: "ses_child_1", subagent: "explore" },
+        }),
+        toolBlock({
+          callID: "c2",
+          filePath: "src/foo.ts",
+          patch: "@@\n+y",
+          actor: { kind: "subagent", sessionID: "ses_child_2", subagent: "hephaestus" },
+        }),
+      ]),
+    ]
+    const { container } = render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
+    const row = container.querySelector(".review-file") as HTMLElement
+    expect(row.title).toContain("explore")
+    expect(row.title).toContain("hephaestus")
+  })
+
+  it("still collapses main + subagent edits onto one row (no duplicate visible attribution)", () => {
+    const messages = [
+      assistant("m1", [
+        toolBlock({
+          callID: "c-main",
+          filePath: "src/foo.ts",
+          patch: "@@\n+m",
+          actor: { kind: "main" },
+        }),
+        toolBlock({
+          callID: "c-sub",
+          filePath: "src/foo.ts",
+          patch: "@@\n+s",
+          actor: { kind: "subagent", sessionID: "ses_child_1", subagent: "hephaestus" },
+        }),
+      ]),
+    ]
+    const { container } = render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
+    expect(container.querySelectorAll(".review-file")).toHaveLength(1)
+    expect(container.querySelector(".review-file-actor")).toBeNull()
+    const row = container.querySelector(".review-file") as HTMLElement
+    expect(row.title).toContain("Modified by: hephaestus")
+  })
+})

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -243,7 +243,6 @@ export default function App() {
       <PromptBox
         busy={busy}
         aborting={state.aborting}
-        contextLabel={state.context?.label}
         onSend={send}
         onAbort={abort}
         searchFiles={searchFiles}

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -34,7 +34,6 @@ type Props = {
    * one.
    */
   aborting?: boolean
-  contextLabel?: string
   onSend: (text: string, mentions?: string[], attachments?: Attachment[]) => void
   onAbort: () => void
   searchFiles?: (query: string) => Promise<FileSearchHit[]>
@@ -70,7 +69,7 @@ function buildInitialAttachments(initial: Props["initial"]): Map<string, Attachm
   return map
 }
 
-export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbort, searchFiles, attachFile, initial, variant = "send" }: Props) {
+export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles, attachFile, initial, variant = "send" }: Props) {
   const { text, setText, ref, backdropRef, pendingCursor } = usePromptText(initial?.text ?? "")
   const [selectedChipStart, setSelectedChipStart] = useState<number | undefined>(undefined)
   const [attachError, setAttachError] = useState<string | undefined>(undefined)
@@ -314,7 +313,6 @@ export function PromptBox({ busy, aborting = false, contextLabel, onSend, onAbor
 
   return (
     <div className={"promptbox" + (variant === "edit" ? " promptbox--edit" : "")}>
-      {contextLabel && <div className="context-chip">{contextLabel}</div>}
       {attachError && <div className="attachment-error">{attachError}</div>}
       {imageAttachments.length > 0 && (
         <ul className="promptbox-thumbs" aria-label="Image attachments">

--- a/webview/src/components/ReviewPanel.tsx
+++ b/webview/src/components/ReviewPanel.tsx
@@ -1,6 +1,14 @@
 import { useEffect, useMemo, useState, type KeyboardEvent, type MouseEvent } from "react"
 import type { Message } from "../hooks/useChatState"
-import type { ReviewChange, ReviewHunkState } from "../protocol"
+import type { ReviewChange, ReviewChangeActor, ReviewHunkState } from "../protocol"
+import {
+  basename,
+  isTextReviewChange,
+  normalizePath,
+  reviewKey,
+  samePath,
+  turnChanges,
+} from "../review-extract"
 
 type DiffHunk = {
   id: string
@@ -120,7 +128,7 @@ export function ReviewPanel({
                   }}
                   role="button"
                   tabIndex={0}
-                  title={change.path}
+                  title={actorTooltip(change)}
                 >
                   <span className="review-file-name">{displayNames.get(change.path) ?? basename(change.path)}</span>
                   <span className="review-file-stat add">+{change.additions}</span>
@@ -151,6 +159,17 @@ export function ReviewPanel({
       </div>
     </div>
   )
+}
+
+// The Review Card intentionally shows only the filename + stats per row;
+// subagent attribution lives on the title tooltip so users can hover to see
+// "Modified by: <subagent>" without the row sprouting an extra label.
+function actorTooltip(change: ReviewChange): string {
+  const subagents = (change.actors ?? [])
+    .filter((actor) => actor.kind === "subagent")
+    .map((actor) => actor.subagent || actor.sessionID || "subagent")
+  if (!subagents.length) return change.path
+  return `${change.path}\nModified by: ${subagents.join(", ")}`
 }
 
 export function disambiguatePaths(paths: string[]): Map<string, string> {
@@ -188,162 +207,6 @@ export function shortestUniqueSuffix(target: string, group: string[]): string {
   return target
 }
 
-export function turnChanges(messages: Message[]) {
-  const changes = messages.flatMap((message) =>
-    message.blocks.flatMap((block, blockIndex) => {
-      const source = `${message.id}:${blockIndex}`
-      if (block.type === "patch" && block.diff) return diffChanges(block.diff, source)
-      if (block.type !== "tool" || block.update.status !== "completed") return []
-      return toolChanges(block.update, block.update.callID || source)
-    }),
-  )
-  // When the same file is modified multiple times in the same conversation,
-  // collapse the rows so only one appears per file — but SUM additions and
-  // deletions across all changes so the row reflects the total work, not
-  // just the last edit. Keep the earliest `kind` (so a file that was created
-  // and later updated still shows as "created"), and keep the most-recent
-  // `source` and `patch` since those drive Action targeting and the popup
-  // review-panel diff view. The host's `handleReviewAllInChange` already
-  // iterates all matching records by path, so Keep/Undo correctly act on
-  // every underlying change.
-  return changes.reduce<ReviewChange[]>((acc, change) => {
-    const existing = acc.findIndex((item) => samePath(item.path, change.path))
-    if (existing < 0) return [...acc, change]
-    const prev = acc[existing]!
-    const copy = acc.slice()
-    copy[existing] = {
-      ...change,
-      additions: prev.additions + change.additions,
-      deletions: prev.deletions + change.deletions,
-      kind: prev.kind === "created" || prev.kind === "deleted" ? prev.kind : change.kind,
-    }
-    return copy
-  }, [])
-}
-
-export function toolChanges(update: { tool: string; title?: string; input?: Record<string, unknown>; metadata?: Record<string, unknown> }, source: string) {
-  if (update.tool === "apply_patch") return patchChanges(update.metadata?.files, source)
-  const filediff = isRecord(update.metadata?.filediff) ? update.metadata.filediff : undefined
-  let patch = typeof filediff?.patch === "string" ? filediff.patch : typeof update.metadata?.diff === "string" ? update.metadata.diff : undefined
-  const isCreate =
-    (update.tool === "write" && update.metadata?.exists === false) ||
-    (update.tool === "edit" && update.input?.oldString === "")
-  // For created files, opencode often doesn't produce a unified diff in
-  // metadata since there's nothing to diff against. Synthesize one from the
-  // tool's input content so the file shows up in the review card.
-  if (!patch && isCreate) patch = synthesizeCreatePatch(update)
-  if (!patch) return []
-  return [{
-    source,
-    path: displayPath(update, filediff),
-    kind: isCreate ? "created" : "updated",
-    additions: typeof filediff?.additions === "number" ? filediff.additions : countDiff(patch, "+"),
-    deletions: typeof filediff?.deletions === "number" ? filediff.deletions : countDiff(patch, "-"),
-    patch,
-  } satisfies ReviewChange]
-}
-
-export function synthesizeCreatePatch(update: { tool: string; input?: Record<string, unknown> }): string | undefined {
-  const content =
-    update.tool === "write" && typeof update.input?.content === "string"
-      ? update.input.content
-      : update.tool === "edit" && typeof update.input?.newString === "string"
-        ? update.input.newString
-        : undefined
-  if (typeof content !== "string" || content === "") return undefined
-  const lines = content.split("\n")
-  // git omits a trailing empty line if the content ends in "\n"; mirror that
-  // so additions counts match what diff/patch consumers expect.
-  if (lines.length > 1 && lines[lines.length - 1] === "") lines.pop()
-  if (!lines.length) return undefined
-  const body = lines.map((line) => `+${line}`).join("\n")
-  return `@@ -0,0 +1,${lines.length} @@\n${body}`
-}
-
-export function patchChanges(files: unknown, source: string) {
-  if (!Array.isArray(files)) return []
-  return files.flatMap((file) => {
-    if (!isRecord(file) || typeof file.relativePath !== "string" || typeof file.patch !== "string") return []
-    return [{
-      source: `${source}:${file.relativePath}`,
-      path: file.relativePath,
-      kind: patchKind(file.type),
-      additions: typeof file.additions === "number" ? file.additions : countDiff(file.patch, "+"),
-      deletions: typeof file.deletions === "number" ? file.deletions : countDiff(file.patch, "-"),
-      patch: file.patch,
-    } satisfies ReviewChange]
-  })
-}
-
-export function diffChanges(diff: string, source: string) {
-  const starts = diff.split("\n").reduce<number[]>((acc, line, index) => (
-    line.startsWith("diff --git ") ? [...acc, index] : acc
-  ), [])
-  if (!starts.length) return createPatchChange(diff, source)
-  const lines = diff.split("\n")
-  return starts.map((start, index) => {
-    const chunk = lines.slice(start, starts[index + 1] ?? lines.length).join("\n")
-    const header = lines[start] ?? ""
-    const match = header.match(/^diff --git a\/(.+) b\/(.+)$/)
-    const path = match?.[2] ?? match?.[1] ?? patchPath(chunk)
-    return {
-      source: `${source}:${index}`,
-      path,
-      kind: chunk.includes("\nnew file mode ") ? "created" : chunk.includes("\ndeleted file mode ") ? "deleted" : "updated",
-      additions: countDiff(chunk, "+"),
-      deletions: countDiff(chunk, "-"),
-      patch: chunk,
-    } satisfies ReviewChange
-  })
-}
-
-export function createPatchChange(patch: string, source: string) {
-  return [{
-    source,
-    path: patchPath(patch),
-    kind: patch.includes("\n--- /dev/null") ? "created" : patch.includes("\n+++ /dev/null") ? "deleted" : "updated",
-    additions: countDiff(patch, "+"),
-    deletions: countDiff(patch, "-"),
-    patch,
-  } satisfies ReviewChange]
-}
-
-export function patchPath(patch: string) {
-  const plus = patch.match(/\n\+\+\+\s+(?:b\/)?(.+)/)?.[1]
-  if (plus && plus !== "/dev/null") return plus
-  const minus = patch.match(/\n---\s+(?:a\/)?(.+)/)?.[1]
-  if (minus && minus !== "/dev/null") return minus
-  const index = patch.match(/^Index:\s+(.+)$/m)?.[1]
-  return index ?? "file"
-}
-
-export function displayPath(update: { title?: string; input?: Record<string, unknown>; metadata?: Record<string, unknown> }, filediff?: Record<string, unknown>) {
-  // The absolute filepath opencode resolved is unambiguous; prefer it. The
-  // model's raw input.filePath can be relative to opencode's internal
-  // directory (e.g., the git worktree root) which differs from our VSCode
-  // workspace folder, and persisted conversations may already have the wrong
-  // relative there.
-  const fromMetadata = typeof update.metadata?.filepath === "string" ? update.metadata.filepath : undefined
-  if (fromMetadata && isAbsolutePath(fromMetadata)) return fromMetadata
-  const fromFilediff = typeof filediff?.file === "string" ? filediff.file : undefined
-  if (fromFilediff && isAbsolutePath(fromFilediff)) return fromFilediff
-  if (typeof update.input?.filePath === "string" && update.input.filePath) return update.input.filePath
-  if (typeof update.title === "string" && update.title.trim()) return update.title
-  return fromFilediff ?? "file"
-}
-
-export function isAbsolutePath(value: string) {
-  // Posix and Windows absolute paths. We don't import node:path in the webview.
-  return value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value) || value.startsWith("\\\\")
-}
-
-export function patchKind(value: unknown): ReviewChange["kind"] {
-  if (value === "add") return "created"
-  if (value === "delete") return "deleted"
-  if (value === "move") return "moved"
-  return "updated"
-}
-
 export function splitDiff(patch: string): { hunks: DiffHunk[] } {
   const lines = patch.split("\n")
   const hunks: DiffHunk[] = []
@@ -374,70 +237,19 @@ export function splitDiff(patch: string): { hunks: DiffHunk[] } {
   return { hunks }
 }
 
-export function reviewKey(change: ReviewChange, hunkID: string) {
-  return `${change.source}:${normalizePath(change.path)}:${hunkID}`
-}
-
-export function samePath(left: string, right?: string) {
-  if (!right) return false
-  return normalizePath(left) === normalizePath(right)
-}
-
-export function normalizePath(value: string) {
-  return value.replace(/\\/g, "/").replace(/^\.?\//, "")
-}
-
-export function isTextReviewChange(change: ReviewChange) {
-  if (change.additions === 0 && change.deletions === 0) return false
-  const name = basename(change.path).toLowerCase()
-  if (!name || name === ".ds_store" || name === "thumbs.db") return false
-  const ext = name.includes(".") ? `.${name.split(".").at(-1)}` : ""
-  if (!ext && name.startsWith(".")) return false
-  return !new Set([
-    ".ai",
-    ".avif",
-    ".bin",
-    ".bmp",
-    ".class",
-    ".db",
-    ".dmg",
-    ".doc",
-    ".docx",
-    ".ds_store",
-    ".eot",
-    ".exe",
-    ".gif",
-    ".heic",
-    ".icns",
-    ".ico",
-    ".jar",
-    ".jpeg",
-    ".jpg",
-    ".mov",
-    ".mp3",
-    ".mp4",
-    ".otf",
-    ".pdf",
-    ".png",
-    ".pyc",
-    ".so",
-    ".sqlite",
-    ".ttf",
-    ".webp",
-    ".woff",
-    ".woff2",
-    ".zip",
-  ]).has(ext)
-}
-
-export function countDiff(patch: string, prefix: "+" | "-") {
-  return patch.split("\n").filter((line) => line.startsWith(prefix) && !line.startsWith(`${prefix}${prefix}${prefix}`)).length
-}
-
-export function basename(value: string) {
-  return value.split(/[\\/]/).filter(Boolean).at(-1) ?? value
-}
-
-export function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null
-}
+// Re-export the shared helpers used by tests so existing import paths
+// (`from "ReviewPanel"`) keep working.
+export {
+  basename,
+  countDiff,
+  isAbsolutePath,
+  isTextReviewChange,
+  normalizePath,
+  patchKind,
+  reviewKey,
+  samePath,
+  synthesizeCreatePatch,
+  toolChanges,
+  turnChanges,
+} from "../review-extract"
+export type { ReviewChangeActor }

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -12,6 +12,7 @@ import type {
   Outbound,
   QuestionInfo,
   ReviewChange,
+  ReviewChangeActor,
   ReviewHunkState,
   Selection,
   ToolUpdate,
@@ -99,7 +100,12 @@ function appendToLastBlock(
   return copy
 }
 
-function upsertTool(messages: Message[], id: string, update: ToolUpdate): Message[] {
+function upsertTool(
+  messages: Message[],
+  id: string,
+  update: ToolUpdate,
+  actor?: ReviewChangeActor,
+): Message[] {
   const idx = messages.findIndex((m) => m.id === id)
   if (idx < 0) return messages
   const msg = messages[idx]
@@ -109,9 +115,14 @@ function upsertTool(messages: Message[], id: string, update: ToolUpdate): Messag
   let blocks: Block[]
   if (existing >= 0) {
     blocks = msg.blocks.slice()
-    blocks[existing] = { type: "tool", update }
+    const prev = blocks[existing]
+    blocks[existing] = {
+      type: "tool",
+      update,
+      actor: actor ?? (prev?.type === "tool" ? prev.actor : undefined),
+    }
   } else {
-    blocks = [...msg.blocks, { type: "tool", update }]
+    blocks = [...msg.blocks, { type: "tool", update, actor }]
   }
   const copy = messages.slice()
   copy[idx] = { ...msg, blocks }
@@ -206,13 +217,15 @@ export function reducer(state: ChatState, action: Action): ChatState {
       }
     case "tool":
       if (state.aborting) return state
-      return { ...state, messages: upsertTool(state.messages, action.id, action.update) }
+      return { ...state, messages: upsertTool(state.messages, action.id, action.update, action.actor) }
     case "patch":
       if (state.aborting) return state
       return {
         ...state,
         messages: state.messages.map((m) =>
-          m.id === action.id ? { ...m, blocks: [...m.blocks, { type: "patch", files: action.files, diff: action.diff }] } : m,
+          m.id === action.id
+            ? { ...m, blocks: [...m.blocks, { type: "patch", files: action.files, diff: action.diff, actor: action.actor }] }
+            : m,
         ),
       }
     case "reviewHunkState": {

--- a/webview/src/protocol.ts
+++ b/webview/src/protocol.ts
@@ -5,6 +5,21 @@
 
 export type ToolStatus = "pending" | "running" | "completed" | "error"
 export type ReviewHunkState = "accepted" | "rejected"
+
+/**
+ * Who produced a file change. `main` is the parent assistant session;
+ * `subagent` is any child session dispatched via `task` / `call_omo_agent`
+ * / etc. `sessionID` is the child opencode session for subagent rows;
+ * `subagent` is the agent slug (e.g. `explore`, `hephaestus`) when omo's
+ * tool metadata surfaced it. Multiple actors can contribute to the same
+ * path — see `ReviewChange.actors`.
+ */
+export type ReviewChangeActor = {
+  kind: "main" | "subagent"
+  sessionID?: string
+  subagent?: string
+}
+
 export type ReviewChange = {
   source: string
   path: string
@@ -12,6 +27,17 @@ export type ReviewChange = {
   additions: number
   deletions: number
   patch: string
+  /**
+   * Set when `kind === "moved"`. The pre-move path of the file. Used by
+   * Undo to restore the file at its original location.
+   */
+  oldPath?: string
+  /**
+   * Attribution for the change. Always at least one entry; aggregated
+   * changes accumulate one entry per contributing actor. Older clients
+   * may not set this — consumers should treat empty as "main".
+   */
+  actors?: ReviewChangeActor[]
 }
 
 export type ToolUpdate = {
@@ -39,8 +65,14 @@ export type QuestionInfo = {
 export type ChatBlock =
   | { type: "text"; text: string }
   | { type: "reasoning"; text: string }
-  | { type: "tool"; update: ToolUpdate }
-  | { type: "patch"; files: string[]; diff?: string }
+  /**
+   * `actor` identifies whether the tool ran on the main session or a child
+   * subagent session. Absent / `kind === "main"` means main. Subagent tool
+   * blocks are appended to the dispatching parent message so review-card
+   * aggregation walks them naturally.
+   */
+  | { type: "tool"; update: ToolUpdate; actor?: ReviewChangeActor }
+  | { type: "patch"; files: string[]; diff?: string; actor?: ReviewChangeActor }
   | { type: "attachment"; mime: string; filename: string; dataUrl: string; bytes: number }
 
 export type ChatMessage = {
@@ -316,8 +348,8 @@ export type Outbound =
   | { type: "assistantStart"; id: string }
   | { type: "textDelta"; id: string; delta: string }
   | { type: "reasoningDelta"; id: string; delta: string }
-  | { type: "tool"; id: string; update: ToolUpdate }
-  | { type: "patch"; id: string; files: string[]; diff?: string }
+  | { type: "tool"; id: string; update: ToolUpdate; actor?: ReviewChangeActor }
+  | { type: "patch"; id: string; files: string[]; diff?: string; actor?: ReviewChangeActor }
   | { type: "reviewHunkState"; key: string; state?: ReviewHunkState }
   | { type: "assistantError"; id: string; message: string }
   | { type: "assistantDone"; id: string; usage?: UsageDelta }

--- a/webview/src/review-extract.ts
+++ b/webview/src/review-extract.ts
@@ -1,0 +1,339 @@
+/**
+ * Shared change-extraction + aggregation used by the host (src/chat/review-changes.ts)
+ * and the webview Review Panel (components/ReviewPanel.tsx). Both must agree on
+ * which file changes a turn contains, otherwise host actions (Keep/Undo all by
+ * path) and webview rendering can drift — e.g. the webview would hide a row the
+ * host still considers pending, or vice versa.
+ *
+ * No vscode / node imports here so this works in the webview's jsdom context.
+ */
+import type { ChatMessage, ReviewChange, ReviewChangeActor, ToolUpdate } from "./protocol"
+
+export type ToolUpdateLike = {
+  callID?: string
+  tool: string
+  status?: string
+  title?: string
+  input?: Record<string, unknown>
+  metadata?: Record<string, unknown>
+}
+
+const BINARY_EXTS = new Set([
+  ".ai", ".avif", ".bin", ".bmp", ".class", ".db", ".dmg", ".doc", ".docx",
+  ".ds_store", ".eot", ".exe", ".gif", ".heic", ".icns", ".ico", ".jar",
+  ".jpeg", ".jpg", ".mov", ".mp3", ".mp4", ".otf", ".pdf", ".png", ".pyc",
+  ".so", ".sqlite", ".ttf", ".webp", ".woff", ".woff2", ".zip",
+])
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+export function basename(value: string): string {
+  return value.split(/[\\/]/).filter(Boolean).at(-1) ?? value
+}
+
+export function normalizePath(value: string): string {
+  return value.replace(/\\/g, "/").replace(/^\.?\//, "")
+}
+
+export function samePath(left: string, right?: string): boolean {
+  if (!right) return false
+  return normalizePath(left) === normalizePath(right)
+}
+
+export function isTextReviewChange(change: ReviewChange): boolean {
+  if (change.additions === 0 && change.deletions === 0 && change.kind !== "deleted") return false
+  return isTextReviewPathName(change.path)
+}
+
+export function isTextReviewPathName(value: string): boolean {
+  const name = basename(value).toLowerCase()
+  if (!name || name === ".ds_store" || name === "thumbs.db") return false
+  const ext = name.includes(".") ? `.${name.split(".").at(-1)}` : ""
+  if (!ext && name.startsWith(".")) return false
+  return !BINARY_EXTS.has(ext)
+}
+
+export function countDiff(patch: string, prefix: "+" | "-"): number {
+  return patch.split("\n").filter((line) => (
+    line.startsWith(prefix) && !line.startsWith(`${prefix}${prefix}${prefix}`)
+  )).length
+}
+
+export function patchKind(value: unknown): ReviewChange["kind"] {
+  if (value === "add") return "created"
+  if (value === "delete") return "deleted"
+  if (value === "move") return "moved"
+  return "updated"
+}
+
+export function isAbsolutePath(value: string): boolean {
+  return value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value) || value.startsWith("\\\\")
+}
+
+export function displayPath(
+  update: { title?: string; input?: Record<string, unknown>; metadata?: Record<string, unknown> },
+  filediff?: Record<string, unknown>,
+): string {
+  // The absolute filepath opencode resolved is unambiguous; prefer it. The
+  // model's raw input.filePath can be relative to opencode's internal
+  // directory (e.g., the git worktree root) which differs from our VSCode
+  // workspace folder, and persisted conversations may already have the wrong
+  // relative there.
+  const fromMetadata = typeof update.metadata?.filepath === "string" ? update.metadata.filepath : undefined
+  if (fromMetadata && isAbsolutePath(fromMetadata)) return fromMetadata
+  const fromFilediff = typeof filediff?.file === "string" ? filediff.file : undefined
+  if (fromFilediff && isAbsolutePath(fromFilediff)) return fromFilediff
+  if (typeof update.input?.filePath === "string" && update.input.filePath) return update.input.filePath
+  if (typeof update.title === "string" && update.title.trim()) return update.title
+  return fromFilediff ?? "file"
+}
+
+export function patchPath(patch: string): string {
+  const plus = patch.match(/(?:^|\n)\+\+\+\s+(?:b\/)?(.+)/)?.[1]
+  if (plus && plus !== "/dev/null") return plus
+  const minus = patch.match(/(?:^|\n)---\s+(?:a\/)?(.+)/)?.[1]
+  if (minus && minus !== "/dev/null") return minus
+  const index = patch.match(/^Index:\s+(.+)$/m)?.[1]
+  return index ?? "file"
+}
+
+export function synthesizeCreatePatch(update: ToolUpdateLike): string | undefined {
+  const content =
+    update.tool === "write" && typeof update.input?.content === "string"
+      ? update.input.content
+      : update.tool === "edit" && typeof update.input?.newString === "string"
+        ? update.input.newString
+        : undefined
+  if (typeof content !== "string" || content === "") return undefined
+  const lines = content.split("\n")
+  if (lines.length > 1 && lines[lines.length - 1] === "") lines.pop()
+  if (!lines.length) return undefined
+  const body = lines.map((line) => `+${line}`).join("\n")
+  return `@@ -0,0 +1,${lines.length} @@\n${body}`
+}
+
+/**
+ * Build review changes from one tool update. Used by both host and webview;
+ * pass the actor (parent vs subagent) so attribution propagates from the
+ * dispatching site. Callers without attribution context may pass undefined
+ * — `aggregateChanges` will treat missing actor as `main`.
+ */
+export function toolChanges(
+  update: ToolUpdateLike,
+  source: string,
+  actor?: ReviewChangeActor,
+): ReviewChange[] {
+  if (update.status && update.status !== "completed") return []
+  if (update.tool === "apply_patch") {
+    return patchChanges(update.metadata?.files, source, actor)
+  }
+  const filediff = isRecord(update.metadata?.filediff) ? update.metadata.filediff : undefined
+  let patch =
+    typeof filediff?.patch === "string"
+      ? filediff.patch
+      : typeof update.metadata?.diff === "string"
+        ? update.metadata.diff
+        : undefined
+  const isCreate =
+    (update.tool === "write" && update.metadata?.exists === false) ||
+    (update.tool === "edit" && update.input?.oldString === "")
+  if (!patch && isCreate) patch = synthesizeCreatePatch(update)
+  if (!patch) return []
+  return [{
+    source,
+    path: displayPath(update, filediff),
+    kind: isCreate ? "created" : "updated",
+    additions: typeof filediff?.additions === "number" ? filediff.additions : countDiff(patch, "+"),
+    deletions: typeof filediff?.deletions === "number" ? filediff.deletions : countDiff(patch, "-"),
+    patch,
+    actors: actor ? [actor] : undefined,
+  } satisfies ReviewChange]
+}
+
+export function patchChanges(
+  files: unknown,
+  source: string,
+  actor?: ReviewChangeActor,
+): ReviewChange[] {
+  if (!Array.isArray(files)) return []
+  return files.flatMap((file) => {
+    if (!isRecord(file) || typeof file.relativePath !== "string" || typeof file.patch !== "string") return []
+    const kind = patchKind(file.type)
+    const oldPath = typeof file.oldPath === "string"
+      ? file.oldPath
+      : typeof file.fromPath === "string"
+        ? file.fromPath
+        : undefined
+    return [{
+      source: `${source}:${file.relativePath}`,
+      path: file.relativePath,
+      kind,
+      additions: typeof file.additions === "number" ? file.additions : countDiff(file.patch, "+"),
+      deletions: typeof file.deletions === "number" ? file.deletions : countDiff(file.patch, "-"),
+      patch: file.patch,
+      oldPath: kind === "moved" ? oldPath : undefined,
+      actors: actor ? [actor] : undefined,
+    } satisfies ReviewChange]
+  })
+}
+
+export function diffChanges(
+  diff: string,
+  source: string,
+  actor?: ReviewChangeActor,
+): ReviewChange[] {
+  const lines = diff.split("\n")
+  const starts = lines.reduce<number[]>((acc, line, index) => (
+    line.startsWith("diff --git ") ? [...acc, index] : acc
+  ), [])
+  if (!starts.length) return createPatchChange(diff, source, actor)
+  return starts.map((start, index) => {
+    const chunk = lines.slice(start, starts[index + 1] ?? lines.length).join("\n")
+    const header = lines[start] ?? ""
+    const match = header.match(/^diff --git a\/(.+) b\/(.+)$/)
+    const pathValue = match?.[2] ?? match?.[1] ?? patchPath(chunk)
+    const oldPath = match?.[1] !== match?.[2] ? match?.[1] : undefined
+    return {
+      source: `${source}:${index}`,
+      path: pathValue,
+      kind: chunk.includes("\nnew file mode ")
+        ? "created"
+        : chunk.includes("\ndeleted file mode ")
+          ? "deleted"
+          : chunk.includes("\nrename to ") || (oldPath && oldPath !== pathValue)
+            ? "moved"
+            : "updated",
+      additions: countDiff(chunk, "+"),
+      deletions: countDiff(chunk, "-"),
+      patch: chunk,
+      oldPath: chunk.includes("\nrename to ") || (oldPath && oldPath !== pathValue) ? oldPath : undefined,
+      actors: actor ? [actor] : undefined,
+    } satisfies ReviewChange
+  })
+}
+
+export function createPatchChange(
+  patch: string,
+  source: string,
+  actor?: ReviewChangeActor,
+): ReviewChange[] {
+  return [{
+    source,
+    path: patchPath(patch),
+    kind: patch.includes("\n--- /dev/null")
+      ? "created"
+      : patch.includes("\n+++ /dev/null")
+        ? "deleted"
+        : "updated",
+    additions: countDiff(patch, "+"),
+    deletions: countDiff(patch, "-"),
+    patch,
+    actors: actor ? [actor] : undefined,
+  } satisfies ReviewChange]
+}
+
+function blockActor(block: { actor?: ReviewChangeActor }): ReviewChangeActor {
+  // Default to `main` so legacy ChatBlocks without `actor` (persisted before
+  // attribution landed) classify correctly. The aggregator drops a single
+  // bare `main` actor on display, so this is invisible to existing UI.
+  return block.actor ?? { kind: "main" }
+}
+
+/**
+ * Walk a turn's message list and emit one ReviewChange per logical file edit.
+ * Multiple records for the same path are PRESERVED at this stage; collapse
+ * them with `aggregateChanges` if you want a per-file row.
+ */
+export function extractChanges(messages: ChatMessage[]): ReviewChange[] {
+  return messages.flatMap((message) =>
+    message.blocks.flatMap((block, blockIndex) => {
+      const source = `${message.id}:${blockIndex}`
+      if (block.type === "patch" && block.diff) {
+        return diffChanges(block.diff, source, blockActor(block))
+      }
+      if (block.type === "tool") {
+        if (block.update.status !== "completed") return []
+        const callSource = block.update.callID || source
+        return toolChanges(block.update, callSource, blockActor(block))
+      }
+      return [] as ReviewChange[]
+    }),
+  )
+}
+
+/**
+ * Collapse multiple ReviewChange records for the same file into one row.
+ * - additions / deletions are SUMMED across all changes
+ * - `kind` prefers "created" / "deleted" / "moved" over "updated" since
+ *   create-then-modify still shows as a creation row
+ * - `actors` is merged (deduped) so the row carries every contributor
+ * - `source` and `patch` are taken from the MOST RECENT change so the
+ *   webview's selected-diff preview shows the latest edit
+ * - `oldPath` (move) propagates through if any contributing record had it
+ */
+export function aggregateChanges(changes: ReviewChange[]): ReviewChange[] {
+  return changes.reduce<ReviewChange[]>((acc, change) => {
+    const existingIndex = acc.findIndex((item) => samePath(item.path, change.path))
+    if (existingIndex < 0) {
+      return [...acc, { ...change, actors: dedupActors(change.actors) }]
+    }
+    const prev = acc[existingIndex]!
+    const merged: ReviewChange = {
+      ...change,
+      additions: prev.additions + change.additions,
+      deletions: prev.deletions + change.deletions,
+      kind: priorityKind(prev.kind, change.kind),
+      oldPath: prev.oldPath ?? change.oldPath,
+      actors: dedupActors([...(prev.actors ?? []), ...(change.actors ?? [])]),
+    }
+    const copy = acc.slice()
+    copy[existingIndex] = merged
+    return copy
+  }, [])
+}
+
+function priorityKind(prev: ReviewChange["kind"], next: ReviewChange["kind"]): ReviewChange["kind"] {
+  // "created" / "deleted" / "moved" are sticky — a follow-up plain update
+  // shouldn't downgrade the row's headline kind. If both are sticky and
+  // they conflict (e.g. created then deleted), prefer the later one since
+  // that's what the user actually needs to see in the panel.
+  if (prev === "updated") return next
+  if (next === "updated") return prev
+  return next
+}
+
+function dedupActors(actors: ReviewChangeActor[] | undefined): ReviewChangeActor[] | undefined {
+  if (!actors || !actors.length) return undefined
+  const seen = new Map<string, ReviewChangeActor>()
+  for (const actor of actors) {
+    const key = `${actor.kind}|${actor.sessionID ?? ""}|${actor.subagent ?? ""}`
+    if (!seen.has(key)) seen.set(key, actor)
+  }
+  return [...seen.values()]
+}
+
+/**
+ * The canonical "what does this turn contain?" function. Used by:
+ *  - webview ReviewPanel to render the review card
+ *  - host syncReviewDecorations / handleReviewAllInChange to drive actions
+ *
+ * Both sides MUST produce the same list — keep this the only place that
+ * collapses multiple records for the same path.
+ */
+export function turnChanges(messages: ChatMessage[]): ReviewChange[] {
+  return aggregateChanges(extractChanges(messages))
+}
+
+/**
+ * Compose a stable per-hunk key. Used by both sides to look up
+ * `reviewHunks[key]` and decide what's pending. MUST stay the same on host
+ * and webview.
+ */
+export function reviewKey(change: ReviewChange, hunkID: string): string {
+  return `${change.source}:${normalizePath(change.path)}:${hunkID}`
+}
+
+/** Re-export the protocol type so consumers only need this one import. */
+export type { ReviewChange, ReviewChangeActor, ToolUpdate }

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -2033,8 +2033,13 @@ button {
   background: var(--vscode-list-hoverBackground);
 }
 .review-file.is-selected {
-  background: var(--vscode-list-activeSelectionBackground, var(--vscode-list-hoverBackground));
-  color: var(--vscode-foreground);
+  /* Use the neutral "inactive selection" token rather than the saturated blue
+     `activeSelectionBackground` — the review card isn't a focused list, so a
+     subdued highlight reads correctly and stays consistent with VS Code's own
+     "not-currently-focused" list rows. Fallback chain keeps it readable on
+     themes that don't define every token. */
+  background: var(--vscode-list-inactiveSelectionBackground, var(--vscode-list-hoverBackground));
+  color: var(--vscode-list-inactiveSelectionForeground, var(--vscode-foreground));
 }
 .review-file.is-selected::before {
   content: "";
@@ -2044,7 +2049,11 @@ button {
   bottom: 4px;
   width: 2px;
   border-radius: 1px;
-  background: var(--vscode-focusBorder, var(--vscode-textLink-foreground));
+  /* Neutral accent stripe — text foreground on dark themes reads as white;
+     on light themes it reads as charcoal. Either way it's the same visual
+     weight as the row text instead of the loud focus-border blue. */
+  background: var(--vscode-foreground);
+  opacity: 0.5;
 }
 .review-file:focus-visible {
   outline: 1px solid var(--vscode-focusBorder);
@@ -2136,14 +2145,6 @@ button {
   height: 16px;
   transform: rotate(90deg);
   opacity: 0.8;
-}
-.context-chip {
-  font-size: 11px;
-  opacity: 0.6;
-  margin-bottom: 4px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 .promptbox-input {
   position: relative;


### PR DESCRIPTION
Closes #150.

## Summary

- Single source of truth for change extraction at `webview/src/review-extract.ts`. Host (`src/chat/review-changes.ts`) and webview (`webview/src/components/ReviewPanel.tsx`) now produce byte-identical change lists from the same input — no more drift between the two sides.
- Subagent file edits captured. Extended `ChildSessionEvent` in `src/chat/stream.ts` with `tool` and `patch` variants, plus `session.created` auto-discovery so opencode's built-in `task` tool (which doesn't surface `metadata.sessionId` early enough) is also covered. `ChatView.appendSubagentBlock` attaches the child's tool/patch blocks to the dispatching parent message with subagent attribution.
- Bidirectional dispatch ↔ discovery merge in `SubagentTracker`. Whichever path arrives second claims the orphan from the other path instead of creating a duplicate popover row.
- Safe Undo via line-anchored hunk location. `parseHunkHeader` + `findHunkInFile` replace the old `current.indexOf(newText)` — repeated identical text blocks no longer cause Undo to mangle the wrong copy. Per-kind handling: created → delete file, deleted → restore content, moved → rename back, updated → reverse the hunk. Structured `ReviewHunkOutcome` (`applied` / `no-op` / `conflict` / `missing` / `unsupported`) — conflicts surface a warning and leave the row pending instead of silently marking it rejected.
- Keep verifies post-change state before accepting (file exists, expected `newText` present at the anchor line).
- Multi-root workspace safety. `workspaceFileUri` / `openFileDocument` / `reviewPathExists` accept an optional `root` hint; `ChatView` passes `backend.directory` so relative paths land on the right copy when two workspace folders share a filename.
- UX cleanup: removed the in-row \"subagent\" label (attribution now lives on the row's hover tooltip); selected row uses `--vscode-list-inactiveSelectionBackground` + `--vscode-foreground` instead of the saturated blue active-selection tokens; dropped the `@<file>` chip above the prompt input.
- `SubagentTracker` now reads `input.subagent_type` as a fallback when omo-style `metadata.agent` is absent, so opencode's built-in `task` tool shows the right slug.

## Files changed

- New: `webview/src/review-extract.ts` (shared extractor); 7 new test files.
- Modified: `src/chat/diff.ts`, `src/chat/fs-ops.ts`, `src/chat/review-changes.ts`, `src/chat/stream.ts`, `src/chat/view.ts`, `src/agents/subagent-tracker.ts`, `webview/src/components/ReviewPanel.tsx`, `webview/src/components/PromptBox.tsx`, `webview/src/App.tsx`, `webview/src/hooks/useChatState.ts`, `webview/src/protocol.ts`, `webview/src/styles.css`, `test/host/mock-opencode-server.ts`, `test/host/subagent-tracker.test.ts`, `test/webview/promptbox.test.tsx`.

## Test plan

- [x] \`bun run test\` — 769/769 (up from 706 on main; +63 tests across SSE routing, attribution, safe undo, integration).
- [x] \`bun run check-types\` — host clean; webview 3 pre-existing errors documented in CLAUDE.md (none introduced by this PR).
- [ ] Manual: subagent edit appears in Review card with correct attribution.
- [ ] Manual: Undo on a repeated-identical-text-block hunk modifies the right occurrence.
- [ ] Manual: Undo on a created file deletes it; Undo on a deleted file restores content; Undo on a moved file moves it back.
- [ ] Manual: file-row selected state uses neutral grey, not saturated blue.
- [ ] Manual: no \`@file\` chip appears above the prompt textarea.