### PR TITLE
fix(review): show M instead of U for edits with empty oldString on existing files

### DIFF
--- a/test/host/review-changes.test.ts
+++ b/test/host/review-changes.test.ts
@@ -36,6 +36,41 @@ describe("toolChanges", () => {
     expect(result[0]?.deletions).toBe(1)
   })
 
+  it("classifies edit with empty oldString as updated when the patch has real deletions", () => {
+    // Regression: a model can call edit with oldString:"" against an EXISTING
+    // file (e.g. to prepend content), and opencode returns a real diff with
+    // both `+` and `-` lines. The `-` lines prove the file pre-existed, so
+    // the review card must render as Modified (M), not Untracked (U).
+    const result = toolChanges(
+      {
+        callID: "c1",
+        tool: "edit",
+        status: "completed",
+        input: { filePath: "README.md", oldString: "", newString: "# Title\n\nNew intro line.\n" },
+        metadata: { filediff: { patch: "@@ -1,3 +1,7 @@\n line\n-old\n+new\n+added\n", additions: 2, deletions: 1 } },
+      },
+      "src1",
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.kind).toBe("updated")
+    expect(result[0]?.additions).toBe(2)
+    expect(result[0]?.deletions).toBe(1)
+  })
+
+  it("still classifies edit with empty oldString as created when the synthesized patch has no deletions", () => {
+    const result = toolChanges(
+      {
+        callID: "c1",
+        tool: "edit",
+        status: "completed",
+        input: { filePath: "fresh.ts", oldString: "", newString: "line1\nline2\n" },
+      },
+      "src1",
+    )
+    expect(result).toHaveLength(1)
+    expect(result[0]?.kind).toBe("created")
+  })
+
   it("returns empty for unrelated tools without patch", () => {
     expect(
       toolChanges({ callID: "c1", tool: "read", status: "completed", input: { filePath: "a.ts" } }, "src1"),

--- a/webview/src/review-extract.ts
+++ b/webview/src/review-extract.ts
@@ -141,10 +141,15 @@ export function toolChanges(
     (update.tool === "edit" && update.input?.oldString === "")
   if (!patch && isCreate) patch = synthesizeCreatePatch(update)
   if (!patch) return []
+  // `edit` with empty oldString can still target an existing file (e.g. to
+  // prepend new content); opencode will emit a real diff with `-` lines.
+  // A real deletion is proof the file pre-existed, so the row should render
+  // as Modified (M), not Untracked (U).
+  const patchHasDeletions = countDiff(patch, "-") > 0
   return [{
     source,
     path: displayPath(update, filediff),
-    kind: isCreate ? "created" : "updated",
+    kind: isCreate && !patchHasDeletions ? "created" : "updated",
     additions: typeof filediff?.additions === "number" ? filediff.additions : countDiff(patch, "+"),
     deletions: typeof filediff?.deletions === "number" ? filediff.deletions : countDiff(patch, "-"),
     patch,


### PR DESCRIPTION
Closes #206

## Summary

The review card was misclassifying edits to **existing** files as `created` (U badge) whenever the model called the `edit` tool with `oldString: ""`. The clearest symptom: a turn with `about.html +33 -0` (truly new) and `README.md +5 -1` (modified) both rendered with the green U badge.

Root cause sat in `webview/src/review-extract.ts:139-141`, where `isCreate` keyed off the model's *input* (`oldString === ""`), not opencode's resulting patch. Models legitimately use empty-`oldString` against existing files (e.g. to prepend content), and opencode then emits a real diff with `-` lines — which our code already had — but the kind was locked in before the patch was inspected.

## Fix

After resolving the patch, check `countDiff(patch, "-") > 0`. Any real deletion is proof the file pre-existed, so demote `isCreate` to `false` for the `kind` assignment. `synthesizeCreatePatch()` still fires when there's no patch and the heuristic suggests creation — that path is untouched.

## Test plan

- [x] `bun run check-types` clean (host + webview)
- [x] `bun run test` — **789 / 789** pass (+2 new regression tests in `test/host/review-changes.test.ts`)
- [x] `bun run compile` — bundle 7.26 MB (unchanged)
- [ ] Visual: ask the assistant to edit an existing file in a way that produces `edit` with empty `oldString` (e.g. "prepend a comment to README"). Confirm the row renders **M** with the right `+N -M` counts. Then ask it to create a brand-new file and confirm that row stays **U**.