### PR TITLE
feat(agents): surface running agents inside the active assistant message

### DIFF
--- a/test/webview/statusbar.test.tsx
+++ b/test/webview/statusbar.test.tsx
@@ -1,10 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { fireEvent, render, screen, cleanup } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import { useState } from "react"
-import { StatusBar, type HeaderPopoverID } from "../../webview/src/components/StatusBar"
-import { MessageView } from "../../webview/src/components/MessageView"
-import type { Message } from "../../webview/src/hooks/useChatState"
+import { StatusBar } from "../../webview/src/components/StatusBar"
+import { AgentActivity } from "../../webview/src/components/AgentActivity"
 
 beforeEach(() => {
   cleanup()
@@ -260,7 +258,7 @@ describe("StatusBar: history popover", () => {
   })
 })
 
-describe("AgentsMenu (StatusBar inline popover)", () => {
+describe("AgentActivity", () => {
   const baseStatus = {
     running: 1,
     waiting: 0,
@@ -278,108 +276,42 @@ describe("AgentsMenu (StatusBar inline popover)", () => {
     ],
   }
 
-  it("renders 'Agents' even when no agentsStatus has been sent yet", () => {
-    render(<StatusBar {...baseProps} />)
-    expect(screen.getByText("Agents")).toBeInTheDocument()
-    expect(screen.getByText("Agents").className).toContain("is-idle")
-  })
-
-  it("renders 'Agents' with is-idle when total === 0", () => {
-    render(
-      <StatusBar
-        {...baseProps}
-        agentsStatus={{ running: 0, waiting: 0, error: 0, total: 0, tasks: [] }}
-      />,
-    )
-    const pill = screen.getByText("Agents")
-    expect(pill).toBeInTheDocument()
-    expect(pill.className).toContain("is-idle")
-    expect(pill.className).not.toContain("is-running")
-  })
-
-  it("opens an empty-state popover when there are no tasks", async () => {
-    const user = userEvent.setup()
-    render(<StatusBar {...baseProps} />)
-    await user.click(screen.getByText("Agents"))
-    expect(screen.getByText("No agents in this chat")).toBeInTheDocument()
+  it("stays hidden until there is active agent work", () => {
+    render(<AgentActivity />)
+    expect(screen.queryByText("Agents")).not.toBeInTheDocument()
+    cleanup()
+    render(<AgentActivity status={{ running: 0, waiting: 0, error: 0, total: 0, tasks: [] }} />)
+    expect(screen.queryByText("Agents")).not.toBeInTheDocument()
   })
 
   it("waits until click to dismiss so outside targets can handle their own click first", async () => {
     const user = userEvent.setup()
-    render(<StatusBar {...baseProps} />)
+    render(<AgentActivity status={baseStatus} />)
     await user.click(screen.getByText("Agents"))
-    expect(screen.getByText("No agents in this chat")).toBeInTheDocument()
+    expect(screen.getByText("Explain this file")).toBeInTheDocument()
     fireEvent.pointerDown(document.body)
-    expect(screen.getByText("No agents in this chat")).toBeInTheDocument()
+    expect(screen.getByText("Explain this file")).toBeInTheDocument()
     fireEvent.click(document.body)
-    expect(screen.queryByText("No agents in this chat")).not.toBeInTheDocument()
-  })
-
-  it("switches directly between header popovers", async () => {
-    const user = userEvent.setup()
-    const conversations = [{ id: "c1", title: "First chat", updatedAt: Date.now() }]
-    render(<StatusBar {...baseProps} conversations={conversations} />)
-    await user.click(screen.getByText("Agents"))
-    expect(screen.getByText("No agents in this chat")).toBeInTheDocument()
-    await user.click(screen.getByRole("button", { name: /chat history/i }))
-    expect(screen.queryByText("No agents in this chat")).not.toBeInTheDocument()
-    expect(screen.getByText("Chat history")).toBeInTheDocument()
-  })
-
-  it("closes the popover and enters edit mode when the pushed user bubble is clicked", async () => {
-    const user = userEvent.setup()
-    const message = {
-      id: "u1",
-      role: "user",
-      backendID: "backend-u1",
-      blocks: [{ type: "text", text: "Explain this file by using subagent" }],
-    } as Message
-    function Harness() {
-      const [activePopover, setActivePopover] = useState<HeaderPopoverID | null>(null)
-      return (
-        <>
-          <StatusBar
-            {...baseProps}
-            activePopover={activePopover}
-            onActivePopoverChange={setActivePopover}
-          />
-          <MessageView
-            message={message}
-            processOpen={false}
-            processOnly={false}
-            onEditMessage={vi.fn()}
-            onBeginEdit={() => setActivePopover(null)}
-          />
-        </>
-      )
-    }
-    render(<Harness />)
-    await user.click(screen.getByText("Agents"))
-    expect(screen.getByText("No agents in this chat")).toBeInTheDocument()
-
-    await user.click(screen.getByText("Explain this file by using subagent"))
-
-    expect(screen.queryByText("No agents in this chat")).not.toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Save & regenerate" })).toBeInTheDocument()
+    expect(screen.queryByText("Explain this file")).not.toBeInTheDocument()
   })
 
   it("renders 'Agents' when a task is running in this chat", () => {
-    render(<StatusBar {...baseProps} agentsStatus={baseStatus} />)
+    render(<AgentActivity status={baseStatus} />)
     expect(screen.getByText("Agents")).toBeInTheDocument()
+    expect(screen.getByText("1 running")).toBeInTheDocument()
   })
 
   it("applies is-running class so the breathing animation can trigger", () => {
-    render(<StatusBar {...baseProps} agentsStatus={baseStatus} />)
-    const pill = screen.getByText("Agents")
+    render(<AgentActivity status={baseStatus} />)
+    const pill = screen.getByRole("button", { name: /open agents/i })
     expect(pill.className).toContain("agents-pill")
     expect(pill.className).toContain("is-running")
   })
 
   it("uses static is-error class when only error tasks remain", () => {
     render(
-      <StatusBar
-        {...baseProps}
-        agentsStatus={{
+      <AgentActivity
+        status={{
           running: 0,
           waiting: 0,
           error: 1,
@@ -398,7 +330,7 @@ describe("AgentsMenu (StatusBar inline popover)", () => {
         }}
       />,
     )
-    const pill = screen.getByText("Agents")
+    const pill = screen.getByRole("button", { name: /open agents/i })
     expect(pill.className).toContain("is-error")
     expect(pill.className).not.toContain("is-running")
   })
@@ -406,9 +338,8 @@ describe("AgentsMenu (StatusBar inline popover)", () => {
   it("opens an inline popover on click and lists tasks", async () => {
     const user = userEvent.setup()
     render(
-      <StatusBar
-        {...baseProps}
-        agentsStatus={{
+      <AgentActivity
+        status={{
           ...baseStatus,
           running: 2,
           total: 2,
@@ -443,7 +374,7 @@ describe("AgentsMenu (StatusBar inline popover)", () => {
 
   it("groups separators are omitted when only one kind is present", async () => {
     const user = userEvent.setup()
-    render(<StatusBar {...baseProps} agentsStatus={baseStatus} />)
+    render(<AgentActivity status={baseStatus} />)
     await user.click(screen.getByText("Agents"))
     expect(screen.getByText("Main")).toBeInTheDocument()
     expect(screen.queryByText("Subagents")).not.toBeInTheDocument()
@@ -452,9 +383,8 @@ describe("AgentsMenu (StatusBar inline popover)", () => {
   it("shows errored subagent rows alongside a running parent", async () => {
     const user = userEvent.setup()
     render(
-      <StatusBar
-        {...baseProps}
-        agentsStatus={{
+      <AgentActivity
+        status={{
           running: 1,
           waiting: 0,
           error: 1,
@@ -488,7 +418,7 @@ describe("AgentsMenu (StatusBar inline popover)", () => {
 
   it("closes the popover when Escape is pressed", async () => {
     const user = userEvent.setup()
-    render(<StatusBar {...baseProps} agentsStatus={baseStatus} />)
+    render(<AgentActivity status={baseStatus} />)
     await user.click(screen.getByText("Agents"))
     expect(screen.getByText("Explain this file")).toBeInTheDocument()
     await user.keyboard("{Escape}")
@@ -497,9 +427,8 @@ describe("AgentsMenu (StatusBar inline popover)", () => {
 
   it("shows a tooltip summarizing the counts", () => {
     render(
-      <StatusBar
-        {...baseProps}
-        agentsStatus={{
+      <AgentActivity
+        status={{
           running: 2,
           waiting: 1,
           error: 0,
@@ -508,7 +437,7 @@ describe("AgentsMenu (StatusBar inline popover)", () => {
         }}
       />,
     )
-    const pill = screen.getByText("Agents")
+    const pill = screen.getByRole("button", { name: /open agents/i })
     expect(pill.getAttribute("title")).toMatch(/2 agents running/)
     expect(pill.getAttribute("title")).toMatch(/1 waiting for input/)
     expect(pill.getAttribute("title")).toMatch(/Click to view/)
@@ -517,9 +446,8 @@ describe("AgentsMenu (StatusBar inline popover)", () => {
   it("renders the subagent slug + prettified model on a subagent row", async () => {
     const user = userEvent.setup()
     render(
-      <StatusBar
-        {...baseProps}
-        agentsStatus={{
+      <AgentActivity
+        status={{
           running: 1,
           waiting: 0,
           error: 0,
@@ -548,9 +476,8 @@ describe("AgentsMenu (StatusBar inline popover)", () => {
   it("prefixes a category label when the dispatch went through a category route", async () => {
     const user = userEvent.setup()
     render(
-      <StatusBar
-        {...baseProps}
-        agentsStatus={{
+      <AgentActivity
+        status={{
           running: 1,
           waiting: 0,
           error: 0,
@@ -579,9 +506,8 @@ describe("AgentsMenu (StatusBar inline popover)", () => {
   it("does not render the agent/model detail line when neither is set", async () => {
     const user = userEvent.setup()
     render(
-      <StatusBar
-        {...baseProps}
-        agentsStatus={{
+      <AgentActivity
+        status={{
           running: 1,
           waiting: 0,
           error: 0,
@@ -604,15 +530,10 @@ describe("AgentsMenu (StatusBar inline popover)", () => {
     expect(screen.queryByText(/category:/)).not.toBeInTheDocument()
   })
 
-  it("renders the empty state once every task has settled (popover is not chat history)", async () => {
-    const user = userEvent.setup()
+  it("hides again once every task has settled", () => {
     render(
-      <StatusBar
-        {...baseProps}
-        // Host filters terminal states out of the wire, so a settled
-        // conversation arrives as an empty tasks array — the popover
-        // shows only what's currently active, never history.
-        agentsStatus={{
+      <AgentActivity
+        status={{
           running: 0,
           waiting: 0,
           error: 0,
@@ -621,18 +542,14 @@ describe("AgentsMenu (StatusBar inline popover)", () => {
         }}
       />,
     )
-    const pill = screen.getByText("Agents")
-    expect(pill.className).toContain("is-idle")
-    await user.click(pill)
-    expect(screen.getByText("No agents in this chat")).toBeInTheDocument()
+    expect(screen.queryByText("Agents")).not.toBeInTheDocument()
   })
 
   it("freezes the elapsed time on error rows using updatedAt - startedAt", async () => {
     const user = userEvent.setup()
     render(
-      <StatusBar
-        {...baseProps}
-        agentsStatus={{
+      <AgentActivity
+        status={{
           running: 0,
           waiting: 0,
           error: 1,

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -104,6 +104,9 @@ export default function App() {
 
   const busy = state.busy || state.messages.some((m) => m.pending)
   const activeProcessID = state.messages.findLast((m) => m.role === "assistant" && m.pending)?.id
+  const agentActivityMessageID = (state.agentsStatus?.total ?? 0) > 0
+    ? activeProcessID ?? state.messages.findLast((m) => m.role === "assistant")?.id
+    : undefined
 
   useEffect(() => {
     if (editingMessageID) setActiveHeaderPopover(null)
@@ -135,7 +138,6 @@ export default function App() {
         selection={state.selection}
         conversations={state.conversations}
         activeConversationID={state.conversationID}
-        agentsStatus={state.agentsStatus}
         activePopover={activeHeaderPopover}
         onActivePopoverChange={setActiveHeaderPopover}
         onSelectAgent={selectAgent}
@@ -225,6 +227,7 @@ export default function App() {
                 onReviewFile={openReviewFile}
                 onEditMessage={editMessage}
                 onRetry={handleRetry}
+                agentActivity={m.id === agentActivityMessageID ? state.agentsStatus : undefined}
               />
             ))}
           </div>

--- a/webview/src/components/AgentActivity.tsx
+++ b/webview/src/components/AgentActivity.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from "react"
+import type { AgentsStatusInfo, AgentsTaskInfo } from "../protocol"
+import { useDismissableMenu } from "../hooks/useDismissableMenu"
+import { formatAgent, formatModel } from "./StatusBar"
+
+export function AgentActivity({ status }: { status?: AgentsStatusInfo }) {
+  const { toggle, ref, open } = useDismissableMenu()
+
+  if (!status || status.total === 0) return null
+
+  const running = status.running > 0
+  const errorOnly = !running && status.error > 0
+  const waitingOnly = !running && !errorOnly && status.waiting > 0
+  const className =
+    "agents-pill agent-activity-pill" +
+    (open ? " is-open" : "") +
+    (running ? " is-running" : "") +
+    (errorOnly ? " is-error" : "") +
+    (waitingOnly ? " is-waiting" : "")
+
+  const tasks = status.tasks ?? []
+  const main = tasks.filter((t) => t.kind === "main")
+  const sub = tasks.filter((t) => t.kind === "subagent")
+
+  return (
+    <div className="agent-activity" ref={ref}>
+      <button
+        type="button"
+        className={className}
+        onClick={toggle}
+        title={buildAgentsTitle(status)}
+        aria-label="Open agents for this response"
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <span className="agent-activity-dot" aria-hidden="true" />
+        <span className="agent-activity-name">Agents</span>
+        <span className="agent-activity-summary">{activitySummary(status)}</span>
+      </button>
+      {open && (
+        <div className="agents-popover agent-activity-popover" role="menu">
+          <div className="agents-popover-title">Agents in this response</div>
+          {tasks.length === 0 && <div className="agents-popover-empty">No active agent details</div>}
+          {tasks.length > 0 && (
+            <div className="agents-popover-scroll">
+              {main.length > 0 && (
+                <>
+                  <div className="agents-popover-section">Main</div>
+                  {main.map((task) => (
+                    <AgentsRow key={task.id} task={task} />
+                  ))}
+                </>
+              )}
+              {sub.length > 0 && (
+                <>
+                  <div className="agents-popover-section">Subagents</div>
+                  {sub.map((task) => (
+                    <AgentsRow key={task.id} task={task} />
+                  ))}
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function AgentsRow({ task }: { task: AgentsTaskInfo }) {
+  const isLive = task.status === "running" || task.status === "waiting"
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    if (!isLive) return
+    const handle = window.setInterval(() => setNow(Date.now()), 1000)
+    return () => window.clearInterval(handle)
+  }, [isLive])
+
+  const elapsedMs = isLive ? now - task.startedAt : task.updatedAt - task.startedAt
+  const elapsed = formatElapsed(elapsedMs)
+  const statusText = task.status === "error" && task.error
+    ? `error · ${task.error}`
+    : task.status
+  const subagentLabel = task.subagent ? formatAgent(task.subagent) : undefined
+  const modelLabel = task.model ? formatModel(`${task.model.providerID}/${task.model.modelID}`) : undefined
+  const categoryLabel = task.category && task.category !== task.subagent ? task.category : undefined
+  const detailParts = [
+    categoryLabel ? `category: ${categoryLabel}` : undefined,
+    subagentLabel,
+    modelLabel,
+  ].filter((part): part is string => Boolean(part))
+  const detail = detailParts.length > 0 ? detailParts.join(" · ") : undefined
+  const tooltip = [task.title, statusText, elapsed, detail].filter(Boolean).join(" · ")
+  return (
+    <div className={`agents-row agents-row-${task.status}`} title={tooltip}>
+      <span className="agents-row-title">{task.title}</span>
+      <span className="agents-row-meta">{statusText} · {elapsed}</span>
+      {detail && <span className="agents-row-detail">{detail}</span>}
+    </div>
+  )
+}
+
+function activitySummary(status: AgentsStatusInfo): string {
+  if (status.running > 0) return `${status.running} running`
+  if (status.waiting > 0) return `${status.waiting} waiting`
+  if (status.error > 0) return `${status.error} error${status.error === 1 ? "" : "s"}`
+  return `${status.total} active`
+}
+
+export function buildAgentsTitle(status?: AgentsStatusInfo): string {
+  if (!status || status.total === 0) {
+    return "No agents in this response"
+  }
+  const lines: string[] = []
+  if (status.running > 0)
+    lines.push(`${status.running} agent${status.running === 1 ? "" : "s"} running`)
+  if (status.waiting > 0) lines.push(`${status.waiting} waiting for input`)
+  if (status.error > 0) lines.push(`${status.error} with errors`)
+  lines.push("Click to view")
+  return lines.join("\n")
+}
+
+export function formatElapsed(ms: number): string {
+  const seconds = Math.max(0, Math.floor(ms / 1000))
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  const remMin = minutes - hours * 60
+  return remMin > 0 ? `${hours}h ${remMin}m` : `${hours}h`
+}

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react"
 import type { Block, Message } from "../hooks/useChatState"
-import type { Attachment, FileSearchHit } from "../protocol"
+import type { AgentsStatusInfo, Attachment, FileSearchHit } from "../protocol"
 import { findMentionRanges, makeAttachmentLabel } from "../mention-tokens"
 import { ImagePreviewModal } from "./ImagePreviewModal"
 import { ImageThumbnail, type Thumbnailable } from "./ImageThumbnail"
@@ -8,6 +8,7 @@ import { Markdown } from "./Markdown"
 import { PromptBox } from "./PromptBox"
 import { ToolTrace, toolHeadline } from "./ToolCard"
 import { ICON_SIZE } from "../design-tokens"
+import { AgentActivity } from "./AgentActivity"
 
 /**
  * Discriminated edit lifecycle for user-message bubbles.
@@ -33,6 +34,7 @@ export function MessageView({
   onBeginEdit,
   onEndEdit,
   onRetry,
+  agentActivity,
   searchFiles,
   attachFile,
 }: {
@@ -45,6 +47,7 @@ export function MessageView({
   onBeginEdit?: (id: string) => void
   onEndEdit?: (id: string) => void
   onRetry?: (assistantID: string) => void
+  agentActivity?: AgentsStatusInfo
   searchFiles?: (query: string) => Promise<FileSearchHit[]>
   attachFile?: () => Promise<{ attachments: Attachment[]; error?: string }>
 }) {
@@ -65,6 +68,7 @@ export function MessageView({
     <div className={`msg role-${message.role}`}>
       {message.ref?.label && <div className="msg-ref">{message.ref.label}</div>}
       {renderMessageBlocks(message, processOpen, processOnly, onReviewFile)}
+      <AgentActivity status={agentActivity} />
       {message.pending && message.blocks.length === 0 && (
         <div className="thinking-dots" role="status" aria-label="Thinking">thinking</div>
       )}

--- a/webview/src/components/StatusBar.tsx
+++ b/webview/src/components/StatusBar.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useRef, useState, type Dispatch, type SetStateAction } from "react"
-import type { AgentsStatusInfo, AgentsTaskInfo, ConversationSummary, Selection } from "../protocol"
+import type { ConversationSummary, Selection } from "../protocol"
 import { useDismissableMenu } from "../hooks/useDismissableMenu"
 import { useHeaderPopoverHeight } from "../hooks/useHeaderPopoverHeight"
 import { StatusIndicator, type StatusIndicatorKind } from "./StatusIndicator"
 
-export type HeaderPopoverID = "selector" | "agents" | "history"
+export type HeaderPopoverID = "selector" | "history"
 type HeaderPopoverSetter = Dispatch<SetStateAction<HeaderPopoverID | null>>
 
 type Props = {
@@ -14,7 +14,6 @@ type Props = {
   selection: Selection
   conversations: ConversationSummary[]
   activeConversationID?: string
-  agentsStatus?: AgentsStatusInfo
   activePopover?: HeaderPopoverID | null
   onActivePopoverChange?: HeaderPopoverSetter
   onSelectAgent: () => void
@@ -33,7 +32,6 @@ export function StatusBar({
   selection,
   conversations,
   activeConversationID,
-  agentsStatus,
   activePopover,
   onActivePopoverChange,
   onSelectAgent,
@@ -94,11 +92,6 @@ export function StatusBar({
         onSelectAgent={onSelectAgent}
         onSelectModel={onSelectModel}
         onSelectVariant={onSelectVariant}
-      />
-      <AgentsMenu
-        status={agentsStatus}
-        open={currentPopover === "agents"}
-        onOpenChange={(open) => setPopoverOpen("agents", open)}
       />
       <button
         type="button"
@@ -302,152 +295,6 @@ function ChatHistoryMenu({
       )}
     </div>
   )
-}
-
-/**
- * Always-visible `Agents` menu in the chat header, sitting between the
- * Model/Agent selector and the new-chat button. The host scopes the snapshot
- * to the active conversation, so `tasks` only contains work for THIS chat.
- * Clicking the pill toggles an inline popover (matching the SelectorMenu
- * pattern) that lists tasks grouped by Main / Subagents.
- *
- * The pill text never changes (always literally `Agents`); state is signalled
- * by color — muted when idle, breathing green while running, attention red
- * for error, amber for waiting.
- */
-function AgentsMenu({
-  status,
-  open,
-  onOpenChange,
-}: {
-  status?: AgentsStatusInfo
-  open: boolean
-  onOpenChange: (open: boolean) => void
-}) {
-  const { toggle, ref } = useDismissableMenu({ open, onOpenChange })
-  const popoverRef = useRef<HTMLDivElement>(null)
-  useHeaderPopoverHeight(open, popoverRef)
-
-  const running = (status?.running ?? 0) > 0
-  const errorOnly = !running && (status?.error ?? 0) > 0
-  const waitingOnly = !running && !errorOnly && (status?.waiting ?? 0) > 0
-  const idle = !running && !errorOnly && !waitingOnly
-  const className =
-    "agents-pill" +
-    (open ? " is-open" : "") +
-    (running ? " is-running" : "") +
-    (errorOnly ? " is-error" : "") +
-    (waitingOnly ? " is-waiting" : "") +
-    (idle ? " is-idle" : "")
-  const tasks = status?.tasks ?? []
-  const main = tasks.filter((t) => t.kind === "main")
-  const sub = tasks.filter((t) => t.kind === "subagent")
-  const empty = tasks.length === 0
-
-  return (
-    <div className="agents-menu" ref={ref}>
-      <button
-        type="button"
-        className={className}
-        onClick={toggle}
-        title={buildAgentsTitle(status)}
-        aria-label="Open agents for this chat"
-        aria-haspopup="menu"
-        aria-expanded={open}
-      >
-        Agents
-      </button>
-      {open && (
-        <div className="agents-popover" role="menu" ref={popoverRef}>
-          <div className="agents-popover-title">Agents in this chat</div>
-          {empty && <div className="agents-popover-empty">No agents in this chat</div>}
-          {!empty && (
-            <div className="agents-popover-scroll">
-              {main.length > 0 && (
-                <>
-                  <div className="agents-popover-section">Main</div>
-                  {main.map((task) => (
-                    <AgentsRow key={task.id} task={task} />
-                  ))}
-                </>
-              )}
-              {sub.length > 0 && (
-                <>
-                  <div className="agents-popover-section">Subagents</div>
-                  {sub.map((task) => (
-                    <AgentsRow key={task.id} task={task} />
-                  ))}
-                </>
-              )}
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  )
-}
-
-function AgentsRow({ task }: { task: AgentsTaskInfo }) {
-  const isLive = task.status === "running" || task.status === "waiting"
-  const [now, setNow] = useState(() => Date.now())
-  useEffect(() => {
-    if (!isLive) return
-    const handle = window.setInterval(() => setNow(Date.now()), 1000)
-    return () => window.clearInterval(handle)
-  }, [isLive])
-  // Live rows tick `now` for a moving stopwatch. Terminal rows freeze
-  // the elapsed at the store's `updatedAt` so a completed subagent
-  // shows its true total runtime, not "minutes since the popover
-  // happened to render".
-  const elapsedMs = isLive ? now - task.startedAt : task.updatedAt - task.startedAt
-  const elapsed = formatElapsed(elapsedMs)
-  const statusText = task.status === "error" && task.error
-    ? `error · ${task.error}`
-    : task.status
-  // Build the per-subagent "agent · model" sublabel from the metadata
-  // omo writes on dispatch (`update.metadata` → AgentTask). Either piece
-  // can be missing — opencode's built-in task tool doesn't publish a
-  // model — so we render whatever subset is present.
-  const subagentLabel = task.subagent ? formatAgent(task.subagent) : undefined
-  const modelLabel = task.model ? formatModel(`${task.model.providerID}/${task.model.modelID}`) : undefined
-  const categoryLabel = task.category && task.category !== task.subagent ? task.category : undefined
-  const detailParts = [
-    categoryLabel ? `category: ${categoryLabel}` : undefined,
-    subagentLabel,
-    modelLabel,
-  ].filter((part): part is string => Boolean(part))
-  const detail = detailParts.length > 0 ? detailParts.join(" · ") : undefined
-  const tooltip = [task.title, statusText, elapsed, detail].filter(Boolean).join(" · ")
-  return (
-    <div className={`agents-row agents-row-${task.status}`} title={tooltip}>
-      <span className="agents-row-title">{task.title}</span>
-      <span className="agents-row-meta">{statusText} · {elapsed}</span>
-      {detail && <span className="agents-row-detail">{detail}</span>}
-    </div>
-  )
-}
-
-export function buildAgentsTitle(status?: AgentsStatusInfo): string {
-  if (!status || status.total === 0) {
-    return "No agents in this chat\nClick to view"
-  }
-  const lines: string[] = []
-  if (status.running > 0)
-    lines.push(`${status.running} agent${status.running === 1 ? "" : "s"} running`)
-  if (status.waiting > 0) lines.push(`${status.waiting} waiting for input`)
-  if (status.error > 0) lines.push(`${status.error} with errors`)
-  lines.push("Click to view")
-  return lines.join("\n")
-}
-
-export function formatElapsed(ms: number): string {
-  const seconds = Math.max(0, Math.floor(ms / 1000))
-  if (seconds < 60) return `${seconds}s`
-  const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return `${minutes}m`
-  const hours = Math.floor(minutes / 60)
-  const remMin = minutes - hours * 60
-  return remMin > 0 ? `${hours}h ${remMin}m` : `${hours}h`
 }
 
 export function formatUpdated(updatedAt: number) {

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -178,25 +178,15 @@ button {
   white-space: nowrap;
 }
 
-/* ===== AgentsMenu =====
-   Always-visible text-only pill that surfaces live main-agent + subagent
-   activity. Sits between the model/agent selector and the new-chat (+)
-   button on the right side of the chat header. While at least one task is
-   running, the text breathes via a 1.6s opacity + green color animation.
-   Waiting / error states use a steady amber / red foreground without
-   animation. Clicking opens an inline popover scoped to the current chat
-   (`.agents-popover`). */
-.agents-menu {
-  /* Intentionally NOT position: relative — `.agents-popover` anchors to
-     the parent `.statusbar` (which IS position: relative) so its right
-     edge lands at the panel's right edge, not the pill's right edge.
-     The pill sits in the middle of the bar with new-chat + history
-     buttons to its right; anchoring to the pill would push the popover
-     leftward off the panel on narrow side views. Matches the same
-     fall-through pattern used by .selector-menu and .history-menu. */
-  flex: 0 0 auto;
-  display: inline-flex;
-  align-items: center;
+/* ===== AgentActivity =====
+   Message-flow activity surface for live main-agent + subagent work. It
+   renders inside the active assistant message, next to the Process panel,
+   so it reads as "work for this response" instead of another header setting. */
+.agent-activity {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  margin: -4px 0 10px;
 }
 .agents-pill {
   flex: 0 0 auto;
@@ -221,6 +211,29 @@ button {
   white-space: nowrap;
   transition: background-color 0.12s ease;
 }
+.agent-activity-pill {
+  gap: 6px;
+  padding: 3px 9px;
+  border: 1px solid var(--vscode-panel-border);
+  background: var(--vscode-editorWidget-background);
+  color: var(--vscode-foreground);
+  font-size: 11px;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08);
+}
+.agent-activity-name {
+  font-weight: 700;
+}
+.agent-activity-summary {
+  font-weight: 500;
+  opacity: 0.7;
+}
+.agent-activity-dot {
+  flex: 0 0 auto;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--color-status-default);
+}
 .agents-pill:hover,
 .agents-pill.is-open {
   background: var(--hover-bg-pill);
@@ -233,11 +246,20 @@ button {
   color: #7ee787;
   animation: agents-breathe 1.6s ease-in-out infinite;
 }
+.agents-pill.is-running .agent-activity-dot {
+  background: #7ee787;
+}
 .agents-pill.is-error {
   color: var(--vscode-errorForeground, #f85149);
 }
+.agents-pill.is-error .agent-activity-dot {
+  background: var(--vscode-errorForeground, #f85149);
+}
 .agents-pill.is-waiting {
   color: var(--vscode-notificationsWarningIcon-foreground, #d29922);
+}
+.agents-pill.is-waiting .agent-activity-dot {
+  background: var(--vscode-notificationsWarningIcon-foreground, #d29922);
 }
 @keyframes agents-breathe {
   0%, 100% { opacity: 1; color: #7ee787; }
@@ -249,16 +271,9 @@ button {
 
 .agents-popover {
   position: absolute;
-  /* Shared layout vocabulary with `.selector-popover` and
-     `.history-popover`: same `top` gap below the statusbar, same
-     `right` anchor to the panel edge, same width-clamp formula,
-     same design tokens (`--z-popover`, `--radius`, the sidebar
-     background fallback) and the same drop shadow — so toggling
-     between the three header popovers feels uniform instead of
-     each one drifting toward its own polish. The 300px cap leaves
-     chat content visible behind the popover even on narrow side
-     panels; row content still fits comfortably with ellipsis on
-     overflow. */
+  /* Same surface vocabulary as the header popovers, but anchored to the
+     inline activity pill so it opens beside the Process panel rather than
+     from the status bar. */
   top: calc(100% + 2px);
   right: 10px;
   width: min(300px, calc(100vw - 20px));
@@ -279,6 +294,13 @@ button {
   flex-direction: column;
   max-height: min(420px, calc(100vh - 80px));
   overflow: hidden;
+}
+.agent-activity-popover {
+  top: calc(100% + 4px);
+  left: 0;
+  right: auto;
+  width: min(320px, calc(100vw - 36px));
+  max-height: min(360px, calc(100vh - 140px));
 }
 .agents-popover-scroll {
   overflow-y: auto;


### PR DESCRIPTION
## Summary

- Move the live `Agents` pill out of the chat status bar into the assistant message that's actually running the work, so per-turn activity reads as "this response is running agents" instead of "the chat has a global Agents shelf."
- New `AgentActivity` component renders inline with the active assistant message and only when there's something to show (`total > 0`). At rest the surface is fully invisible.
- `App.tsx` resolves the right target message (prefers the still-pending assistant turn, falls back to the most recent assistant message) and passes the snapshot to that one `MessageView`.
- `StatusBar` drops `AgentsMenu`, the `agents` popover ID, and the `agentsStatus` prop; existing tests are ported onto the new component.

Closes #170

## Test plan

- [x] `bun run check-types` (host) and `bunx tsc --noEmit` (webview) — clean.
- [x] `bun run test` — 770 tests across 46 files pass (includes the ported `AgentActivity` suite).
- [x] `bun run compile` — webview + esbuild build clean.
- [ ] Visual: pill renders inline with the active response while a subagent runs; popover anchors to the pill, dismisses on outside click and Escape; idle conversations show nothing.
- [ ] Visual: error and waiting color variants apply on the inline pill.