### PR TITLE
feat(review): re-tune MUDR palette and relabel U as Untracked

### DIFF
--- a/webview/src/components/ReviewPanel.tsx
+++ b/webview/src/components/ReviewPanel.tsx
@@ -175,7 +175,7 @@ function ReviewLegend() {
       </span>
       <span className="review-legend-item kind-created">
         <span className="review-legend-letter">U</span>
-        <span className="review-legend-text">New</span>
+        <span className="review-legend-text">Untracked</span>
       </span>
       <span className="review-legend-item kind-deleted">
         <span className="review-legend-letter">D</span>
@@ -202,7 +202,7 @@ function kindLetter(kind: ReviewChange["kind"]): string {
 
 function kindLabel(kind: ReviewChange["kind"]): string {
   switch (kind) {
-    case "created": return "Added"
+    case "created": return "Untracked"
     case "updated": return "Modified"
     case "deleted": return "Deleted"
     case "moved": return "Renamed"

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -2041,8 +2041,14 @@ button {
   outline-offset: -1px;
 }
 /* Kind styling is intentionally confined to the M/U/D/R letter — the filename
-   stays in the default foreground so long paths remain easy to scan and the
-   color encodes a single, unambiguous signal. */
+   stays in the default foreground so long paths remain easy to scan.
+   Palette: M amber (modified is the most common state, so it gets the calm
+   warm tint), U green (new files), D red (deletions), R blue (renames stay
+   distinct from U so a row that turned green vs blue reads at a glance). */
+.review-file.kind-updated .review-file-kind,
+.review-legend-item.kind-updated .review-legend-letter {
+  color: var(--vscode-gitDecoration-modifiedResourceForeground, var(--vscode-charts-yellow, #d29922));
+}
 .review-file.kind-created .review-file-kind,
 .review-legend-item.kind-created .review-legend-letter {
   color: var(--vscode-gitDecoration-addedResourceForeground, #3fb950);
@@ -2053,7 +2059,7 @@ button {
 }
 .review-file.kind-moved .review-file-kind,
 .review-legend-item.kind-moved .review-legend-letter {
-  color: var(--vscode-gitDecoration-renamedResourceForeground, var(--vscode-charts-yellow, #d29922));
+  color: var(--vscode-charts-blue, #79c0ff);
 }
 .review-file-kind,
 .review-legend-letter {


### PR DESCRIPTION
Closes #202

## Summary

Re-tunes the MUDR badge palette so the most common state (Modified) carries the calm warm tint and Renamed stays visually distinct from Untracked.

| Letter | Meaning | Color | Token |
|---|---|---|---|
| **M** | Modified | amber | `--vscode-gitDecoration-modifiedResourceForeground` (fallback `#d29922`) |
| **U** | Untracked | green | `--vscode-gitDecoration-addedResourceForeground` (`#3fb950`) |
| **D** | Deleted | red | `--vscode-gitDecoration-deletedResourceForeground` (`#f85149`) |
| **R** | Renamed | blue | `--vscode-charts-blue` (`#79c0ff`) |

Also relabels U from "New" to "Untracked" in the legend and the row aria-label so the letter and the label reinforce each other.

## Test plan

- [x] `bun run check-types` clean (host + webview)
- [x] `bun run test` — 787 / 787 pass
- [x] `bun run compile` — bundle 7.26 MB
- [ ] Visual: confirm M rows are amber, R rows are blue, and the legend strip mirrors those colors