### PR TITLE
fix(chat): reset turn state when deleting active conversation

### DIFF
--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -373,6 +373,8 @@ export class ChatView implements vscode.WebviewViewProvider {
       this.resetContinuationState()
       this.subscription?.abort()
       this.subscription = undefined
+      this.aborting = false
+      this.currentMainTaskID = undefined
       this.messageMap.clear()
       this.activePermissions.clear(); this.activeQuestions.clear()
       this.activeConversationID = this.conversationSummaries()[0]!.id


### PR DESCRIPTION
## Summary

- Inside `deleteConversation`'s "active conversation was deleted" branch, also clear `this.currentMainTaskID` and `this.aborting` (matching what every other conversation-boundary site does).
- Without these, deleting the active conversation while a turn is in flight either targets a stale Main task row (currentMainTaskID) or — if the user pressed Stop just before deleting — leaves the next auto-selected conversation's first turn silently dropping every SSE event (aborting).

## Test plan

- [x] `bun run check-types` clean.
- [x] `bun run test` — 769/769 pass.
- [ ] Manual: with two conversations, press Stop in the active one then immediately delete it; send a prompt in the auto-selected conversation — assistant streams normally and a Main task row appears for the new turn.

Closes #158