### PR TITLE
chore(chat): tighten context-usage tooltip copy

### DIFF
--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -52,8 +52,8 @@ describe("PromptBox", () => {
       />,
     )
     expect(screen.getByRole("status", { name: /context 25% used/i })).toBeInTheDocument()
-    const indicator = screen.getByTitle(/Context: 50K \/ 200K tokens · 25% · openai\/gpt-5/)
-    expect(indicator).toHaveAttribute("data-tooltip", "50K / 200K tokens · 25%")
+    const indicator = screen.getByTitle(/Context: 50K \/ 200K · 25% · openai\/gpt-5/)
+    expect(indicator).toHaveAttribute("data-tooltip", "50K / 200K · 25%")
   })
 
   it("keeps context usage out of edit composers", () => {

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -766,7 +766,7 @@ function ContextUsageIndicator({ usage }: { usage?: ContextUsage }) {
   const value = clampPercent(percent ?? 0)
   const tooltip = usage
     ? [
-        `${formatTokenCount(usage.tokens)}${usage.limit ? ` / ${formatTokenCount(usage.limit)}` : ""} tokens`,
+        `${formatTokenCount(usage.tokens)}${usage.limit ? ` / ${formatTokenCount(usage.limit)}` : ""}`,
         percent !== undefined ? `${value}%` : undefined,
       ].filter(Boolean).join(" · ")
     : "Context usage unavailable"


### PR DESCRIPTION
Closes #244

## Summary

Follow-up polish to the context-usage indicator (#243). Drops the redundant "tokens" word from the compact tooltip — the line now reads `50K / 200K · 25%`. The indicator's `aria-label` ("Context N% used") and full `title` ("Context: …") already make clear the figures are token counts.

## Test plan

- [x] `bun run test` — 826 pass (49 files); the PromptBox tooltip assertion updated to the new copy.
- [x] `bun run check-types` (host) — clean.
- [x] `cd webview && bunx tsc --noEmit` (webview) — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)