### PR TITLE
fix(chat): narrow mention popover and position beside @ caret

### DIFF
--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -2459,8 +2459,9 @@ button {
 .mention-popover {
   position: absolute;
   bottom: calc(100% + 4px);
-  left: 0;
-  right: 0;
+  left: 8px;
+  right: auto;
+  width: min(240px, calc(100% - 16px));
   max-height: 220px;
   overflow-y: auto;
   margin: 0;
@@ -2479,6 +2480,9 @@ button {
 .promptbox--top .mention-popover {
   bottom: auto;
   top: calc(100% + 4px);
+}
+.promptbox--top .mention-popover {
+  top: 26px;
 }
 .mention-hit {
   display: flex;


### PR DESCRIPTION
## Summary

- Constrain mention popover to `min(240px, calc(100% - 16px))` instead of full width
- Offset `left: 8px` to align with the text area content
- Adjust `top: 26px` for the start-conversation (top) position

## Test plan

- [x] Build passes (`bun run compile`)
- [x] All 789 tests pass (`bun run test`)
- [ ] Visual: popover appears beside the `@` character, not stretching full width

Closes #216