### PR TITLE
feat(review): prefix file names with M/U/D/R status letters

### DIFF
--- a/webview/src/components/ReviewPanel.tsx
+++ b/webview/src/components/ReviewPanel.tsx
@@ -130,6 +130,7 @@ export function ReviewPanel({
                   tabIndex={0}
                   title={actorTooltip(change)}
                 >
+                  <span className="review-file-kind" aria-label={kindLabel(change.kind)}>{kindLetter(change.kind)}</span>
                   <span className="review-file-name">{displayNames.get(change.path) ?? basename(change.path)}</span>
                   <span className="review-file-stat add">+{change.additions}</span>
                   <span className="review-file-stat del">-{change.deletions}</span>
@@ -159,6 +160,26 @@ export function ReviewPanel({
       </div>
     </div>
   )
+}
+
+// Mirrors VS Code's SCM badge letters so users familiar with the gutter can
+// scan the review card without re-learning a separate convention.
+function kindLetter(kind: ReviewChange["kind"]): string {
+  switch (kind) {
+    case "created": return "U"
+    case "updated": return "M"
+    case "deleted": return "D"
+    case "moved": return "R"
+  }
+}
+
+function kindLabel(kind: ReviewChange["kind"]): string {
+  switch (kind) {
+    case "created": return "Added"
+    case "updated": return "Modified"
+    case "deleted": return "Deleted"
+    case "moved": return "Renamed"
+  }
 }
 
 // The Review Card intentionally shows only the filename + stats per row;

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -1996,8 +1996,8 @@ button {
 .review-file {
   position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto auto auto;
-  grid-template-areas: "name add del keep undo";
+  grid-template-columns: auto minmax(0, 1fr) auto auto auto auto;
+  grid-template-areas: "kind name add del keep undo";
   align-items: center;
   gap: 0 6px;
   width: 100%;
@@ -2040,15 +2040,33 @@ button {
   outline: 1px solid var(--vscode-focusBorder);
   outline-offset: -1px;
 }
-.review-file.kind-created .review-file-name {
+.review-file.kind-created .review-file-name,
+.review-file.kind-created .review-file-kind {
   color: var(--vscode-gitDecoration-addedResourceForeground, #3fb950);
 }
-.review-file.kind-deleted .review-file-name {
+.review-file.kind-deleted .review-file-name,
+.review-file.kind-deleted .review-file-kind {
   color: var(--vscode-gitDecoration-deletedResourceForeground, #f85149);
+}
+/* Strikethrough is scoped to the filename only; the D badge should remain
+   legible and not draw a line through the letter itself. */
+.review-file.kind-deleted .review-file-name {
   text-decoration: line-through;
 }
-.review-file.kind-moved .review-file-name {
+.review-file.kind-moved .review-file-name,
+.review-file.kind-moved .review-file-kind {
   color: var(--vscode-gitDecoration-renamedResourceForeground, var(--vscode-charts-yellow, #d29922));
+}
+.review-file-kind {
+  grid-area: kind;
+  width: 12px;
+  flex: 0 0 auto;
+  font-family: var(--vscode-editor-font-family);
+  font-size: 11px;
+  font-weight: 600;
+  text-align: center;
+  color: var(--vscode-descriptionForeground);
+  user-select: none;
 }
 .review-file-name {
   grid-area: name;


### PR DESCRIPTION
Closes #198

## Summary

- Adds a single-letter status badge before each file name in the review card, mirroring VS Code SCM:
  - `M` updated (Modified)
  - `U` created (Untracked / new file)
  - `D` deleted
  - `R` moved (Renamed)
- New `.review-file-kind` grid cell sits before the name column; its color piggybacks on the existing per-kind color so the cue is reinforced rather than duplicated.
- Strikethrough on deleted rows is now scoped to the filename only — the `D` letter stays legible.

## Test plan

- [x] `bun run check-types` (host) clean
- [x] `cd webview && bunx tsc --noEmit` clean
- [x] `bun run test` — 787 / 787 pass (no test changes, badge is additive to existing kind-class selectors)
- [x] `bun run compile` — bundle 7.26 MB (unchanged vs `main`)
- [ ] Visual: open a chat that produces a mix of created/updated/deleted/renamed files and confirm the four letters render with the expected colors and alignment