### PR TITLE
fix(conversation-store): surface migration failures instead of swallowing

### DIFF
--- a/src/chat/conversation-store.ts
+++ b/src/chat/conversation-store.ts
@@ -19,16 +19,21 @@ export type SavedConversation = ConversationSummary & {
  *
  * Existing global storage keys are cleared after the first successful migration
  * so a different workspace doesn't see the same conversations duplicated.
+ *
+ * Writes are awaited sequentially: if any of the data writes reject (e.g. the
+ * workspace storage layer is unavailable), the "migration done" flag is NOT
+ * set, so the next activation retries the migration instead of silently
+ * declaring it complete with no data persisted.
  */
-export function migrateConversationsToWorkspace(context: vscode.ExtensionContext) {
+export async function migrateConversationsToWorkspace(context: vscode.ExtensionContext) {
   if (context.workspaceState.get<boolean>(MIGRATED_TO_WORKSPACE_KEY, false)) return
   const legacy = context.globalState.get<SavedConversation[]>(CONVERSATIONS_KEY)
   if (legacy && legacy.length) {
-    void context.workspaceState.update(CONVERSATIONS_KEY, legacy)
+    await context.workspaceState.update(CONVERSATIONS_KEY, legacy)
     const legacyActive = context.globalState.get<string>(ACTIVE_CONVERSATION_KEY)
-    if (legacyActive) void context.workspaceState.update(ACTIVE_CONVERSATION_KEY, legacyActive)
-    void context.globalState.update(CONVERSATIONS_KEY, undefined)
-    void context.globalState.update(ACTIVE_CONVERSATION_KEY, undefined)
+    if (legacyActive) await context.workspaceState.update(ACTIVE_CONVERSATION_KEY, legacyActive)
+    await context.globalState.update(CONVERSATIONS_KEY, undefined)
+    await context.globalState.update(ACTIVE_CONVERSATION_KEY, undefined)
   }
-  void context.workspaceState.update(MIGRATED_TO_WORKSPACE_KEY, true)
+  await context.workspaceState.update(MIGRATED_TO_WORKSPACE_KEY, true)
 }

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -169,7 +169,11 @@ export class ChatView implements vscode.WebviewViewProvider {
     private indexManager: IndexManager,
     private taskStore?: AgentTaskStore,
   ) {
-    migrateConversationsToWorkspace(context)
+    // Memento.update writes to the in-memory cache synchronously and only the
+    // disk flush is async, so the very-next `workspaceState.get` below still
+    // sees the migrated data. We `.catch` here so a disk-flush rejection is
+    // logged (and the migration-done flag stays unset, retrying next launch).
+    void migrateConversationsToWorkspace(context).catch((e) => log("migrateConversations failed", e))
     this.conversations = context.workspaceState.get<SavedConversation[]>(CONVERSATIONS_KEY) ?? []
     this.activeConversationID = context.workspaceState.get<string>(ACTIVE_CONVERSATION_KEY) ?? ""
     if (!this.conversations.length) this.addConversation("New conversation")

--- a/test/host/migrate-conversations.test.ts
+++ b/test/host/migrate-conversations.test.ts
@@ -30,47 +30,71 @@ function fakeContext(globalInit: Record<string, unknown> = {}, workspaceInit: Re
 }
 
 describe("migrateConversationsToWorkspace", () => {
-  it("does nothing when migration flag is already set", () => {
+  it("does nothing when migration flag is already set", async () => {
     const { context, globalState, workspaceState } = fakeContext(
       { "opencui.conversations": [{ id: "old" }] },
       { "opencui.migratedToWorkspaceState": true },
     )
-    migrateConversationsToWorkspace(context)
+    await migrateConversationsToWorkspace(context)
     // Global still has its data — not migrated
     expect(globalState.store.get("opencui.conversations")).toEqual([{ id: "old" }])
     expect(workspaceState.store.has("opencui.conversations")).toBe(false)
   })
 
-  it("migrates conversations from globalState to workspaceState on first run", () => {
-    const { context, globalState, workspaceState } = fakeContext({
+  it("migrates conversations from globalState to workspaceState on first run", async () => {
+    const { context, workspaceState } = fakeContext({
       "opencui.conversations": [{ id: "c1" }, { id: "c2" }],
       "opencui.activeConversation": "c1",
     })
-    migrateConversationsToWorkspace(context)
+    await migrateConversationsToWorkspace(context)
     expect(workspaceState.store.get("opencui.conversations")).toEqual([{ id: "c1" }, { id: "c2" }])
     expect(workspaceState.store.get("opencui.activeConversation")).toBe("c1")
     expect(workspaceState.store.get("opencui.migratedToWorkspaceState")).toBe(true)
   })
 
-  it("clears global keys after migration so a different workspace doesn't duplicate", () => {
+  it("clears global keys after migration so a different workspace doesn't duplicate", async () => {
     const { context, globalState } = fakeContext({
       "opencui.conversations": [{ id: "c1" }],
       "opencui.activeConversation": "c1",
     })
-    migrateConversationsToWorkspace(context)
+    await migrateConversationsToWorkspace(context)
     expect(globalState.store.has("opencui.conversations")).toBe(false)
     expect(globalState.store.has("opencui.activeConversation")).toBe(false)
   })
 
-  it("sets migrated flag even when there's nothing to migrate (idempotency)", () => {
+  it("sets migrated flag even when there's nothing to migrate (idempotency)", async () => {
     const { context, workspaceState } = fakeContext()
-    migrateConversationsToWorkspace(context)
+    await migrateConversationsToWorkspace(context)
     expect(workspaceState.store.get("opencui.migratedToWorkspaceState")).toBe(true)
   })
 
-  it("doesn't clear global keys when there are no legacy conversations", () => {
+  it("doesn't clear global keys when there are no legacy conversations", async () => {
     const { context, globalState } = fakeContext({})
-    migrateConversationsToWorkspace(context)
+    await migrateConversationsToWorkspace(context)
     expect(globalState.store.has("opencui.conversations")).toBe(false) // never had it
+  })
+
+  it("leaves the migration flag unset when a data write rejects", async () => {
+    const globalStore: Map<string, unknown> = new Map([["opencui.conversations", [{ id: "c1" }]]])
+    const workspaceStore: Map<string, unknown> = new Map()
+    const context = {
+      globalState: {
+        get: <T>(key: string, def?: T): T => (globalStore.has(key) ? (globalStore.get(key) as T) : (def as T)),
+        update: (key: string, value: unknown) => {
+          if (value === undefined) globalStore.delete(key)
+          else globalStore.set(key, value)
+          return Promise.resolve()
+        },
+        keys: () => [...globalStore.keys()],
+      },
+      workspaceState: {
+        get: <T>(key: string, def?: T): T => (workspaceStore.has(key) ? (workspaceStore.get(key) as T) : (def as T)),
+        update: (_key: string, _value: unknown) => Promise.reject(new Error("disk full")),
+        keys: () => [...workspaceStore.keys()],
+      },
+    } as never
+    await expect(migrateConversationsToWorkspace(context)).rejects.toThrow("disk full")
+    // Migration flag must NOT be set — next activation retries.
+    expect(workspaceStore.has("opencui.migratedToWorkspaceState")).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

- Make `migrateConversationsToWorkspace` async and `await` each `Memento.update` sequentially.
- If any data write rejects, the function rejects too and the migration-done flag stays unset — the next activation retries instead of declaring migration complete with zero data persisted.
- Constructor call site logs failures via `.catch` (it can't `await` — constructors are sync). The very-next `workspaceState.get` still returns the migrated data because `Memento.update` writes to the in-memory cache synchronously; the promise only covers disk flush.

## Test plan

- [x] `bun run check-types` clean.
- [x] `bun run test` — 771/771 pass (1 new regression test asserting the flag stays unset when a write rejects).

Closes #164