### PR TITLE
style(chat): unify chatbox widths with the bottom composer

### DIFF
--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -869,9 +869,14 @@ button {
   overflow-y: auto;
   /* Reserve gutter space on BOTH sides so message bubbles don't reflow narrower
      when scrolling appears, AND stay visually centered (the symmetric reserve
-     mirrors the right scrollbar gutter on the left). */
+     mirrors the right scrollbar gutter on the left).
+     Horizontal padding is 2px on purpose: 2px + the 10px reserved gutter (the
+     `::-webkit-scrollbar` width below) sums to the 12px edge gap used by
+     `.bottom-composer`, so message bubbles, the in-place edit box, and the
+     docked composer all line up at the same width. If you change the scrollbar
+     width, adjust this padding so the two still sum to 12px. */
   scrollbar-gutter: stable both-edges;
-  padding: 10px 12px calc(4px + var(--bottom-composer-height, 0px));
+  padding: 10px 2px calc(4px + var(--bottom-composer-height, 0px));
   /* Firefox: thin transparent scrollbar that brightens on hover. */
   scrollbar-width: thin;
   scrollbar-color: transparent transparent;
@@ -2108,7 +2113,9 @@ button {
 }
 .promptbox--top {
   margin: 0;
-  padding: var(--composer-edge-gap) 8px 4px;
+  /* Horizontal gap matches `.bottom-composer` (12px) so the empty-state chatbox
+     is the same width as the docked one. */
+  padding: var(--composer-edge-gap) 12px 4px;
 }
 .promptbox-input {
   background: var(--vscode-input-background);


### PR DESCRIPTION
## Summary

Closes #234.

The three chat input boxes rendered at three different widths. This brings the other two to the **bottom composer's 12px edge gap** so they all line up:

| Chatbox | Before (inset per side) | After |
|---|---|---|
| Bottom composer (docked) | 12px | 12px (reference, unchanged) |
| Top / welcome composer | 8px (too wide) | 12px |
| In-place edit box / message bubbles | ~22px (too narrow) | 12px |

### Changes

- **`.promptbox--top`**: horizontal padding `8px` → `12px`.
- **`.messages`**: horizontal padding `12px` → `2px`. The bubbles' inset is the padding **plus** the reserved 10px scrollbar gutter (`scrollbar-gutter: stable both-edges`, where the `::-webkit-scrollbar` width is 10px). `2px + 10px = 12px` now matches the bottom composer. The in-place edit box follows automatically because it's sized to the bubble. The gutter is kept, so chat content still doesn't reflow narrower when the scrollbar appears.

A comment on `.messages` documents the `padding + gutter = 12px` coupling so a future scrollbar-width change won't silently break the alignment.

> Independent of #233 (shadow removal) — different regions of `styles.css`, no overlap.

## Test plan

- [x] `bun run build:webview` — vite build succeeds, CSS inlines cleanly.
- [x] `bun run test` — 796 passed (47 files).
- [x] `bun run check-types` — clean.
- [ ] Visual check in VS Code: empty-state composer, docked composer, and (after clicking a sent message to edit) the in-place edit box all share the same left/right edges; message bubbles align with the bottom composer; scrollbar still doesn't shove content on appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)