### PR TITLE
chore(release): cut v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.10.1] - 2026-05-29
+
+### Added
+- Context-window usage indicator in the bottom composer. A small ring fills as the active model's context window fills — amber at 85%, red at 95% — and a hover tooltip shows the token count against the model's limit, the percentage, the model id, and the conversation's cumulative cost. Usage is computed host-side from the latest assistant message's token counts (input + output + reasoning + cache read/write) and the model's `limit.context` from the providers config, mirroring opencode's own context accounting. It refreshes after each assistant turn, after a message is removed or reverted, and on connect/select/create, and clears when a new conversation starts; the ring appears only in the primary bottom composer once there is real usage to show. A request-counter guards against a stale async refresh overwriting a newer one.
+
+Closes #242, #244.
+
 ## [0.10.0] - 2026-05-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
Closes #246

## Summary

Cuts **v0.10.1**, a patch release bundling the context-window usage indicator landed since v0.10.0.

- Bumps `package.json` 0.10.0 → 0.10.1.
- Adds the `## [0.10.1] - 2026-05-29` CHANGELOG entry.

### Included
- feat(chat): show context-window usage in the composer (#243, closes #242)
- chore(chat): tighten context-usage tooltip copy (#245, closes #244)

## Test plan

- [x] `bun run test` — 826 pass (49 files).
- [x] `bun run check-types` (host) — clean.
- [x] `cd webview && bunx tsc --noEmit` (webview) — clean.
- [x] `bun run package` (production build) — webview single-file + host bundle emitted.

Tag `v0.10.1` + GitHub Release follow after merge; the publish workflow handles Marketplace + Open VSX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)