### PR TITLE
feat(chat): add two-level @ mention category menu

### DIFF
--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -5,6 +5,13 @@ import { PromptBox, detectMention, extractMentions, findMentionRanges, findChipA
 
 afterEach(cleanup)
 
+/** Type `@`, wait for the category menu, then press Enter to select "Files & Folders". */
+async function enterFilesCategory(user: ReturnType<typeof userEvent.setup>, target: Element) {
+  await user.type(target, "@")
+  await waitFor(() => expect(screen.getByText("Files & Folders")).toBeInTheDocument())
+  await user.keyboard("{Enter}")
+}
+
 describe("PromptBox", () => {
   it("renders a textarea with placeholder", () => {
     render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} />)
@@ -217,7 +224,7 @@ describe("extractMentions", () => {
 })
 
 describe("PromptBox @file autocomplete", () => {
-  it("shows the picker dropdown after typing @ when searchFiles is provided", async () => {
+  it("shows the category menu after typing @, then file hits after selecting Files & Folders", async () => {
     const user = userEvent.setup()
     const searchFiles = vi.fn().mockResolvedValue([
       { path: "src/foo.ts", name: "foo.ts" },
@@ -226,10 +233,9 @@ describe("PromptBox @file autocomplete", () => {
     render(
       <PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} searchFiles={searchFiles} />,
     )
-    await user.type(screen.getByRole("textbox"), "@")
+    await enterFilesCategory(user, screen.getByRole("textbox"))
     await waitFor(() => expect(searchFiles).toHaveBeenCalled())
-    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument())
-    expect(screen.getByText("foo.ts")).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByText("foo.ts")).toBeInTheDocument())
     expect(screen.getByText("bar.ts")).toBeInTheDocument()
   })
 
@@ -260,8 +266,8 @@ describe("PromptBox @file autocomplete", () => {
       <PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} searchFiles={searchFiles} />,
     )
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
-    await user.type(textarea, "@")
-    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument())
+    await enterFilesCategory(user, textarea)
+    await waitFor(() => expect(screen.getByText("foo.ts")).toBeInTheDocument())
     await user.keyboard("{Enter}")
     expect(textarea.value).toBe("@src/foo.ts ")
     expect(screen.queryByRole("listbox")).toBeNull()
@@ -276,11 +282,12 @@ describe("PromptBox @file autocomplete", () => {
     render(
       <PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} searchFiles={searchFiles} />,
     )
-    await user.type(screen.getByRole("textbox"), "@")
-    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument())
+    const textarea = screen.getByRole("textbox")
+    await enterFilesCategory(user, textarea)
+    await waitFor(() => expect(screen.getByText("foo.ts")).toBeInTheDocument())
     await user.keyboard("{ArrowDown}")
     await user.keyboard("{Enter}")
-    expect((screen.getByRole("textbox") as HTMLTextAreaElement).value).toBe("@src/bar.ts ")
+    expect((textarea as HTMLTextAreaElement).value).toBe("@src/bar.ts ")
   })
 
   it("Click on a hit inserts that path", async () => {
@@ -292,8 +299,8 @@ describe("PromptBox @file autocomplete", () => {
     render(
       <PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} searchFiles={searchFiles} />,
     )
-    await user.type(screen.getByRole("textbox"), "@")
-    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument())
+    await enterFilesCategory(user, screen.getByRole("textbox"))
+    await waitFor(() => expect(screen.getByText("bar.ts")).toBeInTheDocument())
     await user.click(screen.getByText("bar.ts"))
     expect((screen.getByRole("textbox") as HTMLTextAreaElement).value).toBe("@src/bar.ts ")
   })
@@ -324,8 +331,8 @@ describe("PromptBox @file autocomplete", () => {
       <PromptBox busy={false} onSend={onSend} onAbort={vi.fn()} searchFiles={searchFiles} />,
     )
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
-    await user.type(textarea, "@")
-    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument())
+    await enterFilesCategory(user, textarea)
+    await waitFor(() => expect(screen.getByText("foo.ts")).toBeInTheDocument())
     await user.keyboard("{Enter}") // pick foo.ts
     await user.type(textarea, "explain this")
     await user.keyboard("{Enter}")
@@ -342,8 +349,8 @@ describe("PromptBox @file autocomplete", () => {
       <PromptBox busy={false} onSend={onSend} onAbort={vi.fn()} searchFiles={searchFiles} />,
     )
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
-    await user.type(textarea, "@")
-    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument())
+    await enterFilesCategory(user, textarea)
+    await waitFor(() => expect(screen.getByText("foo.ts")).toBeInTheDocument())
     await user.keyboard("{Enter}") // inserts "@src/foo.ts "
     await user.clear(textarea)
     await user.type(textarea, "no files here")
@@ -411,8 +418,8 @@ describe("PromptBox mention chip rendering", () => {
     const { container } = render(
       <PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} searchFiles={searchFiles} />,
     )
-    await user.type(screen.getByRole("textbox"), "@")
-    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument())
+    await enterFilesCategory(user, screen.getByRole("textbox"))
+    await waitFor(() => expect(screen.getByText("foo.ts")).toBeInTheDocument())
     await user.keyboard("{Enter}")
     const chip = container.querySelector(".mention-chip")
     expect(chip).not.toBeNull()
@@ -440,8 +447,8 @@ describe("PromptBox mention chip rendering", () => {
       <PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} searchFiles={searchFiles} />,
     )
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
-    await user.type(textarea, "@")
-    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument())
+    await enterFilesCategory(user, textarea)
+    await waitFor(() => expect(screen.getByText("foo.ts")).toBeInTheDocument())
     await user.keyboard("{Enter}") // foo.ts
     await user.type(textarea, "@ba")
     await waitFor(() => expect(screen.getByText("bar.ts")).toBeInTheDocument())
@@ -460,8 +467,8 @@ describe("PromptBox mention chip rendering", () => {
       <PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} searchFiles={searchFiles} />,
     )
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
-    await user.type(textarea, "@")
-    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument())
+    await enterFilesCategory(user, textarea)
+    await waitFor(() => expect(screen.getByText("foo.ts")).toBeInTheDocument())
     await user.keyboard("{Enter}")
     expect(container.querySelector(".mention-chip")).not.toBeNull()
     await user.clear(textarea)
@@ -541,8 +548,8 @@ describe("PromptBox two-step Backspace on chip", () => {
       <PromptBox busy={false} onSend={onSend} onAbort={vi.fn()} searchFiles={searchFiles} />,
     )
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
-    await user.type(textarea, "@")
-    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument())
+    await enterFilesCategory(user, textarea)
+    await waitFor(() => expect(screen.getByText("foo.ts")).toBeInTheDocument())
     await user.keyboard("{Enter}") // text becomes "@src/foo.ts " (cursor at 12)
     return { user, onSend, textarea, ...utils }
   }

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -162,6 +162,8 @@ export default function App() {
           searchFiles={searchFiles}
           attachFile={attachFile}
           position="top"
+          conversations={state.conversations}
+          onOpenConversation={openConversation}
         />
       )}
       <div
@@ -264,6 +266,8 @@ export default function App() {
           onAbort={abort}
           searchFiles={searchFiles}
           attachFile={attachFile}
+          conversations={state.conversations}
+          onOpenConversation={openConversation}
         />
       )}
     </div>

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -1,5 +1,5 @@
-import { useRef, useState, type ReactNode } from "react"
-import type { Attachment, FileSearchHit } from "../protocol"
+import { useEffect, useRef, useState, type ReactNode } from "react"
+import type { Attachment, ConversationSummary, FileSearchHit } from "../protocol"
 import {
   extractMentions,
   findChipAtCaret,
@@ -52,6 +52,8 @@ type Props = {
    */
   variant?: "send" | "edit"
   position?: "top" | "bottom"
+  conversations?: ConversationSummary[]
+  onOpenConversation?: (id: string) => void
 }
 
 function buildInitialAttachments(initial: Props["initial"]): Map<string, Attachment> {
@@ -70,7 +72,7 @@ function buildInitialAttachments(initial: Props["initial"]): Map<string, Attachm
   return map
 }
 
-export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles, attachFile, initial, variant = "send", position = "bottom" }: Props) {
+export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles, attachFile, initial, variant = "send", position = "bottom", conversations, onOpenConversation }: Props) {
   const { text, setText, ref, backdropRef, pendingCursor } = usePromptText(initial?.text ?? "")
   const [selectedChipStart, setSelectedChipStart] = useState<number | undefined>(undefined)
   const [attachError, setAttachError] = useState<string | undefined>(undefined)
@@ -93,6 +95,25 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
   }
   const { mention, hits, activeIndex, setActiveIndex, detectAtCaret, closeMention, insertMention } =
     useMentionPicker({ text, setText, searchFiles, knownMentions, pendingCursor })
+
+  type MentionCategory = "files" | "chats"
+  const [mentionCategory, setMentionCategory] = useState<MentionCategory | null>(null)
+  const [menuIndex, setMenuIndex] = useState(0)
+
+  useEffect(() => {
+    if (!mention) {
+      setMentionCategory(null)
+      setMenuIndex(0)
+    }
+  }, [mention])
+
+  const showCategoryMenu = !!mention && mentionCategory === null && !mention.query
+  const showFileHits = !!mention && hits.length > 0 && (mentionCategory === "files" || (mentionCategory === null && !!mention.query))
+  const showChatList = !!mention && mentionCategory === "chats"
+
+  const filteredConversations = showChatList
+    ? (conversations ?? []).filter((c) => !mention.query || c.title.toLowerCase().includes(mention.query.toLowerCase()))
+    : []
 
   /** Combined set of @-token labels recognized as chips (mentions + attachments). */
   const allKnownLabels = (): Set<string> => {
@@ -233,7 +254,57 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
     // the IME. keyCode 229 is the legacy fallback for older Chromium builds
     // that don't surface isComposing reliably.
     if (e.nativeEvent.isComposing || e.keyCode === 229) return
-    if (mention && hits.length > 0) {
+    if (showCategoryMenu) {
+      const categories: MentionCategory[] = ["files", "chats"]
+      if (e.key === "ArrowDown") {
+        e.preventDefault()
+        setMenuIndex((i) => (i + 1) % categories.length)
+        return
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault()
+        setMenuIndex((i) => (i - 1 + categories.length) % categories.length)
+        return
+      }
+      if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault()
+        setMentionCategory(categories[menuIndex]!)
+        setMenuIndex(0)
+        return
+      }
+      if (e.key === "Escape") {
+        e.preventDefault()
+        closeMention()
+        return
+      }
+    }
+    if (showChatList && filteredConversations.length > 0) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault()
+        setMenuIndex((i) => (i + 1) % filteredConversations.length)
+        return
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault()
+        setMenuIndex((i) => (i - 1 + filteredConversations.length) % filteredConversations.length)
+        return
+      }
+      if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault()
+        const conv = filteredConversations[menuIndex]
+        if (conv && onOpenConversation) {
+          onOpenConversation(conv.id)
+          closeMention()
+        }
+        return
+      }
+      if (e.key === "Escape") {
+        e.preventDefault()
+        closeMention()
+        return
+      }
+    }
+    if (showFileHits && hits.length > 0) {
       if (e.key === "ArrowDown") {
         e.preventDefault()
         setActiveIndex((i) => (i + 1) % hits.length)
@@ -332,6 +403,7 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
         onClose={() => setPreviewImage(null)}
       />
       <div className="promptbox-input">
+        <div className="promptbox-textarea-wrap">
         <div ref={backdropRef} className="promptbox-backdrop" aria-hidden="true">
           {renderHighlightedText(text, allKnownLabels(), selectedChipStart)}
         </div>
@@ -352,7 +424,33 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
             setTimeout(closeMention, 120)
           }}
         />
-        {mention && hits.length > 0 && (
+        {showCategoryMenu && (
+          <ul className="mention-popover" role="listbox" aria-label="Categories">
+            <li
+              role="option"
+              aria-selected={menuIndex === 0}
+              className={"mention-hit mention-category" + (menuIndex === 0 ? " active" : "")}
+              onMouseDown={(e) => { e.preventDefault(); setMentionCategory("files"); setMenuIndex(0) }}
+              onMouseEnter={() => setMenuIndex(0)}
+            >
+              <FolderIcon />
+              <span className="mention-category-label">Files & Folders</span>
+              <ChevronIcon />
+            </li>
+            <li
+              role="option"
+              aria-selected={menuIndex === 1}
+              className={"mention-hit mention-category" + (menuIndex === 1 ? " active" : "")}
+              onMouseDown={(e) => { e.preventDefault(); setMentionCategory("chats"); setMenuIndex(0) }}
+              onMouseEnter={() => setMenuIndex(1)}
+            >
+              <ChatIcon />
+              <span className="mention-category-label">Past Chats</span>
+              <ChevronIcon />
+            </li>
+          </ul>
+        )}
+        {showFileHits && (
           <ul className="mention-popover" role="listbox" aria-label="Files">
             {hits.map((hit, i) => (
               <li
@@ -372,6 +470,28 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
             ))}
           </ul>
         )}
+        {showChatList && (
+          <ul className="mention-popover" role="listbox" aria-label="Past Chats">
+            {filteredConversations.length > 0 ? filteredConversations.map((conv, i) => (
+              <li
+                key={conv.id}
+                role="option"
+                aria-selected={i === menuIndex}
+                className={"mention-hit" + (i === menuIndex ? " active" : "")}
+                onMouseDown={(e) => {
+                  e.preventDefault()
+                  if (onOpenConversation) { onOpenConversation(conv.id); closeMention() }
+                }}
+                onMouseEnter={() => setMenuIndex(i)}
+              >
+                <span className="mention-name">{conv.title || "Untitled"}</span>
+              </li>
+            )) : (
+              <li className="mention-hit mention-empty">No conversations</li>
+            )}
+          </ul>
+        )}
+        </div>
         <div className="promptbox-row">
           <div className="spacer" />
           {attachFile && (
@@ -465,6 +585,32 @@ function StopIcon() {
   return (
     <svg width={ICON_SIZE.xs} height={ICON_SIZE.xs} viewBox="0 0 10 10" aria-hidden="true" style={{ display: "block" }}>
       <rect x="0" y="0" width="10" height="10" rx="1.5" fill="currentColor" />
+    </svg>
+  )
+}
+
+function FolderIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M2 4a1 1 0 0 1 1-1h3.5l1.5 1.5H13a1 1 0 0 1 1 1V12a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V4z"
+        stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+function ChatIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M3 3h10a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1H6l-3 2.5V4a1 1 0 0 1 1-1z"
+        stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+function ChevronIcon() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 16 16" fill="none" aria-hidden="true" className="mention-category-chevron">
+      <path d="M6 4l4 4-4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   )
 }

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -84,7 +84,7 @@
      also update TEXTAREA_MAX_HEIGHT in webview/src/components/PromptBox.tsx
      — the JS clamp on textarea.style.height must match this cap or the
      CSS scrollbar will fight with the inline style. */
-  --message-max-height:  160px;
+  --message-max-height:  120px;
 
   /* === Legacy aliases === */
   --gap: var(--space-3);
@@ -2110,12 +2110,14 @@ button {
   background: var(--vscode-sideBar-background);
 }
 .promptbox-input {
-  position: relative;
   background: var(--vscode-input-background);
   border: 1px solid var(--vscode-input-border, transparent);
   border-radius: var(--radius);
 }
 .promptbox-input:focus-within { border-color: var(--color-border-focus); }
+.promptbox-textarea-wrap {
+  position: relative;
+}
 .promptbox-backdrop {
   position: absolute;
   inset: 0;
@@ -2509,6 +2511,24 @@ button {
 .mention-hit.active .mention-path {
   color: var(--vscode-list-activeSelectionForeground);
   opacity: 0.8;
+}
+.mention-category {
+  align-items: center;
+  gap: 8px;
+  padding: 5px 10px;
+}
+.mention-category-label {
+  flex: 1;
+  font-weight: 500;
+}
+.mention-category-chevron {
+  opacity: 0.5;
+  flex-shrink: 0;
+}
+.mention-empty {
+  opacity: 0.5;
+  cursor: default;
+  font-style: italic;
 }
 
 /* ===== Buttons ===== */


### PR DESCRIPTION
## Summary

- Typing `@` with empty query shows a category menu: Files & Folders, Past Chats
- Selecting Files & Folders drills into file search (existing behavior)
- Selecting Past Chats shows conversation list; picking one switches to it
- Typing `@foo` bypasses categories and shows file results directly
- Popover anchored to textarea wrapper so it appears beside the text, not below buttons
- Reduce max chatbox height from 160px to 120px

## Test plan

- [x] Build passes (`bun run compile`)
- [x] Type-check passes (`bun run check-types`)
- [x] All 789 tests pass (`bun run test`)
- [ ] Visual: typing `@` shows category menu with icons and chevrons
- [ ] Visual: selecting Files & Folders shows file search results
- [ ] Visual: popover appears right below textarea, not below button row

Closes #214