### PR TITLE
chore(review): remove the MUDR legend strip

### DIFF
--- a/webview/src/components/ReviewPanel.tsx
+++ b/webview/src/components/ReviewPanel.tsx
@@ -108,7 +108,6 @@ export function ReviewPanel({
       </div>
       <div className="review-body-clip" aria-hidden={!open}>
         <div className="review-body">
-          <ReviewLegend />
           <div className="review-files">
             {pendingChanges.map(({ change }) => {
               const isSelected = change.source === selected.source && change.path === selected.path
@@ -159,32 +158,6 @@ export function ReviewPanel({
           </div>
         </div>
       </div>
-    </div>
-  )
-}
-
-// Self-documenting key strip above the file list. Each letter uses the same
-// kind-color as the row badge so a reader can map color → meaning without
-// having to learn the convention separately.
-function ReviewLegend() {
-  return (
-    <div className="review-legend" role="note">
-      <span className="review-legend-item kind-updated">
-        <span className="review-legend-letter">M</span>
-        <span className="review-legend-text">Modified</span>
-      </span>
-      <span className="review-legend-item kind-created">
-        <span className="review-legend-letter">U</span>
-        <span className="review-legend-text">Untracked</span>
-      </span>
-      <span className="review-legend-item kind-deleted">
-        <span className="review-legend-letter">D</span>
-        <span className="review-legend-text">Deleted</span>
-      </span>
-      <span className="review-legend-item kind-moved">
-        <span className="review-legend-letter">R</span>
-        <span className="review-legend-text">Renamed</span>
-      </span>
     </div>
   )
 }

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -2042,54 +2042,29 @@ button {
 }
 /* Kind styling is intentionally confined to the M/U/D/R letter — the filename
    stays in the default foreground so long paths remain easy to scan.
-   Palette: M amber (modified is the most common state, so it gets the calm
-   warm tint), U green (new files), D red (deletions), R blue (renames stay
-   distinct from U so a row that turned green vs blue reads at a glance). */
-.review-file.kind-updated .review-file-kind,
-.review-legend-item.kind-updated .review-legend-letter {
+   Palette: M amber, U green, D red, R blue. */
+.review-file.kind-updated .review-file-kind {
   color: var(--vscode-gitDecoration-modifiedResourceForeground, var(--vscode-charts-yellow, #d29922));
 }
-.review-file.kind-created .review-file-kind,
-.review-legend-item.kind-created .review-legend-letter {
+.review-file.kind-created .review-file-kind {
   color: var(--vscode-gitDecoration-addedResourceForeground, #3fb950);
 }
-.review-file.kind-deleted .review-file-kind,
-.review-legend-item.kind-deleted .review-legend-letter {
+.review-file.kind-deleted .review-file-kind {
   color: var(--vscode-gitDecoration-deletedResourceForeground, #f85149);
 }
-.review-file.kind-moved .review-file-kind,
-.review-legend-item.kind-moved .review-legend-letter {
+.review-file.kind-moved .review-file-kind {
   color: var(--vscode-charts-blue, #79c0ff);
-}
-.review-file-kind,
-.review-legend-letter {
-  font-family: var(--vscode-editor-font-family);
-  font-weight: 600;
-  color: var(--vscode-descriptionForeground);
-  user-select: none;
 }
 .review-file-kind {
   grid-area: kind;
   width: 12px;
   flex: 0 0 auto;
+  font-family: var(--vscode-editor-font-family);
   font-size: 11px;
+  font-weight: 600;
   text-align: center;
-}
-.review-legend {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 4px 12px;
-  padding: 0 4px 2px 8px;
-  font-size: 10px;
   color: var(--vscode-descriptionForeground);
-}
-.review-legend-item {
-  display: inline-flex;
-  align-items: baseline;
-  gap: 4px;
-}
-.review-legend-letter {
-  font-size: 11px;
+  user-select: none;
 }
 .review-file-name {
   grid-area: name;


### PR DESCRIPTION
Closes #204

## Summary

- Removes the legend strip above the review file list. The colored `M / U / D / R` badge on each row stays.
- Drops the `ReviewLegend` component, its mount point, and every `.review-legend*` CSS rule. Per-kind color rules collapse to single-selector form.

## Test plan

- [x] `bun run check-types` clean (host + webview)
- [x] `bun run test` — 787 / 787 pass
- [x] `bun run compile` — bundle 7.26 MB
- [ ] Visual: open a review card with several kinds and confirm the legend strip is gone and per-row letters still render with their kind color