### PR TITLE
fix(review): correct Keep/Undo logic and cut v0.9.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",

--- a/src/chat/fs-ops.ts
+++ b/src/chat/fs-ops.ts
@@ -1,8 +1,10 @@
 import * as vscode from "vscode"
 import * as path from "path"
+import * as os from "os"
 import type { ReviewChange, ReviewHunkState } from "../protocol"
 import { stripWorkspaceFolderPrefix, normalizePath } from "./paths"
 import { findHunkInFile, findHunkText, type ReviewDiffHunk } from "./diff"
+import { log } from "../output"
 
 const SHELL_LANGS = new Set([
   "bash", "sh", "shell", "shellscript", "zsh", "fish", "powershell", "ps", "ps1", "bat", "cmd",
@@ -59,15 +61,85 @@ export async function workspaceFileUri(relPath: string, root?: string) {
 }
 
 export async function existingWorkspaceFileUri(relPath: string, root?: string): Promise<vscode.Uri | undefined> {
-  for (const { uri } of workspaceFileUriCandidates(relPath, root)) {
+  return (await findExistingWorkspaceFile(relPath, root)).uri
+}
+
+/**
+ * Find a file by trying the workspace candidates first, then by walking
+ * ancestor directories of `root` if the standard candidates miss. The
+ * ancestor walk handles a real case: opencode reports `relativePath`
+ * anchored to a directory ABOVE the VS Code workspace (e.g. a git worktree
+ * root or the user's home), so joining against the workspace alone produces
+ * malformed paths and stat fails even though the file exists. The walk
+ * stops at the user's home directory when `root` is under home, otherwise
+ * at the filesystem root.
+ *
+ * `..` segments in `relPath` skip the ancestor fallback — a model emitting
+ * `../../etc/passwd` should never escape via this code.
+ *
+ * Returns the matched URI plus the list of paths we attempted, for
+ * logging on misses.
+ */
+export async function findExistingWorkspaceFile(
+  relPath: string,
+  root?: string,
+  options: { home?: string; preferAbsolute?: string } = {},
+): Promise<{ uri?: vscode.Uri; tried: string[] }> {
+  const tried: string[] = []
+  // Opencode-reported absolute path (when available, e.g. apply_patch's
+  // `files[].absolutePath`) is the unambiguous resolution — try it first
+  // before falling through to the workspace candidates.
+  if (options.preferAbsolute && path.isAbsolute(options.preferAbsolute)) {
+    const uri = vscode.Uri.file(options.preferAbsolute)
+    tried.push(uri.fsPath)
     try {
       await vscode.workspace.fs.stat(uri)
-      return uri
+      return { uri, tried }
     } catch {
-      // Try the next plausible base.
+      // continue
     }
   }
-  return undefined
+  for (const { uri } of workspaceFileUriCandidates(relPath, root)) {
+    if (tried.includes(uri.fsPath)) continue
+    tried.push(uri.fsPath)
+    try {
+      await vscode.workspace.fs.stat(uri)
+      return { uri, tried }
+    } catch {
+      // continue
+    }
+  }
+  if (!path.isAbsolute(relPath) && !hasParentSegment(relPath) && root) {
+    const home = options.home ?? os.homedir()
+    for (const ancestor of ancestorRoots(root, home)) {
+      const uri = vscode.Uri.file(path.join(ancestor, normalizePath(relPath)))
+      if (tried.includes(uri.fsPath)) continue
+      tried.push(uri.fsPath)
+      try {
+        await vscode.workspace.fs.stat(uri)
+        return { uri, tried }
+      } catch {
+        // continue
+      }
+    }
+  }
+  return { tried }
+}
+
+function hasParentSegment(relPath: string): boolean {
+  return normalizePath(relPath).split("/").some((seg) => seg === "..")
+}
+
+function ancestorRoots(root: string, home: string): string[] {
+  const resolved = path.resolve(root)
+  const result: string[] = []
+  let current = path.dirname(resolved)
+  while (current && current !== path.dirname(current)) {
+    result.push(current)
+    if (current === home) break
+    current = path.dirname(current)
+  }
+  return result
 }
 
 export async function reviewPathExists(relPath: string, root?: string): Promise<boolean> {
@@ -170,28 +242,43 @@ async function acceptHunk(
   // Keep is a verification: confirm the file is in the expected post-change
   // state. We don't mutate anything — opencode already applied the change.
   if (change.kind === "created") {
-    const exists = await reviewPathExists(change.path, root)
-    if (!exists) {
-      return reportConflict(change.path, `${change.path} was created but is no longer present.`, silent)
+    const { uri, tried } = await findExistingWorkspaceFile(change.path, root, { preferAbsolute: change.absolutePath })
+    if (!uri) {
+      return reportConflict(change.path, `${change.path} was created but is no longer present.`, silent, tried)
     }
     return { status: "applied" }
   }
   if (change.kind === "deleted") {
-    const exists = await reviewPathExists(change.path, root)
-    if (exists) {
-      return reportConflict(change.path, `${change.path} was deleted but still exists.`, silent)
+    const { uri, tried } = await findExistingWorkspaceFile(change.path, root, { preferAbsolute: change.absolutePath })
+    if (uri) {
+      return reportConflict(change.path, `${change.path} was deleted but still exists.`, silent, tried)
     }
     return { status: "applied" }
   }
-  const existing = await existingWorkspaceFileUri(change.path, root)
+  const { uri: existing, tried } = await findExistingWorkspaceFile(change.path, root, { preferAbsolute: change.absolutePath })
   if (!existing) {
-    return reportMissing(change.path, `${change.path} is no longer present.`, silent)
+    return reportMissing(change.path, `${change.path} is no longer present.`, silent, tried)
   }
   // For an update / move, the expected newText should be locatable at the
   // hunk's anchor line. If it isn't, the file has drifted — surface that
   // rather than silently marking the hunk accepted.
   const doc = await vscode.workspace.openTextDocument(existing)
-  const located = findHunkInFile(doc.getText(), hunk)
+  const text = doc.getText()
+  // Pure-deletion hunks need a different check: `findHunkInFile` returns a
+  // zero-width match at the anchor for `newText === ""`, which would let
+  // Keep silently succeed even when the deletion was reverted. Verify by
+  // asserting the removed block is no longer anywhere in the file.
+  if (hunk.newText === "" && hunk.oldText !== "") {
+    if (text.includes(hunk.oldText)) {
+      return reportConflict(
+        change.path,
+        `Cannot confirm deletion in ${change.path}: the removed lines are still present.`,
+        silent,
+      )
+    }
+    return { status: "applied" }
+  }
+  const located = findHunkInFile(text, hunk)
   if (!located) {
     return reportConflict(
       change.path,
@@ -232,7 +319,7 @@ async function undoCreate(
   root: string | undefined,
   silent: boolean,
 ): Promise<ReviewHunkOutcome> {
-  const existing = await existingWorkspaceFileUri(change.path, root)
+  const { uri: existing } = await findExistingWorkspaceFile(change.path, root, { preferAbsolute: change.absolutePath })
   if (!existing) {
     // Nothing to undo — file already gone (e.g. user manually removed it).
     return { status: "no-op", reason: `${change.path} is already absent.` }
@@ -264,7 +351,7 @@ async function undoDelete(
   }
   // If the file is back already, leave it alone — surface conflict instead of
   // clobbering whatever's there now.
-  const existing = await existingWorkspaceFileUri(change.path, root)
+  const { uri: existing } = await findExistingWorkspaceFile(change.path, root, { preferAbsolute: change.absolutePath })
   if (existing) {
     return reportConflict(
       change.path,
@@ -299,7 +386,7 @@ async function undoMove(
       silent,
     )
   }
-  const fromUri = await existingWorkspaceFileUri(change.path, root)
+  const { uri: fromUri } = await findExistingWorkspaceFile(change.path, root, { preferAbsolute: change.absolutePath })
   if (!fromUri) {
     return reportMissing(change.path, `${change.path} is no longer present; cannot move back.`, silent)
   }
@@ -335,9 +422,9 @@ async function undoUpdate(
   root: string | undefined,
   silent: boolean,
 ): Promise<ReviewHunkOutcome> {
-  const existing = await existingWorkspaceFileUri(change.path, root)
+  const { uri: existing, tried } = await findExistingWorkspaceFile(change.path, root, { preferAbsolute: change.absolutePath })
   if (!existing) {
-    return reportMissing(change.path, `${change.path} is no longer present.`, silent)
+    return reportMissing(change.path, `${change.path} is no longer present.`, silent, tried)
   }
   const doc = await vscode.workspace.openTextDocument(existing)
   const current = doc.getText()
@@ -364,13 +451,19 @@ async function undoUpdate(
   return { status: "applied" }
 }
 
-function reportConflict(p: string, reason: string, silent: boolean): ReviewHunkOutcome {
+function reportConflict(p: string, reason: string, silent: boolean, tried?: string[]): ReviewHunkOutcome {
   if (!silent) vscode.window.showWarningMessage(`OpenCode Panel: ${reason}`)
+  if (tried && tried.length > 0) {
+    log(`reviewHunk conflict on ${p}: ${reason} (tried: ${tried.join(", ")})`)
+  }
   return { status: "conflict", reason }
 }
 
-function reportMissing(p: string, reason: string, silent: boolean): ReviewHunkOutcome {
+function reportMissing(p: string, reason: string, silent: boolean, tried?: string[]): ReviewHunkOutcome {
   if (!silent) vscode.window.showWarningMessage(`OpenCode Panel: ${reason}`)
+  if (tried && tried.length > 0) {
+    log(`reviewHunk missing on ${p}: ${reason} (tried: ${tried.join(", ")})`)
+  }
   return { status: "missing", reason }
 }
 

--- a/src/chat/review-actions.ts
+++ b/src/chat/review-actions.ts
@@ -1,0 +1,90 @@
+import type { ReviewChange, ReviewHunkState } from "../protocol"
+import { reviewHunk as defaultReviewHunk, type ReviewHunkOutcome } from "./fs-ops"
+import { splitReviewDiff, type ReviewDiffHunk } from "./diff"
+import { reviewKey } from "../../webview/src/review-extract"
+
+export type HunkUpdate = { key: string; state: ReviewHunkState }
+
+export type ReviewAllForPathResult = {
+  applied: number
+  conflicts: number
+  hunkUpdates: HunkUpdate[]
+}
+
+export type ReviewHunkRunner = (
+  change: ReviewChange,
+  hunk: ReviewDiffHunk,
+  action: ReviewHunkState,
+  options: { silent?: boolean; root?: string },
+) => Promise<ReviewHunkOutcome>
+
+export type ReviewAllForPathOptions = {
+  root?: string
+  reviewedKeys: Record<string, ReviewHunkState>
+  runReviewHunk?: ReviewHunkRunner
+}
+
+/**
+ * Apply Keep / Undo to every per-tool record matching a single path.
+ *
+ * Why iterate per-tool records instead of the aggregated row: aggregateChanges
+ * collapses multiple ReviewChange records into one row by KEEPING ONLY the
+ * last contributing record's `patch`. Acting on the aggregated patch alone
+ * silently skips every earlier tool call's hunks — a half-undo the user
+ * never sees. We act on the un-aggregated extract so every hunk reaches
+ * `reviewHunk()`, then key the UI state on the aggregated row so the panel,
+ * decorations, and snapshots stay coherent.
+ *
+ * Reverse order for Undo: when two records edited the same lines (A: orig →
+ * rev1, B: rev1 → final), only newest-first iteration leaves each record's
+ * `newText` anchor matchable. For non-overlapping edits the order still
+ * matters because reverting a downstream hunk first keeps upstream line
+ * anchors unshifted.
+ */
+export async function reviewAllForPath(
+  records: ReviewChange[],
+  aggregated: ReviewChange | undefined,
+  action: ReviewHunkState,
+  options: ReviewAllForPathOptions,
+): Promise<ReviewAllForPathResult> {
+  if (!aggregated || records.length === 0) {
+    return { applied: 0, conflicts: 0, hunkUpdates: [] }
+  }
+  const aggregatedHunks = splitReviewDiff(aggregated.patch).hunks
+  const aggregatedKeys = aggregatedHunks.map((hunk) => reviewKey(aggregated, hunk.id))
+  if (aggregatedKeys.length > 0 && aggregatedKeys.every((key) => options.reviewedKeys[key])) {
+    return { applied: 0, conflicts: 0, hunkUpdates: [] }
+  }
+  const runner = options.runReviewHunk ?? defaultReviewHunk
+  const ordered = action === "rejected" ? records.slice().reverse() : records
+  let applied = 0
+  let conflicts = 0
+  for (const record of ordered) {
+    const hunks = splitReviewDiff(record.patch).hunks
+    let firstHunk = true
+    for (const hunk of hunks) {
+      if (action === "rejected" && !hunk.reversible) {
+        conflicts += 1
+        continue
+      }
+      if (!firstHunk && record.kind !== "updated") {
+        continue
+      }
+      const outcome = await runner(record, hunk, action, { silent: true, root: options.root })
+      firstHunk = false
+      if (outcome.status === "applied" || outcome.status === "no-op") {
+        applied += 1
+        continue
+      }
+      conflicts += 1
+    }
+  }
+  const hunkUpdates: HunkUpdate[] = []
+  if (applied > 0) {
+    for (const key of aggregatedKeys) {
+      if (options.reviewedKeys[key]) continue
+      hunkUpdates.push({ key, state: action })
+    }
+  }
+  return { applied, conflicts, hunkUpdates }
+}

--- a/src/chat/review-changes.ts
+++ b/src/chat/review-changes.ts
@@ -7,6 +7,7 @@
 import type { ChatMessage, ReviewChange, ToolUpdate as WireToolUpdate } from "../protocol"
 import {
   displayPath,
+  extractChanges,
   patchChanges,
   patchKind,
   patchPath,
@@ -28,6 +29,7 @@ export function toolChanges(update: WireToolUpdate, source: string): ReviewChang
 
 export {
   displayPath,
+  extractChanges,
   patchChanges,
   patchKind,
   patchPath,

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -35,7 +35,8 @@ import { SubagentDispatch } from "./subagent-dispatch"
 export { summarizePrompt } from "./subagent-dispatch"
 import { relativeToCwd, samePath } from "./paths"
 import { isTextReviewPath, reviewKey, splitReviewDiff } from "./diff"
-import { reviewChanges } from "./review-changes"
+import { extractChanges, reviewChanges } from "./review-changes"
+import { reviewAllForPath } from "./review-actions"
 import { buildPrompt, readMentions } from "./prompt-builder"
 import { buildManifest } from "../workspace-context/manifest"
 import { collectAutoContext } from "../workspace-context/collector"
@@ -57,7 +58,6 @@ import {
   applyCode,
   openFile,
   openFileDocument,
-  reviewHunk,
   reviewPathExists,
 } from "./fs-ops"
 
@@ -1340,65 +1340,39 @@ export class ChatView implements vscode.WebviewViewProvider {
   }
 
   private async handleReviewAllInChange(source: string, requestedPath: string, action: ReviewHunkState) {
-    const all = reviewChanges(this.messages)
-    // Match every change for this path, not just the one matching `source`.
-    // A single physical edit can show up as multiple ReviewChange records
-    // (tool block + patch block of the same hunk produce different sources
-    // and therefore different reviewKeys). If we only mark the source-matched
-    // record's hunks reviewed, the other record's hunks still spawn codelenses
-    // and decorations on the next sync.
-    const targets = all.filter((c) => samePath(c.path, requestedPath))
-    if (!targets.length) {
-      log("reviewAllInChange: no matching change", { source, path: requestedPath, available: all.map((c) => ({ source: c.source, path: c.path })) })
+    // The webview's review row is keyed on the AGGREGATED change (one row per
+    // path), but the action must iterate the UN-aggregated per-tool records:
+    // `aggregateChanges` keeps only the LAST contributing record's `patch`,
+    // so acting on the aggregated patch alone would silently miss every
+    // earlier tool call's hunks. We pass both into the pure helper — records
+    // drive the fs ops, the aggregated row drives the UI state updates.
+    const aggregatedAll = reviewChanges(this.messages)
+    const aggregated = aggregatedAll.find((c) => samePath(c.path, requestedPath))
+    if (!aggregated) {
+      log("reviewAllInChange: no matching change", { source, path: requestedPath, available: aggregatedAll.map((c) => c.path) })
+      return
+    }
+    const records = extractChanges(this.messages).filter((c) => samePath(c.path, requestedPath))
+    if (!records.length) {
+      log("reviewAllInChange: aggregated row has no underlying records", { source, path: requestedPath })
       return
     }
     const root = this.backendDirectory()
-    // Files might be intentionally missing (a `deleted` change leaves the file
-    // gone, which is the desired post-change state). Only the `updated` /
-    // `moved` cases require the file present; the helpers handle that.
-    let conflicts = 0
-    let applied = 0
-    for (const change of targets) {
-      const hunks = splitReviewDiff(change.patch).hunks
-      let firstHunk = true
-      for (const hunk of hunks) {
-        const key = reviewKey(change, hunk.id)
-        if (this.reviewHunks[key]) continue
-        if (action === "rejected" && !hunk.reversible) {
-          conflicts += 1
-          continue
-        }
-        // For non-update kinds (created / deleted / moved) the action is a
-        // whole-file operation; running it once per hunk would double-act.
-        // Skip all but the first hunk in those cases.
-        if (!firstHunk && change.kind !== "updated") {
-          // Mirror whatever the first hunk produced — it already applied or
-          // conflicted as a whole-file op.
-          this.post({ type: "reviewHunkState", key, state: action })
-          continue
-        }
-        const outcome = await reviewHunk(change, hunk, action, { silent: true, root })
-        firstHunk = false
-        if (outcome.status === "applied" || outcome.status === "no-op") {
-          this.post({ type: "reviewHunkState", key, state: action })
-          applied += 1
-          continue
-        }
-        // Per requirement: do NOT silently mark a hunk rejected when the undo
-        // couldn't be applied safely — leave the row pending so the user can
-        // see the conflict and decide what to do.
-        conflicts += 1
-        log(`reviewAllInChange: ${outcome.status} on ${change.path}: ${"reason" in outcome ? outcome.reason : ""}`)
-      }
+    const result = await reviewAllForPath(records, aggregated, action, {
+      root,
+      reviewedKeys: this.reviewHunks,
+    })
+    for (const update of result.hunkUpdates) {
+      this.post({ type: "reviewHunkState", key: update.key, state: update.state })
     }
-    if (conflicts > 0) {
+    if (result.conflicts > 0) {
       const verb = action === "accepted" ? "accept" : "undo"
       vscode.window.showWarningMessage(
-        `OpenCode Panel: couldn't ${verb} ${conflicts} hunk${conflicts === 1 ? "" : "s"} in ${requestedPath} — the file has changed since the diff was produced.`,
+        `OpenCode Panel: couldn't ${verb} ${result.conflicts} hunk${result.conflicts === 1 ? "" : "s"} in ${requestedPath} — the file has changed since the diff was produced.`,
       )
     }
-    if (applied > 0) await this.syncReviewDecorations()
-    else log("reviewAllInChange: no hunks applied", { source, path: requestedPath, action, conflicts })
+    if (result.applied > 0) await this.syncReviewDecorations()
+    else log("reviewAllInChange: no hunks applied", { source, path: requestedPath, action, conflicts: result.conflicts })
   }
 
   private backendDirectory(): string | undefined {

--- a/test/host/review-actions.test.ts
+++ b/test/host/review-actions.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import * as vscode from "vscode"
-import { reviewHunk } from "../../src/chat/fs-ops"
+import { reviewHunk, findExistingWorkspaceFile, type ReviewHunkOutcome } from "../../src/chat/fs-ops"
 import { splitReviewDiff } from "../../src/chat/diff"
-import type { ReviewChange } from "../../webview/src/protocol"
+import { reviewKey } from "../../webview/src/review-extract"
+import { reviewAllForPath } from "../../src/chat/review-actions"
+import type { ReviewChange, ReviewHunkState } from "../../webview/src/protocol"
 
 // Treat the in-memory filesystem as the single source of truth for these
 // tests. The vscode mock in test/host/setup.ts stubs `workspace.fs.stat`/
@@ -264,3 +266,283 @@ describe("reviewHunk: moved files", () => {
     expect(outcome.status).toBe("unsupported")
   })
 })
+
+describe("reviewAllForPath: multi-tool turn", () => {
+  // `applyEdit` in the shared mock just returns `true`; for these tests we need
+  // it to actually mutate the on-disk file map so chained undos see the
+  // previous one's effect. We patch it per-block to mirror each
+  // WorkspaceEdit's `.replace(uri, range, text)` calls onto `files`.
+  beforeEach(() => {
+    ;(vscode.workspace.applyEdit as ReturnType<typeof vi.fn>).mockImplementation(
+      async (edit: unknown) => {
+        const ops = (edit as { edits?: Array<{ uri: vscode.Uri; range: vscode.Range; text: string }> }).edits
+        if (!ops) return true
+        for (const op of [...ops].reverse()) {
+          const entry = files.get(op.uri.fsPath)
+          if (!entry) continue
+          const start = offsetFromPosition(entry.content, op.range.start)
+          const end = offsetFromPosition(entry.content, op.range.end)
+          entry.content = entry.content.slice(0, start) + op.text + entry.content.slice(end)
+        }
+        return true
+      },
+    )
+  })
+
+  function buildUpdate(opts: {
+    source: string
+    path: string
+    oldText: string
+    newText: string
+    line: number
+  }): ReviewChange {
+    const patch = [
+      `@@ -${opts.line},1 +${opts.line},1 @@`,
+      `-${opts.oldText}`,
+      `+${opts.newText}`,
+    ].join("\n")
+    return {
+      source: opts.source,
+      path: opts.path,
+      kind: "updated",
+      additions: 1,
+      deletions: 1,
+      patch,
+    }
+  }
+
+  function aggregateLike(records: ReviewChange[]): ReviewChange {
+    // Mirror the production `aggregateChanges` rule: source/patch from the
+    // LAST contributing record, additions/deletions summed, kind taken via
+    // priorityKind. These tests use only `updated` records unless a test
+    // explicitly overrides `kind`, so plain `updated` is the default.
+    const last = records[records.length - 1]!
+    return {
+      ...last,
+      additions: records.reduce((sum, r) => sum + r.additions, 0),
+      deletions: records.reduce((sum, r) => sum + r.deletions, 0),
+    }
+  }
+
+  it("layered edits on the same line: reverse-order undo restores the original", async () => {
+    files.set("/workspace/foo.ts", { content: "alpha\nfinal\ngamma\n" })
+    const recordA = buildUpdate({ source: "callA", path: "foo.ts", oldText: "beta", newText: "rev1", line: 2 })
+    const recordB = buildUpdate({ source: "callB", path: "foo.ts", oldText: "rev1", newText: "final", line: 2 })
+    const aggregated = aggregateLike([recordA, recordB])
+    const result = await reviewAllForPath([recordA, recordB], aggregated, "rejected", { reviewedKeys: {} })
+    expect(result.applied).toBe(2)
+    expect(result.conflicts).toBe(0)
+    expect(files.get("/workspace/foo.ts")?.content).toBe("alpha\nbeta\ngamma\n")
+    expect(result.hunkUpdates.length).toBeGreaterThan(0)
+    for (const update of result.hunkUpdates) {
+      expect(update.state).toBe("rejected")
+    }
+  })
+
+  it("non-overlapping edits in same file: reverse-order undo restores both lines", async () => {
+    files.set("/workspace/foo.ts", { content: "one\ntwo-revA\nthree\nfour\nfive-revB\n" })
+    const recordA = buildUpdate({ source: "callA", path: "foo.ts", oldText: "two", newText: "two-revA", line: 2 })
+    const recordB = buildUpdate({ source: "callB", path: "foo.ts", oldText: "five", newText: "five-revB", line: 5 })
+    const aggregated = aggregateLike([recordA, recordB])
+    const result = await reviewAllForPath([recordA, recordB], aggregated, "rejected", { reviewedKeys: {} })
+    expect(result.applied).toBe(2)
+    expect(result.conflicts).toBe(0)
+    expect(files.get("/workspace/foo.ts")?.content).toBe("one\ntwo\nthree\nfour\nfive\n")
+  })
+
+  it("undo iterates per-tool records in REVERSE order; keep iterates forward", async () => {
+    const seen: Array<{ source: string; action: ReviewHunkState }> = []
+    const runner = vi.fn(async (change: ReviewChange, _hunk, action) => {
+      seen.push({ source: change.source, action })
+      return { status: "applied" } satisfies ReviewHunkOutcome
+    })
+    const recordA = buildUpdate({ source: "callA", path: "foo.ts", oldText: "X", newText: "Y", line: 1 })
+    const recordB = buildUpdate({ source: "callB", path: "foo.ts", oldText: "Y", newText: "Z", line: 1 })
+    const aggregated = aggregateLike([recordA, recordB])
+
+    await reviewAllForPath([recordA, recordB], aggregated, "rejected", { reviewedKeys: {}, runReviewHunk: runner })
+    expect(seen.map((s) => s.source)).toEqual(["callB", "callA"])
+
+    seen.length = 0
+    await reviewAllForPath([recordA, recordB], aggregated, "accepted", { reviewedKeys: {}, runReviewHunk: runner })
+    expect(seen.map((s) => s.source)).toEqual(["callA", "callB"])
+  })
+
+  it("is idempotent: a re-click with all aggregated hunks already marked is a no-op", async () => {
+    const runner = vi.fn(async () => ({ status: "applied" }) satisfies ReviewHunkOutcome)
+    const record = buildUpdate({ source: "callA", path: "foo.ts", oldText: "X", newText: "Y", line: 1 })
+    const aggregated = aggregateLike([record])
+    const reviewedKeys: Record<string, ReviewHunkState> = {}
+    for (const hunk of splitReviewDiff(aggregated.patch).hunks) {
+      reviewedKeys[reviewKey(aggregated, hunk.id)] = "rejected"
+    }
+    const result = await reviewAllForPath([record], aggregated, "rejected", { reviewedKeys, runReviewHunk: runner })
+    expect(result.applied).toBe(0)
+    expect(result.conflicts).toBe(0)
+    expect(result.hunkUpdates).toHaveLength(0)
+    expect(runner).not.toHaveBeenCalled()
+  })
+
+  it("mixed conflict: one record applies, one drift-conflicts; aggregated hunks still marked because applied > 0", async () => {
+    // line 1 has drifted out from under us, line 5 still matches recordB.
+    files.set("/workspace/foo.ts", { content: "drifted\ntwo\nthree\nfour\nfive-revB\n" })
+    const recordA = buildUpdate({ source: "callA", path: "foo.ts", oldText: "one", newText: "one-revA", line: 1 })
+    const recordB = buildUpdate({ source: "callB", path: "foo.ts", oldText: "five", newText: "five-revB", line: 5 })
+    const aggregated = aggregateLike([recordA, recordB])
+    const result = await reviewAllForPath([recordA, recordB], aggregated, "rejected", { reviewedKeys: {} })
+    expect(result.applied).toBe(1)
+    expect(result.conflicts).toBe(1)
+    expect(result.hunkUpdates.length).toBeGreaterThan(0)
+    expect(files.get("/workspace/foo.ts")?.content).toBe("drifted\ntwo\nthree\nfour\nfive\n")
+  })
+
+  it("mixed kind (create + update): reverse undo reverts the edit then deletes the file", async () => {
+    files.set("/workspace/new.ts", { content: "hello-edited\n" })
+    const createRecord: ReviewChange = {
+      source: "callA",
+      path: "new.ts",
+      kind: "created",
+      additions: 1,
+      deletions: 0,
+      patch: "@@ -0,0 +1,1 @@\n+hello",
+    }
+    const editRecord = buildUpdate({ source: "callB", path: "new.ts", oldText: "hello", newText: "hello-edited", line: 1 })
+    const aggregated: ReviewChange = { ...editRecord, kind: "created" }
+    const result = await reviewAllForPath([createRecord, editRecord], aggregated, "rejected", { reviewedKeys: {} })
+    expect(result.applied).toBe(2)
+    expect(result.conflicts).toBe(0)
+    expect(deletes.map((u) => u.fsPath)).toContain("/workspace/new.ts")
+    expect(files.has("/workspace/new.ts")).toBe(false)
+  })
+
+  it("returns zeros when no records match (defensive)", async () => {
+    const aggregated = buildUpdate({ source: "callA", path: "foo.ts", oldText: "X", newText: "Y", line: 1 })
+    const result = await reviewAllForPath([], aggregated, "rejected", { reviewedKeys: {} })
+    expect(result.applied).toBe(0)
+    expect(result.conflicts).toBe(0)
+    expect(result.hunkUpdates).toHaveLength(0)
+  })
+})
+
+describe("findExistingWorkspaceFile: ancestor fallback", () => {
+  const HOME = "/Users/u"
+
+  it("finds a file at an ancestor of root when standard candidates miss", async () => {
+    files.set("/Users/u/Desktop/demo/index.html", { content: "<html></html>" })
+    const result = await findExistingWorkspaceFile("Desktop/demo/index.html", "/Users/u/Desktop/demo", { home: HOME })
+    expect(result.uri?.fsPath).toBe("/Users/u/Desktop/demo/index.html")
+    expect(result.tried).toContain("/Users/u/Desktop/demo/Desktop/demo/index.html")
+    expect(result.tried).toContain("/Users/u/Desktop/demo/index.html")
+  })
+
+  it("stops the ancestor walk at the home directory", async () => {
+    files.set("/Users/other/leaked.txt", { content: "secret" })
+    const result = await findExistingWorkspaceFile("other/leaked.txt", "/Users/u/Desktop/demo", { home: HOME })
+    expect(result.uri).toBeUndefined()
+    expect(result.tried.some((p) => p.startsWith("/Users/other"))).toBe(false)
+  })
+
+  it("skips the ancestor fallback when relPath contains '..' segments", async () => {
+    files.set("/etc/passwd", { content: "root:x:0:0" })
+    const result = await findExistingWorkspaceFile("../../etc/passwd", "/Users/u/Desktop/demo", { home: HOME })
+    expect(result.uri).toBeUndefined()
+    // The ancestor walk should not have appended an /etc/passwd candidate.
+    expect(result.tried.some((p) => p === "/etc/passwd")).toBe(false)
+  })
+
+  it("reports a conflict when neither the standard candidates nor the ancestor walk find the file", async () => {
+    const { change, hunk } = makeChange({
+      path: "Desktop/demo/index.html",
+      kind: "created",
+      patch: "@@ -0,0 +1,1 @@\n+hello",
+    })
+    const outcome = await reviewHunk(change, hunk, "accepted", { silent: true, root: "/Users/u/Desktop/demo" })
+    expect(outcome.status).toBe("conflict")
+  })
+})
+
+describe("findExistingWorkspaceFile: preferAbsolute (apply_patch absolute-path hint)", () => {
+  it("uses the absolute hint when it resolves, bypassing the relative candidates", async () => {
+    files.set("/Users/u/Desktop/demo/index.html", { content: "<html></html>" })
+    const result = await findExistingWorkspaceFile(
+      "Desktop/demo/index.html",
+      "/Users/u/Desktop/demo",
+      { home: "/Users/u", preferAbsolute: "/Users/u/Desktop/demo/index.html" },
+    )
+    expect(result.uri?.fsPath).toBe("/Users/u/Desktop/demo/index.html")
+    // The hint is tried first.
+    expect(result.tried[0]).toBe("/Users/u/Desktop/demo/index.html")
+  })
+
+  it("falls through to the workspace candidates when the absolute hint misses", async () => {
+    files.set("/workspace/foo.ts", { content: "hi" })
+    const result = await findExistingWorkspaceFile("foo.ts", undefined, {
+      preferAbsolute: "/does/not/exist/foo.ts",
+    })
+    expect(result.uri?.fsPath).toBe("/workspace/foo.ts")
+    expect(result.tried).toContain("/does/not/exist/foo.ts")
+    expect(result.tried).toContain("/workspace/foo.ts")
+  })
+
+  it("ignores a non-absolute preferAbsolute value", async () => {
+    files.set("/workspace/foo.ts", { content: "hi" })
+    const result = await findExistingWorkspaceFile("foo.ts", undefined, {
+      preferAbsolute: "relative/foo.ts",
+    })
+    expect(result.uri?.fsPath).toBe("/workspace/foo.ts")
+    expect(result.tried).not.toContain("relative/foo.ts")
+  })
+
+  it("Keep on a created file with absolutePath set succeeds when the absolute file exists", async () => {
+    files.set("/Users/u/somewhere/index.html", { content: "<html></html>" })
+    const change: ReviewChange = {
+      source: "src1",
+      path: "Desktop/demo/index.html",
+      kind: "created",
+      additions: 1,
+      deletions: 0,
+      patch: "@@ -0,0 +1,1 @@\n+<html></html>",
+      absolutePath: "/Users/u/somewhere/index.html",
+    }
+    const hunk = splitReviewDiff(change.patch).hunks[0]!
+    const outcome = await reviewHunk(change, hunk, "accepted", { silent: true, root: "/workspace" })
+    expect(outcome.status).toBe("applied")
+  })
+})
+
+describe("acceptHunk: pure-deletion verification", () => {
+  it("Keep on a pure deletion applies when the removed lines are gone", async () => {
+    files.set("/workspace/foo.ts", { content: "alpha\ngamma\n" })
+    const { change, hunk } = makeChange({
+      path: "foo.ts",
+      patch: "@@ -2,1 +1,0 @@\n-beta",
+    })
+    const outcome = await reviewHunk(change, hunk, "accepted", { silent: true })
+    expect(outcome.status).toBe("applied")
+  })
+
+  it("Keep on a pure deletion conflicts when the removed lines are still present", async () => {
+    files.set("/workspace/foo.ts", { content: "alpha\nbeta\ngamma\n" })
+    const { change, hunk } = makeChange({
+      path: "foo.ts",
+      patch: "@@ -2,1 +1,0 @@\n-beta",
+    })
+    const outcome = await reviewHunk(change, hunk, "accepted", { silent: true })
+    expect(outcome.status).toBe("conflict")
+    if (outcome.status === "conflict") {
+      expect(outcome.reason).toMatch(/removed lines are still present/i)
+    }
+  })
+})
+
+function offsetFromPosition(text: string, pos: { line: number; character: number }): number {
+  let offset = 0
+  let line = 0
+  while (line < pos.line && offset <= text.length) {
+    const idx = text.indexOf("\n", offset)
+    if (idx < 0) return text.length
+    offset = idx + 1
+    line++
+  }
+  return Math.min(offset + pos.character, text.length)
+}

--- a/webview/src/protocol.ts
+++ b/webview/src/protocol.ts
@@ -33,6 +33,15 @@ export type ReviewChange = {
    */
   oldPath?: string
   /**
+   * Absolute filesystem path reported by opencode when available
+   * (apply_patch's `files[].absolutePath` / `filename` / `path` if any of
+   * those is absolute). Display continues to use `path`; the host resolver
+   * uses this as a preferred candidate so relative paths anchored ABOVE
+   * the VS Code workspace resolve correctly without relying on the
+   * ancestor-walk heuristic.
+   */
+  absolutePath?: string
+  /**
    * Attribution for the change. Always at least one entry; aggregated
    * changes accumulate one entry per contributing actor. Older clients
    * may not set this — consumers should treat empty as "main".

--- a/webview/src/review-extract.ts
+++ b/webview/src/review-extract.ts
@@ -174,9 +174,24 @@ export function patchChanges(
       deletions: typeof file.deletions === "number" ? file.deletions : countDiff(file.patch, "-"),
       patch: file.patch,
       oldPath: kind === "moved" ? oldPath : undefined,
+      absolutePath: pickAbsolutePath(file),
       actors: actor ? [actor] : undefined,
     } satisfies ReviewChange]
   })
+}
+
+/**
+ * opencode's apply_patch `files[]` schema is opaque — we read whichever
+ * absolute-path field happens to be present. Used to give the host resolver
+ * an unambiguous candidate when `relativePath` is anchored above the VS Code
+ * workspace.
+ */
+function pickAbsolutePath(file: Record<string, unknown>): string | undefined {
+  for (const key of ["absolutePath", "filename", "path", "fullPath"] as const) {
+    const value = file[key]
+    if (typeof value === "string" && isAbsolutePath(value)) return value
+  }
+  return undefined
 }
 
 export function diffChanges(
@@ -286,6 +301,7 @@ export function aggregateChanges(changes: ReviewChange[]): ReviewChange[] {
       deletions: prev.deletions + change.deletions,
       kind: priorityKind(prev.kind, change.kind),
       oldPath: prev.oldPath ?? change.oldPath,
+      absolutePath: change.absolutePath ?? prev.absolutePath,
       actors: dedupActors([...(prev.actors ?? []), ...(change.actors ?? [])]),
     }
     const copy = acc.slice()


### PR DESCRIPTION
Closes #188.

## Summary
- Undo no longer silently half-reverts when a turn has multiple tool calls to the same file. Iterates per-tool records (newest-first for Undo) instead of the aggregated row's single patch.
- Keep on a created file resolves correctly when opencode anchors `relativePath` above the workspace. Honors an absolute-path hint from `apply_patch` metadata, then falls back to walking ancestors of `root` up to home (no `..` traversal).
- Keep on a pure-deletion hunk now verifies the deletion actually happened (`findHunkInFile` returns a zero-width match for `newText === ""`, which silently "succeeded" before).
- Path conflicts log the attempted candidates to the output channel.

## Files
- New `src/chat/review-actions.ts` — pure `reviewAllForPath` helper, unit-testable in isolation.
- `src/chat/fs-ops.ts` — `findExistingWorkspaceFile(...)` returns `{uri?, tried[]}`, honors `preferAbsolute`, falls back to ancestor walk. `acceptHunk` special-cases pure-deletion hunks.
- `src/chat/view.ts` — `handleReviewAllInChange` thinned to a wrapper over the new helper.
- `webview/src/protocol.ts` — `ReviewChange` gains optional `absolutePath`.
- `webview/src/review-extract.ts` — `patchChanges` reads any absolute-path field from opencode's apply_patch metadata; `aggregateChanges` merges it.
- `test/host/review-actions.test.ts` — 16 new tests covering layered/non-overlapping undo, reverse-order requirement, idempotence, mixed conflict, mixed kind, ancestor fallback, home stop, `..` rejection, pure-deletion Keep apply/conflict, absolute-hint resolution.

## Test plan
- [x] `bun run test` — 787 / 787 pass
- [x] `bun run check-types` — clean
- [x] `cd webview && bunx tsc --noEmit` — clean
- [ ] Manual: prompt model to edit one file twice in one turn, click Undo, confirm both reverts land
- [ ] Manual: trigger an `apply_patch` to a created file with workspace one level deeper than the path's anchor, click Keep, confirm no conflict toast

## Cuts v0.9.7
Version bumped in `package.json`. Tag + GitHub release will follow this merge.