### PR TITLE
fix(test): update promptbox placeholder assertion

### DIFF
--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -8,7 +8,7 @@ afterEach(cleanup)
 describe("PromptBox", () => {
   it("renders a textarea with placeholder", () => {
     render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} />)
-    expect(screen.getByPlaceholderText(/Ask OpenCode Panel/i)).toBeInTheDocument()
+    expect(screen.getByPlaceholderText(/@ for file, Enter to send/i)).toBeInTheDocument()
   })
 
   it("uses a compact one-row textarea in edit mode", () => {


### PR DESCRIPTION
## Summary

- Update the placeholder text assertion in `promptbox.test.tsx` from `/Ask OpenCode Panel/i` to `/@ for file, Enter to send/i` to match the new placeholder from #211

## Test plan

- [x] All 789 tests pass (`bun run test`)

Closes #212