### PR TITLE
chore(release): cut v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [0.9.0] - 2026-05-20
+## [0.9.1] - 2026-05-21
+
+### Changed
+- Agents popover normalized to share its layout vocabulary with the other two header popovers (Model/Agent selector, Chat history). Same `top` gap below the statusbar (`calc(100% + 2px)`, was `+ 6px`), same design tokens (`var(--z-popover)` instead of raw `50`, `var(--radius)` instead of `4px`, `--vscode-sideBar-background` fallback instead of `--vscode-editorWidget-background`), and the same `0 8px 24px / .32` drop shadow. Toggling between the three popovers now feels like one family.
+- Agents popover default width capped at 300px (was 360px) so chat content stays visible behind it on narrow side panels. Row content still fits comfortably with ellipsis on overflow. The `min(…, calc(100vw - 20px))` clamp still kicks in on narrower panels.
+- All three header popovers (`SelectorMenu`, `AgentsMenu`, `ChatHistoryMenu`) share dismiss boilerplate via a new `useDismissableMenu` hook (`webview/src/hooks/useDismissableMenu.ts`). One source for the open state, the outer ref, the outside-click + Escape listeners. Action handlers use the semantic `close()` helper instead of `setOpen(false)`.
+
+
 
 ### Added
 - Subagent file edits flow into the Review card. The host now extends `ChildSessionEvent` (`src/chat/stream.ts`) with `tool` and `patch` variants and listens for `session.created` events whose `parentID` matches the current session — so opencode's built-in `task` tool (which doesn't reliably publish `metadata.sessionId` on the parent's tool call) is covered alongside the omo / `call_omo_agent` flow that already worked. `ChatView.appendSubagentBlock` resolves which parent assistant bubble owns the child session via `AgentTaskStore.getByChildSession(...).messageID` (with a fallback to the most-recent assistant message), then appends the child's tool/patch block to that bubble with a `ReviewChangeActor` of `{ kind: "subagent", sessionID, subagent }`. The Review card now lists subagent-only files just like main-agent ones; aggregation is deterministic across both sides. Subagent attribution lives on the row's `title` tooltip ("Modified by: <slug>") rather than as a visible inline label. Closes #150.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",

--- a/webview/src/components/StatusBar.tsx
+++ b/webview/src/components/StatusBar.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import type { AgentsStatusInfo, AgentsTaskInfo, ConversationSummary, Selection } from "../protocol"
+import { useDismissableMenu } from "../hooks/useDismissableMenu"
 import { StatusIndicator, type StatusIndicatorKind } from "./StatusIndicator"
 
 type Props = {
@@ -118,29 +119,11 @@ function ChatHistoryMenu({
   onRename: (id: string, title: string) => void
   onDelete: (id: string) => void
 }) {
-  const [open, setOpen] = useState(false)
+  const { open, toggle, close, ref } = useDismissableMenu()
   const [renamingID, setRenamingID] = useState<string>()
   const [renamingTitle, setRenamingTitle] = useState("")
   const [confirmDeleteID, setConfirmDeleteID] = useState<string>()
   const [query, setQuery] = useState("")
-  const ref = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (!open) return
-    const onPointerDown = (event: PointerEvent) => {
-      if (ref.current?.contains(event.target as Node)) return
-      setOpen(false)
-    }
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOpen(false)
-    }
-    window.addEventListener("pointerdown", onPointerDown)
-    window.addEventListener("keydown", onKeyDown)
-    return () => {
-      window.removeEventListener("pointerdown", onPointerDown)
-      window.removeEventListener("keydown", onKeyDown)
-    }
-  }, [open])
 
   useEffect(() => {
     if (!open) {
@@ -192,7 +175,7 @@ function ChatHistoryMenu({
     <div className="history-menu" ref={ref}>
       <button
         className={`history-trigger ${open ? "is-open" : ""}`}
-        onClick={() => setOpen(!open)}
+        onClick={toggle}
         aria-label="Chat history"
         title={activeTitle ? `Chat history: ${activeTitle}` : "Chat history"}
       >
@@ -206,7 +189,7 @@ function ChatHistoryMenu({
               type="button"
               className="history-new"
               onClick={() => {
-                setOpen(false)
+                close()
                 onCreate()
               }}
             >
@@ -263,7 +246,7 @@ function ChatHistoryMenu({
                       <button
                         className="history-open"
                         onClick={() => {
-                          setOpen(false)
+                          close()
                           onOpen(conversation.id)
                         }}
                         title={conversation.title}
@@ -305,25 +288,7 @@ function ChatHistoryMenu({
  * for error, amber for waiting.
  */
 function AgentsMenu({ status }: { status?: AgentsStatusInfo }) {
-  const [open, setOpen] = useState(false)
-  const ref = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (!open) return
-    const onPointerDown = (event: PointerEvent) => {
-      if (ref.current?.contains(event.target as Node)) return
-      setOpen(false)
-    }
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOpen(false)
-    }
-    window.addEventListener("pointerdown", onPointerDown)
-    window.addEventListener("keydown", onKeyDown)
-    return () => {
-      window.removeEventListener("pointerdown", onPointerDown)
-      window.removeEventListener("keydown", onKeyDown)
-    }
-  }, [open])
+  const { open, toggle, ref } = useDismissableMenu()
 
   const running = (status?.running ?? 0) > 0
   const errorOnly = !running && (status?.error ?? 0) > 0
@@ -346,7 +311,7 @@ function AgentsMenu({ status }: { status?: AgentsStatusInfo }) {
       <button
         type="button"
         className={className}
-        onClick={() => setOpen((value) => !value)}
+        onClick={toggle}
         title={buildAgentsTitle(status)}
         aria-label="Open agents for this chat"
         aria-haspopup="menu"
@@ -489,25 +454,7 @@ function SelectorMenu({
   onSelectModel: () => void
   onSelectVariant: () => void
 }) {
-  const [open, setOpen] = useState(false)
-  const ref = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (!open) return
-    const onPointerDown = (event: PointerEvent) => {
-      if (ref.current?.contains(event.target as Node)) return
-      setOpen(false)
-    }
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOpen(false)
-    }
-    window.addEventListener("pointerdown", onPointerDown)
-    window.addEventListener("keydown", onKeyDown)
-    return () => {
-      window.removeEventListener("pointerdown", onPointerDown)
-      window.removeEventListener("keydown", onKeyDown)
-    }
-  }, [open])
+  const { open, toggle, close, ref } = useDismissableMenu()
 
   const prettyModel = formatModel(model)
   const prettyAgent = formatAgent(agent)
@@ -518,7 +465,7 @@ function SelectorMenu({
     <div className="selector-menu" ref={ref}>
       <button
         className={`selector-trigger ${open ? "is-open" : ""}`}
-        onClick={() => setOpen(!open)}
+        onClick={toggle}
         title={triggerTitle}
         aria-label="Change agent, model, and effort"
         aria-expanded={open}
@@ -544,7 +491,7 @@ function SelectorMenu({
             role="menuitem"
             onClick={() => {
               onSelectModel()
-              setOpen(false)
+              close()
             }}
           >
             <span className="selector-row-label">Model</span>
@@ -557,7 +504,7 @@ function SelectorMenu({
             role="menuitem"
             onClick={() => {
               onSelectVariant()
-              setOpen(false)
+              close()
             }}
             title="Change effort / thinking budget for the current model"
           >
@@ -571,7 +518,7 @@ function SelectorMenu({
             role="menuitem"
             onClick={() => {
               onSelectAgent()
-              setOpen(false)
+              close()
             }}
           >
             <span className="selector-row-label">Agent</span>

--- a/webview/src/hooks/useDismissableMenu.ts
+++ b/webview/src/hooks/useDismissableMenu.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef, useState } from "react"
+
+/**
+ * Shared open/close state for the inline popover menus in the status bar
+ * (Model/Agent selector, Agents pill, Chat history). Owns the `useState`,
+ * the ref for the outer container, and the pointerdown + Escape listeners
+ * that dismiss the popover when the user clicks outside or hits Escape.
+ *
+ * The caller still renders its own trigger and popover JSX; only the
+ * boilerplate moves in here. Attach the returned `ref` to the outermost
+ * container (the same element the popover is positioned relative to) so
+ * the outside-click check can tell "still inside" from "elsewhere".
+ */
+export function useDismissableMenu(): {
+  open: boolean
+  setOpen: (value: boolean) => void
+  toggle: () => void
+  close: () => void
+  ref: React.RefObject<HTMLDivElement>
+} {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (event: PointerEvent) => {
+      if (ref.current?.contains(event.target as Node)) return
+      setOpen(false)
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false)
+    }
+    window.addEventListener("pointerdown", onPointerDown)
+    window.addEventListener("keydown", onKeyDown)
+    return () => {
+      window.removeEventListener("pointerdown", onPointerDown)
+      window.removeEventListener("keydown", onKeyDown)
+    }
+  }, [open])
+
+  return {
+    open,
+    setOpen,
+    toggle: () => setOpen(!open),
+    close: () => setOpen(false),
+    ref,
+  }
+}

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -178,7 +178,13 @@ button {
    animation. Clicking opens an inline popover scoped to the current chat
    (`.agents-popover`). */
 .agents-menu {
-  position: relative;
+  /* Intentionally NOT position: relative — `.agents-popover` anchors to
+     the parent `.statusbar` (which IS position: relative) so its right
+     edge lands at the panel's right edge, not the pill's right edge.
+     The pill sits in the middle of the bar with new-chat + history
+     buttons to its right; anchoring to the pill would push the popover
+     leftward off the panel on narrow side views. Matches the same
+     fall-through pattern used by .selector-menu and .history-menu. */
   flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
@@ -234,22 +240,26 @@ button {
 
 .agents-popover {
   position: absolute;
-  top: calc(100% + 6px);
-  /* Anchor the popover's right edge to the pill so it grows leftward.
-     With the pill sitting next to the new-chat (+) button on the right
-     side of the header, a left-anchored popover (min-width 260px) would
-     overflow the sidebar's right edge — especially in narrow side
-     panels. Growing leftward keeps the popover inside the panel. */
-  right: -4px;
-  min-width: 260px;
-  max-width: 360px;
-  background: var(--vscode-dropdown-background, var(--vscode-editorWidget-background));
+  /* Shared layout vocabulary with `.selector-popover` and
+     `.history-popover`: same `top` gap below the statusbar, same
+     `right` anchor to the panel edge, same width-clamp formula,
+     same design tokens (`--z-popover`, `--radius`, the sidebar
+     background fallback) and the same drop shadow — so toggling
+     between the three header popovers feels uniform instead of
+     each one drifting toward its own polish. The 300px cap leaves
+     chat content visible behind the popover even on narrow side
+     panels; row content still fits comfortably with ellipsis on
+     overflow. */
+  top: calc(100% + 2px);
+  right: 10px;
+  width: min(300px, calc(100vw - 20px));
+  background: var(--vscode-dropdown-background, var(--vscode-sideBar-background));
   color: var(--vscode-foreground);
   border: 1px solid var(--vscode-dropdown-border, var(--vscode-panel-border));
-  border-radius: 4px;
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.32);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.32);
   padding: 8px 0;
-  z-index: 50;
+  z-index: var(--z-popover);
   font-size: 12px;
   /* Cap how tall the popover can grow before scrolling — without this a
      long-running Hephaestus session can produce 20+ historical


### PR DESCRIPTION
## Summary

- Agents popover normalized to share its layout vocabulary with the Selector / History popovers (same `top` gap, `--z-popover`, `--radius`, sidebar background fallback, shared shadow).
- Agents popover default width capped at 300px (was 360px) — chat stays visible behind it on narrow side panels.
- All three header popovers share dismiss boilerplate via a new `useDismissableMenu` hook; action handlers use the semantic `close()` helper.

## Test plan

- [x] `bun run test` — 769/769 pass.
- [x] `bun run check-types` — clean.
- [x] `cd webview && bunx tsc --noEmit` — the 3 known pre-existing errors only.
- [ ] Manual: toggle the three header popovers (Model/Agent, Agents, History) and verify the gap below the statusbar, drop shadow, and corner radius all match.

Closes #154