### PR TITLE
feat(chat): browse the project tree in the @-picker (files-only selection)

### DIFF
--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -11,7 +11,7 @@ import {
   type ToolUpdate,
 } from "./stream"
 import { getEditorContext, formatContextHeader } from "../context"
-import { searchWorkspaceFiles } from "../file-search"
+import { searchWorkspaceFiles, listWorkspaceDir } from "../file-search"
 import { pickAttachments } from "../attachments"
 import { log } from "../output"
 import { getWorkspaceRoots, primaryWorkspaceRoot } from "../workspace-root"
@@ -569,6 +569,15 @@ export class ChatView implements vscode.WebviewViewProvider {
         } catch (e) {
           log("fileSearch failed", e)
           this.post({ type: "fileSearchResult", requestID: msg.requestID, hits: [] })
+        }
+        return
+      case "listDir":
+        try {
+          const entries = await listWorkspaceDir(msg.path)
+          this.post({ type: "listDirResult", requestID: msg.requestID, entries })
+        } catch (e) {
+          log("listDir failed", e)
+          this.post({ type: "listDirResult", requestID: msg.requestID, entries: [] })
         }
         return
       case "attachFile":

--- a/src/file-search.ts
+++ b/src/file-search.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode"
 import * as path from "path"
-import type { FileSearchHit } from "./protocol"
+import type { DirEntry, FileSearchHit } from "./protocol"
 
 const MAX_FILES = 5000
 const MAX_HITS = 30
@@ -30,6 +30,43 @@ export async function searchWorkspaceFiles(query: string): Promise<FileSearchHit
   const all = await loadFiles()
   const recent = getRecentlyOpenedPaths()
   return rankHits(all, query, recent).slice(0, MAX_HITS)
+}
+
+/**
+ * List the immediate children (subfolders + files) of a workspace-relative
+ * folder for the @-picker's drill-down browser. Derived from the same cached
+ * file index the search uses, so the ignore-globs and 30s cache are shared.
+ */
+export async function listWorkspaceDir(dir: string): Promise<DirEntry[]> {
+  return dirEntriesFrom(await loadFiles(), dir)
+}
+
+/**
+ * Pure derivation of a folder's immediate children from the flat file index.
+ * `dir` is "" for the workspace root; a trailing slash is tolerated. Folders
+ * come first (alphabetical), then files (alphabetical). Folders are inferred
+ * from file paths, so one that holds only ignored files never appears — there
+ * would be nothing to drill into anyway.
+ */
+export function dirEntriesFrom(files: FileSearchHit[], dir: string): DirEntry[] {
+  const prefix = dir ? dir.replace(/\/+$/, "") + "/" : ""
+  const folders = new Set<string>()
+  const fileEntries: DirEntry[] = []
+  for (const hit of files) {
+    if (prefix && !hit.path.startsWith(prefix)) continue
+    const rest = hit.path.slice(prefix.length)
+    const slash = rest.indexOf("/")
+    if (slash === -1) {
+      fileEntries.push({ name: rest, path: hit.path, kind: "file" })
+    } else {
+      folders.add(rest.slice(0, slash))
+    }
+  }
+  const folderEntries: DirEntry[] = [...folders]
+    .sort((a, b) => a.localeCompare(b))
+    .map((name) => ({ name, path: prefix + name, kind: "folder" }))
+  fileEntries.sort((a, b) => a.name.localeCompare(b.name))
+  return [...folderEntries, ...fileEntries]
 }
 
 /**

--- a/test/host/file-search.test.ts
+++ b/test/host/file-search.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { rankHits } from "../../src/file-search"
+import { rankHits, dirEntriesFrom } from "../../src/file-search"
 
 const fixtures = [
   { path: "src/foo.ts", name: "foo.ts" },
@@ -103,5 +103,47 @@ describe("rankHits", () => {
       expect(out[0]?.path).toBe("src/foo.ts")
       expect(out[1]?.path).toBe("src/bar.ts")
     })
+  })
+})
+
+describe("dirEntriesFrom", () => {
+  it("lists root-level entries, folders first", () => {
+    const out = dirEntriesFrom(fixtures, "")
+    expect(out).toEqual([
+      { name: "deep", path: "deep", kind: "folder" },
+      { name: "lib", path: "lib", kind: "folder" },
+      { name: "src", path: "src", kind: "folder" },
+    ])
+  })
+
+  it("lists a folder's immediate children, folders before files, each alphabetical", () => {
+    const out = dirEntriesFrom(fixtures, "src")
+    expect(out).toEqual([
+      { name: "bar", path: "src/bar", kind: "folder" },
+      { name: "foo", path: "src/foo", kind: "folder" },
+      { name: "bar.ts", path: "src/bar.ts", kind: "file" },
+      { name: "foo.ts", path: "src/foo.ts", kind: "file" },
+    ])
+  })
+
+  it("distinguishes a folder from a same-stem sibling file", () => {
+    const out = dirEntriesFrom(fixtures, "src")
+    // src/bar (folder, inferred from src/bar/foo.tsx) and src/bar.ts (file) are distinct.
+    expect(out.find((e) => e.path === "src/bar")?.kind).toBe("folder")
+    expect(out.find((e) => e.path === "src/bar.ts")?.kind).toBe("file")
+  })
+
+  it("returns only files when a folder has no subfolders", () => {
+    expect(dirEntriesFrom(fixtures, "src/foo")).toEqual([
+      { name: "index.ts", path: "src/foo/index.ts", kind: "file" },
+    ])
+  })
+
+  it("tolerates a trailing slash on the dir", () => {
+    expect(dirEntriesFrom(fixtures, "src/")).toEqual(dirEntriesFrom(fixtures, "src"))
+  })
+
+  it("returns empty for a folder with no matching files", () => {
+    expect(dirEntriesFrom(fixtures, "does/not/exist")).toEqual([])
   })
 })

--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -5,10 +5,10 @@ import { PromptBox, detectMention, extractMentions, findMentionRanges, findChipA
 
 afterEach(cleanup)
 
-/** Type `@`, wait for the category menu, then press Enter to select "Files & Folders". */
+/** Type `@`, wait for the category menu, then press Enter to select "Files". */
 async function enterFilesCategory(user: ReturnType<typeof userEvent.setup>, target: Element) {
   await user.type(target, "@")
-  await waitFor(() => expect(screen.getByText("Files & Folders")).toBeInTheDocument())
+  await waitFor(() => expect(screen.getByText("Files")).toBeInTheDocument())
   await user.keyboard("{Enter}")
 }
 
@@ -233,7 +233,7 @@ describe("extractMentions", () => {
 })
 
 describe("PromptBox @file autocomplete", () => {
-  it("shows the category menu after typing @, then file hits after selecting Files & Folders", async () => {
+  it("shows the category menu after typing @, then file hits after selecting Files", async () => {
     const user = userEvent.setup()
     const searchFiles = vi.fn().mockResolvedValue([
       { path: "src/foo.ts", name: "foo.ts" },
@@ -372,6 +372,108 @@ describe("PromptBox @file autocomplete", () => {
     render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} />)
     await user.type(screen.getByRole("textbox"), "@foo")
     expect(screen.queryByRole("listbox")).toBeNull()
+  })
+})
+
+describe("PromptBox @ folder browser (drill-down)", () => {
+  const makeBrowser = () => {
+    const searchFiles = vi.fn().mockResolvedValue([])
+    const listDir = vi.fn().mockImplementation(async (path: string) => {
+      if (path === "") return [
+        { name: "src", path: "src", kind: "folder" },
+        { name: "README.md", path: "README.md", kind: "file" },
+      ]
+      if (path === "src") return [
+        { name: "chat", path: "src/chat", kind: "folder" },
+        { name: "server.ts", path: "src/server.ts", kind: "file" },
+      ]
+      return []
+    })
+    return { searchFiles, listDir }
+  }
+
+  it("shows the project root (folders + files) with a breadcrumb after picking Files", async () => {
+    const user = userEvent.setup()
+    const { searchFiles, listDir } = makeBrowser()
+    render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} searchFiles={searchFiles} listDir={listDir} />)
+    await enterFilesCategory(user, screen.getByRole("textbox"))
+    await waitFor(() => expect(listDir).toHaveBeenCalledWith(""))
+    await waitFor(() => expect(screen.getByText("src")).toBeInTheDocument())
+    expect(screen.getByText("README.md")).toBeInTheDocument()
+    expect(screen.getByText("Project root")).toBeInTheDocument()
+  })
+
+  it("drills into a folder on Enter, listing its children — and never inserts the folder", async () => {
+    const user = userEvent.setup()
+    const { searchFiles, listDir } = makeBrowser()
+    render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} searchFiles={searchFiles} listDir={listDir} />)
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    await enterFilesCategory(user, textarea)
+    await waitFor(() => expect(screen.getByText("src")).toBeInTheDocument())
+    await user.keyboard("{Enter}") // src is first (folder) → drills in
+    await waitFor(() => expect(listDir).toHaveBeenCalledWith("src"))
+    await waitFor(() => expect(screen.getByText("server.ts")).toBeInTheDocument())
+    expect(screen.getByText("chat")).toBeInTheDocument()
+    // Folder was navigated, never inserted as a mention.
+    expect(textarea.value).toBe("@")
+  })
+
+  it("ArrowRight also drills into the highlighted folder", async () => {
+    const user = userEvent.setup()
+    const { searchFiles, listDir } = makeBrowser()
+    render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} searchFiles={searchFiles} listDir={listDir} />)
+    await enterFilesCategory(user, screen.getByRole("textbox"))
+    await waitFor(() => expect(screen.getByText("src")).toBeInTheDocument())
+    await user.keyboard("{ArrowRight}")
+    await waitFor(() => expect(listDir).toHaveBeenCalledWith("src"))
+    expect(screen.getByText("server.ts")).toBeInTheDocument()
+  })
+
+  it("inserts a file (the only selectable leaf) and closes the picker", async () => {
+    const user = userEvent.setup()
+    const { searchFiles, listDir } = makeBrowser()
+    render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} searchFiles={searchFiles} listDir={listDir} />)
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    await enterFilesCategory(user, textarea)
+    await waitFor(() => expect(screen.getByText("README.md")).toBeInTheDocument())
+    await user.click(screen.getByText("README.md"))
+    expect(textarea.value).toBe("@README.md ")
+    expect(screen.queryByText("Project root")).toBeNull()
+  })
+
+  it("goes back up a level via the breadcrumb button", async () => {
+    const user = userEvent.setup()
+    const { searchFiles, listDir } = makeBrowser()
+    render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} searchFiles={searchFiles} listDir={listDir} />)
+    await enterFilesCategory(user, screen.getByRole("textbox"))
+    await waitFor(() => expect(screen.getByText("src")).toBeInTheDocument())
+    await user.keyboard("{Enter}") // into src
+    await waitFor(() => expect(screen.getByText("server.ts")).toBeInTheDocument())
+    await user.click(screen.getByRole("button", { name: /Go up a folder/i }))
+    await waitFor(() => expect(screen.getByText("README.md")).toBeInTheDocument())
+  })
+
+  it("typing a query switches from the browser to the flat file search", async () => {
+    const user = userEvent.setup()
+    const { listDir } = makeBrowser()
+    const searchFiles = vi.fn().mockResolvedValue([{ path: "src/foo.ts", name: "foo.ts" }])
+    render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} searchFiles={searchFiles} listDir={listDir} />)
+    const textarea = screen.getByRole("textbox")
+    await enterFilesCategory(user, textarea)
+    await waitFor(() => expect(screen.getByText("src")).toBeInTheDocument()) // browser
+    await user.type(textarea, "foo")
+    await waitFor(() => expect(searchFiles).toHaveBeenCalledWith("foo"))
+    await waitFor(() => expect(screen.getByText("foo.ts")).toBeInTheDocument())
+    expect(screen.queryByText("Project root")).toBeNull()
+  })
+
+  it("falls back to the flat search when no listDir is provided", async () => {
+    const user = userEvent.setup()
+    const searchFiles = vi.fn().mockResolvedValue([{ path: "src/foo.ts", name: "foo.ts" }])
+    render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} searchFiles={searchFiles} />)
+    await enterFilesCategory(user, screen.getByRole("textbox"))
+    await waitFor(() => expect(screen.getByText("foo.ts")).toBeInTheDocument())
+    expect(screen.queryByText("Project root")).toBeNull()
   })
 })
 

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -29,6 +29,7 @@ export default function App() {
     editMessage,
     reviewAllInChange,
     searchFiles,
+    listDir,
     attachFile,
     startIndex,
     stopIndex,
@@ -217,6 +218,7 @@ export default function App() {
           onSend={send}
           onAbort={abort}
           searchFiles={searchFiles}
+          listDir={listDir}
           attachFile={attachFile}
           position="top"
           conversations={state.conversations}
@@ -273,6 +275,7 @@ export default function App() {
                   setEditingMessageID((current) => current === id ? null : current)
                 }}
                 searchFiles={searchFiles}
+                listDir={listDir}
                 attachFile={attachFile}
               />
             )}
@@ -325,6 +328,7 @@ export default function App() {
             onSend={send}
             onAbort={abort}
             searchFiles={searchFiles}
+            listDir={listDir}
             attachFile={attachFile}
             conversations={state.conversations}
             onOpenConversation={openConversation}

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react"
 import type { Block, Message } from "../hooks/useChatState"
-import type { AgentsStatusInfo, Attachment, FileSearchHit } from "../protocol"
+import type { AgentsStatusInfo, Attachment, DirEntry, FileSearchHit } from "../protocol"
 import { findMentionRanges, makeAttachmentLabel } from "../mention-tokens"
 import { ImagePreviewModal } from "./ImagePreviewModal"
 import { ImageThumbnail, type Thumbnailable } from "./ImageThumbnail"
@@ -36,6 +36,7 @@ export function MessageView({
   onRetry,
   agentActivity,
   searchFiles,
+  listDir,
   attachFile,
 }: {
   message: Message
@@ -49,6 +50,7 @@ export function MessageView({
   onRetry?: (assistantID: string) => void
   agentActivity?: AgentsStatusInfo
   searchFiles?: (query: string) => Promise<FileSearchHit[]>
+  listDir?: (path: string) => Promise<DirEntry[]>
   attachFile?: () => Promise<{ attachments: Attachment[]; error?: string }>
 }) {
   if (message.role === "user") {
@@ -60,6 +62,7 @@ export function MessageView({
         onBeginEdit={onBeginEdit}
         onEndEdit={onEndEdit}
         searchFiles={searchFiles}
+        listDir={listDir}
         attachFile={attachFile}
       />
     )
@@ -133,6 +136,7 @@ function UserMessageView({
   onBeginEdit,
   onEndEdit,
   searchFiles,
+  listDir,
   attachFile,
 }: {
   message: Message
@@ -141,6 +145,7 @@ function UserMessageView({
   onBeginEdit?: (id: string) => void
   onEndEdit?: (id: string) => void
   searchFiles?: (query: string) => Promise<FileSearchHit[]>
+  listDir?: (path: string) => Promise<DirEntry[]>
   attachFile?: () => Promise<{ attachments: Attachment[]; error?: string }>
 }) {
   const originalText = message.blocks
@@ -263,6 +268,7 @@ function UserMessageView({
             onSend={handleSubmit}
             onAbort={exitEditing}
             searchFiles={searchFiles}
+            listDir={listDir}
             attachFile={attachFile}
             variant="edit"
             initial={{

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type ReactNode } from "react"
-import type { Attachment, ConversationSummary, FileSearchHit } from "../protocol"
+import type { Attachment, ConversationSummary, DirEntry, FileSearchHit } from "../protocol"
 import {
   extractMentions,
   findChipAtCaret,
@@ -11,6 +11,7 @@ import { clipboardHasImage, readPastedImages } from "../paste-attachments"
 import { usePromptText } from "../hooks/usePromptText"
 import { useImageAttachments } from "../hooks/useImageAttachments"
 import { useMentionPicker } from "../hooks/useMentionPicker"
+import { useFileBrowser } from "../hooks/useFileBrowser"
 import { ImagePreviewModal } from "./ImagePreviewModal"
 import { ImageThumbnail } from "./ImageThumbnail"
 import { ICON_SIZE } from "../design-tokens"
@@ -39,6 +40,7 @@ type Props = {
   onSend: (text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) => void
   onAbort: () => void
   searchFiles?: (query: string) => Promise<FileSearchHit[]>
+  listDir?: (path: string) => Promise<DirEntry[]>
   attachFile?: () => Promise<{ attachments: Attachment[]; error?: string }>
   /**
    * Pre-fill the input with text, mention paths, and attachments. Used by
@@ -91,7 +93,7 @@ function buildInitialConversations(
   return map
 }
 
-export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles, attachFile, initial, variant = "send", position = "bottom", conversations, onOpenConversation }: Props) {
+export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles, listDir, attachFile, initial, variant = "send", position = "bottom", conversations, onOpenConversation }: Props) {
   const { text, setText, ref, backdropRef, pendingCursor } = usePromptText(initial?.text ?? "")
   const [selectedChipStart, setSelectedChipStart] = useState<number | undefined>(undefined)
   const [attachError, setAttachError] = useState<string | undefined>(undefined)
@@ -130,8 +132,23 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
   }, [mention])
 
   const showCategoryMenu = !!mention && mentionCategory === null && !mention.query
-  const showFileHits = !!mention && hits.length > 0 && (mentionCategory === "files" || (mentionCategory === null && !!mention.query))
+  // Browse the project tree when the Files category is open and nothing's been
+  // typed yet; typing a query switches to the flat fuzzy search below. Requires
+  // the host's listDir — without it we fall back to the flat search so the
+  // picker still works (and existing flat-search tests stay valid).
+  const showBrowse = !!mention && mentionCategory === "files" && !mention.query && !!listDir
+  const showFileHits = !showBrowse && !!mention && hits.length > 0 && (mentionCategory === "files" || (mentionCategory === null && !!mention.query))
   const showChatList = !!mention && mentionCategory === "chats"
+
+  const {
+    dir: browseDir,
+    entries: browseEntries,
+    index: browseIndex,
+    setIndex: setBrowseIndex,
+    canGoUp,
+    drillInto,
+    goUp,
+  } = useFileBrowser({ listDir, active: showBrowse })
 
   const filteredConversations = showChatList
     ? (conversations ?? []).filter((c) => !mention.query || c.title.toLowerCase().includes(mention.query.toLowerCase()))
@@ -373,6 +390,43 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
         return
       }
     }
+    if (showBrowse) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault()
+        if (browseEntries.length > 0) setBrowseIndex((i) => (i + 1) % browseEntries.length)
+        return
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault()
+        if (browseEntries.length > 0) setBrowseIndex((i) => (i - 1 + browseEntries.length) % browseEntries.length)
+        return
+      }
+      if (e.key === "ArrowRight") {
+        const entry = browseEntries[browseIndex]
+        if (entry?.kind === "folder") {
+          e.preventDefault()
+          drillInto(entry)
+          return
+        }
+      }
+      if (e.key === "ArrowLeft" && canGoUp) {
+        e.preventDefault()
+        goUp()
+        return
+      }
+      if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault()
+        const entry = browseEntries[browseIndex]
+        if (entry?.kind === "folder") drillInto(entry)
+        else if (entry) insertMention(entry)
+        return
+      }
+      if (e.key === "Escape") {
+        e.preventDefault()
+        closeMention()
+        return
+      }
+    }
     if (e.key === "Backspace" && !e.shiftKey && !e.metaKey && !e.altKey) {
       const ta = e.currentTarget
       // Only intercept when there's no real text selection
@@ -486,7 +540,7 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
               onMouseEnter={() => setMenuIndex(0)}
             >
               <FolderIcon />
-              <span className="mention-category-label">Files & Folders</span>
+              <span className="mention-category-label">Files</span>
               <ChevronIcon />
             </li>
             <li
@@ -501,6 +555,44 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
               <ChevronIcon />
             </li>
           </ul>
+        )}
+        {showBrowse && (
+          <div className="mention-popover mention-browser">
+            <div className="mention-breadcrumb">
+              <button
+                type="button"
+                className="mention-breadcrumb-up"
+                aria-label="Go up a folder"
+                disabled={!canGoUp}
+                onMouseDown={(e) => { e.preventDefault(); if (canGoUp) goUp() }}
+              >
+                <span className="mention-breadcrumb-chevron" aria-hidden="true"><ChevronIcon /></span>
+                <span className="mention-breadcrumb-path">{browseDir === "" ? "Project root" : browseDir}</span>
+              </button>
+            </div>
+            <ul role="listbox" aria-label="Project files">
+              {browseEntries.length > 0 ? browseEntries.map((entry, i) => (
+                <li
+                  key={entry.path}
+                  role="option"
+                  aria-selected={i === browseIndex}
+                  className={"mention-hit" + (i === browseIndex ? " active" : "") + (entry.kind === "folder" ? " mention-folder" : "")}
+                  onMouseDown={(e) => {
+                    e.preventDefault()
+                    if (entry.kind === "folder") drillInto(entry)
+                    else insertMention(entry)
+                  }}
+                  onMouseEnter={() => setBrowseIndex(i)}
+                >
+                  {entry.kind === "folder" && <FolderIcon />}
+                  <span className="mention-name">{entry.name}</span>
+                  {entry.kind === "folder" && <ChevronIcon />}
+                </li>
+              )) : (
+                <li className="mention-hit mention-empty">Empty folder</li>
+              )}
+            </ul>
+          </div>
         )}
         {showFileHits && (
           <ul className="mention-popover" role="listbox" aria-label="Files">

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -6,6 +6,7 @@ import type {
   ChatBlock,
   ChatMessage,
   ConversationSummary,
+  DirEntry,
   EditorContextRef,
   FileSearchHit,
   IndexStatusInfo,
@@ -333,6 +334,7 @@ export function reducer(state: ChatState, action: Action): ChatState {
 export function useChatState() {
   const [state, dispatch] = useReducer(reducer, initial)
   const fileSearchPending = useRef(new Map<number, (hits: FileSearchHit[]) => void>())
+  const listDirPending = useRef(new Map<number, (entries: DirEntry[]) => void>())
   const attachPending = useRef(
     new Map<number, (result: { attachments: Attachment[]; error?: string }) => void>(),
   )
@@ -345,6 +347,14 @@ export function useChatState() {
         if (resolver) {
           fileSearchPending.current.delete(msg.requestID)
           resolver(msg.hits)
+        }
+        return
+      }
+      if (msg.type === "listDirResult") {
+        const resolver = listDirPending.current.get(msg.requestID)
+        if (resolver) {
+          listDirPending.current.delete(msg.requestID)
+          resolver(msg.entries)
         }
         return
       }
@@ -377,6 +387,16 @@ export function useChatState() {
         vscode.post({ type: "fileSearch", requestID, query })
         setTimeout(() => {
           if (fileSearchPending.current.delete(requestID)) resolve([])
+        }, 5000)
+      })
+    },
+    listDir(path: string): Promise<DirEntry[]> {
+      const requestID = nextRequestID.current++
+      return new Promise<DirEntry[]>((resolve) => {
+        listDirPending.current.set(requestID, resolve)
+        vscode.post({ type: "listDir", requestID, path })
+        setTimeout(() => {
+          if (listDirPending.current.delete(requestID)) resolve([])
         }, 5000)
       })
     },

--- a/webview/src/hooks/useFileBrowser.ts
+++ b/webview/src/hooks/useFileBrowser.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useState } from "react"
+import type { DirEntry } from "../protocol"
+
+/** Parent of a workspace-relative folder path. "" (root) has no parent. */
+export function parentDir(dir: string): string {
+  const i = dir.lastIndexOf("/")
+  return i === -1 ? "" : dir.slice(0, i)
+}
+
+/**
+ * Owns the drill-down state for the @-picker's folder browser: the current
+ * folder, its immediate children (fetched via `listDir`), and the active row.
+ * Folders are navigation-only — `drillInto` follows a folder, files are left
+ * to the caller's `insertMention`. When the browser deactivates (the user
+ * typed a query, switched category, or closed the picker) it resets to the
+ * workspace root so reopening always starts fresh.
+ */
+export function useFileBrowser(opts: {
+  listDir?: (path: string) => Promise<DirEntry[]>
+  active: boolean
+}) {
+  const { listDir, active } = opts
+  const [dir, setDir] = useState("")
+  const [entries, setEntries] = useState<DirEntry[]>([])
+  const [index, setIndex] = useState(0)
+  const dirRef = useRef(dir)
+  dirRef.current = dir
+
+  useEffect(() => {
+    if (!active) {
+      setDir("")
+      setEntries([])
+      setIndex(0)
+    }
+  }, [active])
+
+  useEffect(() => {
+    if (!active || !listDir) return
+    let cancelled = false
+    void listDir(dir).then((result) => {
+      // Drop stale results — the user may have drilled again while we awaited.
+      if (cancelled || dirRef.current !== dir) return
+      setEntries(result)
+      setIndex(0)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [active, dir, listDir])
+
+  return {
+    dir,
+    entries,
+    index,
+    setIndex,
+    canGoUp: dir !== "",
+    drillInto: (entry: DirEntry) => {
+      if (entry.kind === "folder") setDir(entry.path)
+    },
+    goUp: () => setDir((d) => parentDir(d)),
+  }
+}

--- a/webview/src/protocol.ts
+++ b/webview/src/protocol.ts
@@ -181,6 +181,13 @@ export type WorkspaceInfo = {
 export type FileSearchHit = { path: string; name: string }
 
 /**
+ * One immediate child of a folder, used by the @-picker's drill-down browser.
+ * `path` is workspace-relative; folders are navigation-only (never inserted as
+ * a mention), files are the selectable leaves.
+ */
+export type DirEntry = { name: string; path: string; kind: "file" | "folder" }
+
+/**
  * Status snapshot of the optional semantic index — Phase 6 of the
  * workspace-context plan. `disabled` is the default; flipping
  * `opencui.indexing.semantic.enabled` true plus configuring a real
@@ -388,6 +395,7 @@ export type Outbound =
   | { type: "indexStatus"; status: IndexStatusInfo }
   | { type: "agentsStatus"; status: AgentsStatusInfo }
   | { type: "fileSearchResult"; requestID: number; hits: FileSearchHit[] }
+  | { type: "listDirResult"; requestID: number; entries: DirEntry[] }
   | { type: "attachmentResult"; requestID: number; attachments: Attachment[]; error?: string }
   | { type: "clear" }
 
@@ -410,6 +418,7 @@ export type Inbound =
   | { type: "selectModel" }
   | { type: "selectVariant" }
   | { type: "fileSearch"; requestID: number; query: string }
+  | { type: "listDir"; requestID: number; path: string }
   | { type: "attachFile"; requestID: number }
   | { type: "permissionReply"; id: string; response: "once" | "always" | "reject" }
   | { type: "questionReply"; id: string; answers: string[][] }

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -2561,17 +2561,16 @@ button {
    the current folder's entries. Folders (trailing chevron) drill in; files are
    the selectable leaves. Reuses .mention-popover for positioning + chrome. */
 .mention-browser {
-  display: flex;
-  flex-direction: column;
+  /* Scroll the popover itself (overflow-y: auto comes from .mention-popover)
+     rather than a nested flex child. A single block scroller gets the same
+     overlay scrollbar as the flat file list, instead of a nested flex scroller
+     which reserves a classic gutter and insets the rows. */
   padding: 0;
-  overflow: hidden;
 }
 .mention-browser > ul {
   margin: 0;
   padding: 4px 0;
   list-style: none;
-  overflow-y: auto;
-  min-height: 0;
 }
 .mention-browser .mention-hit {
   align-items: center;
@@ -2589,7 +2588,12 @@ button {
   white-space: nowrap;
 }
 .mention-breadcrumb {
-  flex-shrink: 0;
+  /* Pinned at the top of the single scroller while entries scroll beneath it.
+     Opaque background so scrolling rows don't bleed through. */
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--vscode-quickInput-background, var(--vscode-editorWidget-background));
   border-bottom: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
 }
 .mention-breadcrumb-up {

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -2494,6 +2494,41 @@ button {
   border-radius: var(--radius);
   box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
   z-index: var(--z-popover);
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+  transition: scrollbar-color 0.18s ease;
+}
+.mention-popover:hover,
+.mention-popover:focus-within {
+  scrollbar-color: var(--vscode-scrollbarSlider-background, var(--color-scrollbar-thumb)) transparent;
+}
+.mention-popover::-webkit-scrollbar {
+  width: 8px;
+  background: transparent;
+}
+.mention-popover::-webkit-scrollbar-track {
+  background: transparent;
+}
+.mention-popover::-webkit-scrollbar-thumb {
+  background: transparent;
+  border: 2px solid transparent;
+  border-radius: 5px;
+  background-clip: padding-box;
+  transition: background-color 0.18s ease;
+}
+.mention-popover:hover::-webkit-scrollbar-thumb,
+.mention-popover:focus-within::-webkit-scrollbar-thumb,
+.mention-popover:active::-webkit-scrollbar-thumb {
+  background-color: var(--vscode-scrollbarSlider-background, var(--color-scrollbar-thumb));
+}
+.mention-popover::-webkit-scrollbar-thumb:hover {
+  background-color: var(--vscode-scrollbarSlider-hoverBackground, rgba(100, 100, 100, 0.7));
+}
+.mention-popover::-webkit-scrollbar-thumb:active {
+  background-color: var(--vscode-scrollbarSlider-activeBackground, rgba(80, 80, 80, 0.8));
+}
+.mention-popover::-webkit-scrollbar-corner {
+  background: transparent;
 }
 /* In edit-in-place mode the message bubble is stuck at the top of the scroll
    container, so a picker drawn above the textarea gets clipped by the status

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -2557,6 +2557,75 @@ button {
   font-style: italic;
 }
 
+/* @-picker drill-down browser: a breadcrumb pinned above a scrolling list of
+   the current folder's entries. Folders (trailing chevron) drill in; files are
+   the selectable leaves. Reuses .mention-popover for positioning + chrome. */
+.mention-browser {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+}
+.mention-browser > ul {
+  margin: 0;
+  padding: 4px 0;
+  list-style: none;
+  overflow-y: auto;
+  min-height: 0;
+}
+.mention-browser .mention-hit {
+  align-items: center;
+}
+.mention-browser .mention-hit:not(.mention-folder) {
+  /* Indent files so their names line up under folder names, which are pushed
+     right by the folder icon + gap. */
+  padding-left: 32px;
+}
+.mention-folder .mention-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mention-breadcrumb {
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
+}
+.mention-breadcrumb-up {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 5px 10px;
+  background: transparent;
+  border: 0;
+  color: var(--vscode-descriptionForeground);
+  font-size: 11px;
+  text-align: left;
+  cursor: pointer;
+}
+.mention-breadcrumb-up:hover:not(:disabled) {
+  background: var(--hover-bg-row);
+}
+.mention-breadcrumb-up:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+.mention-breadcrumb-chevron {
+  display: inline-flex;
+  /* ChevronIcon points right; rotate to point left so it reads as back/up. */
+  transform: rotate(180deg);
+  opacity: 0.6;
+  flex-shrink: 0;
+}
+.mention-breadcrumb-path {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
 /* ===== Buttons ===== */
 .btn {
   background: var(--vscode-button-secondaryBackground);


### PR DESCRIPTION
## Summary

Closes #236.

Adds a **drill-down folder browser** to the `@`-picker so you can see and navigate the project structure, while keeping selection **files-only** — which removes the "open vs select a folder" ambiguity entirely.

After typing `@` and choosing **Files**:

- **Folders** are navigation-only — `Enter` / `→` / click drills in; they are **never** inserted as a mention.
- **Files** are the only selectable leaf — `Enter` / click inserts the `@path` chip (unchanged).
- A **breadcrumb** shows the current location; `←` or the breadcrumb button goes up a level.
- **Typing a query** falls back to the existing flat fuzzy search across the whole repo; clearing it returns to browsing.
- If the host doesn't provide directory listing, the picker **falls back** to the flat search (graceful degradation).
- The category label "Files & Folders" is now "Files".

## How it's built

Reuses the existing `fileSearch` request/response shape:

- **Protocol** (`protocol.ts`): `DirEntry = { name, path, kind: "file" | "folder" }`, plus `listDir` (inbound) / `listDirResult` (outbound).
- **Host** (`file-search.ts`): `listWorkspaceDir(dir)` derives a folder's immediate children from the **same cached file index** the search uses (so the ignore-globs and 30s cache come for free). The derivation is a pure `dirEntriesFrom(files, dir)` — folders first (alphabetical), then files. Wired via a `listDir` case in `view.ts`.
- **Webview**: `listDir` request/response in `useChatState` (mirrors `searchFiles`), threaded through `App` + `MessageView`. A new `useFileBrowser` hook owns the drill state (current dir, entries, active row, `drillInto`/`goUp`). `PromptBox` renders the breadcrumb + folder/file rows and routes the browse keys.

Folders that contain only ignored files (e.g. under `node_modules`) never appear — there'd be nothing to drill into.

## Test plan

- [x] `bun run test` — **809 passed** (47 files); +13 new (6 host `dirEntriesFrom`, 7 webview browser-flow including drill-in, file-insert, folder-never-inserted, go-up, typing-switches-to-search, and the no-`listDir` fallback).
- [x] `bun run check-types` (host) and `bunx tsc --noEmit` (webview) — both clean.
- [x] `bun run package` — production build succeeds.
- [ ] Manual check in VS Code: `@` → Files → browse, drill with click/→, breadcrumb up, insert a file, type to search.

> Independent of the other open PRs (#233, #235) — separate areas of the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)