### PR TITLE
feat(review): move color to status letter, add MUDR legend

### DIFF
--- a/webview/src/components/ReviewPanel.tsx
+++ b/webview/src/components/ReviewPanel.tsx
@@ -108,6 +108,7 @@ export function ReviewPanel({
       </div>
       <div className="review-body-clip" aria-hidden={!open}>
         <div className="review-body">
+          <ReviewLegend />
           <div className="review-files">
             {pendingChanges.map(({ change }) => {
               const isSelected = change.source === selected.source && change.path === selected.path
@@ -158,6 +159,32 @@ export function ReviewPanel({
           </div>
         </div>
       </div>
+    </div>
+  )
+}
+
+// Self-documenting key strip above the file list. Each letter uses the same
+// kind-color as the row badge so a reader can map color → meaning without
+// having to learn the convention separately.
+function ReviewLegend() {
+  return (
+    <div className="review-legend" role="note">
+      <span className="review-legend-item kind-updated">
+        <span className="review-legend-letter">M</span>
+        <span className="review-legend-text">Modified</span>
+      </span>
+      <span className="review-legend-item kind-created">
+        <span className="review-legend-letter">U</span>
+        <span className="review-legend-text">New</span>
+      </span>
+      <span className="review-legend-item kind-deleted">
+        <span className="review-legend-letter">D</span>
+        <span className="review-legend-text">Deleted</span>
+      </span>
+      <span className="review-legend-item kind-moved">
+        <span className="review-legend-letter">R</span>
+        <span className="review-legend-text">Renamed</span>
+      </span>
     </div>
   )
 }

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -2040,33 +2040,50 @@ button {
   outline: 1px solid var(--vscode-focusBorder);
   outline-offset: -1px;
 }
-.review-file.kind-created .review-file-name,
-.review-file.kind-created .review-file-kind {
+/* Kind styling is intentionally confined to the M/U/D/R letter — the filename
+   stays in the default foreground so long paths remain easy to scan and the
+   color encodes a single, unambiguous signal. */
+.review-file.kind-created .review-file-kind,
+.review-legend-item.kind-created .review-legend-letter {
   color: var(--vscode-gitDecoration-addedResourceForeground, #3fb950);
 }
-.review-file.kind-deleted .review-file-name,
-.review-file.kind-deleted .review-file-kind {
+.review-file.kind-deleted .review-file-kind,
+.review-legend-item.kind-deleted .review-legend-letter {
   color: var(--vscode-gitDecoration-deletedResourceForeground, #f85149);
 }
-/* Strikethrough is scoped to the filename only; the D badge should remain
-   legible and not draw a line through the letter itself. */
-.review-file.kind-deleted .review-file-name {
-  text-decoration: line-through;
-}
-.review-file.kind-moved .review-file-name,
-.review-file.kind-moved .review-file-kind {
+.review-file.kind-moved .review-file-kind,
+.review-legend-item.kind-moved .review-legend-letter {
   color: var(--vscode-gitDecoration-renamedResourceForeground, var(--vscode-charts-yellow, #d29922));
+}
+.review-file-kind,
+.review-legend-letter {
+  font-family: var(--vscode-editor-font-family);
+  font-weight: 600;
+  color: var(--vscode-descriptionForeground);
+  user-select: none;
 }
 .review-file-kind {
   grid-area: kind;
   width: 12px;
   flex: 0 0 auto;
-  font-family: var(--vscode-editor-font-family);
   font-size: 11px;
-  font-weight: 600;
   text-align: center;
+}
+.review-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 12px;
+  padding: 0 4px 2px 8px;
+  font-size: 10px;
   color: var(--vscode-descriptionForeground);
-  user-select: none;
+}
+.review-legend-item {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+}
+.review-legend-letter {
+  font-size: 11px;
 }
 .review-file-name {
   grid-area: name;


### PR DESCRIPTION
Closes #200

## Summary

- File names in the review card now render in the default text color regardless of kind — no per-kind tint, no strikethrough on deleted rows. Only the `M / U / D / R` letter carries the color.
- A compact legend strip sits at the top of the file list and spells out the mapping: `M Modified  U New  D Deleted  R Renamed`. The legend letters reuse the same color tokens as the row badges, so the key is self-documenting.

## Test plan

- [x] `bun run check-types` clean
- [x] `cd webview && bunx tsc --noEmit` clean
- [x] `bun run test` — 787 / 787 pass
- [x] `bun run compile` — bundle 7.26 MB
- [ ] Visual: open a chat with a mix of created/updated/deleted/renamed files, confirm filenames are neutral and the legend letters match the row badge colors