### PR TITLE
feat(chat): move start-conversation chatbox to top

### DIFF
--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -153,6 +153,17 @@ export default function App() {
           <IndexStatus status={state.indexStatus} onStart={startIndex} onStop={stopIndex} />
         </div>
       )}
+      {state.messages.length === 0 && (
+        <PromptBox
+          busy={busy}
+          aborting={state.aborting}
+          onSend={send}
+          onAbort={abort}
+          searchFiles={searchFiles}
+          attachFile={attachFile}
+          position="top"
+        />
+      )}
       <div
         className="messages"
         ref={scrollRef}
@@ -182,19 +193,6 @@ export default function App() {
           }
         }}
       >
-        {state.messages.length === 0 && (
-          <div className="welcome">
-            <div className="welcome-title">OpenCode Panel</div>
-            <div className="welcome-sub">Ask about the current file, refactor code, or run a task.</div>
-            <div className="welcome-suggestions">
-              {WELCOME_PROMPTS.map((prompt) => (
-                <button key={prompt} className="welcome-suggestion" onClick={() => send(prompt)}>
-                  {prompt}
-                </button>
-              ))}
-            </div>
-          </div>
-        )}
         {groupTurns(state.messages).map((turn) => (
           <div className="turn" key={turn.key}>
             {turn.user && (
@@ -258,24 +256,19 @@ export default function App() {
         onOpenReviewChange={openReviewChangeDebounced}
         onReviewAllInChange={reviewAllInChange}
       />
-      <PromptBox
-        busy={busy}
-        aborting={state.aborting}
-        onSend={send}
-        onAbort={abort}
-        searchFiles={searchFiles}
-        attachFile={attachFile}
-      />
+      {state.messages.length > 0 && (
+        <PromptBox
+          busy={busy}
+          aborting={state.aborting}
+          onSend={send}
+          onAbort={abort}
+          searchFiles={searchFiles}
+          attachFile={attachFile}
+        />
+      )}
     </div>
   )
 }
-
-const WELCOME_PROMPTS = [
-  "Explain this file",
-  "Find bugs in the current file",
-  "Add tests for this file",
-  "Refactor this for readability",
-]
 
 type Turn = { user?: Message; assistants: Message[]; key: string }
 

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -51,6 +51,7 @@ type Props = {
    * replies will be discarded. onAbort is repurposed as the Cancel handler.
    */
   variant?: "send" | "edit"
+  position?: "top" | "bottom"
 }
 
 function buildInitialAttachments(initial: Props["initial"]): Map<string, Attachment> {
@@ -69,7 +70,7 @@ function buildInitialAttachments(initial: Props["initial"]): Map<string, Attachm
   return map
 }
 
-export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles, attachFile, initial, variant = "send" }: Props) {
+export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles, attachFile, initial, variant = "send", position = "bottom" }: Props) {
   const { text, setText, ref, backdropRef, pendingCursor } = usePromptText(initial?.text ?? "")
   const [selectedChipStart, setSelectedChipStart] = useState<number | undefined>(undefined)
   const [attachError, setAttachError] = useState<string | undefined>(undefined)
@@ -312,7 +313,7 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
   })()
 
   return (
-    <div className={"promptbox" + (variant === "edit" ? " promptbox--edit" : "")}>
+    <div className={"promptbox" + (variant === "edit" ? " promptbox--edit" : "") + (position === "top" ? " promptbox--top" : "")}>
       {attachError && <div className="attachment-error">{attachError}</div>}
       {imageAttachments.length > 0 && (
         <ul className="promptbox-thumbs" aria-label="Image attachments">
@@ -338,7 +339,7 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
           ref={ref}
           value={text}
           rows={variant === "edit" ? 1 : 2}
-          placeholder="Ask OpenCode Panel…  (Enter to send, Shift+Enter for newline, @ to attach a file)"
+          placeholder="@ for file, Enter to send"
           onChange={(e) => updateText(e.target.value, e.target.selectionStart ?? e.target.value.length)}
           onKeyDown={onKeyDown}
           onPaste={onPaste}
@@ -371,69 +372,69 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
             ))}
           </ul>
         )}
-      </div>
-      <div className="promptbox-row">
-        {attachFile && (
-          <button
-            type="button"
-            className="icon-btn attach-btn"
-            aria-label="Attach image, PDF, or code/text file"
-            title="Attach image, PDF, or code/text file"
-            disabled={attaching || busy}
-            onClick={handleAttachClick}
-          >
-            <svg width={ICON_SIZE.lg} height={ICON_SIZE.lg} viewBox="0 0 16 16" aria-hidden="true">
-              <path
-                d="M10.5 2.5a3 3 0 0 1 3 3v6.5a3.5 3.5 0 0 1-7 0V5a2 2 0 1 1 4 0v6.5a1.5 1.5 0 0 1-3 0V5.5"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.2"
-                strokeLinecap="round"
-              />
-            </svg>
-          </button>
-        )}
-        <div className="spacer" />
-        {variant === "edit" ? (
-          <button
-            className="btn primary icon"
-            onClick={submit}
-            disabled={busy || (!text.trim() && !hasActiveAttachment)}
-            aria-label="Save & regenerate"
-            title="Save & regenerate"
-          >
-            <SendIcon />
-          </button>
-        ) : aborting ? (
-          <button
-            className="btn danger icon"
-            disabled
-            aria-busy="true"
-            aria-label="Stopping…"
-            title="Stopping…"
-          >
-            <StopIcon />
-          </button>
-        ) : busy ? (
-          <button
-            className="btn danger icon"
-            onClick={onAbort}
-            aria-label="Stop"
-            title="Stop"
-          >
-            <StopIcon />
-          </button>
-        ) : (
-          <button
-            className="btn primary icon"
-            onClick={submit}
-            disabled={!text.trim() && !hasActiveAttachment}
-            aria-label="Send"
-            title="Send"
-          >
-            <SendIcon />
-          </button>
-        )}
+        <div className="promptbox-row">
+          <div className="spacer" />
+          {attachFile && (
+            <button
+              type="button"
+              className="icon-btn attach-btn"
+              aria-label="Attach image, PDF, or code/text file"
+              title="Attach image, PDF, or code/text file"
+              disabled={attaching || busy}
+              onClick={handleAttachClick}
+            >
+              <svg width={ICON_SIZE.lg} height={ICON_SIZE.lg} viewBox="5.5 1.5 8 14" aria-hidden="true" style={{ display: "block" }}>
+                <path
+                  d="M10.5 2.5a3 3 0 0 1 3 3v6.5a3.5 3.5 0 0 1-7 0V5a2 2 0 1 1 4 0v6.5a1.5 1.5 0 0 1-3 0V5.5"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.2"
+                  strokeLinecap="round"
+                />
+              </svg>
+            </button>
+          )}
+          {variant === "edit" ? (
+            <button
+              className="btn primary icon"
+              onClick={submit}
+              disabled={busy || (!text.trim() && !hasActiveAttachment)}
+              aria-label="Save & regenerate"
+              title="Save & regenerate"
+            >
+              <SendIcon />
+            </button>
+          ) : aborting ? (
+            <button
+              className="btn danger icon"
+              disabled
+              aria-busy="true"
+              aria-label="Stopping…"
+              title="Stopping…"
+            >
+              <StopIcon />
+            </button>
+          ) : busy ? (
+            <button
+              className="btn danger icon"
+              onClick={onAbort}
+              aria-label="Stop"
+              title="Stop"
+            >
+              <StopIcon />
+            </button>
+          ) : (
+            <button
+              className="btn primary icon"
+              onClick={submit}
+              disabled={!text.trim() && !hasActiveAttachment}
+              aria-label="Send"
+              title="Send"
+            >
+              <SendIcon />
+            </button>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -918,7 +918,7 @@ button {
 
 .welcome {
   text-align: center;
-  padding: 14vh 10px 0;
+  padding: 16px 10px 0;
 }
 .welcome-title { font-size: 18px; font-weight: 600; opacity: 0.7; }
 .welcome-sub { font-size: 12px; margin-top: 6px; opacity: 0.55; }
@@ -2106,7 +2106,7 @@ button {
      border-top, the bordered `.promptbox-input` below provides the
      visual boundary, matching the edit-mode bubble's single-border
      look. */
-  padding: 4px 8px;
+  padding: 10px 8px 4px;
   background: var(--vscode-sideBar-background);
 }
 .promptbox-input {
@@ -2212,10 +2212,7 @@ button {
   display: flex;
   align-items: center;
   gap: 6px;
-  /* Match the edit-mode tighter spacing (was 6 px) — the non-view phase
-     selector overrides this to 3 px; matching it here keeps the send
-     prompt and edit overlay visually consistent. */
-  margin-top: 3px;
+  padding: 0 4px 4px;
   min-width: 0;
 }
 .promptbox-row .spacer { flex: 1; }
@@ -2476,7 +2473,8 @@ button {
 /* In edit-in-place mode the message bubble is stuck at the top of the scroll
    container, so a picker drawn above the textarea gets clipped by the status
    bar. Flip it to render below the textarea instead. */
-.promptbox--edit .mention-popover {
+.promptbox--edit .mention-popover,
+.promptbox--top .mention-popover {
   bottom: auto;
   top: calc(100% + 4px);
 }


### PR DESCRIPTION
## Summary

- Move the PromptBox to the top when no conversation is active, keep it at the bottom during conversations
- Remove the welcome screen (title, subtitle, suggestion buttons)
- Simplify placeholder to "@ for file, Enter to send"
- Move attach + send icons inside the bordered input area, grouped on the right
- Consistent 10px gap from the status bar in both states
- Flip the @ mention popover downward when chatbox is at the top
- Center paperclip icon by tightening SVG viewBox

## Test plan

- [x] Build passes (`bun run compile`)
- [x] All 789 tests pass (`bun run test`)
- [x] Type-check passes (`bun run check-types`)
- [ ] Visual verification: empty state shows chatbox at top with correct spacing
- [ ] Visual verification: @ popover opens downward in empty state
- [ ] Visual verification: attach and send icons aligned on the right inside border

Closes #210