### PR TITLE
fix(mentions): match path even when shorter than a colliding chip

### DIFF
--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -205,6 +205,15 @@ describe("extractMentions", () => {
   it("returns [] when known set empty", () => {
     expect(extractMentions("anything @here", new Set())).toEqual([])
   })
+
+  it("finds a path whose first occurrence is inside a longer prefix-collision chip", () => {
+    // `src/foo.ts` is a prefix of `src/foo.tsx`. indexOf finds the `.ts` first
+    // inside the longer chip; the trailing `x` fails the whitespace check. The
+    // implementation must keep scanning past that hit to find the real one.
+    const known = new Set(["src/foo.tsx", "src/foo.ts"])
+    const out = extractMentions("@src/foo.tsx and @src/foo.ts", known)
+    expect(out.sort()).toEqual(["src/foo.ts", "src/foo.tsx"])
+  })
 })
 
 describe("PromptBox @file autocomplete", () => {

--- a/webview/src/mention-tokens.ts
+++ b/webview/src/mention-tokens.ts
@@ -45,11 +45,21 @@ export function extractMentions(text: string, known: Set<string>): string[] {
   const out: string[] = []
   for (const path of known) {
     const token = "@" + path
-    const idx = text.indexOf(token)
-    if (idx < 0) continue
-    const after = text[idx + token.length] ?? ""
-    if (after && !/\s/.test(after)) continue
-    out.push(path)
+    // Loop past prefix collisions: when `path` is a prefix of another known
+    // path (`src/foo.ts` vs `src/foo.tsx`), the first occurrence inside the
+    // longer chip fails the trailing-boundary check — but a later occurrence
+    // may still be valid.
+    let from = 0
+    while (true) {
+      const idx = text.indexOf(token, from)
+      if (idx < 0) break
+      const after = text[idx + token.length] ?? ""
+      if (!after || /\s/.test(after)) {
+        out.push(path)
+        break
+      }
+      from = idx + token.length
+    }
   }
   return out
 }


### PR DESCRIPTION
## Summary

- `extractMentions` now loops past prefix-collision hits, matching what `findMentionRanges` already does next door.
- Adds a regression test covering `@src/foo.tsx and @src/foo.ts` with both paths in the `known` set.

## Test plan

- [x] `bun run check-types` clean.
- [x] `bun run test` — 770/770 pass (1 new test).

Closes #160