### PR TITLE
chore(release): cut v0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.9.3] - 2026-05-22
+
+### Changed
+- Status-bar hover backgrounds consolidated behind three semantic tokens in `:root` (`webview/src/styles.css`): `--hover-bg-pill` (for the selector trigger, Agents pill, and the two icon buttons), `--hover-bg-icon` (toolbar-style hover used by `.history-action` inside the chat-history popover and by the Review panel's bulk/file action buttons), and `--hover-bg-row` (list-row hover used by `.selector-row`, `.history-item`, and other menu rows). Tweaking how a category feels — "soften icon hovers", "make pill hovers more saturated" — is now a one-line change instead of touching 5+ selectors. `.history-new` keeps its green-tinted hover intentionally.
+- All four bar-level controls (`.selector-trigger`, `.agents-pill`, `.new-chat-trigger`, `.history-trigger`) now share `--hover-bg-pill` so the bar reads as one family on hover. Previously the two icon buttons used `--vscode-toolbar-hoverBackground` while the two pills used `--vscode-button-secondaryHoverBackground`, which in some themes rendered as visibly different colors. Each component still keeps its natural shape — circles for icon-only buttons, rounded rects for text content.
+
+### Fixed
+- `+` (`.new-chat-trigger`) hover background is now a perfect circle even on narrow panels. The button is a direct child of `.statusbar` (unlike `.history-trigger`, which is protected by its `.history-menu` wrapper's `flex: 0 0 auto`), so on narrow widths it compressed below 22px wide while keeping height 22px — turning the `border-radius: 50%` into an ellipse. Added `flex: 0 0 auto` directly on the shared `.history-trigger, .new-chat-trigger` rule so the 22×22 square holds regardless of available space.
+
+Closes #168.
+
 ## [0.9.2] - 2026-05-21
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -43,6 +43,15 @@
   --color-border-focus: var(--vscode-foreground); /* intentional: text colour, not focusBorder blue */
   --color-accent:       var(--vscode-focusBorder);
 
+  /* === Hover backgrounds ===
+     Three distinct surfaces share a hover treatment across the webview.
+     Tweaking how a category feels (e.g. "soften icon hovers") is a one-line
+     change here. The `.history-new` button intentionally opts out — its
+     green tint is part of its meaning, not a generic hover. */
+  --hover-bg-pill: var(--vscode-button-secondaryHoverBackground);
+  --hover-bg-icon: var(--vscode-toolbar-hoverBackground, var(--vscode-list-hoverBackground));
+  --hover-bg-row:  var(--vscode-list-hoverBackground);
+
   /* === Fixed UI colors (theme-independent) ===
      Status dots and the recurring scrollbar-thumb grey used in multiple
      scrollers. */
@@ -214,7 +223,7 @@ button {
 }
 .agents-pill:hover,
 .agents-pill.is-open {
-  background: var(--vscode-button-secondaryHoverBackground);
+  background: var(--hover-bg-pill);
 }
 .agents-pill.is-idle {
   color: var(--vscode-foreground);
@@ -361,7 +370,7 @@ button {
 }
 .selector-trigger:hover,
 .selector-trigger.is-open {
-  background: var(--vscode-button-secondaryHoverBackground);
+  background: var(--hover-bg-pill);
 }
 .selector-prefix {
   /* "MODEL" / "AGENT" labels are hidden globally so the trigger stays
@@ -431,7 +440,7 @@ button {
   text-align: left;
 }
 .selector-row:hover {
-  background: var(--vscode-list-hoverBackground);
+  background: var(--hover-bg-row);
 }
 .selector-row-label {
   color: var(--vscode-descriptionForeground);
@@ -468,6 +477,11 @@ button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  /* `flex: 0 0 auto` keeps the 22x22 square even when the bar runs out of
+     room — without it, the new-chat button shrinks below 22px wide (no
+     `.history-menu`-style wrapper to protect it) and the 50% radius draws
+     an ellipse instead of a circle. */
+  flex: 0 0 auto;
   width: 22px;
   height: 22px;
   padding: 0;
@@ -481,7 +495,7 @@ button {
 .history-trigger:hover,
 .history-trigger.is-open,
 .new-chat-trigger:hover {
-  background: var(--vscode-toolbar-hoverBackground, var(--vscode-list-hoverBackground));
+  background: var(--hover-bg-pill);
 }
 .new-chat-icon {
   position: relative;
@@ -650,7 +664,7 @@ button {
   border-radius: 4px;
 }
 .history-item:hover {
-  background: var(--vscode-list-hoverBackground);
+  background: var(--hover-bg-row);
 }
 .history-item.is-active {
   background: var(--vscode-list-activeSelectionBackground, var(--vscode-list-hoverBackground));
@@ -714,7 +728,7 @@ button {
   outline: 1px solid var(--vscode-focusBorder);
 }
 .history-action:hover {
-  background: var(--vscode-toolbar-hoverBackground, var(--vscode-list-hoverBackground));
+  background: var(--hover-bg-icon);
   color: var(--vscode-foreground);
 }
 .history-action.danger {


### PR DESCRIPTION
## Summary

- Consolidates status-bar hover backgrounds behind three semantic tokens in `:root` (`webview/src/styles.css`): `--hover-bg-pill`, `--hover-bg-icon`, `--hover-bg-row`. Tweaking how a category feels — "soften icon hovers", "make pill hovers more saturated" — is now a one-line change instead of touching 5+ selectors.
- All four bar-level controls (`.selector-trigger`, `.agents-pill`, `.new-chat-trigger`, `.history-trigger`) now share `--hover-bg-pill` so the bar reads as one family on hover. Previously the two icon buttons used `--vscode-toolbar-hoverBackground` and the two pills used `--vscode-button-secondaryHoverBackground`, which in some themes rendered as visibly different colors. Each component keeps its natural shape — circles for icon-only buttons, rounded rects for text content.
- Fixes the `+` icon hover rendering as an ellipse on narrow panels. `.new-chat-trigger` is a direct child of `.statusbar` (unlike `.history-trigger`, protected by its `.history-menu` wrapper's `flex: 0 0 auto`), so it compressed below 22px wide while keeping height 22px. Added `flex: 0 0 auto` to the shared icon-button rule so the 22×22 square holds regardless of available space.

## Test plan

- [x] `bun run test` — 774/774 pass (no behavioral change requiring new tests).
- [x] `bun run check-types` — clean.
- [x] `cd webview && bunx tsc --noEmit` — clean.
- [ ] Manual: hover each of the four status-bar controls — color matches across all four. Narrow the panel to its minimum and hover `+` — background is a perfect circle, not an ellipse.

Closes #168.