### PR TITLE
chore(gitignore): ignore local tool state dirs (.omo, .sisyphus)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ npm-debug.log*
 # Contributor-private assistant instructions (Claude Code).
 CLAUDE.md
 
+# Local tool state (run-continuation caches, not source).
+.omo/
+.sisyphus/
+
 # Secrets — never accidentally commit a .env
 .env
 .env.*


### PR DESCRIPTION
## Summary

- Add `.omo/` and `.sisyphus/` to `.gitignore`. Both are local run-continuation caches created by contributor-side tools — not source — and were appearing as untracked in every `git status`.

Closes #172

## Test plan

- [x] `git status` after the change shows no `.omo/` / `.sisyphus/` entries (worktree is clean).
- [x] No tracked files were removed (those dirs were never tracked).