### PR TITLE
feat(chat): use opencode's LLM-generated session titles

### DIFF
--- a/src/chat/stream.ts
+++ b/src/chat/stream.ts
@@ -109,6 +109,7 @@ export type StreamHandlers = {
    * subagent's session record is written, so we never miss its events.
    */
   onChildSessionDiscovered?: (info: ChildSessionInfo) => void
+  onSessionTitleUpdate?: (title: string) => void
 }
 
 export type ChildSessionInfo = {
@@ -331,12 +332,18 @@ export function subscribeSession(
         }
         return
       case "session.created":
-      case "session.updated":
-        // The if-statement above this switch already handles the
-        // child-session-discovery subset of these. Beyond that we
-        // don't need to act on them — opencode emits a session.updated
-        // for almost every internal state tick.
         return
+      case "session.updated": {
+        const info = props?.info
+        if (
+          info && typeof info === "object" &&
+          info.id === sessionID &&
+          typeof info.title === "string" && info.title
+        ) {
+          handlers.onSessionTitleUpdate?.(info.title)
+        }
+        return
+      }
       case "server.connected":
       case "server.heartbeat":
       case "session.next.agent.switched":

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -1225,6 +1225,11 @@ export class ChatView implements vscode.WebviewViewProvider {
           this.continuationState.collapseToGraceIfSettled()
         })
       },
+      onSessionTitleUpdate: (title) => {
+        this.manager.rename(this.manager.getActiveID(), title)
+        void this.manager.persist()
+        this.postConversationsList()
+      },
       onChildSessionDiscovered: (info) => {
         if (this.aborting) return
         // Register for SSE routing IMMEDIATELY so we don't miss the child's


### PR DESCRIPTION
## Summary
- Listen for `session.updated` SSE events on the parent session
- When opencode's title agent produces a title, update the conversation via `manager.rename`
- Prompt-based title remains as instant fallback until the LLM title arrives

Closes #222

## Test plan
- [x] `bun run check-types` — pass
- [x] `bun run test` — 789/789 pass
- [ ] Manual: start a new conversation → verify title updates from "New conversation" → prompt snippet → LLM-generated title

🤖 Generated with [Claude Code](https://claude.com/claude-code)