### PR TITLE
feat(prompt): enable browser spell-check on chat and custom-answer textareas

### DIFF
--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -338,6 +338,7 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
           ref={ref}
           value={text}
           rows={variant === "edit" ? 1 : 2}
+          spellCheck
           placeholder="Ask OpenCode Panel…  (Enter to send, Shift+Enter for newline, @ to attach a file)"
           onChange={(e) => updateText(e.target.value, e.target.selectionStart ?? e.target.value.length)}
           onKeyDown={onKeyDown}

--- a/webview/src/components/QuestionDialog.tsx
+++ b/webview/src/components/QuestionDialog.tsx
@@ -144,6 +144,7 @@ function QuestionItem({
           className="question-custom"
           placeholder={question.options.length > 0 ? "Or type a custom answer…" : "Type your answer…"}
           rows={2}
+          spellCheck
           value={answer.custom}
           onChange={(e) => onCustomChange(e.target.value)}
           // IME-aware Enter handler: in chat composers Enter sends; here we


### PR DESCRIPTION
## Summary

- Set `spellCheck` on the `<textarea>` in `webview/src/components/PromptBox.tsx` (covers both the bottom prompt and the in-place edit variant, since `MessageView` reuses the same component) and on `QuestionDialog.tsx`'s custom-answer textarea.
- React doesn't default `spellCheck` on, so misspellings were never being underlined. With the attribute on, Chromium's spellcheck runs against the OS dictionary and the native right-click menu surfaces suggestions.
- No suppression on contextmenu anywhere in the webview, so right-click → "did you mean…" should work out of the box.

Closes #192

## Test plan

- [x] `bun run check-types` (host) + `bunx tsc --noEmit` (webview) — clean.
- [x] `bun run test` — 787 tests across 46 files pass.
- [ ] Manual: type a misspelled word in the chat prompt → red underline appears. Right-click → native context menu lists corrections.
- [ ] Manual: same check in the in-place message edit (click a sent user bubble to edit) and in `QuestionDialog`'s custom-answer textarea.
- [ ] If the native context menu turns out to be suppressed by the VS Code webview on your platform, the squigglies are still visual-only — open a follow-up for the fallback (re-enable `oncontextmenu` on the textarea, or add a small "Fix spelling" affordance).