### PR TITLE
chore(release): cut v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-05-21
+
+### Fixed
+- Header popovers (Model/Agent, Agents, Chat history) no longer paint over the sticky user-message bubble. Each popover now publishes its measured height to `--header-popover-height` while open (new hook `webview/src/hooks/useHeaderPopoverHeight.ts`, observed via `ResizeObserver`), and the sticky user bubble (`.msg.role-user`) reads that variable in its `top` so the two stack instead of overlapping. The variable clears on close so the bubble snaps back to `top: 0` without flicker.
+
+### Changed
+- Header popovers dismiss on `click` instead of `pointerdown`. Dismissing on pointerdown removed the bubble's CSS-var offset before the browser delivered the bubble's `click`, so a click on the pushed-down bubble landed on whatever was previously underneath it. Routing through `click` lets the bubble see its own activation first, which makes the "click the pushed bubble to close the popover and enter edit mode" gesture work.
+- `useDismissableMenu` now supports controlled open state via optional `open` / `onOpenChange` props. `StatusBar` hoists the active-popover identity (`"selector" | "agents" | "history" | null`) up to `App.tsx`, which (a) keeps the three popovers mutually exclusive without each one having to know about the others and (b) lets `MessageView` close whichever popover is open when the user clicks the pushed user bubble to enter edit mode (via new `onBeginEdit` / `onEndEdit` callbacks plumbed App → MessageView).
+
+### Added
+- 5 new tests in `test/webview/statusbar.test.tsx` covering the dismissal-timing change (pointerdown leaves the popover open; click closes it), direct popover-to-popover switching, and the click-pushed-bubble → close-popover → enter-edit gesture end-to-end. Total 774 passing (was 769).
+- `ResizeObserver` stub in `test/webview/setup.ts` — jsdom doesn't ship one, and the new hook constructs one on mount.
+
+Closes #166.
+
 ## [0.9.1] - 2026-05-21
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",

--- a/test/webview/setup.ts
+++ b/test/webview/setup.ts
@@ -9,3 +9,15 @@ import { vi } from "vitest"
   getState: vi.fn(),
   setState: vi.fn(),
 })
+
+// jsdom doesn't ship a ResizeObserver implementation. `useHeaderPopoverHeight`
+// (and any future hook that observes layout) constructs one on mount; tests
+// only need the constructor and disconnect/observe to exist as no-ops, since
+// they don't exercise the resize-driven side effect.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+;(globalThis as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+  ResizeObserverStub

--- a/test/webview/statusbar.test.tsx
+++ b/test/webview/statusbar.test.tsx
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
-import { render, screen, cleanup } from "@testing-library/react"
+import { fireEvent, render, screen, cleanup } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import { StatusBar } from "../../webview/src/components/StatusBar"
+import { useState } from "react"
+import { StatusBar, type HeaderPopoverID } from "../../webview/src/components/StatusBar"
+import { MessageView } from "../../webview/src/components/MessageView"
+import type { Message } from "../../webview/src/hooks/useChatState"
 
 beforeEach(() => {
   cleanup()
@@ -299,6 +302,65 @@ describe("AgentsMenu (StatusBar inline popover)", () => {
     render(<StatusBar {...baseProps} />)
     await user.click(screen.getByText("Agents"))
     expect(screen.getByText("No agents in this chat")).toBeInTheDocument()
+  })
+
+  it("waits until click to dismiss so outside targets can handle their own click first", async () => {
+    const user = userEvent.setup()
+    render(<StatusBar {...baseProps} />)
+    await user.click(screen.getByText("Agents"))
+    expect(screen.getByText("No agents in this chat")).toBeInTheDocument()
+    fireEvent.pointerDown(document.body)
+    expect(screen.getByText("No agents in this chat")).toBeInTheDocument()
+    fireEvent.click(document.body)
+    expect(screen.queryByText("No agents in this chat")).not.toBeInTheDocument()
+  })
+
+  it("switches directly between header popovers", async () => {
+    const user = userEvent.setup()
+    const conversations = [{ id: "c1", title: "First chat", updatedAt: Date.now() }]
+    render(<StatusBar {...baseProps} conversations={conversations} />)
+    await user.click(screen.getByText("Agents"))
+    expect(screen.getByText("No agents in this chat")).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: /chat history/i }))
+    expect(screen.queryByText("No agents in this chat")).not.toBeInTheDocument()
+    expect(screen.getByText("Chat history")).toBeInTheDocument()
+  })
+
+  it("closes the popover and enters edit mode when the pushed user bubble is clicked", async () => {
+    const user = userEvent.setup()
+    const message = {
+      id: "u1",
+      role: "user",
+      backendID: "backend-u1",
+      blocks: [{ type: "text", text: "Explain this file by using subagent" }],
+    } as Message
+    function Harness() {
+      const [activePopover, setActivePopover] = useState<HeaderPopoverID | null>(null)
+      return (
+        <>
+          <StatusBar
+            {...baseProps}
+            activePopover={activePopover}
+            onActivePopoverChange={setActivePopover}
+          />
+          <MessageView
+            message={message}
+            processOpen={false}
+            processOnly={false}
+            onEditMessage={vi.fn()}
+            onBeginEdit={() => setActivePopover(null)}
+          />
+        </>
+      )
+    }
+    render(<Harness />)
+    await user.click(screen.getByText("Agents"))
+    expect(screen.getByText("No agents in this chat")).toBeInTheDocument()
+
+    await user.click(screen.getByText("Explain this file by using subagent"))
+
+    expect(screen.queryByText("No agents in this chat")).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Save & regenerate" })).toBeInTheDocument()
   })
 
   it("renders 'Agents' when a task is running in this chat", () => {

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -4,7 +4,7 @@ import type { Message } from "./hooks/useChatState"
 import type { Attachment } from "./protocol"
 import { MessageView } from "./components/MessageView"
 import { PromptBox } from "./components/PromptBox"
-import { StatusBar } from "./components/StatusBar"
+import { StatusBar, type HeaderPopoverID } from "./components/StatusBar"
 import { PermissionDialog } from "./components/PermissionDialog"
 import { QuestionDialog } from "./components/QuestionDialog"
 import { ReviewPanel } from "./components/ReviewPanel"
@@ -40,6 +40,8 @@ export default function App() {
   // re-engage stick mode on every text delta).
   const programmaticScroll = useRef(false)
   const lastScrollTop = useRef(0)
+  const [activeHeaderPopover, setActiveHeaderPopover] = useState<HeaderPopoverID | null>(null)
+  const [editingMessageID, setEditingMessageID] = useState<string | null>(null)
   // Distance-from-bottom threshold for *re-engaging* stick mode once the
   // user has manually disengaged it. Smaller than the old 80 px because we
   // now use scroll direction, not just position.
@@ -104,6 +106,10 @@ export default function App() {
   const activeProcessID = state.messages.findLast((m) => m.role === "assistant" && m.pending)?.id
 
   useEffect(() => {
+    if (editingMessageID) setActiveHeaderPopover(null)
+  }, [editingMessageID])
+
+  useEffect(() => {
     if (!stickToBottom.current) return
     scrollToBottom()
   }, [state.messages])
@@ -130,6 +136,8 @@ export default function App() {
         conversations={state.conversations}
         activeConversationID={state.conversationID}
         agentsStatus={state.agentsStatus}
+        activePopover={activeHeaderPopover}
+        onActivePopoverChange={setActiveHeaderPopover}
         onSelectAgent={selectAgent}
         onSelectModel={selectModel}
         onSelectVariant={selectVariant}
@@ -196,6 +204,13 @@ export default function App() {
                 busy={busy}
                 onReviewFile={openReviewFile}
                 onEditMessage={editMessage}
+                onBeginEdit={(id) => {
+                  setActiveHeaderPopover(null)
+                  setEditingMessageID(id)
+                }}
+                onEndEdit={(id) => {
+                  setEditingMessageID((current) => current === id ? null : current)
+                }}
                 searchFiles={searchFiles}
                 attachFile={attachFile}
               />

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -30,6 +30,8 @@ export function MessageView({
   busy,
   onReviewFile,
   onEditMessage,
+  onBeginEdit,
+  onEndEdit,
   onRetry,
   searchFiles,
   attachFile,
@@ -40,6 +42,8 @@ export function MessageView({
   busy?: boolean
   onReviewFile?: (path: string) => void
   onEditMessage?: (id: string, text: string, mentions?: string[], attachments?: Attachment[]) => void
+  onBeginEdit?: (id: string) => void
+  onEndEdit?: (id: string) => void
   onRetry?: (assistantID: string) => void
   searchFiles?: (query: string) => Promise<FileSearchHit[]>
   attachFile?: () => Promise<{ attachments: Attachment[]; error?: string }>
@@ -50,6 +54,8 @@ export function MessageView({
         message={message}
         busy={busy}
         onEditMessage={onEditMessage}
+        onBeginEdit={onBeginEdit}
+        onEndEdit={onEndEdit}
         searchFiles={searchFiles}
         attachFile={attachFile}
       />
@@ -120,12 +126,16 @@ function UserMessageView({
   message,
   busy,
   onEditMessage,
+  onBeginEdit,
+  onEndEdit,
   searchFiles,
   attachFile,
 }: {
   message: Message
   busy?: boolean
   onEditMessage?: (id: string, text: string, mentions?: string[], attachments?: Attachment[]) => void
+  onBeginEdit?: (id: string) => void
+  onEndEdit?: (id: string) => void
   searchFiles?: (query: string) => Promise<FileSearchHit[]>
   attachFile?: () => Promise<{ attachments: Attachment[]; error?: string }>
 }) {
@@ -146,6 +156,7 @@ function UserMessageView({
     if (editPhase !== "editing") return
     setEditPhase("view")
     setEditPlaceholderHeight(null)
+    onEndEdit?.(message.id)
   }
 
   // Click-outside cancels the edit. We listen on the document so any click
@@ -159,7 +170,7 @@ function UserMessageView({
     }
     document.addEventListener("pointerdown", onPointerDown)
     return () => document.removeEventListener("pointerdown", onPointerDown)
-  }, [editPhase])
+  }, [editPhase, message.id, onEndEdit])
 
   // Re-derive attachment labels (same algorithm PromptBox originally used) and
   // wrap each attachment block into the Attachment shape, including a synthetic
@@ -212,6 +223,7 @@ function UserMessageView({
     if (!editable) return
     if (editPhase === "editing") return
     if (typeof window !== "undefined" && window.getSelection?.()?.toString()) return
+    onBeginEdit?.(message.id)
     setEditPlaceholderHeight(bubbleRef.current?.getBoundingClientRect().height ?? null)
     setEditPhase("editing")
   }

--- a/webview/src/components/StatusBar.tsx
+++ b/webview/src/components/StatusBar.tsx
@@ -1,7 +1,11 @@
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState, type Dispatch, type SetStateAction } from "react"
 import type { AgentsStatusInfo, AgentsTaskInfo, ConversationSummary, Selection } from "../protocol"
 import { useDismissableMenu } from "../hooks/useDismissableMenu"
+import { useHeaderPopoverHeight } from "../hooks/useHeaderPopoverHeight"
 import { StatusIndicator, type StatusIndicatorKind } from "./StatusIndicator"
+
+export type HeaderPopoverID = "selector" | "agents" | "history"
+type HeaderPopoverSetter = Dispatch<SetStateAction<HeaderPopoverID | null>>
 
 type Props = {
   connected: boolean
@@ -11,6 +15,8 @@ type Props = {
   conversations: ConversationSummary[]
   activeConversationID?: string
   agentsStatus?: AgentsStatusInfo
+  activePopover?: HeaderPopoverID | null
+  onActivePopoverChange?: HeaderPopoverSetter
   onSelectAgent: () => void
   onSelectModel: () => void
   onSelectVariant: () => void
@@ -28,6 +34,8 @@ export function StatusBar({
   conversations,
   activeConversationID,
   agentsStatus,
+  activePopover,
+  onActivePopoverChange,
   onSelectAgent,
   onSelectModel,
   onSelectVariant,
@@ -40,6 +48,12 @@ export function StatusBar({
   const model = selection.model ?? "default"
   const variant = selection.modelVariant
   const active = conversations.find((c) => c.id === activeConversationID)
+  const [localActivePopover, setLocalActivePopover] = useState<HeaderPopoverID | null>(null)
+  const currentPopover = activePopover === undefined ? localActivePopover : activePopover
+  const setCurrentPopover = onActivePopoverChange ?? setLocalActivePopover
+  const setPopoverOpen = (id: HeaderPopoverID, open: boolean) => {
+    setCurrentPopover((current) => open ? id : current === id ? null : current)
+  }
 
   const showStatus = !connected || Boolean(error) || Boolean(continuationPending)
   const statusLabel: string | undefined = error
@@ -75,11 +89,17 @@ export function StatusBar({
         agent={agent}
         model={model}
         variant={variant}
+        open={currentPopover === "selector"}
+        onOpenChange={(open) => setPopoverOpen("selector", open)}
         onSelectAgent={onSelectAgent}
         onSelectModel={onSelectModel}
         onSelectVariant={onSelectVariant}
       />
-      <AgentsMenu status={agentsStatus} />
+      <AgentsMenu
+        status={agentsStatus}
+        open={currentPopover === "agents"}
+        onOpenChange={(open) => setPopoverOpen("agents", open)}
+      />
       <button
         type="button"
         className="new-chat-trigger"
@@ -93,6 +113,8 @@ export function StatusBar({
         conversations={conversations}
         activeID={activeConversationID}
         activeTitle={active?.title}
+        open={currentPopover === "history"}
+        onOpenChange={(open) => setPopoverOpen("history", open)}
         onCreate={onCreateConversation}
         onOpen={onOpenConversation}
         onRename={onRenameConversation}
@@ -106,6 +128,8 @@ function ChatHistoryMenu({
   conversations,
   activeID,
   activeTitle,
+  open,
+  onOpenChange,
   onCreate,
   onOpen,
   onRename,
@@ -114,12 +138,16 @@ function ChatHistoryMenu({
   conversations: ConversationSummary[]
   activeID?: string
   activeTitle?: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
   onCreate: () => void
   onOpen: (id: string) => void
   onRename: (id: string, title: string) => void
   onDelete: (id: string) => void
 }) {
-  const { open, toggle, close, ref } = useDismissableMenu()
+  const { toggle, close, ref } = useDismissableMenu({ open, onOpenChange })
+  const popoverRef = useRef<HTMLDivElement>(null)
+  useHeaderPopoverHeight(open, popoverRef)
   const [renamingID, setRenamingID] = useState<string>()
   const [renamingTitle, setRenamingTitle] = useState("")
   const [confirmDeleteID, setConfirmDeleteID] = useState<string>()
@@ -182,7 +210,7 @@ function ChatHistoryMenu({
         <span className="history-clock" />
       </button>
       {open && (
-        <div className="history-popover">
+        <div className="history-popover" ref={popoverRef}>
           <div className="history-popover-header">
             <div className="history-popover-title">Chat history</div>
             <button
@@ -287,8 +315,18 @@ function ChatHistoryMenu({
  * by color — muted when idle, breathing green while running, attention red
  * for error, amber for waiting.
  */
-function AgentsMenu({ status }: { status?: AgentsStatusInfo }) {
-  const { open, toggle, ref } = useDismissableMenu()
+function AgentsMenu({
+  status,
+  open,
+  onOpenChange,
+}: {
+  status?: AgentsStatusInfo
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const { toggle, ref } = useDismissableMenu({ open, onOpenChange })
+  const popoverRef = useRef<HTMLDivElement>(null)
+  useHeaderPopoverHeight(open, popoverRef)
 
   const running = (status?.running ?? 0) > 0
   const errorOnly = !running && (status?.error ?? 0) > 0
@@ -320,7 +358,7 @@ function AgentsMenu({ status }: { status?: AgentsStatusInfo }) {
         Agents
       </button>
       {open && (
-        <div className="agents-popover" role="menu">
+        <div className="agents-popover" role="menu" ref={popoverRef}>
           <div className="agents-popover-title">Agents in this chat</div>
           {empty && <div className="agents-popover-empty">No agents in this chat</div>}
           {!empty && (
@@ -443,6 +481,8 @@ function SelectorMenu({
   agent,
   model,
   variant,
+  open,
+  onOpenChange,
   onSelectAgent,
   onSelectModel,
   onSelectVariant,
@@ -450,11 +490,15 @@ function SelectorMenu({
   agent: string
   model: string
   variant?: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
   onSelectAgent: () => void
   onSelectModel: () => void
   onSelectVariant: () => void
 }) {
-  const { open, toggle, close, ref } = useDismissableMenu()
+  const { toggle, close, ref } = useDismissableMenu({ open, onOpenChange })
+  const popoverRef = useRef<HTMLDivElement>(null)
+  useHeaderPopoverHeight(open, popoverRef)
 
   const prettyModel = formatModel(model)
   const prettyAgent = formatAgent(agent)
@@ -484,7 +528,7 @@ function SelectorMenu({
         <span className="selector-secondary">{prettyAgent}</span>
       </button>
       {open && (
-        <div className="selector-popover" role="menu">
+        <div className="selector-popover" role="menu" ref={popoverRef}>
           <button
             type="button"
             className="selector-row"

--- a/webview/src/hooks/useDismissableMenu.ts
+++ b/webview/src/hooks/useDismissableMenu.ts
@@ -1,9 +1,15 @@
 import { useEffect, useRef, useState } from "react"
 
+type DismissableMenuOptions = {
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}
+
 /**
  * Shared open/close state for the inline popover menus in the status bar
- * (Model/Agent selector, Agents pill, Chat history). Owns the `useState`,
- * the ref for the outer container, and the pointerdown + Escape listeners
+ * (Model/Agent selector, Agents pill, Chat history). Owns either local
+ * open state or a controlled open value, the ref for the outer container,
+ * and the click + Escape listeners
  * that dismiss the popover when the user clicks outside or hits Escape.
  *
  * The caller still renders its own trigger and popover JSX; only the
@@ -11,29 +17,42 @@ import { useEffect, useRef, useState } from "react"
  * container (the same element the popover is positioned relative to) so
  * the outside-click check can tell "still inside" from "elsewhere".
  */
-export function useDismissableMenu(): {
+export function useDismissableMenu(options: DismissableMenuOptions = {}): {
   open: boolean
   setOpen: (value: boolean) => void
   toggle: () => void
   close: () => void
   ref: React.RefObject<HTMLDivElement>
 } {
-  const [open, setOpen] = useState(false)
+  const [localOpen, setLocalOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
+  const controlled = options.open !== undefined
+  const open = controlled ? options.open! : localOpen
+  const setOpen = (value: boolean) => {
+    if (controlled) {
+      options.onOpenChange?.(value)
+      return
+    }
+    setLocalOpen(value)
+  }
 
   useEffect(() => {
     if (!open) return
-    const onPointerDown = (event: PointerEvent) => {
+    // Close on the completed click rather than pointerdown. Header popovers
+    // publish a height that pushes the sticky user bubble down; dismissing on
+    // pointerdown can remove that height before the browser delivers the
+    // bubble's click, so click-to-edit never sees the activation.
+    const onClick = (event: MouseEvent) => {
       if (ref.current?.contains(event.target as Node)) return
       setOpen(false)
     }
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") setOpen(false)
     }
-    window.addEventListener("pointerdown", onPointerDown)
+    window.addEventListener("click", onClick)
     window.addEventListener("keydown", onKeyDown)
     return () => {
-      window.removeEventListener("pointerdown", onPointerDown)
+      window.removeEventListener("click", onClick)
       window.removeEventListener("keydown", onKeyDown)
     }
   }, [open])

--- a/webview/src/hooks/useHeaderPopoverHeight.ts
+++ b/webview/src/hooks/useHeaderPopoverHeight.ts
@@ -1,0 +1,33 @@
+import { useLayoutEffect, type RefObject } from "react"
+
+/**
+ * While `open` is true, observe `popoverRef`'s height and publish it as
+ * `--header-popover-height` on document.documentElement. Used by the three
+ * statusbar menus (Selector / Agents / History) so the sticky user-message
+ * bubble (`.msg.role-user`) can shift down by that amount and not be
+ * painted over by the popover.
+ *
+ * Only one popover is open at a time (StatusBar owns one active-popover
+ * state), so a single shared variable is enough.
+ */
+export function useHeaderPopoverHeight(
+  open: boolean,
+  popoverRef: RefObject<HTMLElement | null>,
+) {
+  useLayoutEffect(() => {
+    if (!open) return
+    const el = popoverRef.current
+    if (!el) return
+    const update = () => {
+      const h = Math.round(el.getBoundingClientRect().height)
+      document.documentElement.style.setProperty("--header-popover-height", `${h}px`)
+    }
+    update()
+    const ro = new ResizeObserver(update)
+    ro.observe(el)
+    return () => {
+      ro.disconnect()
+      document.documentElement.style.removeProperty("--header-popover-height")
+    }
+  }, [open, popoverRef])
+}

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -921,8 +921,14 @@ button {
   /* Sticks to the top of the messages container as the chat scrolls. While the
      AI streams its answer, the user's question stays visible above. When the
      user scrolls into a different turn, the next user message takes over the
-     pinned slot — Claude.ai / ChatGPT-style "section header" pattern. */
-  top: 0;
+     pinned slot — Claude.ai / ChatGPT-style "section header" pattern.
+
+     The `top` value is normally 0 but lifts to the open header popover's
+     height while one of the statusbar popovers (Model/Agent, Agents,
+     History) is open — published by `useHeaderPopoverHeight` in
+     `StatusBar.tsx` as `--header-popover-height`. Without this, the
+     popover (z-index 20) would paint over the sticky bubble (z-index 2). */
+  top: var(--header-popover-height, 0px);
   z-index: var(--z-bubble-sticky);
   padding: var(--bubble-padding);
   /* Solid opaque background so scrolling content underneath never bleeds


### PR DESCRIPTION
## Summary

- New `useHeaderPopoverHeight` hook + `--header-popover-height` CSS var make the sticky user-message bubble drop by exactly the open popover's height so they stack instead of overlap (z-index 20 popover no longer paints over z-index 2 bubble).
- `useDismissableMenu` learned a controlled-open mode; `StatusBar` hoists the active-popover identity to `App.tsx` so the three popovers stay mutually exclusive and `MessageView` can dismiss whichever one is open when the user clicks the pushed bubble.
- Dismissal moved from `pointerdown` to `click` so the pushed bubble sees its own activation first — enables the click-pushed-bubble → close-popover → enter-edit gesture.

## Test plan

- [x] `bun run test` — 774/774 pass (5 new statusbar tests).
- [x] `bun run check-types` — clean.
- [x] `cd webview && bunx tsc --noEmit` — clean.
- [ ] Manual: scroll a long turn so the user bubble pins → open each of the three header popovers; the bubble should drop by the popover's height and snap back on close. Clicking the pushed bubble should close the popover and enter edit mode in one gesture.

Closes #166