### PR TITLE
chore(release): cut v0.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.9.4] - 2026-05-22
+
+### Changed
+- Live agent activity moved out of the chat status bar and into the assistant message that's actually running the work. New `webview/src/components/AgentActivity.tsx` renders a compact `Agents · N running` pill inline with the active response, with an anchored popover listing Main + Subagents (running breathes green, error red, waiting amber). `StatusBar` drops the `AgentsMenu` block, the `agents` popover ID, and the `agentsStatus` prop — `App.tsx` now resolves the right host message (`agentActivityMessageID` prefers the still-pending assistant turn, falls back to the most recent assistant message) and passes the snapshot to that single `MessageView`. At rest the surface is fully invisible (`total === 0` renders nothing), so the status bar stays for chat-wide settings and per-turn activity stays next to the response.
+
+### Fixed
+- Tooling-state directories `.omo/` and `.sisyphus/` no longer appear as untracked in `git status`. Added both to `.gitignore` so an accidental `git add -A` can't sweep them into a commit. No tracked files removed.
+
+Closes #170, #172.
+
 ## [0.9.3] - 2026-05-22
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Bump `package.json` to `0.9.4`.
- Add `[0.9.4]` section to `CHANGELOG.md` covering the agent-activity surface relocation (#170 / PR #171) and the local-tool-dirs gitignore (#172 / PR #173).
- Unblocks the corrective re-publish: the existing `v0.9.4` tag pointed at the gitignore commit while `package.json` still said `0.9.3`, so the publish workflow's tag/version guard refused to ship. The marketplace is untouched, so `v0.9.4` is still claimable — once this merges we'll delete + recreate the `v0.9.4` tag and Release on the new commit so the workflow re-fires.

Closes #174

## Test plan

- [x] `git log --oneline` and `git diff` confirm only `package.json` + `CHANGELOG.md` changed.
- [ ] After merge: tag `v0.9.4` recreated on the bump commit; publish workflow run completes; `0.9.4` visible on the VS Code Marketplace.