### PR TITLE
feat(chat): inject past-chat context via @ mention instead of switching

### DIFF
--- a/src/chat/conversation-manager.ts
+++ b/src/chat/conversation-manager.ts
@@ -65,6 +65,16 @@ export class ConversationManager {
     return conversation
   }
 
+  getMessages(id: string): ChatMessage[] | undefined {
+    const conv = this.conversations.find((c) => c.id === id)
+    if (!conv) return undefined
+    return conv.messages.map((m) => ({ ...m, pending: false }))
+  }
+
+  getTitle(id: string): string | undefined {
+    return this.conversations.find((c) => c.id === id)?.title
+  }
+
   summaries(): ConversationSummary[] {
     return this.conversations
       .map((c) => ({ id: c.id, title: c.title, updatedAt: c.updatedAt }))

--- a/src/chat/prompt-builder.ts
+++ b/src/chat/prompt-builder.ts
@@ -1,12 +1,15 @@
 import * as vscode from "vscode"
 import * as path from "path"
 import type { getEditorContext } from "../context"
+import type { ChatMessage } from "../protocol"
 import type { WorkspaceRoot } from "../workspace-root"
 import type { PromptContextBlock } from "../workspace-context/types"
 import { log } from "../output"
 
 export const DEFAULT_MENTION_MAX_BYTES = 200_000
+export const DEFAULT_CONVERSATION_MAX_BYTES = 100_000
 const MENTION_MAX_FILES = 20
+const CONVERSATION_MAX_MESSAGES = 29
 
 export function buildPrompt(
   userText: string,
@@ -117,6 +120,91 @@ export async function readMentions(
     }
   }
   const block = blocks.length > 0 ? ["Files attached:", ...blocks].join("\n") : undefined
+  return { block, bytes, capped, failed }
+}
+
+export type ConversationMentionResult = {
+  block?: string
+  bytes: Record<string, { included: number; original: number }>
+  capped: string[]
+  failed: string[]
+}
+
+export function formatConversationContext(title: string, messages: ChatMessage[]): string {
+  const total = messages.length
+  let selected: ChatMessage[]
+  let truncationNote = ""
+  if (total <= CONVERSATION_MAX_MESSAGES + 1) {
+    selected = messages
+  } else {
+    const first = messages[0]!
+    const tail = messages.slice(-(CONVERSATION_MAX_MESSAGES))
+    const tailStart = total - CONVERSATION_MAX_MESSAGES
+    selected = tailStart > 0 ? [first, ...tail] : messages
+    truncationNote = ` (first message + last ${CONVERSATION_MAX_MESSAGES} of ${total} total)`
+  }
+  const lines: string[] = [`Past conversation "${title}"${truncationNote}:`]
+  for (const msg of selected) {
+    const role = msg.role === "user" ? "User" : "Assistant"
+    const parts: string[] = []
+    for (const block of msg.blocks) {
+      if (block.type === "text" && block.text.trim()) {
+        parts.push(block.text.trim())
+      } else if (block.type === "tool") {
+        const name = block.update.tool
+        const label = block.update.title ?? block.update.input?.path ?? ""
+        parts.push(`[${name}${label ? `: ${label}` : ""}]`)
+      } else if (block.type === "patch") {
+        const files = block.files.join(", ")
+        parts.push(`[patched ${files}]`)
+      }
+    }
+    if (parts.length > 0) {
+      lines.push(`${role}: ${parts.join("\n")}`)
+    }
+  }
+  return lines.join("\n")
+}
+
+export function readConversationMentions(
+  ids: string[] | undefined,
+  getMessages: (id: string) => ChatMessage[] | undefined,
+  getTitle: (id: string) => string | undefined,
+  maxBytes: number = DEFAULT_CONVERSATION_MAX_BYTES,
+): ConversationMentionResult {
+  if (!ids || ids.length === 0) {
+    return { bytes: {}, capped: [], failed: [] }
+  }
+  const seen = new Set<string>()
+  const blocks: string[] = []
+  const bytes: Record<string, { included: number; original: number }> = {}
+  const capped: string[] = []
+  const failed: string[] = []
+  let totalBytes = 0
+  for (const id of ids) {
+    if (!id || seen.has(id)) continue
+    seen.add(id)
+    const messages = getMessages(id)
+    const title = getTitle(id) ?? "Untitled conversation"
+    if (!messages) {
+      failed.push(id)
+      continue
+    }
+    const formatted = formatConversationContext(title, messages)
+    const formattedBytes = Buffer.byteLength(formatted, "utf8")
+    const remaining = maxBytes - totalBytes
+    if (remaining <= 0) {
+      capped.push(id)
+      continue
+    }
+    const truncated = formattedBytes > remaining
+    const content = truncated ? formatted.slice(0, remaining) : formatted
+    const includedBytes = Buffer.byteLength(content, "utf8")
+    blocks.push(content)
+    bytes[id] = { included: includedBytes, original: formattedBytes }
+    totalBytes += includedBytes
+  }
+  const block = blocks.length > 0 ? blocks.join("\n\n") : undefined
   return { block, bytes, capped, failed }
 }
 

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -37,7 +37,7 @@ import { relativeToCwd, samePath } from "./paths"
 import { isTextReviewPath, reviewKey, splitReviewDiff } from "./diff"
 import { extractChanges, reviewChanges } from "./review-changes"
 import { reviewAllForPath } from "./review-actions"
-import { buildPrompt, readMentions } from "./prompt-builder"
+import { buildPrompt, readMentions, readConversationMentions } from "./prompt-builder"
 import { buildManifest } from "../workspace-context/manifest"
 import { collectAutoContext } from "../workspace-context/collector"
 import { RecentEditsTracker } from "../workspace-context/recent-edits"
@@ -405,6 +405,7 @@ export class ChatView implements vscode.WebviewViewProvider {
             ref: msg.ref,
             backendID: msg.backendID,
             mentions: msg.mentions,
+            conversationMentions: msg.conversationMentions,
           },
         ]
         this.saveActive()
@@ -556,10 +557,10 @@ export class ChatView implements vscode.WebviewViewProvider {
         return
       }
       case "send":
-        await this.handleSend(msg.text, msg.mentions, msg.attachments)
+        await this.handleSend(msg.text, msg.mentions, msg.attachments, msg.conversationMentions)
         return
       case "editMessage":
-        await this.handleEdit(msg.id, msg.text, msg.mentions, msg.attachments)
+        await this.handleEdit(msg.id, msg.text, msg.mentions, msg.attachments, msg.conversationMentions)
         return
       case "fileSearch":
         try {
@@ -817,7 +818,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     // assistant message ended (session.idle clears this.aborting).
   }
 
-  private async handleSend(text: string, mentions?: string[], attachments?: Attachment[]) {
+  private async handleSend(text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) {
     const ctx = getEditorContext()
     const label = formatContextHeader(ctx)
     const userMessageID = "u_" + Date.now()
@@ -829,6 +830,7 @@ export class ChatView implements vscode.WebviewViewProvider {
       ref: { path: ctx.filePath, label },
       attachments,
       mentions,
+      conversationMentions,
     })
     this.updateTitleFromPrompt(text)
 
@@ -920,6 +922,48 @@ export class ChatView implements vscode.WebviewViewProvider {
       })
       manifest.totals.skippedItems += 1
     }
+    const convResult = readConversationMentions(
+      conversationMentions,
+      (id) => this.manager.getMessages(id),
+      (id) => this.manager.getTitle(id),
+    )
+    for (const [id, info] of Object.entries(convResult.bytes)) {
+      const title = this.manager.getTitle(id) ?? id
+      manifest.items.push({
+        id: `conv_mention_${id}`,
+        source: "conversation",
+        kind: "conversation",
+        label: title,
+        reason: "Past conversation attached via @-mention",
+        status: info.included < info.original ? "truncated" : "included",
+        bytes: info.included,
+      })
+      manifest.totals.includedItems += 1
+      manifest.totals.includedBytes += info.included
+      if (info.included < info.original) manifest.totals.truncatedItems += 1
+    }
+    for (const id of convResult.capped) {
+      manifest.items.push({
+        id: `conv_capped_${id}`,
+        source: "conversation",
+        kind: "conversation",
+        label: this.manager.getTitle(id) ?? id,
+        reason: "Skipped: conversation mention byte cap exceeded",
+        status: "skipped",
+      })
+      manifest.totals.skippedItems += 1
+    }
+    for (const id of convResult.failed) {
+      manifest.items.push({
+        id: `conv_failed_${id}`,
+        source: "conversation",
+        kind: "conversation",
+        label: id,
+        reason: "Skipped: conversation not found",
+        status: "skipped",
+      })
+      manifest.totals.skippedItems += 1
+    }
     manifest.totals.budgetBytes = settings.maxBytes
     if (settings.showManifest) {
       this.post({ type: "userMessageContext", id: userMessageID, context: manifest })
@@ -942,7 +986,13 @@ export class ChatView implements vscode.WebviewViewProvider {
     }
     parts.push({
       type: "text",
-      text: buildPrompt(text, ctx, mentionResult.block, backend.workspace, auto.blocks),
+      text: buildPrompt(
+        text,
+        ctx,
+        [mentionResult.block, convResult.block].filter(Boolean).join("\n\n") || undefined,
+        backend.workspace,
+        auto.blocks,
+      ),
     })
     type PromptBody = NonNullable<Parameters<typeof backend.client.session.prompt>[0]["body"]>
     const body: PromptBody = {
@@ -982,7 +1032,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     // No UI action here — the SSE subscription owns assistant lifecycle.
   }
 
-  private async handleEdit(webviewID: string, text: string, mentions?: string[], attachments?: Attachment[]) {
+  private async handleEdit(webviewID: string, text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) {
     const target = this.messages.find((m) => m.id === webviewID && m.role === "user")
     if (!target) {
       log("editMessage: user message not found", webviewID)
@@ -1015,7 +1065,7 @@ export class ChatView implements vscode.WebviewViewProvider {
       this.queueReviewDecorationsSync()
     }
 
-    await this.handleSend(trimmed, mentions, attachments)
+    await this.handleSend(trimmed, mentions, attachments, conversationMentions)
   }
 
   private async attachSubscription(backend: Backend, sessionID: string) {

--- a/test/webview/message-view.test.tsx
+++ b/test/webview/message-view.test.tsx
@@ -155,7 +155,7 @@ describe("MessageView (user role)", () => {
     await user.clear(textarea)
     await user.type(textarea, "updated text")
     await user.click(screen.getByRole("button", { name: "Save & regenerate" }))
-    expect(onEditMessage).toHaveBeenCalledWith("u-edit", "updated text", undefined, undefined)
+    expect(onEditMessage).toHaveBeenCalledWith("u-edit", "updated text", undefined, undefined, undefined)
   })
 
   it("clicking Save with unchanged content does NOT fire onEditMessage", async () => {
@@ -228,7 +228,7 @@ describe("MessageView (user role)", () => {
     await user.clear(textarea)
     await user.type(textarea, "via shortcut")
     await user.keyboard("{Meta>}{Enter}{/Meta}")
-    expect(onEditMessage).toHaveBeenCalledWith("u-cmd", "via shortcut", undefined, undefined)
+    expect(onEditMessage).toHaveBeenCalledWith("u-cmd", "via shortcut", undefined, undefined, undefined)
   })
 
   it("renders the editor-context label when message has ref", () => {
@@ -356,7 +356,7 @@ describe("MessageView edit preserves mentions + attachments", () => {
     await user.clear(textarea)
     await user.type(textarea, "@src/foo.ts rewrite it")
     await user.click(screen.getByRole("button", { name: "Save & regenerate" }))
-    expect(onEditMessage).toHaveBeenCalledWith("u-mention", "@src/foo.ts rewrite it", ["src/foo.ts"], undefined)
+    expect(onEditMessage).toHaveBeenCalledWith("u-mention", "@src/foo.ts rewrite it", ["src/foo.ts"], undefined, undefined)
   })
 
   it("drops mentions whose @token was deleted in the edited text", async () => {
@@ -376,7 +376,7 @@ describe("MessageView edit preserves mentions + attachments", () => {
     await user.clear(textarea)
     await user.type(textarea, "no mentions here")
     await user.click(screen.getByRole("button", { name: "Save & regenerate" }))
-    expect(onEditMessage).toHaveBeenCalledWith("u-mention", "no mentions here", undefined, undefined)
+    expect(onEditMessage).toHaveBeenCalledWith("u-mention", "no mentions here", undefined, undefined, undefined)
   })
 
   it("re-derives attachments and forwards them when their label is still in the text", async () => {
@@ -535,6 +535,6 @@ describe("MessageView edit preserves mentions + attachments", () => {
     await user.clear(textarea)
     await user.type(textarea, "no attachments now")
     await user.click(screen.getByRole("button", { name: "Save & regenerate" }))
-    expect(onEditMessage).toHaveBeenCalledWith("u-att", "no attachments now", undefined, undefined)
+    expect(onEditMessage).toHaveBeenCalledWith("u-att", "no attachments now", undefined, undefined, undefined)
   })
 })

--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -47,7 +47,7 @@ describe("PromptBox", () => {
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
     await user.type(textarea, "  hello world  ")
     await user.keyboard("{Enter}")
-    expect(onSend).toHaveBeenCalledWith("hello world", undefined, undefined)
+    expect(onSend).toHaveBeenCalledWith("hello world", undefined, undefined, undefined)
     expect(textarea.value).toBe("")
   })
 
@@ -69,7 +69,7 @@ describe("PromptBox", () => {
     render(<PromptBox busy={false} onSend={onSend} onAbort={vi.fn()} />)
     await user.type(screen.getByRole("textbox"), "hello")
     await user.click(screen.getByRole("button", { name: /^Send$/ }))
-    expect(onSend).toHaveBeenCalledWith("hello", undefined, undefined)
+    expect(onSend).toHaveBeenCalledWith("hello", undefined, undefined, undefined)
   })
 
   it("renders Stop button (not Send) when busy", () => {
@@ -125,7 +125,7 @@ describe("PromptBox", () => {
     await user.type(textarea, "你好")
     // After IME ends, a normal Enter event has isComposing === false.
     await user.keyboard("{Enter}")
-    expect(onSend).toHaveBeenCalledWith("你好", undefined, undefined)
+    expect(onSend).toHaveBeenCalledWith("你好", undefined, undefined, undefined)
   })
 
   it("does not submit empty/whitespace input on Enter", async () => {
@@ -336,7 +336,7 @@ describe("PromptBox @file autocomplete", () => {
     await user.keyboard("{Enter}") // pick foo.ts
     await user.type(textarea, "explain this")
     await user.keyboard("{Enter}")
-    expect(onSend).toHaveBeenCalledWith("@src/foo.ts explain this", ["src/foo.ts"], undefined)
+    expect(onSend).toHaveBeenCalledWith("@src/foo.ts explain this", ["src/foo.ts"], undefined, undefined)
   })
 
   it("does not pass mentions when the inserted @path was deleted before Send", async () => {
@@ -355,7 +355,7 @@ describe("PromptBox @file autocomplete", () => {
     await user.clear(textarea)
     await user.type(textarea, "no files here")
     await user.keyboard("{Enter}")
-    expect(onSend).toHaveBeenCalledWith("no files here", undefined, undefined)
+    expect(onSend).toHaveBeenCalledWith("no files here", undefined, undefined, undefined)
   })
 
   it("does not open the picker when searchFiles is not provided", async () => {
@@ -605,7 +605,7 @@ describe("PromptBox two-step Backspace on chip", () => {
     const { user, onSend, textarea } = await setupChip()
     await user.type(textarea, "explain")
     await user.keyboard("{Enter}")
-    expect(onSend).toHaveBeenCalledWith("@src/foo.ts explain", ["src/foo.ts"], undefined)
+    expect(onSend).toHaveBeenCalledWith("@src/foo.ts explain", ["src/foo.ts"], undefined, undefined)
   })
 })
 
@@ -835,7 +835,7 @@ describe("PromptBox attachments (inline @chip flow)", () => {
     await user.clear(textarea)
     await user.type(textarea, "no attachments here")
     await user.keyboard("{Enter}")
-    expect(onSend).toHaveBeenCalledWith("no attachments here", undefined, undefined)
+    expect(onSend).toHaveBeenCalledWith("no attachments here", undefined, undefined, undefined)
   })
 
   it("renders an error message when attachFile returns one", async () => {

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -97,7 +97,7 @@ export default function App() {
           })
         }
       }
-      editMessage(m.id, text, m.mentions, attachments)
+      editMessage(m.id, text, m.mentions, attachments, m.conversationMentions)
       return
     }
   }

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -43,7 +43,7 @@ export function MessageView({
   processOnly: boolean
   busy?: boolean
   onReviewFile?: (path: string) => void
-  onEditMessage?: (id: string, text: string, mentions?: string[], attachments?: Attachment[]) => void
+  onEditMessage?: (id: string, text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) => void
   onBeginEdit?: (id: string) => void
   onEndEdit?: (id: string) => void
   onRetry?: (assistantID: string) => void
@@ -137,7 +137,7 @@ function UserMessageView({
 }: {
   message: Message
   busy?: boolean
-  onEditMessage?: (id: string, text: string, mentions?: string[], attachments?: Attachment[]) => void
+  onEditMessage?: (id: string, text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) => void
   onBeginEdit?: (id: string) => void
   onEndEdit?: (id: string) => void
   searchFiles?: (query: string) => Promise<FileSearchHit[]>
@@ -206,12 +206,9 @@ function UserMessageView({
         ? "Saving your message — try again in a moment"
         : "Edit and regenerate"
 
-  const handleSubmit = (text: string, mentions?: string[], attachments?: Attachment[]) => {
+  const handleSubmit = (text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) => {
     const trimmed = text.trim()
     if (!trimmed && !attachments?.length) return
-    // Bail if nothing changed — clicking Save with the original content
-    // shouldn't trigger a regenerate. Compare text + mention set + attachment
-    // count; the text covers the vast majority of cases.
     const sameText = trimmed === originalText.trim()
     const sameMentionCount = (mentions?.length ?? 0) === (message.mentions?.length ?? 0)
     const sameAttachCount = (attachments?.length ?? 0) === attachmentBlocks.length
@@ -219,7 +216,7 @@ function UserMessageView({
       exitEditing()
       return
     }
-    onEditMessage?.(message.id, trimmed, mentions, attachments)
+    onEditMessage?.(message.id, trimmed, mentions, attachments, conversationMentions)
     exitEditing()
   }
 
@@ -272,6 +269,7 @@ function UserMessageView({
               text: originalText,
               mentions: message.mentions,
               attachments: initialAttachments,
+              conversationMentions: message.conversationMentions,
             }}
           />
         </div>

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -5,6 +5,7 @@ import {
   findChipAtCaret,
   findMentionRanges,
   makeAttachmentLabel,
+  makeConversationLabel,
 } from "../mention-tokens"
 import { clipboardHasImage, readPastedImages } from "../paste-attachments"
 import { usePromptText } from "../hooks/usePromptText"
@@ -21,6 +22,7 @@ export {
   findChipAtCaret,
   findMentionRanges,
   makeAttachmentLabel,
+  makeConversationLabel,
   formatBytes,
 } from "../mention-tokens"
 
@@ -34,7 +36,7 @@ type Props = {
    * one.
    */
   aborting?: boolean
-  onSend: (text: string, mentions?: string[], attachments?: Attachment[]) => void
+  onSend: (text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) => void
   onAbort: () => void
   searchFiles?: (query: string) => Promise<FileSearchHit[]>
   attachFile?: () => Promise<{ attachments: Attachment[]; error?: string }>
@@ -44,7 +46,7 @@ type Props = {
    * left off — same picker, same chips, same paperclip — instead of a
    * stripped-down textarea.
    */
-  initial?: { text?: string; mentions?: string[]; attachments?: Attachment[] }
+  initial?: { text?: string; mentions?: string[]; attachments?: Attachment[]; conversationMentions?: string[] }
   /**
    * "send" (default) renders the standard Send/Stop bottom row. "edit"
    * renders Cancel + Save & regenerate, plus a warning that subsequent
@@ -72,6 +74,23 @@ function buildInitialAttachments(initial: Props["initial"]): Map<string, Attachm
   return map
 }
 
+function buildInitialConversations(
+  initial: Props["initial"],
+  conversations: ConversationSummary[] | undefined,
+): Map<string, string> {
+  const map = new Map<string, string>()
+  if (!initial?.conversationMentions || !conversations) return map
+  const existing = new Set<string>(initial.mentions ?? [])
+  for (const id of initial.conversationMentions) {
+    const conv = conversations.find((c) => c.id === id)
+    if (!conv) continue
+    const label = makeConversationLabel(conv.title, existing)
+    existing.add(label)
+    map.set(label, id)
+  }
+  return map
+}
+
 export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles, attachFile, initial, variant = "send", position = "bottom", conversations, onOpenConversation }: Props) {
   const { text, setText, ref, backdropRef, pendingCursor } = usePromptText(initial?.text ?? "")
   const [selectedChipStart, setSelectedChipStart] = useState<number | undefined>(undefined)
@@ -89,9 +108,12 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
   // re-applied every render. After mount these mutate freely.
   const knownMentions = useRef<Set<string>>(undefined as never)
   const knownAttachments = useRef<Map<string, Attachment>>(undefined as never)
+  const knownConversations = useRef<Map<string, string>>(undefined as never)
   if (!knownMentions.current) {
     knownMentions.current = new Set<string>(initial?.mentions ?? [])
     knownAttachments.current = buildInitialAttachments(initial)
+    knownConversations.current = buildInitialConversations(initial, conversations)
+    for (const label of knownConversations.current.keys()) knownMentions.current.add(label)
   }
   const { mention, hits, activeIndex, setActiveIndex, detectAtCaret, closeMention, insertMention } =
     useMentionPicker({ text, setText, searchFiles, knownMentions, pendingCursor })
@@ -115,11 +137,32 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
     ? (conversations ?? []).filter((c) => !mention.query || c.title.toLowerCase().includes(mention.query.toLowerCase()))
     : []
 
-  /** Combined set of @-token labels recognized as chips (mentions + attachments). */
+  /** Combined set of @-token labels recognized as chips (mentions + attachments + conversations). */
   const allKnownLabels = (): Set<string> => {
     const all = new Set<string>(knownMentions.current)
     for (const k of knownAttachments.current.keys()) all.add(k)
+    for (const k of knownConversations.current.keys()) all.add(k)
     return all
+  }
+
+  const insertConversationMention = (conv: ConversationSummary) => {
+    if (!mention) return
+    const existing = new Set([
+      ...knownMentions.current,
+      ...knownAttachments.current.keys(),
+      ...knownConversations.current.keys(),
+    ])
+    const label = makeConversationLabel(conv.title, existing)
+    knownConversations.current.set(label, conv.id)
+    knownMentions.current.add(label)
+    const before = text.slice(0, mention.start)
+    const after = text.slice(mention.start + 1 + mention.query.length)
+    const insert = "@" + label
+    const needsSpace = !after.startsWith(" ")
+    const next = before + insert + (needsSpace ? " " : "") + after
+    pendingCursor.current = before.length + insert.length + 1
+    setText(next)
+    closeMention()
   }
 
   const updateText = (next: string, caret: number) => {
@@ -143,15 +186,21 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
     // files first, pasted images second.
     for (const a of imageAttachments) activeAttachments.push(a)
     if ((!trimmed && activeAttachments.length === 0) || busy) return
-    const mentions = extractMentions(text, knownMentions.current)
+    const allMentions = extractMentions(text, knownMentions.current)
+    const fileMentions = allMentions.filter((m) => !knownConversations.current.has(m))
+    const convIDs = allMentions
+      .map((m) => knownConversations.current.get(m))
+      .filter((id): id is string => !!id)
     onSend(
       trimmed,
-      mentions.length ? mentions : undefined,
+      fileMentions.length ? fileMentions : undefined,
       activeAttachments.length ? activeAttachments : undefined,
+      convIDs.length ? convIDs : undefined,
     )
     setText("")
     knownMentions.current.clear()
     knownAttachments.current.clear()
+    knownConversations.current.clear()
     clearImageAttachments()
     setSelectedChipStart(undefined)
     setAttachError(undefined)
@@ -292,10 +341,7 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
       if (e.key === "Enter" || e.key === "Tab") {
         e.preventDefault()
         const conv = filteredConversations[menuIndex]
-        if (conv && onOpenConversation) {
-          onOpenConversation(conv.id)
-          closeMention()
-        }
+        if (conv) insertConversationMention(conv)
         return
       }
       if (e.key === "Escape") {
@@ -480,7 +526,7 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
                 className={"mention-hit" + (i === menuIndex ? " active" : "")}
                 onMouseDown={(e) => {
                   e.preventDefault()
-                  if (onOpenConversation) { onOpenConversation(conv.id); closeMention() }
+                  insertConversationMention(conv)
                 }}
                 onMouseEnter={() => setMenuIndex(i)}
               >

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -180,6 +180,7 @@ export function reducer(state: ChatState, action: Action): ChatState {
             ref: action.ref,
             backendID: action.backendID,
             mentions: action.mentions,
+            conversationMentions: action.conversationMentions,
           },
         ],
       }
@@ -363,11 +364,11 @@ export function useChatState() {
 
   return {
     state,
-    send(text: string, mentions?: string[], attachments?: Attachment[]) {
-      vscode.post({ type: "send", text, mentions, attachments })
+    send(text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) {
+      vscode.post({ type: "send", text, mentions, attachments, conversationMentions })
     },
-    editMessage(id: string, text: string, mentions?: string[], attachments?: Attachment[]) {
-      vscode.post({ type: "editMessage", id, text, mentions, attachments })
+    editMessage(id: string, text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) {
+      vscode.post({ type: "editMessage", id, text, mentions, attachments, conversationMentions })
     },
     searchFiles(query: string): Promise<FileSearchHit[]> {
       const requestID = nextRequestID.current++

--- a/webview/src/mention-tokens.ts
+++ b/webview/src/mention-tokens.ts
@@ -117,6 +117,14 @@ export function findMentionRanges(text: string, known: Set<string>): Array<{ sta
   return out
 }
 
+export function makeConversationLabel(title: string, existing: Set<string>): string {
+  const cleaned = "chat:" + title.replace(/\s+/g, "_").slice(0, 60)
+  if (!existing.has(cleaned)) return cleaned
+  let i = 2
+  while (existing.has(`${cleaned}_${i}`)) i++
+  return `${cleaned}_${i}`
+}
+
 /**
  * Build a chip-safe label for an attachment filename. Spaces would break the
  * `@token` boundary detection, so we replace whitespace with `_`. If the

--- a/webview/src/protocol.ts
+++ b/webview/src/protocol.ts
@@ -107,6 +107,11 @@ export type ChatMessage = {
    */
   mentions?: string[]
   /**
+   * Past-conversation IDs the user attached via the @ picker. Persisted so
+   * the edit flow can restore them.
+   */
+  conversationMentions?: string[]
+  /**
    * Manifest of context the host attached when this turn was sent. Persisted
    * so historical messages can show what was included. Always set for new
    * messages, undefined for messages from before the manifest landed.
@@ -292,6 +297,7 @@ export type PromptContextManifestItemSource =
   | "opencode"
   | "omo"
   | "external"
+  | "conversation"
 
 export type PromptContextManifestItemKind =
   | "file"
@@ -302,6 +308,7 @@ export type PromptContextManifestItemKind =
   | "symbol"
   | "summary"
   | "indexResult"
+  | "conversation"
 
 export type PromptContextManifestItem = {
   id: string
@@ -345,7 +352,7 @@ export type Outbound =
   | { type: "restore"; conversationID: string; messages: ChatMessage[]; reviewHunks?: Record<string, ReviewHunkState> }
   | { type: "context"; ref: EditorContextRef }
   | { type: "workspace"; workspace?: WorkspaceInfo }
-  | { type: "userMessage"; id: string; text: string; ref?: EditorContextRef; backendID?: string; attachments?: Attachment[]; mentions?: string[]; context?: PromptContextManifest }
+  | { type: "userMessage"; id: string; text: string; ref?: EditorContextRef; backendID?: string; attachments?: Attachment[]; mentions?: string[]; conversationMentions?: string[]; context?: PromptContextManifest }
   | { type: "userMessageBackendID"; id: string; backendID: string }
   /**
    * Followup to `userMessage` after the host finishes reading mentions and
@@ -387,8 +394,8 @@ export type Outbound =
 /** Messages sent from the webview to the extension host. */
 export type Inbound =
   | { type: "mounted" }
-  | { type: "send"; text: string; mentions?: string[]; attachments?: Attachment[] }
-  | { type: "editMessage"; id: string; text: string; mentions?: string[]; attachments?: Attachment[] }
+  | { type: "send"; text: string; mentions?: string[]; attachments?: Attachment[]; conversationMentions?: string[] }
+  | { type: "editMessage"; id: string; text: string; mentions?: string[]; attachments?: Attachment[]; conversationMentions?: string[] }
   | { type: "abort" }
   | { type: "newSession" }
   | { type: "createConversation" }


### PR DESCRIPTION
## Summary
- Selecting a past chat from the `@` picker inserts a `@chat:title` mention chip instead of switching conversations
- On send, the host resolves conversation IDs to message history and includes as prompt context (text blocks + tool/patch one-liners)
- First-message + last-29 strategy for large conversations, with a separate 100 KB byte budget
- `chat:` prefix distinguishes conversation chips from file chips
- Full edit-flow support — conversation mentions persist on message re-edit

Closes #220

## Test plan
- [x] `bun run check-types` — host + webview pass
- [x] `bun run test` — 789/789 pass
- [x] `bun run compile` — builds successfully
- [ ] Manual: type `@` → Past Chats → select a chat → verify `@chat:title` chip appears → send → verify conversation history included in prompt context

🤖 Generated with [Claude Code](https://claude.com/claude-code)