### PR TITLE
style(chat): remove drop shadow from user message bubbles

### DIFF
--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -969,44 +969,11 @@ button {
   border: var(--bubble-border-width) solid var(--color-border);
   border-radius: var(--radius);
   word-break: break-word;
-  /* Soft drop shadow gives the pinned bubble a subtle natural-fade transition
-     against the scrolling content below it, regardless of theme contrast. */
-  box-shadow: 0 12px 18px -10px var(--vscode-widget-shadow, rgba(0, 0, 0, 0.45));
   /* Animate only paint changes. Size-affecting properties stay out of this
      transition so entering/exiting edit mode cannot briefly resize the row. */
   transition:
     background-color 0.18s ease,
     border-color 0.18s ease;
-}
-/* Extra gradient strip below the bubble for stronger visual feathering.
-   Uses a high-contrast shadow color with explicit alpha so it shows up
-   reliably across all themes (light/dark) where the bubble background may
-   be close to the surrounding panel color. */
-.msg.role-user::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: -16px;
-  height: 16px;
-  background: linear-gradient(
-    to bottom,
-    rgba(0, 0, 0, 0.18) 0%,
-    rgba(0, 0, 0, 0.06) 40%,
-    transparent 100%
-  );
-  pointer-events: none;
-}
-/* Light themes: invert the shadow to a soft dark-blue tint for visibility. */
-@media (prefers-color-scheme: light) {
-  .msg.role-user::after {
-    background: linear-gradient(
-      to bottom,
-      rgba(50, 65, 90, 0.12) 0%,
-      rgba(50, 65, 90, 0.04) 40%,
-      transparent 100%
-    );
-  }
 }
 /* All rules in this block target the non-view edit phase. Keeping them keyed
    to `[data-edit-phase]` makes it clear the overlay owns edit-mode chrome. */
@@ -1183,7 +1150,6 @@ button {
   border: var(--bubble-border-width) solid var(--color-border-focus);
   border-radius: var(--radius);
   background: var(--color-bg-input);
-  box-shadow: 0 12px 18px -10px var(--vscode-widget-shadow, rgba(0, 0, 0, 0.45));
   animation: user-edit-border-in 0.18s ease both;
 }
 @keyframes user-edit-border-in {


### PR DESCRIPTION
## Summary

Closes #232.

Removes the drop-shadow treatment from the pinned user message bubbles in the chat panel. The effect was three cooperating pieces, all removed:

- `box-shadow` on `.msg.role-user` (the sticky bubble).
- The `::after` gradient feather strip below the bubble, plus its `prefers-color-scheme: light` override (a dark-blue-tinted variant).
- The matching `box-shadow` on `.user-edit-layer` — the in-place edit overlay deliberately mirrored the bubble's shadow so entering edit mode didn't change the look; with the bubble flat, the overlay must be flat too.

Sticky pinning, opaque background, border, and radius are unchanged, so scrolling content still doesn't bleed through and the bubble still reads as a distinct box — just without the shadow.

## Test plan

- [x] `bun run compile` — webview vite build + host esbuild both succeed; CSS inlines cleanly into the single-file bundle.
- [x] Grep confirms no remaining `role-user::after`, `widget-shadow`, or `0 12px 18px` references in `webview/src/`.
- [ ] Visual check in VS Code: user bubbles render flat (no shadow / no gradient strip) in both dark and light themes; entering/leaving in-place edit shows no shadow flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)