### PR TITLE
feat(chat): show context-window usage in the composer

### DIFF
--- a/src/chat/stream.ts
+++ b/src/chat/stream.ts
@@ -50,8 +50,10 @@ export type Toast = {
 
 export type MessageUsage = {
   model?: string
+  providerID?: string
+  modelID?: string
   cost?: number
-  tokens?: { input: number; output: number; reasoning: number }
+  tokens?: { input: number; output: number; reasoning: number; cacheRead?: number; cacheWrite?: number }
 }
 
 export type StreamHandlers = {
@@ -774,12 +776,16 @@ function extractUsage(info: any): MessageUsage | undefined {
   if (!model && info.cost === undefined && !info.tokens) return undefined
   return {
     model,
+    providerID: typeof info.providerID === "string" ? info.providerID : undefined,
+    modelID: typeof info.modelID === "string" ? info.modelID : undefined,
     cost: typeof info.cost === "number" ? info.cost : undefined,
     tokens: info.tokens
       ? {
           input: info.tokens.input ?? 0,
           output: info.tokens.output ?? 0,
           reasoning: info.tokens.reasoning ?? 0,
+          cacheRead: info.tokens.cache?.read ?? 0,
+          cacheWrite: info.tokens.cache?.write ?? 0,
         }
       : undefined,
   }

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -20,6 +20,7 @@ import type {
   Attachment,
   ChatBlock,
   ChatMessage,
+  ContextUsage,
   Inbound,
   Outbound,
   ToolUpdate as WireToolUpdate,
@@ -112,6 +113,7 @@ export class ChatView implements vscode.WebviewViewProvider {
   /** Webview ID of the user message currently awaiting a backend ID from the stream. */
   private pendingUserBackendID?: string
   private reviewHunks: Record<string, ReviewHunkState> = {}
+  private contextUsageRequest = 0
   /**
    * True between user-pressed Stop and the subsequent `session.idle` event.
    * While true, drop incoming SSE message/tool deltas — opencode keeps draining
@@ -230,6 +232,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.reviewHunks = {}
     await this.manager.persist()
     this.sendConversationState()
+    this.post({ type: "contextUsage", usage: undefined })
     if (this.taskStore) this.postAgentsStatus(this.taskStore.list())
   }
 
@@ -308,6 +311,7 @@ export class ChatView implements vscode.WebviewViewProvider {
    * resets the subscription + in-flight per-turn state.
    */
   private resetSessionState() {
+    this.contextUsageRequest++
     this.resetSessionTracking()
     this.subscription?.abort()
     this.subscription = undefined
@@ -325,6 +329,8 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.applyActiveSnapshot()
     await this.manager.persist()
     this.sendConversationState()
+    this.post({ type: "contextUsage", usage: undefined })
+    if (this.sessionID) void this.refreshContextUsage()
     if (this.taskStore) this.postAgentsStatus(this.taskStore.list())
   }
 
@@ -349,6 +355,8 @@ export class ChatView implements vscode.WebviewViewProvider {
       this.applyActiveSnapshot()
       await this.manager.persist()
       this.sendConversationState()
+      this.post({ type: "contextUsage", usage: undefined })
+      if (this.sessionID) void this.refreshContextUsage()
       return
     }
     await this.manager.persist()
@@ -530,6 +538,23 @@ export class ChatView implements vscode.WebviewViewProvider {
     }
   }
 
+  private async refreshContextUsage(backend?: Backend) {
+    const sessionID = this.sessionID
+    if (!sessionID) {
+      this.post({ type: "contextUsage", usage: undefined })
+      return
+    }
+    const request = ++this.contextUsageRequest
+    try {
+      const activeBackend = backend ?? await this.servers.ensure()
+      const usage = await readContextUsage(activeBackend, sessionID)
+      if (request !== this.contextUsageRequest || this.sessionID !== sessionID) return
+      this.post({ type: "contextUsage", usage })
+    } catch (e) {
+      log("context usage refresh failed", e)
+    }
+  }
+
   private async onMessage(msg: Inbound) {
     switch (msg.type) {
       case "mounted": {
@@ -549,8 +574,9 @@ export class ChatView implements vscode.WebviewViewProvider {
         this.post({ type: "indexStatus", status: this.indexManager.currentStatus() })
         if (this.taskStore) this.postAgentsStatus(this.taskStore.list())
         try {
-          await this.servers.ensure()
+          const backend = await this.servers.ensure()
           this.post({ type: "connected", connected: true })
+          if (this.sessionID) void this.refreshContextUsage(backend)
         } catch (e) {
           this.post({ type: "connected", connected: false, error: (e as Error).message })
         }
@@ -1118,6 +1144,7 @@ export class ChatView implements vscode.WebviewViewProvider {
           void this.subagentDispatch.recordMainTaskFinish(classified.status, classified.error)
         }
         this.post({ type: "assistantDone", id: webviewID, usage: payload.usage })
+        void this.refreshContextUsage(backend)
       },
       onTextDelta: (mid, delta) => {
         if (this.aborting) return
@@ -1177,6 +1204,7 @@ export class ChatView implements vscode.WebviewViewProvider {
         if (!webviewID) return
         this.messageMap.delete(backendID)
         this.post({ type: "messageRemoved", id: webviewID })
+        void this.refreshContextUsage(backend)
       },
       onToast: (toast) => this.surfaceToast(toast),
       onSessionError: (message) => {
@@ -1565,6 +1593,93 @@ export function taskTitleFromUpdate(update: ToolUpdate): string {
   }
   if (update.title && update.title.trim()) return update.title.trim()
   return "Background agent"
+}
+
+type ContextUsageMessageInfo = {
+  role?: string
+  providerID?: string
+  modelID?: string
+  cost?: number
+  tokens?: {
+    input?: number
+    output?: number
+    reasoning?: number
+    cache?: { read?: number; write?: number }
+  }
+}
+
+type ContextUsageMessage = { info?: ContextUsageMessageInfo }
+type ContextUsageProvider = {
+  id?: string
+  models?: Record<string, { limit?: { context?: number } } | undefined>
+}
+
+async function readContextUsage(backend: Backend, sessionID: string): Promise<ContextUsage | undefined> {
+  const [messagesRes, providersRes] = await Promise.all([
+    backend.client.session.messages({
+      path: { id: sessionID },
+      query: { directory: backend.directory, limit: 100 },
+    }),
+    backend.client.config.providers(),
+  ])
+  if (messagesRes.error) throw new Error(`session.messages failed: ${JSON.stringify(messagesRes.error)}`)
+  if (providersRes.error) throw new Error(`config.providers failed: ${JSON.stringify(providersRes.error)}`)
+
+  const messages = (messagesRes.data ?? []) as ContextUsageMessage[]
+  const providers = ((providersRes.data as { providers?: ContextUsageProvider[] } | undefined)?.providers ?? [])
+  return contextUsageFromMessages(messages, providers)
+}
+
+export function contextUsageFromMessages(
+  messages: ContextUsageMessage[],
+  providers: ContextUsageProvider[],
+): ContextUsage | undefined {
+  const last = messages.findLast((item) =>
+    item.info?.role === "assistant" && numberOrZero(item.info.tokens?.output) > 0
+  )
+  if (!last?.info?.tokens) return undefined
+
+  const tokens = contextTokenCount(last.info.tokens)
+  if (tokens <= 0) return undefined
+
+  const providerID = last.info.providerID
+  const modelID = last.info.modelID
+  const limit = findContextLimit(providers, providerID, modelID)
+  const cost = messages.reduce((sum, item) => {
+    const info = item.info
+    return info?.role === "assistant" && typeof info.cost === "number" ? sum + info.cost : sum
+  }, 0)
+  return {
+    tokens,
+    limit,
+    percent: limit ? Math.round((tokens / limit) * 100) : undefined,
+    model: providerID && modelID ? `${providerID}/${modelID}` : undefined,
+    cost: cost > 0 ? cost : undefined,
+  }
+}
+
+function contextTokenCount(tokens: NonNullable<ContextUsageMessageInfo["tokens"]>): number {
+  return (
+    numberOrZero(tokens.input) +
+    numberOrZero(tokens.output) +
+    numberOrZero(tokens.reasoning) +
+    numberOrZero(tokens.cache?.read) +
+    numberOrZero(tokens.cache?.write)
+  )
+}
+
+function findContextLimit(
+  providers: ContextUsageProvider[],
+  providerID: string | undefined,
+  modelID: string | undefined,
+): number | undefined {
+  if (!providerID || !modelID) return undefined
+  const value = providers.find((provider) => provider.id === providerID)?.models?.[modelID]?.limit?.context
+  return typeof value === "number" && value > 0 ? value : undefined
+}
+
+function numberOrZero(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0
 }
 
 function collectSymbolFocus(activeRel: string | undefined, mentions: string[] | undefined): string[] {

--- a/test/host/context-usage.test.ts
+++ b/test/host/context-usage.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+import { contextUsageFromMessages } from "../../src/chat/view"
+
+describe("contextUsageFromMessages", () => {
+  it("matches opencode's context calculation from the latest assistant token usage", () => {
+    const usage = contextUsageFromMessages(
+      [
+        {
+          info: {
+            role: "assistant",
+            providerID: "openai",
+            modelID: "gpt-5",
+            cost: 0.01,
+            tokens: { input: 1_000, output: 500, reasoning: 200, cache: { read: 100, write: 50 } },
+          },
+        },
+        {
+          info: {
+            role: "assistant",
+            providerID: "openai",
+            modelID: "gpt-5",
+            cost: 0.02,
+            tokens: { input: 10_000, output: 2_000, reasoning: 1_000, cache: { read: 500, write: 500 } },
+          },
+        },
+      ],
+      [
+        {
+          id: "openai",
+          models: {
+            "gpt-5": { limit: { context: 200_000 } },
+          },
+        },
+      ],
+    )
+
+    expect(usage).toMatchObject({
+      tokens: 14_000,
+      limit: 200_000,
+      percent: 7,
+      model: "openai/gpt-5",
+    })
+    expect(usage?.cost).toBeCloseTo(0.03)
+  })
+
+  it("returns undefined until an assistant message has output tokens", () => {
+    expect(
+      contextUsageFromMessages(
+        [{ info: { role: "assistant", tokens: { input: 100, output: 0 } } }],
+        [],
+      ),
+    ).toBeUndefined()
+  })
+})

--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -42,6 +42,34 @@ describe("PromptBox", () => {
     expect((screen.getByRole("button", { name: /^Send$/ }) as HTMLButtonElement).disabled).toBe(true)
   })
 
+  it("renders context usage in the bottom-left composer control", () => {
+    render(
+      <PromptBox
+        busy={false}
+        onSend={vi.fn()}
+        onAbort={vi.fn()}
+        contextUsage={{ tokens: 50_000, limit: 200_000, percent: 25, model: "openai/gpt-5" }}
+      />,
+    )
+    expect(screen.getByRole("status", { name: /context 25% used/i })).toBeInTheDocument()
+    const indicator = screen.getByTitle(/Context: 50K \/ 200K tokens · 25% · openai\/gpt-5/)
+    expect(indicator).toHaveAttribute("data-tooltip", "50K / 200K tokens · 25%")
+  })
+
+  it("keeps context usage out of edit composers", () => {
+    render(
+      <PromptBox
+        busy={false}
+        onSend={vi.fn()}
+        onAbort={vi.fn()}
+        variant="edit"
+        initial={{ text: "hi" }}
+        contextUsage={{ tokens: 50_000, limit: 200_000, percent: 25 }}
+      />,
+    )
+    expect(screen.queryByRole("status", { name: /context/i })).not.toBeInTheDocument()
+  })
+
   it("Send button enables once user types", async () => {
     const user = userEvent.setup()
     render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} />)

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -224,6 +224,7 @@ export default function App() {
           conversations={state.conversations}
           activeConversationID={state.conversationID}
           onOpenConversation={openConversation}
+          contextUsage={state.contextUsage}
         />
       )}
       <div
@@ -336,6 +337,7 @@ export default function App() {
             conversations={state.conversations}
             activeConversationID={state.conversationID}
             onOpenConversation={openConversation}
+            contextUsage={state.contextUsage}
           />
         </div>
       )}

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState, type ReactNode } from "react"
-import type { Attachment, ConversationSummary, DirEntry, FileSearchHit } from "../protocol"
+import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react"
+import type { Attachment, ContextUsage, ConversationSummary, DirEntry, FileSearchHit } from "../protocol"
 import {
   extractMentions,
   findChipAtCaret,
@@ -65,6 +65,7 @@ type Props = {
   conversations?: ConversationSummary[]
   activeConversationID?: string
   onOpenConversation?: (id: string) => void
+  contextUsage?: ContextUsage
 }
 
 function buildInitialAttachments(initial: Props["initial"]): Map<string, Attachment> {
@@ -111,7 +112,7 @@ function extractConversationLabels(text: string | undefined): string[] {
   return Array.from(text.matchAll(/@chat:\S+/g), (match) => match[0].slice(1))
 }
 
-export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles, listDir, attachFile, initial, variant = "send", position = "bottom", conversations, activeConversationID, onOpenConversation }: Props) {
+export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles, listDir, attachFile, initial, variant = "send", position = "bottom", conversations, activeConversationID, onOpenConversation, contextUsage }: Props) {
   const { text, setText, ref, backdropRef, pendingCursor } = usePromptText(initial?.text ?? "")
   const [selectedChipStart, setSelectedChipStart] = useState<number | undefined>(undefined)
   const [attachError, setAttachError] = useState<string | undefined>(undefined)
@@ -690,6 +691,9 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
         )}
         </div>
         <div className="promptbox-row">
+          {variant === "send" && position === "bottom" && (
+            <ContextUsageIndicator usage={contextUsage} />
+          )}
           <div className="spacer" />
           {attachFile && (
             <button
@@ -755,6 +759,61 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
       </div>
     </div>
   )
+}
+
+function ContextUsageIndicator({ usage }: { usage?: ContextUsage }) {
+  const percent = usage?.percent ?? (usage?.limit ? Math.round((usage.tokens / usage.limit) * 100) : undefined)
+  const value = clampPercent(percent ?? 0)
+  const tooltip = usage
+    ? [
+        `${formatTokenCount(usage.tokens)}${usage.limit ? ` / ${formatTokenCount(usage.limit)}` : ""} tokens`,
+        percent !== undefined ? `${value}%` : undefined,
+      ].filter(Boolean).join(" · ")
+    : "Context usage unavailable"
+  const title = usage
+    ? [
+        `Context: ${tooltip}`,
+        usage.model,
+        typeof usage.cost === "number" && usage.cost > 0 ? `$${usage.cost.toFixed(4)} spent` : undefined,
+      ].filter(Boolean).join(" · ")
+    : "Context usage appears after the first response"
+  const className = [
+    "context-usage",
+    usage ? "is-ready" : "is-empty",
+    value >= 95 ? "danger" : value >= 85 ? "warn" : "",
+  ].filter(Boolean).join(" ")
+  const style = { "--context-usage-deg": `${value * 3.6}deg` } as CSSProperties
+
+  return (
+    <span
+      className={className}
+      role="status"
+      aria-label={usage ? `Context ${value}% used` : "Context usage unavailable"}
+      title={title}
+      data-tooltip={tooltip}
+      style={style}
+    >
+      <span className="context-usage-ring" aria-hidden="true" />
+    </span>
+  )
+}
+
+function clampPercent(value: number): number {
+  if (!Number.isFinite(value)) return 0
+  return Math.max(0, Math.min(100, Math.round(value)))
+}
+
+function formatTokenCount(value: number): string {
+  if (!Number.isFinite(value)) return "0"
+  if (value >= 1_000_000) {
+    const millions = value / 1_000_000
+    return `${millions >= 10 ? Math.round(millions) : Number(millions.toFixed(1))}M`
+  }
+  if (value >= 1_000) {
+    const thousands = value / 1_000
+    return `${thousands >= 10 ? Math.round(thousands) : Number(thousands.toFixed(1))}K`
+  }
+  return Math.max(0, Math.round(value)).toLocaleString()
 }
 
 function SendIcon() {

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -5,6 +5,7 @@ import type {
   Attachment,
   ChatBlock,
   ChatMessage,
+  ContextUsage,
   ConversationSummary,
   DirEntry,
   EditorContextRef,
@@ -44,6 +45,7 @@ export type ChatState = {
   selection: Selection
   conversations: ConversationSummary[]
   conversationID?: string
+  contextUsage?: ContextUsage
   context?: EditorContextRef
   messages: Message[]
   reviewHunks: Record<string, ReviewHunkState>
@@ -142,12 +144,15 @@ export function reducer(state: ChatState, action: Action): ChatState {
       return { ...state, connected: action.connected, error: action.error }
     case "selection":
       return { ...state, selection: action.selection }
+    case "contextUsage":
+      return { ...state, contextUsage: action.usage }
     case "conversations":
       return { ...state, conversations: action.conversations, conversationID: action.activeID }
     case "restore":
       return {
         ...state,
         busy: false,
+        contextUsage: undefined,
         conversationID: action.conversationID,
         messages: action.messages,
         reviewHunks: action.reviewHunks ?? {},

--- a/webview/src/protocol.ts
+++ b/webview/src/protocol.ts
@@ -133,12 +133,24 @@ export type Todo = {
 
 export type UsageDelta = {
   model?: string
+  providerID?: string
+  modelID?: string
   cost?: number
   tokens?: {
     input: number
     output: number
     reasoning: number
+    cacheRead?: number
+    cacheWrite?: number
   }
+}
+
+export type ContextUsage = {
+  tokens: number
+  percent?: number
+  limit?: number
+  model?: string
+  cost?: number
 }
 
 export type Selection = {
@@ -355,6 +367,7 @@ export type Outbound =
   | { type: "ready"; connected: boolean; selection: Selection }
   | { type: "connected"; connected: boolean; error?: string }
   | { type: "selection"; selection: Selection }
+  | { type: "contextUsage"; usage?: ContextUsage }
   | { type: "conversations"; conversations: ConversationSummary[]; activeID?: string }
   | { type: "restore"; conversationID: string; messages: ChatMessage[]; reviewHunks?: Record<string, ReviewHunkState> }
   | { type: "context"; ref: EditorContextRef }

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -2200,6 +2200,80 @@ button {
 }
 .promptbox-row .spacer { flex: 1; }
 
+.context-usage {
+  --context-usage-color: var(--vscode-progressBar-background, var(--vscode-focusBorder));
+  --context-usage-track: var(--vscode-editorWidget-border, rgba(128, 128, 128, 0.35));
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  flex: 0 0 auto;
+  color: var(--vscode-descriptionForeground);
+}
+
+.context-usage::before {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 0;
+  bottom: calc(100% + 8px);
+  z-index: var(--z-popover);
+  max-width: 260px;
+  padding: 4px 7px;
+  border: 1px solid var(--vscode-editorWidget-border, var(--color-border));
+  border-radius: var(--radius-sm);
+  background: var(--vscode-editorWidget-background, var(--vscode-sideBar-background));
+  color: var(--vscode-editorWidget-foreground, var(--vscode-foreground));
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28);
+  font-size: 11px;
+  line-height: 1.25;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(2px);
+  transition: opacity 0.12s ease, transform 0.12s ease;
+}
+
+.context-usage:hover::before,
+.context-usage:focus-visible::before {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.context-usage-ring {
+  position: relative;
+  display: block;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: conic-gradient(
+    var(--context-usage-color) var(--context-usage-deg, 0deg),
+    var(--context-usage-track) 0deg
+  );
+}
+
+.context-usage-ring::after {
+  content: "";
+  position: absolute;
+  inset: 3px;
+  border-radius: 50%;
+  background: var(--color-bg-input);
+}
+
+.context-usage.is-empty .context-usage-ring {
+  background: conic-gradient(var(--context-usage-track) 0deg, var(--context-usage-track) 360deg);
+  opacity: 0.75;
+}
+
+.context-usage.warn {
+  --context-usage-color: var(--vscode-editorWarning-foreground, #cca700);
+}
+
+.context-usage.danger {
+  --context-usage-color: var(--vscode-editorError-foreground, #f14c4c);
+}
+
 .bottom-composer {
   position: absolute;
   left: 0;


### PR DESCRIPTION
Closes #242

## Summary

Adds a compact **context-window usage indicator** to the bottom chat composer so you can see how full the model's context window is as a conversation grows.

- **Ring indicator** (conic-gradient) that fills with usage; turns amber at ≥85% and red at ≥95%.
- **Hover tooltip** with precise tokens / limit, percent, model id, and cumulative cost.
- Shown only in the primary bottom composer (`variant="send"`, `position="bottom"`) — never in edit boxes — and only once there's real usage.

### How it works

- **Host** (`src/chat/view.ts`): new pure, exported `contextUsageFromMessages(messages, providers)` computes usage from the latest assistant message's token counts (`input + output + reasoning + cache.read + cache.write`) and the model's `limit.context` from `config.providers` — mirroring opencode's own context accounting. `refreshContextUsage()` posts a new `contextUsage` protocol message after an assistant turn finishes, after a message is removed/reverted, and on connect/select/create; usage is cleared on new conversation. A `contextUsageRequest` counter guards against a stale async refresh overwriting a newer one.
- **Protocol** (`webview/src/protocol.ts`): new `ContextUsage` type + `contextUsage` Outbound variant; `UsageDelta`/`MessageUsage` extended with `providerID`/`modelID` and cache token fields.
- **Stream** (`src/chat/stream.ts`): `extractUsage` now carries `providerID`/`modelID` and cache read/write tokens.
- **Webview** (`useChatState.ts`, `App.tsx`, `PromptBox.tsx`, `styles.css`): `contextUsage` in reducer state (cleared on `restore`), threaded to both composers; `ContextUsageIndicator` renders the ring + tooltip.

## Test plan

- [x] `bun run test` — 826 pass (49 files); includes new `contextUsageFromMessages` host tests (token sum, provider-limit %, cumulative cost; undefined until first output tokens) and PromptBox webview tests (renders in bottom send composer; absent in edit composer).
- [x] `bun run check-types` (host) — clean.
- [x] `cd webview && bunx tsc --noEmit` (webview) — clean.
- [ ] Visual: confirm in the VS Code panel that the ring fills after a turn, tooltip shows tokens/limit/model/cost, and amber/red thresholds trigger near the limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)