### PR TITLE
fix(context): ignore non-file active editors (#230)

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -11,6 +11,14 @@ export function getEditorContext(): EditorContext {
   const editor = vscode.window.activeTextEditor
   if (!editor) return {}
   const doc = editor.document
+  // Only real files carry a usable filesystem path. Non-file editors (Output
+  // panels, untitled buffers, diff/virtual docs) expose a URI whose "path" is
+  // actually a title like "extension-output-…OpenCode Panel". Surfacing that
+  // as the active editor made the symbols collector join it onto the workspace
+  // root and ask the language server to read a file that can't exist — noisy
+  // (but harmless) under WSL remote, where Uri.file() became a vscode-remote://
+  // URI (#230).
+  if (doc.uri.scheme !== "file") return {}
   const sel = editor.selection
   const ctx: EditorContext = {
     filePath: doc.uri.fsPath,

--- a/test/host/editor-context.test.ts
+++ b/test/host/editor-context.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach } from "vitest"
+import * as vscode from "vscode"
+import { getEditorContext, formatContextHeader } from "../../src/context"
+
+type FakeSelection = {
+  isEmpty: boolean
+  start: { line: number }
+  end: { line: number }
+}
+type FakeEditor = {
+  document: {
+    uri: { fsPath: string; scheme: string }
+    languageId: string
+    getText: (sel: FakeSelection) => string
+  }
+  selection: FakeSelection
+}
+type MutableWindow = { activeTextEditor?: FakeEditor }
+const win = vscode.window as unknown as MutableWindow
+
+const EMPTY_SELECTION: FakeSelection = {
+  isEmpty: true,
+  start: { line: 0 },
+  end: { line: 0 },
+}
+
+function setActive(uri: { fsPath: string; scheme: string } | undefined, selection = EMPTY_SELECTION) {
+  win.activeTextEditor = uri
+    ? {
+        document: {
+          uri,
+          languageId: "typescript",
+          getText: () => "selected text",
+        },
+        selection,
+      }
+    : undefined
+}
+
+describe("getEditorContext", () => {
+  beforeEach(() => {
+    setActive(undefined)
+  })
+
+  it("returns empty context when there is no active editor", () => {
+    expect(getEditorContext()).toEqual({})
+  })
+
+  it("reports file path, relative path, and language for a real file", () => {
+    setActive({ fsPath: "/workspace/src/foo.ts", scheme: "file" })
+    expect(getEditorContext()).toEqual({
+      filePath: "/workspace/src/foo.ts",
+      relativePath: "src/foo.ts",
+      language: "typescript",
+    })
+  })
+
+  it("captures a non-empty selection on a real file", () => {
+    setActive({ fsPath: "/workspace/src/foo.ts", scheme: "file" }, {
+      isEmpty: false,
+      start: { line: 4 },
+      end: { line: 8 },
+    })
+    expect(getEditorContext().selection).toEqual({
+      startLine: 5,
+      endLine: 9,
+      text: "selected text",
+    })
+  })
+
+  // #230: when the OpenCode Panel Output view is focused it is the active
+  // "text editor", but its URI scheme is `output` and the path is the channel
+  // title. Treating that as a file made the symbols collector read a bogus
+  // path. Non-file editors must produce no editor context at all.
+  it("ignores the Output panel (scheme `output`)", () => {
+    setActive({
+      fsPath: "/extension-output-haoyangzeng.opencui-#1-OpenCode Panel",
+      scheme: "output",
+    })
+    expect(getEditorContext()).toEqual({})
+  })
+
+  it("ignores untitled buffers (scheme `untitled`)", () => {
+    setActive({ fsPath: "/Untitled-1", scheme: "untitled" })
+    expect(getEditorContext()).toEqual({})
+  })
+
+  it("renders no context header for a non-file editor", () => {
+    setActive({ fsPath: "/whatever", scheme: "output" })
+    expect(formatContextHeader(getEditorContext())).toBe("")
+  })
+})


### PR DESCRIPTION
## Summary

Closes #230.

When a non-file editor — an **Output panel**, untitled buffer, or diff/virtual doc — is the active editor, `getEditorContext()` read its URI as though it were a real file. The OpenCode Panel **Output** view's URI path is actually its channel title (`extension-output-…OpenCode Panel`), so:

1. `getEditorContext()` returned that title as `relativePath`.
2. `collectSymbolFocus()` pushed it (it isn't absolute, so it passed the filter).
3. `collectSymbols()` joined it onto the workspace root, built a `vscode.Uri.file()`, and asked the language server for symbols of a file that can't exist.

Under **WSL remote**, `Uri.file()` resolves to a `vscode-remote://` URI, which is exactly the path in the reporter's log:

```
vscode-remote://wsl+ubuntu-24.04/home/user/repos/slideshow/extension-output-haoyangzeng.opencui-%231-OpenCode Panel kann nicht gelesen werden
```

The error was caught and skipped (symbol collection for real files still worked), but it was noisy and confusing in the logs.

### Fix

Guard `getEditorContext()` on `doc.uri.scheme === "file"`, mirroring the existing check in `collectOpenTabs` (`open-tabs.ts`). Non-file editors now yield empty editor context, so no bogus path reaches `symbolFocus`, the context header, or the manifest editor item.

> Note: this addresses the `symbols collector: provider failed` log line, which the reporter's environment data and the issue thread point to. The separate "file/path resolution doesn't work" / "extension looks wrong" remarks aren't explained by this log; I've asked the reporter for a screenshot/clip to confirm whether a second WSL issue is hiding there.

## Test plan

- [x] New `test/host/editor-context.test.ts` — covers real-file context (path/relative/language/selection), and that `output` + `untitled` schemes produce empty context and no context header.
- [x] `bun run test` — 796 passed (47 files).
- [x] `bun run check-types` — clean.
- [ ] Manual WSL verification: open the OpenCode Panel Output view, focus it, send a prompt, confirm the `symbols collector: provider failed` line no longer appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)