### PR TITLE
chore(release): cut v0.9.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.9.10] - 2026-05-27
+
+### Changed
+- The bottom composer now floats over the scroll area as an absolute-positioned overlay instead of being a fixed flex child. A `ResizeObserver` tracks the composer's rendered height and injects it as a `--bottom-composer-height` CSS custom property so the scroll container's bottom padding stays in sync. The conversation scrolls edge-to-edge underneath the composer, and content is never clipped behind it.
+- Entering or exiting in-place edit mode preserves the scroll position. `App.tsx` captures `scrollTop` and the stick-to-bottom flag before toggling `editingMessageID`, then restores both in a `useLayoutEffect` before paint — prevents the transcript from creeping upward when Chromium re-anchors around the edit overlay.
+- `PromptBox` now emits explicit `promptbox--send` / `promptbox--bottom` / `promptbox--top` class names so CSS can target each variant independently. The bottom send composer carries its own border and background (previously only the inner `.promptbox-input` was bordered).
+
+Closes #228.
+
+## [0.9.9] - 2026-05-26
+
+### Added
+- Two-level `@` mention category menu. Typing `@` with an empty query shows a category picker (Files & Folders, Past Chats); selecting a category drills into the existing file search or the conversation list. Typing `@foo` bypasses categories and jumps straight to file results.
+- Past-chat context injection via `@` mention. Selecting a past chat from the `@` picker inserts a `@chat:title` chip instead of switching conversations. On send the host resolves conversation IDs to message history and injects it as prompt context (first message + last 29, 100 KB byte budget).
+- Conversations are renamed to opencode's LLM-generated session title once the title agent produces one. The prompt-based title remains as an instant fallback until the server title arrives.
+
+### Changed
+- The start-conversation chatbox is now at the top of the panel (the welcome screen with title, subtitle, and suggestion buttons is removed). Placeholder simplified to "@ for file, Enter to send"; attach + send icons moved inside the bordered input area.
+- `@` mention popover narrowed to `min(240px, calc(100% - 16px))` and positioned beside the `@` caret instead of stretching full width.
+- Status bar icons unified to 11px with centered 22px hover circles.
+- Removed `useHeaderPopoverHeight` hook — popovers now overlay sticky user bubbles instead of pushing them down.
+
+Closes #210, #214, #216, #218, #220, #222, #224, #226.
+
 ## [0.9.8] - 2026-05-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",

--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -28,6 +28,15 @@ describe("PromptBox", () => {
     expect((screen.getByRole("textbox") as HTMLTextAreaElement).rows).toBe(2)
   })
 
+  it("applies bottom composer chrome only to the send composer", () => {
+    const { container, rerender } = render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} />)
+    expect(container.querySelector(".promptbox")).toHaveClass("promptbox--bottom")
+
+    rerender(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} variant="edit" initial={{ text: "hi" }} />)
+    expect(container.querySelector(".promptbox")).toHaveClass("promptbox--edit")
+    expect(container.querySelector(".promptbox")).not.toHaveClass("promptbox--bottom")
+  })
+
   it("Send button is disabled when textarea is empty", () => {
     render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} />)
     expect((screen.getByRole("button", { name: /^Send$/ }) as HTMLButtonElement).disabled).toBe(true)

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties } from "react"
 import { useChatState } from "./hooks/useChatState"
 import type { Message } from "./hooks/useChatState"
 import type { Attachment } from "./protocol"
@@ -34,24 +34,45 @@ export default function App() {
     stopIndex,
   } = useChatState()
   const scrollRef = useRef<HTMLDivElement>(null)
+  const composerRef = useRef<HTMLDivElement>(null)
   const stickToBottom = useRef(true)
   // Tracks whether the next onScroll fired from our own scrollTop= write
   // (so the synthetic event doesn't masquerade as a user gesture and
   // re-engage stick mode on every text delta).
   const programmaticScroll = useRef(false)
   const lastScrollTop = useRef(0)
+  const pendingScrollRestore = useRef<{ top: number; stick: boolean } | null>(null)
   const [activeHeaderPopover, setActiveHeaderPopover] = useState<HeaderPopoverID | null>(null)
   const [editingMessageID, setEditingMessageID] = useState<string | null>(null)
+  const [bottomComposerHeight, setBottomComposerHeight] = useState(0)
   // Distance-from-bottom threshold for *re-engaging* stick mode once the
   // user has manually disengaged it. Smaller than the old 80 px because we
   // now use scroll direction, not just position.
   const STICK_REENGAGE_PX = 8
 
+  const setProgrammaticScrollTop = (top: number) => {
+    if (!scrollRef.current) return
+    const el = scrollRef.current
+    const maxTop = Math.max(0, el.scrollHeight - el.clientHeight)
+    const nextTop = Math.max(0, Math.min(top, maxTop))
+    if (Math.abs(el.scrollTop - nextTop) > 0.5) {
+      programmaticScroll.current = true
+    }
+    el.scrollTop = nextTop
+    lastScrollTop.current = scrollRef.current.scrollTop
+  }
+
   const scrollToBottom = () => {
     if (!scrollRef.current) return
-    programmaticScroll.current = true
-    scrollRef.current.scrollTop = scrollRef.current.scrollHeight
-    lastScrollTop.current = scrollRef.current.scrollTop
+    setProgrammaticScrollTop(scrollRef.current.scrollHeight - scrollRef.current.clientHeight)
+  }
+
+  const captureScrollForLocalLayoutChange = () => {
+    if (!scrollRef.current) return
+    pendingScrollRestore.current = {
+      top: scrollRef.current.scrollTop,
+      stick: stickToBottom.current,
+    }
   }
   const [reviewRequest, setReviewRequest] = useState<{ path: string; key: number }>()
   const openReviewFile = (path: string) => {
@@ -117,6 +138,38 @@ export default function App() {
     scrollToBottom()
   }, [state.messages])
 
+  useLayoutEffect(() => {
+    if (state.messages.length === 0) {
+      setBottomComposerHeight(0)
+      return
+    }
+    const el = composerRef.current
+    if (!el) return
+    const update = () => setBottomComposerHeight(el.getBoundingClientRect().height)
+    update()
+    const observer = new ResizeObserver(update)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [state.messages.length])
+
+  useLayoutEffect(() => {
+    if (!stickToBottom.current) return
+    scrollToBottom()
+  }, [bottomComposerHeight])
+
+  // Entering/exiting in-place edit swaps a regular user bubble for an absolute
+  // overlay. Chromium may treat the overlay's extra scrollable overflow as a
+  // reason to adjust the scroll anchor, especially when the conversation is at
+  // the bottom. Restore the pre-toggle scroll offset before paint so editing a
+  // visible bubble does not make the whole transcript creep upward.
+  useLayoutEffect(() => {
+    const restore = pendingScrollRestore.current
+    if (!restore) return
+    pendingScrollRestore.current = null
+    setProgrammaticScrollTop(restore.top)
+    stickToBottom.current = restore.stick
+  }, [editingMessageID])
+
   // When the user opens a different conversation from the History menu, jump
   // to the bottom (most recent messages) and re-enable sticky-bottom mode so
   // the previous conversation's scroll position doesn't leave the new one
@@ -129,8 +182,12 @@ export default function App() {
     })
   }, [state.conversationID])
 
+  const appStyle = state.messages.length > 0
+    ? ({ "--bottom-composer-height": `${bottomComposerHeight}px` } as CSSProperties)
+    : undefined
+
   return (
-    <div className="app">
+    <div className="app" style={appStyle}>
       <StatusBar
         connected={state.connected}
         error={state.error}
@@ -207,10 +264,12 @@ export default function App() {
                 onReviewFile={openReviewFile}
                 onEditMessage={editMessage}
                 onBeginEdit={(id) => {
+                  captureScrollForLocalLayoutChange()
                   setActiveHeaderPopover(null)
                   setEditingMessageID(id)
                 }}
                 onEndEdit={(id) => {
+                  captureScrollForLocalLayoutChange()
                   setEditingMessageID((current) => current === id ? null : current)
                 }}
                 searchFiles={searchFiles}
@@ -259,16 +318,18 @@ export default function App() {
         onReviewAllInChange={reviewAllInChange}
       />
       {state.messages.length > 0 && (
-        <PromptBox
-          busy={busy}
-          aborting={state.aborting}
-          onSend={send}
-          onAbort={abort}
-          searchFiles={searchFiles}
-          attachFile={attachFile}
-          conversations={state.conversations}
-          onOpenConversation={openConversation}
-        />
+        <div className="bottom-composer" ref={composerRef}>
+          <PromptBox
+            busy={busy}
+            aborting={state.aborting}
+            onSend={send}
+            onAbort={abort}
+            searchFiles={searchFiles}
+            attachFile={attachFile}
+            conversations={state.conversations}
+            onOpenConversation={openConversation}
+          />
+        </div>
       )}
     </div>
   )

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -429,8 +429,14 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
     return findMentionRanges(text, new Set(knownAttachments.current.keys())).length > 0
   })()
 
+  const classes = [
+    "promptbox",
+    variant === "edit" ? "promptbox--edit" : "promptbox--send",
+    position === "top" ? "promptbox--top" : variant === "send" ? "promptbox--bottom" : "",
+  ].filter(Boolean).join(" ")
+
   return (
-    <div className={"promptbox" + (variant === "edit" ? " promptbox--edit" : "") + (position === "top" ? " promptbox--top" : "")}>
+    <div className={classes}>
       {attachError && <div className="attachment-error">{attachError}</div>}
       {imageAttachments.length > 0 && (
         <ul className="promptbox-thumbs" aria-label="Image attachments">

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -69,6 +69,7 @@
      textarea aligned — they used to be coupled only by code comments. */
   --bubble-padding:      var(--space-1);
   --bubble-text-padding: var(--space-1);
+  --composer-edge-gap:   var(--space-4);
   /* Border width of `.msg.role-user`. Referenced by `.user-edit-layer` so the
      overlay's `top/left/right` offset and its own border-width stay in lock-
      step with the placeholder's resting border — bump this once and the
@@ -107,9 +108,11 @@ button {
 }
 
 .app {
+  position: relative;
   display: flex;
   flex-direction: column;
   height: 100vh;
+  overflow: hidden;
 }
 
 /* ===== Status bar ===== */
@@ -868,7 +871,7 @@ button {
      when scrolling appears, AND stay visually centered (the symmetric reserve
      mirrors the right scrollbar gutter on the left). */
   scrollbar-gutter: stable both-edges;
-  padding: 10px 12px 4px;
+  padding: 10px 12px calc(4px + var(--bottom-composer-height, 0px));
   /* Firefox: thin transparent scrollbar that brightens on hover. */
   scrollbar-width: thin;
   scrollbar-color: transparent transparent;
@@ -2094,22 +2097,32 @@ button {
 }
 /* ===== Prompt box ===== */
 .promptbox {
-  /* Tight chrome to match the in-place edit bubble: 4 px around, no
-     border-top. The send box used to carry an 8 × 10 padding + a
-     panel-border-top separator, which made it visually weigh ~20 % more
-     than the edit affordance for the same content. Without the
-     border-top, the bordered `.promptbox-input` below provides the
-     visual boundary, matching the edit-mode bubble's single-border
-     look. */
-  padding: 10px 8px 4px;
-  background: var(--vscode-sideBar-background);
+  padding: var(--bubble-padding);
+  background: transparent;
+}
+.promptbox--bottom {
+  margin: 0;
+  border: var(--bubble-border-width) solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-bg-input);
+}
+.promptbox--top {
+  margin: 0;
+  padding: var(--composer-edge-gap) 8px 4px;
 }
 .promptbox-input {
   background: var(--vscode-input-background);
   border: 1px solid var(--vscode-input-border, transparent);
   border-radius: var(--radius);
 }
+.promptbox--bottom .promptbox-input {
+  background: transparent;
+  border: 0;
+}
 .promptbox-input:focus-within { border-color: var(--color-border-focus); }
+.promptbox--bottom:focus-within {
+  border-color: var(--color-border-focus);
+}
 .promptbox-textarea-wrap {
   position: relative;
 }
@@ -2213,6 +2226,20 @@ button {
   min-width: 0;
 }
 .promptbox-row .spacer { flex: 1; }
+
+.bottom-composer {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: var(--z-overlay);
+  padding: var(--composer-edge-gap) 12px var(--composer-edge-gap);
+  background: transparent;
+  pointer-events: none;
+}
+.bottom-composer > .promptbox {
+  pointer-events: auto;
+}
 
 /* ===== System reminder callout ===== */
 .system-reminder {


### PR DESCRIPTION
## Summary
- Float bottom composer over scroll area with ResizeObserver-tracked padding
- Preserve scroll position when toggling in-place edit mode
- Explicit `promptbox--send` / `promptbox--bottom` class names for variant styling
- Backfill v0.9.9 CHANGELOG entry
- Bump version to 0.9.10

## Test plan
- [x] `bun run test` — 790/790 pass
- [x] `bun run check-types` — pass
- [ ] Visual: composer floats over scroll, content not clipped
- [ ] Visual: entering/exiting edit mode doesn't shift scroll position

Closes #228