### PR TITLE
chore(extensibility): unstick top friction zones from audit

### DIFF
--- a/src/agents/task-store.ts
+++ b/src/agents/task-store.ts
@@ -68,8 +68,27 @@ export type AgentTask = {
   error?: string
 }
 
-const ACTIVE_STATUSES: ReadonlyArray<AgentTaskStatus> = ["running", "waiting"]
-const ATTENTION_STATUSES: ReadonlyArray<AgentTaskStatus> = ["running", "waiting", "error"]
+/**
+ * `running` and `waiting` are the statuses that mean opencode is still
+ * doing work for this task. Consulted by `markSessionIdle` / abort paths
+ * to decide which tasks to settle on session close.
+ */
+export type ActiveStatus = "running" | "waiting"
+export const ACTIVE_STATUSES: ReadonlyArray<AgentTaskStatus> = ["running", "waiting"]
+
+/**
+ * Statuses the Agents popover shows. Active work plus `error` so a
+ * failed task stays visible until the user starts the next turn. Exported
+ * so call sites (e.g. `summarizeAgentTasks` in `src/chat/view.ts`) iterate
+ * the same set and `isAttentionStatus` narrows the union, instead of
+ * duplicating the membership check inline.
+ */
+export type AttentionStatus = ActiveStatus | "error"
+export const ATTENTION_STATUSES: ReadonlyArray<AgentTaskStatus> = ["running", "waiting", "error"]
+
+export function isAttentionStatus(status: AgentTaskStatus): status is AttentionStatus {
+  return ATTENTION_STATUSES.includes(status)
+}
 
 /**
  * One main task per user turn. `turnID` is minted by ChatView at prompt
@@ -111,12 +130,30 @@ export function subagentTaskIDByChildSession(childSessionID: string): string {
  * the same convention to the popover so abort signals settle as
  * `cancelled` (filtered out of the active-only popover) instead of
  * painting the row red.
+ *
+ * Adding a new classification (timeout, rate-limit, quota-exceeded, …)
+ * is a one-line append to `TERMINAL_CLASSIFIERS` — see
+ * `docs/extensibility.md` for the recipe.
  */
+type TerminalRule = {
+  pattern: RegExp
+  status: "cancelled" | "error"
+}
+
+const TERMINAL_CLASSIFIERS: ReadonlyArray<TerminalRule> = [
+  { pattern: /^aborted$/i, status: "cancelled" },
+]
+
 export function classifyTerminal(message: string | undefined): {
   status: "cancelled" | "error"
   error?: string
 } {
-  if (message && /^aborted$/i.test(message.trim())) return { status: "cancelled" }
+  const trimmed = message?.trim()
+  if (trimmed) {
+    for (const rule of TERMINAL_CLASSIFIERS) {
+      if (rule.pattern.test(trimmed)) return { status: rule.status }
+    }
+  }
   return { status: "error", error: message }
 }
 

--- a/src/chat/stream.ts
+++ b/src/chat/stream.ts
@@ -330,6 +330,12 @@ export function subscribeSession(
           markActivity(sessionID)
         }
         return
+      default:
+        // Unknown opencode event type — log so a new SDK event surfaces
+        // in the output channel instead of silently vanishing. Add a
+        // matching `case` above to actually route it.
+        log(`[sse] unhandled type: ${type}`)
+        return
     }
   }
 
@@ -432,6 +438,11 @@ export function subscribeSession(
       }
       case "message.part.delta":
         childCb({ type: "busy", sessionID: childSid })
+        return
+      default:
+        // Unknown event for a tracked child session — log and drop. Same
+        // contract as the parent route's default branch.
+        log(`[sse:child:${childSid}] unhandled type: ${type}`)
         return
     }
   }

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -44,7 +44,15 @@ import { collectAutoContext } from "../workspace-context/collector"
 import { RecentEditsTracker } from "../workspace-context/recent-edits"
 import { readContextSettings } from "../workspace-context/budget"
 import type { IndexManager } from "../indexing/index-manager"
-import { AgentTaskStore, classifyTerminal, mainTaskID, type AgentTask } from "../agents/task-store"
+import {
+  AgentTaskStore,
+  ATTENTION_STATUSES,
+  classifyTerminal,
+  isAttentionStatus,
+  mainTaskID,
+  type AgentTask,
+  type AttentionStatus,
+} from "../agents/task-store"
 import { SubagentTracker } from "../agents/subagent-tracker"
 import type { AgentsStatusInfo, AgentsTaskInfo } from "../protocol"
 import { toWire } from "./wire-format"
@@ -1754,21 +1762,19 @@ export function summarizeAgentTasks(
     ? tasks.filter((task) => task.conversationID === conversationID)
     : tasks
 
-  // The popover shows ONLY currently-active work — the latest main task
-  // and any subagents that are still running / waiting / errored. We drop
-  // `completed` and `cancelled` rows so the popover reflects "what's
-  // happening right now," not a per-chat history. A second user prompt
-  // gets its own main row (see mainTaskID's per-turn keying); the prior
-  // turn's row is settled and filtered out.
+  // The popover shows ONLY currently-active work — main tasks and any
+  // subagents whose status is in ATTENTION_STATUSES. `completed` and
+  // `cancelled` rows are dropped so the popover reflects "what's happening
+  // right now," not a per-chat history. A second user prompt gets its own
+  // main row (see mainTaskID's per-turn keying); the prior turn's row is
+  // settled and filtered out.
+  const counts: Record<AttentionStatus, number> = Object.fromEntries(
+    ATTENTION_STATUSES.map((status) => [status, 0]),
+  ) as Record<AttentionStatus, number>
   const items: AgentsTaskInfo[] = []
-  let running = 0
-  let waiting = 0
-  let error = 0
   for (const task of scoped) {
-    if (task.status === "running") running += 1
-    else if (task.status === "waiting") waiting += 1
-    else if (task.status === "error") error += 1
-    else continue
+    if (!isAttentionStatus(task.status)) continue
+    counts[task.status] += 1
     items.push({
       id: task.id,
       kind: task.kind,
@@ -1789,7 +1795,13 @@ export function summarizeAgentTasks(
     if (a.kind !== b.kind) return a.kind === "main" ? -1 : 1
     return a.startedAt - b.startedAt
   })
-  return { running, waiting, error, total: running + waiting + error, tasks: items }
+  return {
+    running: counts.running,
+    waiting: counts.waiting,
+    error: counts.error,
+    total: counts.running + counts.waiting + counts.error,
+    tasks: items,
+  }
 }
 
 export function taskTitleFromUpdate(update: ToolUpdate): string {


### PR DESCRIPTION
Closes #178

## Summary

Three small refactors that turn each top friction zone surfaced by the extensibility audit into a single-site extension:

- **`classifyTerminal` is table-driven.** `src/agents/task-store.ts` — the rule that maps terminal error messages to `cancelled` vs `error` is now a `TERMINAL_CLASSIFIERS` array. The single existing rule (`/^aborted$/i` → `cancelled`) preserves behaviour exactly. Adding a new classification (timeout, rate-limit, quota-exceeded) is a one-line append.
- **Status sets exported + consumed.** `ACTIVE_STATUSES` and `ATTENTION_STATUSES` are now exported from `task-store.ts`, with matching `ActiveStatus` / `AttentionStatus` type aliases and an `isAttentionStatus` type predicate. `summarizeAgentTasks` in `src/chat/view.ts` iterates the set + uses the predicate instead of three hardcoded `task.status === "..."` checks. The `AgentsStatusInfo` wire shape stays unchanged so the webview is untouched.
- **SSE default-branch logging.** Both `route()` and `routeChildSessionEvent()` in `src/chat/stream.ts` now have a `default:` case that emits `[sse] unhandled type: <name>` through the existing `log()` helper. When opencode ships a new SSE event, it surfaces in the output channel instead of silently dropping.

Net change: 3 files, +78 / −18.

No behaviour change for end users — popover still shows the same statuses, abort still maps to Stopped, all 770 tests pass unchanged.

## Test plan

- [x] `bun run check-types` — clean (host).
- [x] `cd webview && bunx tsc --noEmit` — clean (webview).
- [x] `bun run test` — 770/770 pass.
- [x] `bun run compile` — produces both bundles.
- [ ] Smoke test in Extension Development Host: press Stop mid-stream and confirm the Agents popover settles the main row as **Stopped/cancelled** (not red `error`). This exercises the table-driven `classifyTerminal("Aborted")` path.
- [ ] Smoke test in Extension Development Host: open Output → "OpenCode Panel" channel during a normal session and confirm no `[sse] unhandled type:` lines appear for the known opencode events.