### PR TITLE
ci(release): publish to Open VSX alongside VS Code Marketplace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,15 @@ jobs:
       - name: Production build
         run: bun run package
 
-      - name: Publish to Marketplace
+      - name: Package .vsix
+        run: bunx @vscode/vsce package --no-dependencies
+
+      - name: Publish to VS Code Marketplace
         run: bunx @vscode/vsce publish --no-dependencies --pat "$VSCE_PAT"
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Publish to Open VSX
+        run: bunx ovsx publish *.vsix -p "$OVSX_PAT"
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}


### PR DESCRIPTION
## Summary
- Packages the `.vsix` once, then publishes to both VS Code Marketplace and Open VSX Registry
- `OVSX_PAT` secret is already configured in the repo

Closes #190

## Test plan
- [x] Verified `OVSX_PAT` secret is set in repo settings
- [x] Workflow syntax is valid
- [ ] Will be exercised on the next release tag