### PR TITLE
fix(chat): reset aborting flag on conversation boundary

### DIFF
--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -240,6 +240,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.resetContinuationState()
     this.subscription?.abort()
     this.subscription = undefined
+    this.aborting = false
     this.sessionID = undefined
     this.currentMainTaskID = undefined
     this.messageMap.clear()
@@ -277,6 +278,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.resetContinuationState()
     this.subscription?.abort()
     this.subscription = undefined
+    this.aborting = false
     this.currentMainTaskID = undefined
     this.taskStoreUnsub?.dispose()
     this.taskStoreUnsub = undefined
@@ -333,6 +335,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.resetContinuationState()
     this.subscription?.abort()
     this.subscription = undefined
+    this.aborting = false
     this.currentMainTaskID = undefined
     this.messageMap.clear()
     this.activePermissions.clear(); this.activeQuestions.clear()


### PR DESCRIPTION
## Summary

- Reset `this.aborting = false` in `createConversation`, `selectConversation`, and `dispose` (alongside the existing `this.subscription = undefined` line).
- Without this, an abort that's still in flight when the user switches conversations leaves the flag stuck `true`, and the new conversation's first turn silently drops every SSE event.

## Test plan

- [x] `bun run check-types` clean.
- [x] `bun run test` — 769/769 pass.
- [ ] Manual: in extension dev host, send a prompt in conv A, press Stop while streaming, immediately switch to conv B, send a prompt — assistant streams normally.

Closes #156