### PR TITLE
fix(webview): clear the three pre-existing tsc errors

### DIFF
--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -358,7 +358,7 @@ function renderMessageBlocks(message: Message, processOpen: boolean, processOnly
     return <ProcessPanel blocks={message.blocks} pending={pending} openKey={`process-only-${message.id}-${message.blocks.length}`} defaultOpen={processOpen} onReviewFile={onReviewFile} />
   }
 
-  const finalTextIndex = lastTextIndex(message.blocks, message.pending)
+  const finalTextIndex = lastTextIndex(message.blocks, Boolean(message.pending))
   if (finalTextIndex < 0) {
     if (!hasProcessBlocks(message.blocks)) return renderBlocks(message.blocks, false, onReviewFile)
     return <ProcessPanel blocks={message.blocks} pending={pending} openKey={`process-${message.id}-${message.blocks.length}`} defaultOpen={processOpen} onReviewFile={onReviewFile} />

--- a/webview/tsconfig.json
+++ b/webview/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary

- Bump `webview/tsconfig.json` target+lib from ES2022 to ES2023 so `Array.prototype.findLast` (used at `App.tsx:104`) is in scope.
- Coerce `message.pending` to a boolean at the `lastTextIndex` call site in `MessageView.tsx:361`.
- Removes the "three pre-existing type errors" caveat from CLAUDE.md's testing section — the webview typecheck is now clean.

## Test plan

- [x] `cd webview && bunx tsc --noEmit` — silent.
- [x] `bun run check-types` — clean.
- [x] `bun run test` — 770/770 pass.
- [x] `bun run package` — built bundle produced (`dist/webview/index.html`).

Closes #162