### PR TITLE
feat(chat): run opencode slash-commands from the chat input

### DIFF
--- a/src/chat/builtin-commands.ts
+++ b/src/chat/builtin-commands.ts
@@ -1,0 +1,56 @@
+/**
+ * opencode's built-in commands (`/compact`, `/share`, …) are NOT returned by
+ * `command.list` — that endpoint only lists user-defined custom commands (the
+ * `.opencode/command/*.md` templates). The built-ins live in opencode's TUI
+ * layer and map to dedicated session endpoints. We surface a useful subset in
+ * the same `/` picker by merging these synthetic entries into the pushed
+ * command list and routing them host-side to their endpoints instead of
+ * `session.command`.
+ */
+import { randomBytes } from "node:crypto"
+import type { CommandInfo } from "../protocol"
+
+/**
+ * Built-ins shown in the `/` picker. All are argument-less, so the picker's
+ * smart-select runs them immediately. A custom command of the same name takes
+ * precedence (see withBuiltinCommands) and is dispatched through the normal
+ * `session.command` path instead.
+ */
+export const BUILTIN_COMMANDS: ReadonlyArray<CommandInfo> = [
+  { name: "compact", description: "Summarize and compact the session", takesArguments: false },
+  { name: "init", description: "Analyze the codebase and write AGENTS.md", takesArguments: false },
+  { name: "share", description: "Create a shareable link for this session", takesArguments: false },
+  { name: "unshare", description: "Disable sharing for this session", takesArguments: false },
+]
+
+export const BUILTIN_COMMAND_NAMES: ReadonlySet<string> = new Set(BUILTIN_COMMANDS.map((c) => c.name))
+
+/**
+ * Append the built-ins to the workspace's custom commands, skipping any whose
+ * name a custom command already claims (custom wins). Pure for testability.
+ */
+export function withBuiltinCommands(custom: CommandInfo[]): CommandInfo[] {
+  const claimed = new Set(custom.map((c) => c.name))
+  return [...custom, ...BUILTIN_COMMANDS.filter((b) => !claimed.has(b.name))]
+}
+
+const CROCKFORD = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+/**
+ * Generate a ULID-style, time-sortable message id for `session.init`, which
+ * requires a client-supplied `messageID`. opencode's own ids are ULID-like;
+ * a timestamp-prefixed Crockford-base32 string gives uniqueness and the
+ * lexicographic ordering opencode relies on.
+ */
+export function generateMessageID(): string {
+  let now = Date.now()
+  let time = ""
+  for (let i = 0; i < 10; i++) {
+    time = CROCKFORD[now % 32] + time
+    now = Math.floor(now / 32)
+  }
+  const rand = randomBytes(16)
+  let tail = ""
+  for (let i = 0; i < 16; i++) tail += CROCKFORD[rand[i]! % 32]
+  return "msg_" + time + tail
+}

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -30,6 +30,7 @@ import type {
   ReviewChangeActor,
   ReviewHunkState,
 } from "../protocol"
+import { BUILTIN_COMMAND_NAMES, withBuiltinCommands, generateMessageID } from "./builtin-commands"
 import { migrateConversationsToWorkspace } from "./conversation-store"
 import { ConversationManager } from "./conversation-manager"
 import { ContinuationState } from "./continuation-state"
@@ -115,6 +116,8 @@ export class ChatView implements vscode.WebviewViewProvider {
   private pendingUserBackendID?: string
   private reviewHunks: Record<string, ReviewHunkState> = {}
   private contextUsageRequest = 0
+  /** Names from the last `command.list` fetch — lets a custom command shadow a built-in. */
+  private customCommandNames = new Set<string>()
   /**
    * True between user-pressed Stop and the subsequent `session.idle` event.
    * While true, drop incoming SSE message/tool deltas — opencode keeps draining
@@ -573,13 +576,16 @@ export class ChatView implements vscode.WebviewViewProvider {
         log("command.list failed", res.error)
         return
       }
-      const commands: CommandInfo[] = res.data.map((c) => ({
+      const custom: CommandInfo[] = res.data.map((c) => ({
         name: c.name,
         description: c.description,
         agent: c.agent,
         takesArguments: /\$ARGUMENTS\b/.test(c.template),
       }))
-      this.post({ type: "commands", commands })
+      this.customCommandNames = new Set(custom.map((c) => c.name))
+      // Merge opencode's built-ins (/compact, /share, …); a custom command of
+      // the same name wins and is dispatched through session.command instead.
+      this.post({ type: "commands", commands: withBuiltinCommands(custom) })
     } catch (e) {
       log("command.list refresh failed", e)
     }
@@ -1113,6 +1119,12 @@ export class ChatView implements vscode.WebviewViewProvider {
    * substitutions) and runs the turn. The existing SSE subscription renders it.
    */
   private async handleRunCommand(command: string, args: string) {
+    // A built-in (/compact, /share, …) maps to a dedicated session endpoint,
+    // not session.command — unless a custom command of the same name shadows it.
+    if (!this.customCommandNames.has(command) && BUILTIN_COMMAND_NAMES.has(command)) {
+      await this.handleBuiltinCommand(command)
+      return
+    }
     const ctx = getEditorContext()
     const label = formatContextHeader(ctx)
     const userMessageID = "u_" + Date.now()
@@ -1177,6 +1189,145 @@ export class ChatView implements vscode.WebviewViewProvider {
       log("command call threw", e)
     }
     // No UI action here — the SSE subscription owns assistant lifecycle.
+  }
+
+  /**
+   * Dispatch an opencode built-in command to its dedicated session endpoint.
+   * `/compact` and `/init` run a server-side turn (rendered via the existing
+   * SSE subscription); `/share` and `/unshare` are one-shot actions surfaced
+   * through a VS Code notification.
+   */
+  private async handleBuiltinCommand(command: string) {
+    let backend: Backend
+    try {
+      backend = await this.servers.ensure()
+    } catch (e) {
+      this.post({ type: "connected", connected: false, error: (e as Error).message })
+      return
+    }
+    switch (command) {
+      case "compact":
+        return this.runCompact(backend)
+      case "init":
+        return this.runInit(backend)
+      case "share":
+        return this.runShare(backend)
+      case "unshare":
+        return this.runUnshare(backend)
+    }
+  }
+
+  /** Post the typed-invocation bubble and key the Agents popover for a built-in turn. */
+  private async beginBuiltinTurn(display: string) {
+    const ctx = getEditorContext()
+    const userMessageID = "u_" + Date.now()
+    this.pendingUserBackendID = userMessageID
+    this.post({
+      type: "userMessage",
+      id: userMessageID,
+      text: display,
+      ref: { path: ctx.filePath, label: formatContextHeader(ctx) },
+    })
+    this.updateTitleFromPrompt(display)
+    await this.subagentDispatch.recordMainTaskStart(display)
+  }
+
+  private async runCompact(backend: Backend) {
+    if (!this.sessionID) {
+      void vscode.window.showInformationMessage("Nothing to compact yet.")
+      return
+    }
+    if (!this.subscription) await this.attachSubscription(backend, this.sessionID)
+    await this.beginBuiltinTurn("/compact")
+    const sel = this.prefs.get()
+    const body = sel.modelProviderID && sel.modelID ? { providerID: sel.modelProviderID, modelID: sel.modelID } : undefined
+    try {
+      const res = await backend.client.session.summarize({
+        path: { id: this.sessionID },
+        query: { directory: backend.directory },
+        body,
+      })
+      if (res.error) log("compact failed", res.error)
+    } catch (e) {
+      log("compact threw", e)
+    }
+  }
+
+  private async runInit(backend: Backend) {
+    const sel = this.prefs.get()
+    if (!sel.modelProviderID || !sel.modelID) {
+      void vscode.window.showWarningMessage("Select a model before running /init.")
+      return
+    }
+    if (!this.sessionID) {
+      const created = await backend.client.session.create({ body: {} })
+      if (created.error || !created.data) {
+        log("session.create failed", created.error)
+        return
+      }
+      this.sessionID = created.data.id
+      this.manager.updateActive((conversation) => ({ ...conversation, sessionID: this.sessionID }))
+      void this.manager.persist()
+      await this.attachSubscription(backend, this.sessionID)
+    } else if (!this.subscription) {
+      await this.attachSubscription(backend, this.sessionID)
+    }
+    await this.beginBuiltinTurn("/init")
+    try {
+      const res = await backend.client.session.init({
+        path: { id: this.sessionID },
+        query: { directory: backend.directory },
+        body: { providerID: sel.modelProviderID, modelID: sel.modelID, messageID: generateMessageID() },
+      })
+      if (res.error) log("init failed", res.error)
+    } catch (e) {
+      log("init threw", e)
+    }
+  }
+
+  private async runShare(backend: Backend) {
+    if (!this.sessionID) {
+      void vscode.window.showInformationMessage("Start a conversation before sharing.")
+      return
+    }
+    try {
+      const res = await backend.client.session.share({
+        path: { id: this.sessionID },
+        query: { directory: backend.directory },
+      })
+      if (res.error || !res.data) {
+        log("share failed", res.error)
+        void vscode.window.showErrorMessage("Failed to share session.")
+        return
+      }
+      const url = res.data.share?.url
+      if (!url) {
+        void vscode.window.showInformationMessage("Session shared.")
+        return
+      }
+      const pick = await vscode.window.showInformationMessage(`Session shared: ${url}`, "Copy Link")
+      if (pick === "Copy Link") await vscode.env.clipboard.writeText(url)
+    } catch (e) {
+      log("share threw", e)
+    }
+  }
+
+  private async runUnshare(backend: Backend) {
+    if (!this.sessionID) return
+    try {
+      const res = await backend.client.session.unshare({
+        path: { id: this.sessionID },
+        query: { directory: backend.directory },
+      })
+      if (res.error) {
+        log("unshare failed", res.error)
+        void vscode.window.showErrorMessage("Failed to disable sharing.")
+        return
+      }
+      void vscode.window.showInformationMessage("Session sharing disabled.")
+    } catch (e) {
+      log("unshare threw", e)
+    }
   }
 
   private async handleEdit(webviewID: string, text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) {

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -20,6 +20,7 @@ import type {
   Attachment,
   ChatBlock,
   ChatMessage,
+  CommandInfo,
   ContextUsage,
   Inbound,
   Outbound,
@@ -555,6 +556,35 @@ export class ChatView implements vscode.WebviewViewProvider {
     }
   }
 
+  /**
+   * Fetch the workspace's opencode custom commands and push them to the webview
+   * for the `/` picker. Workspace/directory-scoped (not per-session), so there
+   * is no request-sequence guard — a redundant refresh just re-sends the same
+   * list. `takesArguments` (template contains `$ARGUMENTS`) drives the picker's
+   * smart run UX.
+   */
+  private async refreshCommands(backend?: Backend) {
+    try {
+      const activeBackend = backend ?? (await this.servers.ensure())
+      const res = await activeBackend.client.command.list({
+        query: { directory: activeBackend.directory },
+      })
+      if (res.error || !res.data) {
+        log("command.list failed", res.error)
+        return
+      }
+      const commands: CommandInfo[] = res.data.map((c) => ({
+        name: c.name,
+        description: c.description,
+        agent: c.agent,
+        takesArguments: /\$ARGUMENTS\b/.test(c.template),
+      }))
+      this.post({ type: "commands", commands })
+    } catch (e) {
+      log("command.list refresh failed", e)
+    }
+  }
+
   private async onMessage(msg: Inbound) {
     switch (msg.type) {
       case "mounted": {
@@ -576,6 +606,7 @@ export class ChatView implements vscode.WebviewViewProvider {
         try {
           const backend = await this.servers.ensure()
           this.post({ type: "connected", connected: true })
+          void this.refreshCommands(backend)
           if (this.sessionID) void this.refreshContextUsage(backend)
         } catch (e) {
           this.post({ type: "connected", connected: false, error: (e as Error).message })
@@ -584,6 +615,9 @@ export class ChatView implements vscode.WebviewViewProvider {
       }
       case "send":
         await this.handleSend(msg.text, msg.mentions, msg.attachments, msg.conversationMentions)
+        return
+      case "runCommand":
+        await this.handleRunCommand(msg.command, msg.arguments)
         return
       case "editMessage":
         await this.handleEdit(msg.id, msg.text, msg.mentions, msg.attachments, msg.conversationMentions)
@@ -1072,6 +1106,79 @@ export class ChatView implements vscode.WebviewViewProvider {
     // No UI action here — the SSE subscription owns assistant lifecycle.
   }
 
+  /**
+   * Run an opencode custom command. Unlike handleSend this skips the entire
+   * auto-context/manifest pipeline: `session.command` takes no `parts`, so the
+   * server expands the command's own template (including its `!shell` / `@file`
+   * substitutions) and runs the turn. The existing SSE subscription renders it.
+   */
+  private async handleRunCommand(command: string, args: string) {
+    const ctx = getEditorContext()
+    const label = formatContextHeader(ctx)
+    const userMessageID = "u_" + Date.now()
+    // Show the typed invocation, never the expanded template — the SSE
+    // onUserMessage only associates the backend id, it never rewrites the text.
+    const display = "/" + command + (args ? " " + args : "")
+    this.pendingUserBackendID = userMessageID
+    this.post({
+      type: "userMessage",
+      id: userMessageID,
+      text: display,
+      ref: { path: ctx.filePath, label },
+    })
+    this.updateTitleFromPrompt(display)
+
+    let backend: Backend
+    try {
+      backend = await this.servers.ensure()
+    } catch (e) {
+      this.post({ type: "connected", connected: false, error: (e as Error).message })
+      return
+    }
+
+    if (!this.sessionID) {
+      const created = await backend.client.session.create({ body: {} })
+      if (created.error || !created.data) {
+        log("session.create failed", created.error)
+        return
+      }
+      this.sessionID = created.data.id
+      this.manager.updateActive((conversation) => ({ ...conversation, sessionID: this.sessionID }))
+      void this.manager.persist()
+      log("created session", this.sessionID)
+      await this.attachSubscription(backend, this.sessionID)
+    } else if (!this.subscription) {
+      await this.attachSubscription(backend, this.sessionID)
+    }
+
+    // A command is a real main-agent turn (it can spawn subagents), so it must
+    // key the Agents popover identically to a prompt. Finish is handled by the
+    // shared SSE onAssistantEnd / onSessionIdle paths.
+    await this.subagentDispatch.recordMainTaskStart(display)
+
+    const sel = this.prefs.get()
+    // session.command's `model` is a single "providerID/modelID" string, unlike
+    // promptAsync's { providerID, modelID } object.
+    const model = sel.modelProviderID && sel.modelID ? `${sel.modelProviderID}/${sel.modelID}` : undefined
+    log("command dispatch", { sessionID: this.sessionID, command, agent: sel.agent ?? "default", model: model ?? "default" })
+    try {
+      const res = await backend.client.session.command({
+        path: { id: this.sessionID },
+        query: { directory: backend.directory },
+        body: {
+          command,
+          arguments: args,
+          ...(sel.agent ? { agent: sel.agent } : {}),
+          ...(model ? { model } : {}),
+        },
+      })
+      if (res.error) log("command failed", res.error)
+    } catch (e) {
+      log("command call threw", e)
+    }
+    // No UI action here — the SSE subscription owns assistant lifecycle.
+  }
+
   private async handleEdit(webviewID: string, text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) {
     const target = this.messages.find((m) => m.id === webviewID && m.role === "user")
     if (!target) {
@@ -1304,6 +1411,9 @@ export class ChatView implements vscode.WebviewViewProvider {
     } catch {
       // error already surfaced via handler
     }
+    // Refresh the command list on every (re)connect — picks up newly-added
+    // command files and survives an opencode server restart.
+    void this.refreshCommands(backend)
   }
 
   private ensureWebviewID(opencodeID: string): string {

--- a/test/host/builtin-commands.test.ts
+++ b/test/host/builtin-commands.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest"
+import {
+  BUILTIN_COMMANDS,
+  BUILTIN_COMMAND_NAMES,
+  withBuiltinCommands,
+  generateMessageID,
+} from "../../src/chat/builtin-commands"
+
+describe("withBuiltinCommands", () => {
+  it("appends every built-in to an empty custom list", () => {
+    const merged = withBuiltinCommands([])
+    expect(merged.map((c) => c.name)).toEqual(BUILTIN_COMMANDS.map((c) => c.name))
+    expect(merged.every((c) => c.takesArguments === false)).toBe(true)
+  })
+
+  it("keeps custom commands first, built-ins after", () => {
+    const merged = withBuiltinCommands([{ name: "deploy", takesArguments: true }])
+    expect(merged[0]!.name).toBe("deploy")
+    expect(merged).toHaveLength(1 + BUILTIN_COMMANDS.length)
+  })
+
+  it("lets a custom command shadow a built-in of the same name", () => {
+    const custom = [{ name: "compact", description: "my own", takesArguments: true }]
+    const merged = withBuiltinCommands(custom)
+    const compacts = merged.filter((c) => c.name === "compact")
+    expect(compacts).toHaveLength(1)
+    // The surviving entry is the custom one (takesArguments / description preserved).
+    expect(compacts[0]).toEqual({ name: "compact", description: "my own", takesArguments: true })
+    expect(merged).toHaveLength(custom.length + BUILTIN_COMMANDS.length - 1)
+  })
+
+  it("exposes the built-in names as a set for routing", () => {
+    expect(BUILTIN_COMMAND_NAMES.has("compact")).toBe(true)
+    expect(BUILTIN_COMMAND_NAMES.has("share")).toBe(true)
+    expect(BUILTIN_COMMAND_NAMES.has("nope")).toBe(false)
+  })
+})
+
+describe("generateMessageID", () => {
+  it("produces a prefixed, fixed-length, Crockford-base32 id", () => {
+    const id = generateMessageID()
+    expect(id).toMatch(/^msg_[0-9A-HJKMNP-TV-Z]{26}$/)
+  })
+
+  it("is unique across calls", () => {
+    const ids = new Set(Array.from({ length: 100 }, () => generateMessageID()))
+    expect(ids.size).toBe(100)
+  })
+})

--- a/test/host/e2e-mock-opencode.test.ts
+++ b/test/host/e2e-mock-opencode.test.ts
@@ -83,6 +83,33 @@ describe("E2E (mock opencode): SDK ↔ HTTP server", () => {
     expect(typeof body.model).toBe("string")
     expect(body.model).toBe("openai/gpt-5")
   })
+
+  it("session.summarize (the /compact endpoint) round-trips", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const res = await client.session.summarize({
+      path: { id: "ses_test" },
+      body: { providerID: "openai", modelID: "gpt-5" },
+    })
+    expect(res.error).toBeUndefined()
+    expect(res.data).toBe(true)
+  })
+
+  it("session.share (the /share endpoint) returns a share url", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const res = await client.session.share({ path: { id: "ses_test" } })
+    expect(res.error).toBeUndefined()
+    expect(res.data?.share?.url).toBe("https://opencode.ai/s/abc123")
+  })
+
+  it("session.init (the /init endpoint) accepts a client-supplied messageID", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const res = await client.session.init({
+      path: { id: "ses_test" },
+      body: { providerID: "openai", modelID: "gpt-5", messageID: "msg_0123456789ABCDEFGHJKMNPQRS" },
+    })
+    expect(res.error).toBeUndefined()
+    expect(res.data).toBe(true)
+  })
 })
 
 describe("E2E (mock opencode): subscribeSession streaming", () => {

--- a/test/host/e2e-mock-opencode.test.ts
+++ b/test/host/e2e-mock-opencode.test.ts
@@ -48,6 +48,41 @@ describe("E2E (mock opencode): SDK ↔ HTTP server", () => {
     expect(server.reverts).toHaveLength(1)
     expect((server.reverts[0]!.body as { messageID?: string })?.messageID).toBe("msg_abc")
   })
+
+  it("command.list returns the workspace's commands", async () => {
+    server.setCommands([
+      { name: "deploy", description: "Ship it", template: "Deploy $ARGUMENTS" },
+      { name: "compact", description: "Compact", template: "Summarize the session" },
+    ])
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const res = await client.command.list({ query: { directory: "/tmp" } })
+    expect(res.error).toBeUndefined()
+    expect(res.data?.map((c) => c.name)).toEqual(["deploy", "compact"])
+  })
+
+  it("session.command records the command body with a string model", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    await client.session.command({
+      path: { id: "ses_test" },
+      query: { directory: "/tmp" },
+      body: { command: "deploy", arguments: "prod", agent: "plan", model: "openai/gpt-5" },
+    })
+    expect(server.commandCalls).toHaveLength(1)
+    const body = server.commandCalls[0]!.body as {
+      command?: string
+      arguments?: string
+      agent?: string
+      model?: unknown
+    }
+    expect(server.commandCalls[0]!.sessionID).toBe("ses_test")
+    expect(body.command).toBe("deploy")
+    expect(body.arguments).toBe("prod")
+    expect(body.agent).toBe("plan")
+    // Guards the #1 trap: session.command's model is a STRING, not the
+    // { providerID, modelID } object that promptAsync takes.
+    expect(typeof body.model).toBe("string")
+    expect(body.model).toBe("openai/gpt-5")
+  })
 })
 
 describe("E2E (mock opencode): subscribeSession streaming", () => {

--- a/test/host/mock-opencode-server.ts
+++ b/test/host/mock-opencode-server.ts
@@ -27,6 +27,10 @@ export type MockOpencodeServer = {
   prompts: Array<{ sessionID: string; body: unknown }>
   /** Records of every revert call. */
   reverts: Array<{ sessionID: string; body: unknown }>
+  /** Records of every session.command call. */
+  commandCalls: Array<{ sessionID: string; body: unknown }>
+  /** Configure what GET /command returns. */
+  setCommands: (commands: Array<Record<string, unknown>>) => void
   /**
    * Configure what GET /session/status returns. Pass `undefined` to clear
    * the entry. Tests use this to drive the watchdog's recovery path.
@@ -41,6 +45,8 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
   const sseClients: ServerResponse[] = []
   const prompts: Array<{ sessionID: string; body: unknown }> = []
   const reverts: Array<{ sessionID: string; body: unknown }> = []
+  const commandCalls: Array<{ sessionID: string; body: unknown }> = []
+  let commands: Array<Record<string, unknown>> = []
   const sessionStatuses = new Map<string, { type: "idle" | "busy" | "retry" }>()
   let statusPolls = 0
   let clientResolver: (() => void) | undefined
@@ -114,6 +120,12 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
       return
     }
 
+    // Custom command list
+    if (path === "/command" && req.method === "GET") {
+      reply(res, 200, commands)
+      return
+    }
+
     // Session create
     if (path === "/session" && req.method === "POST") {
       reply(res, 200, { id: "ses_test", title: "Test Session" })
@@ -127,6 +139,15 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
       prompts.push({ sessionID: promptMatch[1]!, body })
       res.statusCode = 204
       res.end()
+      return
+    }
+
+    // Session command — runs a custom command; returns the created message.
+    const commandMatch = path.match(/^\/session\/([^/]+)\/command$/)
+    if (commandMatch && req.method === "POST") {
+      const body = await readBody(req)
+      commandCalls.push({ sessionID: commandMatch[1]!, body })
+      reply(res, 200, { info: { id: "msg_cmd", role: "assistant", sessionID: commandMatch[1] }, parts: [] })
       return
     }
 
@@ -183,6 +204,10 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
     },
     prompts,
     reverts,
+    commandCalls,
+    setCommands(next) {
+      commands = next
+    },
     setSessionStatus(sessionID, status) {
       if (status) sessionStatuses.set(sessionID, status)
       else sessionStatuses.delete(sessionID)

--- a/test/host/mock-opencode-server.ts
+++ b/test/host/mock-opencode-server.ts
@@ -151,6 +151,28 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
       return
     }
 
+    // Built-in command endpoints: /compact → summarize, /init → init,
+    // /share → share (POST) / unshare (DELETE).
+    if (path.match(/^\/session\/[^/]+\/summarize$/) && req.method === "POST") {
+      await readBody(req)
+      reply(res, 200, true)
+      return
+    }
+    if (path.match(/^\/session\/[^/]+\/init$/) && req.method === "POST") {
+      await readBody(req)
+      reply(res, 200, true)
+      return
+    }
+    const shareMatch = path.match(/^\/session\/([^/]+)\/share$/)
+    if (shareMatch && req.method === "POST") {
+      reply(res, 200, { id: shareMatch[1], title: "Test Session", share: { url: "https://opencode.ai/s/abc123" } })
+      return
+    }
+    if (shareMatch && req.method === "DELETE") {
+      reply(res, 200, { id: shareMatch[1], title: "Test Session" })
+      return
+    }
+
     // Session revert
     const revertMatch = path.match(/^\/session\/([^/]+)\/revert$/)
     if (revertMatch && req.method === "POST") {

--- a/test/webview/command-tokens.test.ts
+++ b/test/webview/command-tokens.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest"
+import { detectCommand, filterCommands, parseCommandInput } from "../../webview/src/command-tokens"
+
+describe("detectCommand", () => {
+  it("opens on a bare leading slash with an empty query", () => {
+    expect(detectCommand("/", 1)).toEqual({ query: "" })
+  })
+
+  it("captures the command name typed after the slash", () => {
+    expect(detectCommand("/dep", 4)).toEqual({ query: "dep" })
+  })
+
+  it("stays open while the caret is at the end of the name, before the space", () => {
+    expect(detectCommand("/dep foo", 4)).toEqual({ query: "dep" })
+  })
+
+  it("closes once the caret moves past the first space (now editing args)", () => {
+    expect(detectCommand("/dep foo", 8)).toBeUndefined()
+    expect(detectCommand("/dep ", 5)).toBeUndefined()
+  })
+
+  it("never triggers mid-string — the slash must be the first character", () => {
+    expect(detectCommand("a/b", 3)).toBeUndefined()
+    expect(detectCommand("look /dep", 9)).toBeUndefined()
+    expect(detectCommand("1/2", 3)).toBeUndefined()
+  })
+})
+
+describe("filterCommands", () => {
+  const cmds = [{ name: "deploy" }, { name: "review" }, { name: "redeploy" }, { name: "compact" }]
+
+  it("returns the full list for an empty query", () => {
+    expect(filterCommands(cmds, "")).toHaveLength(4)
+  })
+
+  it("is case-insensitive", () => {
+    expect(filterCommands(cmds, "DEP").map((c) => c.name)).toEqual(["deploy", "redeploy"])
+  })
+
+  it("surfaces prefix matches before substring matches", () => {
+    // "deploy" is a prefix match; "redeploy" only contains "dep".
+    expect(filterCommands(cmds, "dep").map((c) => c.name)).toEqual(["deploy", "redeploy"])
+  })
+
+  it("returns [] when nothing matches", () => {
+    expect(filterCommands(cmds, "zzz")).toEqual([])
+  })
+})
+
+describe("parseCommandInput", () => {
+  it("splits a name with no arguments", () => {
+    expect(parseCommandInput("/deploy")).toEqual({ name: "deploy", args: "" })
+  })
+
+  it("splits a name and its argument remainder", () => {
+    expect(parseCommandInput("/deploy prod now")).toEqual({ name: "deploy", args: "prod now" })
+  })
+
+  it("trims surrounding whitespace from the arguments", () => {
+    expect(parseCommandInput("/deploy   prod  ")).toEqual({ name: "deploy", args: "prod" })
+  })
+
+  it("returns undefined for non-slash input", () => {
+    expect(parseCommandInput("hello world")).toBeUndefined()
+  })
+})

--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest"
-import { render, screen, cleanup, waitFor } from "@testing-library/react"
+import { render, screen, cleanup, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { PromptBox, detectMention, extractMentions, findMentionRanges, findChipAtCaret, makeAttachmentLabel } from "../../webview/src/components/PromptBox"
 
@@ -15,7 +15,7 @@ async function enterFilesCategory(user: ReturnType<typeof userEvent.setup>, targ
 describe("PromptBox", () => {
   it("renders a textarea with placeholder", () => {
     render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} />)
-    expect(screen.getByPlaceholderText(/@ for file, Enter to send/i)).toBeInTheDocument()
+    expect(screen.getByPlaceholderText(/for commands.*for files.*Enter to send/i)).toBeInTheDocument()
   })
 
   it("uses a compact one-row textarea in edit mode", () => {
@@ -1308,5 +1308,113 @@ describe("PromptBox image paste from clipboard", () => {
     await user.click(screen.getByRole("button", { name: /Preview pasted-image\.png/i }))
     await user.click(screen.getByRole("button", { name: /Close preview/i }))
     await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull())
+  })
+})
+
+describe("PromptBox / command picker", () => {
+  const COMMANDS = [
+    { name: "deploy", description: "Ship it", takesArguments: true },
+    { name: "compact", description: "Compact the session", takesArguments: false },
+    { name: "review", description: "Review changes", takesArguments: true },
+  ]
+
+  it("opens the command picker listing all commands when you type /", async () => {
+    const user = userEvent.setup()
+    render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} commands={COMMANDS} onRunCommand={vi.fn()} />)
+    await user.type(screen.getByRole("textbox"), "/")
+    const list = await screen.findByRole("listbox", { name: /Commands/i })
+    expect(within(list).getByText("/deploy")).toBeInTheDocument()
+    expect(within(list).getByText("/compact")).toBeInTheDocument()
+    expect(within(list).getByText("/review")).toBeInTheDocument()
+  })
+
+  it("filters commands as you type", async () => {
+    const user = userEvent.setup()
+    render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} commands={COMMANDS} onRunCommand={vi.fn()} />)
+    await user.type(screen.getByRole("textbox"), "/dep")
+    const list = await screen.findByRole("listbox", { name: /Commands/i })
+    expect(within(list).getByText("/deploy")).toBeInTheDocument()
+    expect(within(list).queryByText("/compact")).toBeNull()
+    expect(within(list).queryByText("/review")).toBeNull()
+  })
+
+  it("selecting an argument-taking command inserts /name and waits (does not run)", async () => {
+    const user = userEvent.setup()
+    const onRunCommand = vi.fn()
+    render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} commands={COMMANDS} onRunCommand={onRunCommand} />)
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    await user.type(textarea, "/deploy")
+    await screen.findByRole("listbox", { name: /Commands/i })
+    await user.keyboard("{Enter}")
+    expect(textarea.value).toBe("/deploy ")
+    expect(onRunCommand).not.toHaveBeenCalled()
+    expect(screen.queryByRole("listbox", { name: /Commands/i })).toBeNull()
+  })
+
+  it("selecting an argument-less command runs it immediately and clears", async () => {
+    const user = userEvent.setup()
+    const onRunCommand = vi.fn()
+    render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} commands={COMMANDS} onRunCommand={onRunCommand} />)
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    await user.type(textarea, "/compact")
+    await screen.findByRole("listbox", { name: /Commands/i })
+    await user.keyboard("{Enter}")
+    expect(onRunCommand).toHaveBeenCalledWith("compact", "")
+    expect(textarea.value).toBe("")
+  })
+
+  it("typing /name args + Enter runs the command with its arguments", async () => {
+    const user = userEvent.setup()
+    const onRunCommand = vi.fn()
+    const onSend = vi.fn()
+    render(<PromptBox busy={false} onSend={onSend} onAbort={vi.fn()} commands={COMMANDS} onRunCommand={onRunCommand} />)
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    await user.type(textarea, "/deploy prod")
+    await user.keyboard("{Enter}")
+    expect(onRunCommand).toHaveBeenCalledWith("deploy", "prod")
+    expect(onSend).not.toHaveBeenCalled()
+    expect(textarea.value).toBe("")
+  })
+
+  it("an unknown /command sends as a normal prompt (backward compatible)", async () => {
+    const user = userEvent.setup()
+    const onRunCommand = vi.fn()
+    const onSend = vi.fn()
+    render(<PromptBox busy={false} onSend={onSend} onAbort={vi.fn()} commands={COMMANDS} onRunCommand={onRunCommand} />)
+    await user.type(screen.getByRole("textbox"), "/nope thing")
+    await user.keyboard("{Enter}")
+    expect(onRunCommand).not.toHaveBeenCalled()
+    expect(onSend).toHaveBeenCalledWith("/nope thing", undefined, undefined, undefined)
+  })
+
+  it("does not open the picker when there are no commands", async () => {
+    const user = userEvent.setup()
+    render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} commands={[]} onRunCommand={vi.fn()} />)
+    await user.type(screen.getByRole("textbox"), "/")
+    expect(screen.queryByRole("listbox", { name: /Commands/i })).toBeNull()
+  })
+
+  it("does not run a command on Enter during IME composition", async () => {
+    const user = userEvent.setup()
+    const onRunCommand = vi.fn()
+    render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} commands={COMMANDS} onRunCommand={onRunCommand} />)
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    await user.type(textarea, "/compact")
+    await screen.findByRole("listbox", { name: /Commands/i })
+    const event = new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true })
+    Object.defineProperty(event, "isComposing", { value: true, configurable: true })
+    textarea.dispatchEvent(event)
+    expect(onRunCommand).not.toHaveBeenCalled()
+  })
+
+  it("does not run a command while busy", async () => {
+    const user = userEvent.setup()
+    const onRunCommand = vi.fn()
+    render(<PromptBox busy={true} onSend={vi.fn()} onAbort={vi.fn()} commands={COMMANDS} onRunCommand={onRunCommand} />)
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    await user.type(textarea, "/compact")
+    await screen.findByRole("listbox", { name: /Commands/i })
+    await user.keyboard("{Enter}")
+    expect(onRunCommand).not.toHaveBeenCalled()
   })
 })

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -14,6 +14,7 @@ export default function App() {
   const {
     state,
     send,
+    runCommand,
     abort,
     newSession,
     openConversation,
@@ -225,6 +226,8 @@ export default function App() {
           activeConversationID={state.conversationID}
           onOpenConversation={openConversation}
           contextUsage={state.contextUsage}
+          commands={state.commands}
+          onRunCommand={runCommand}
         />
       )}
       <div
@@ -338,6 +341,8 @@ export default function App() {
             activeConversationID={state.conversationID}
             onOpenConversation={openConversation}
             contextUsage={state.contextUsage}
+            commands={state.commands}
+            onRunCommand={runCommand}
           />
         </div>
       )}

--- a/webview/src/command-tokens.ts
+++ b/webview/src/command-tokens.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure helpers for the `/`-command picker. Kept separate from PromptBox.tsx so
+ * the component file is just JSX + state, and so these functions can be tested
+ * without rendering anything. Mirrors mention-tokens.ts.
+ */
+
+export type CommandTokenState = {
+  /** Query typed after the leading `/` (excludes the slash itself). */
+  query: string
+}
+
+/**
+ * Returns the active command token if the caret sits inside the leading
+ * `/command` name, else undefined. Unlike the `@`-mention picker (which
+ * triggers anywhere), a slash command must be the very FIRST character —
+ * `/` is far too common in normal prose (paths, dates, fractions) to trigger
+ * mid-string. The picker closes once a space is typed (the user has moved on
+ * to arguments).
+ */
+export function detectCommand(text: string, caret: number): CommandTokenState | undefined {
+  if (!text.startsWith("/")) return undefined
+  const firstSpace = text.indexOf(" ")
+  // Caret must sit within the first token (the command name); once it moves
+  // past the first space the user is editing arguments, not the command.
+  if (firstSpace !== -1 && caret > firstSpace) return undefined
+  const end = firstSpace === -1 ? text.length : firstSpace
+  return { query: text.slice(1, end) }
+}
+
+/**
+ * Filter commands by a (case-insensitive) query, surfacing prefix matches
+ * before substring matches. An empty query returns the full list.
+ */
+export function filterCommands<T extends { name: string }>(commands: T[], query: string): T[] {
+  const q = query.toLowerCase()
+  if (!q) return commands
+  const starts: T[] = []
+  const contains: T[] = []
+  for (const c of commands) {
+    const name = c.name.toLowerCase()
+    if (name.startsWith(q)) starts.push(c)
+    else if (name.includes(q)) contains.push(c)
+  }
+  return [...starts, ...contains]
+}
+
+/**
+ * Split a leading-`/` input into its command name and the (trimmed) argument
+ * remainder. Returns undefined when the text is not a slash invocation. Used by
+ * submit routing to decide whether a typed `/name args` is a known command.
+ */
+export function parseCommandInput(text: string): { name: string; args: string } | undefined {
+  if (!text.startsWith("/")) return undefined
+  const firstSpace = text.indexOf(" ")
+  if (firstSpace === -1) return { name: text.slice(1), args: "" }
+  return { name: text.slice(1, firstSpace), args: text.slice(firstSpace + 1).trim() }
+}

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react"
-import type { Attachment, ContextUsage, ConversationSummary, DirEntry, FileSearchHit } from "../protocol"
+import type { Attachment, CommandInfo, ContextUsage, ConversationSummary, DirEntry, FileSearchHit } from "../protocol"
 import {
   extractMentions,
   findChipAtCaret,
@@ -7,10 +7,12 @@ import {
   makeAttachmentLabel,
   makeConversationLabel,
 } from "../mention-tokens"
+import { parseCommandInput } from "../command-tokens"
 import { clipboardHasImage, readPastedImages } from "../paste-attachments"
 import { usePromptText } from "../hooks/usePromptText"
 import { useImageAttachments } from "../hooks/useImageAttachments"
 import { useMentionPicker } from "../hooks/useMentionPicker"
+import { useCommandPicker } from "../hooks/useCommandPicker"
 import { useFileBrowser } from "../hooks/useFileBrowser"
 import {
   conversationDisplayTitle,
@@ -32,6 +34,7 @@ export {
   makeConversationLabel,
   formatBytes,
 } from "../mention-tokens"
+export { detectCommand, filterCommands, parseCommandInput } from "../command-tokens"
 
 type Props = {
   busy: boolean
@@ -66,6 +69,14 @@ type Props = {
   activeConversationID?: string
   onOpenConversation?: (id: string) => void
   contextUsage?: ContextUsage
+  /** Workspace opencode commands for the `/` picker. Empty disables it. */
+  commands?: CommandInfo[]
+  /**
+   * Run an opencode command. Only wired for the primary send composer — the
+   * in-message edit composers leave it undefined so a `/`-leading edit stays a
+   * normal prompt edit (preserving revert semantics).
+   */
+  onRunCommand?: (command: string, args: string) => void
 }
 
 function buildInitialAttachments(initial: Props["initial"]): Map<string, Attachment> {
@@ -112,7 +123,7 @@ function extractConversationLabels(text: string | undefined): string[] {
   return Array.from(text.matchAll(/@chat:\S+/g), (match) => match[0].slice(1))
 }
 
-export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles, listDir, attachFile, initial, variant = "send", position = "bottom", conversations, activeConversationID, onOpenConversation, contextUsage }: Props) {
+export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles, listDir, attachFile, initial, variant = "send", position = "bottom", conversations, activeConversationID, onOpenConversation, contextUsage, commands = [], onRunCommand }: Props) {
   const { text, setText, ref, backdropRef, pendingCursor } = usePromptText(initial?.text ?? "")
   const [selectedChipStart, setSelectedChipStart] = useState<number | undefined>(undefined)
   const [attachError, setAttachError] = useState<string | undefined>(undefined)
@@ -138,6 +149,15 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
   }
   const { mention, hits, activeIndex, setActiveIndex, detectAtCaret, closeMention, insertMention } =
     useMentionPicker({ text, setText, searchFiles, knownMentions, pendingCursor })
+  const {
+    command,
+    filtered: commandHits,
+    activeIndex: commandIndex,
+    setActiveIndex: setCommandIndex,
+    detectAtCaret: detectCommandAtCaret,
+    closeCommand,
+    insertCommand,
+  } = useCommandPicker({ text, setText, commands, pendingCursor })
 
   type MentionCategory = "files" | "chats"
   const [mentionCategory, setMentionCategory] = useState<MentionCategory | null>(null)
@@ -218,11 +238,57 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
   const updateText = (next: string, caret: number) => {
     setText(next)
     setSelectedChipStart(undefined)
+    // The `/` and `@` pickers are mutually exclusive: a leading slash command
+    // wins, and we close the mention picker so they never render together.
+    if (detectCommandAtCaret(next, caret)) {
+      closeMention()
+      return
+    }
     detectAtCaret(next, caret)
+  }
+
+  /** Clear the composer to its empty state after a send or command run. */
+  const clearComposer = () => {
+    setText("")
+    knownMentions.current.clear()
+    knownAttachments.current.clear()
+    knownConversations.current.clear()
+    clearImageAttachments()
+    setSelectedChipStart(undefined)
+    setAttachError(undefined)
+    closeMention()
+    closeCommand()
+  }
+
+  const runCommandAndClear = (command: string, args: string) => {
+    // Respect busy on the picker-run path too (submit already guards busy).
+    if (busy || !onRunCommand) return
+    onRunCommand(command, args)
+    clearComposer()
+  }
+
+  /**
+   * Pick path for the `/` dropdown. A command whose template takes `$ARGUMENTS`
+   * inserts `/name ` and waits for the user to type args; an argument-less
+   * command runs the moment it is chosen.
+   */
+  const chooseCommand = (cmd: CommandInfo) => {
+    if (cmd.takesArguments) insertCommand(cmd)
+    else runCommandAndClear(cmd.name, "")
   }
 
   const submit = () => {
     const trimmed = text.trim()
+    // Route a typed `/name args` to the command path when the name matches a
+    // known command. Unknown slashes (and prose like `/etc/hosts`) fall through
+    // to a normal prompt send. Edit composers never route (no onRunCommand).
+    if (variant === "send" && !busy && onRunCommand) {
+      const parsed = parseCommandInput(trimmed)
+      if (parsed && commands.some((c) => c.name === parsed.name)) {
+        runCommandAndClear(parsed.name, parsed.args)
+        return
+      }
+    }
     const activeAttachments: Attachment[] = []
     if (knownAttachments.current.size > 0) {
       const labelsInText = extractMentions(text, new Set(knownAttachments.current.keys()))
@@ -247,14 +313,7 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
       activeAttachments.length ? activeAttachments : undefined,
       convIDs.length ? convIDs : undefined,
     )
-    setText("")
-    knownMentions.current.clear()
-    knownAttachments.current.clear()
-    knownConversations.current.clear()
-    clearImageAttachments()
-    setSelectedChipStart(undefined)
-    setAttachError(undefined)
-    closeMention()
+    clearComposer()
   }
 
   const handleAttachClick = async () => {
@@ -353,6 +412,39 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
     // the IME. keyCode 229 is the legacy fallback for older Chromium builds
     // that don't surface isComposing reliably.
     if (e.nativeEvent.isComposing || e.keyCode === 229) return
+    if (command) {
+      // When nothing matches we only handle Escape — Enter must fall through to
+      // submit so `/unknown` sends as a normal prompt.
+      if (commandHits.length === 0) {
+        if (e.key === "Escape") {
+          e.preventDefault()
+          closeCommand()
+          return
+        }
+      } else {
+        if (e.key === "ArrowDown") {
+          e.preventDefault()
+          setCommandIndex((i) => (i + 1) % commandHits.length)
+          return
+        }
+        if (e.key === "ArrowUp") {
+          e.preventDefault()
+          setCommandIndex((i) => (i - 1 + commandHits.length) % commandHits.length)
+          return
+        }
+        if (e.key === "Enter" || e.key === "Tab") {
+          e.preventDefault()
+          const cmd = commandHits[commandIndex]
+          if (cmd) chooseCommand(cmd)
+          return
+        }
+        if (e.key === "Escape") {
+          e.preventDefault()
+          closeCommand()
+          return
+        }
+      }
+    }
     if (showCategoryMenu) {
       const categories: MentionCategory[] = ["files", "chats"]
       if (e.key === "ArrowDown") {
@@ -556,7 +648,7 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
           ref={ref}
           value={text}
           rows={variant === "edit" ? 1 : 2}
-          placeholder="@ for file, Enter to send"
+          placeholder="/ for commands, @ for files, Enter to send"
           onChange={(e) => updateText(e.target.value, e.target.selectionStart ?? e.target.value.length)}
           onKeyDown={onKeyDown}
           onPaste={onPaste}
@@ -566,7 +658,10 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
           }}
           onBlur={() => {
             // Defer so onMouseDown on a hit can fire first.
-            setTimeout(closeMention, 120)
+            setTimeout(() => {
+              closeMention()
+              closeCommand()
+            }, 120)
           }}
         />
         {showCategoryMenu && (
@@ -686,6 +781,28 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
               <li className="mention-hit mention-empty">
                 {pastConversations.length === 0 ? "No past chats" : `No chats match "${mention.query}"`}
               </li>
+            )}
+          </ul>
+        )}
+        {command && (
+          <ul className="mention-popover" role="listbox" aria-label="Commands">
+            {commandHits.length > 0 ? commandHits.map((cmd, i) => (
+              <li
+                key={cmd.name}
+                role="option"
+                aria-selected={i === commandIndex}
+                className={"mention-hit" + (i === commandIndex ? " active" : "")}
+                onMouseDown={(e) => {
+                  e.preventDefault()
+                  chooseCommand(cmd)
+                }}
+                onMouseEnter={() => setCommandIndex(i)}
+              >
+                <span className="mention-name">/{cmd.name}</span>
+                <span className="mention-path">{cmd.description ?? (cmd.agent ? `agent: ${cmd.agent}` : "")}</span>
+              </li>
+            )) : (
+              <li className="mention-hit mention-empty">No commands match "/{command.query}"</li>
             )}
           </ul>
         )}

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -785,7 +785,7 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
           </ul>
         )}
         {command && (
-          <ul className="mention-popover" role="listbox" aria-label="Commands">
+          <ul className="mention-popover command-popover" role="listbox" aria-label="Commands">
             {commandHits.length > 0 ? commandHits.map((cmd, i) => (
               <li
                 key={cmd.name}

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -5,6 +5,7 @@ import type {
   Attachment,
   ChatBlock,
   ChatMessage,
+  CommandInfo,
   ContextUsage,
   ConversationSummary,
   DirEntry,
@@ -46,6 +47,8 @@ export type ChatState = {
   conversations: ConversationSummary[]
   conversationID?: string
   contextUsage?: ContextUsage
+  /** Workspace opencode commands for the `/` picker (pushed by the host). */
+  commands: CommandInfo[]
   context?: EditorContextRef
   messages: Message[]
   reviewHunks: Record<string, ReviewHunkState>
@@ -68,6 +71,7 @@ const initial: ChatState = {
   continuationPending: false,
   selection: {},
   conversations: [],
+  commands: [],
   messages: [],
   reviewHunks: {},
 }
@@ -137,7 +141,7 @@ export { initial as initialChatState }
 export function reducer(state: ChatState, action: Action): ChatState {
   switch (action.type) {
     case "reset":
-      return { ...initial, selection: state.selection, context: state.context, connected: state.connected }
+      return { ...initial, selection: state.selection, context: state.context, connected: state.connected, commands: state.commands }
     case "ready":
       return { ...state, connected: action.connected, selection: action.selection }
     case "connected":
@@ -146,6 +150,8 @@ export function reducer(state: ChatState, action: Action): ChatState {
       return { ...state, selection: action.selection }
     case "contextUsage":
       return { ...state, contextUsage: action.usage }
+    case "commands":
+      return { ...state, commands: action.commands }
     case "conversations":
       return { ...state, conversations: action.conversations, conversationID: action.activeID }
     case "restore":
@@ -330,7 +336,7 @@ export function reducer(state: ChatState, action: Action): ChatState {
       return { ...state, messages: next, busy: state.busy && anyPending }
     }
     case "clear":
-      return { ...initial, selection: state.selection, context: state.context, connected: state.connected }
+      return { ...initial, selection: state.selection, context: state.context, connected: state.connected, commands: state.commands }
     default:
       return state
   }
@@ -381,6 +387,9 @@ export function useChatState() {
     state,
     send(text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) {
       vscode.post({ type: "send", text, mentions, attachments, conversationMentions })
+    },
+    runCommand(command: string, args: string) {
+      vscode.post({ type: "runCommand", command, arguments: args })
     },
     editMessage(id: string, text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) {
       vscode.post({ type: "editMessage", id, text, mentions, attachments, conversationMentions })

--- a/webview/src/hooks/useCommandPicker.ts
+++ b/webview/src/hooks/useCommandPicker.ts
@@ -1,0 +1,72 @@
+import { useEffect, useState } from "react"
+import type { CommandInfo } from "../protocol"
+import { detectCommand, filterCommands, type CommandTokenState } from "../command-tokens"
+
+/**
+ * Owns the `/`-command picker state: detection (does the caret sit inside the
+ * leading `/command` name?) and arrow-key navigation index. Much simpler than
+ * useMentionPicker — the command list is already in memory (pushed once by the
+ * host), so there is no async search to debounce. The caller owns the textarea
+ * text + caret refs; this hook decides what to show and exposes `insertCommand`
+ * for the "insert and wait for args" pick path (the run-immediately path is the
+ * caller's, since only it knows `onRunCommand`).
+ */
+export function useCommandPicker(opts: {
+  text: string
+  setText: (next: string) => void
+  commands: CommandInfo[]
+  pendingCursor: React.MutableRefObject<number | null>
+}) {
+  const { text, setText, commands, pendingCursor } = opts
+  const [command, setCommand] = useState<CommandTokenState | undefined>(undefined)
+  const [activeIndex, setActiveIndex] = useState(0)
+
+  const filtered = command ? filterCommands(commands, command.query) : []
+
+  // Reset the highlight to the top whenever the query changes.
+  useEffect(() => {
+    setActiveIndex(0)
+  }, [command?.query])
+
+  const closeCommand = () => setCommand(undefined)
+
+  /**
+   * Recompute the command-token state from the current text + caret. An empty
+   * command list never opens the picker — a bare `/` should behave as plain
+   * text when there is nothing to run. Returns whether the picker is open so
+   * the caller can keep the `@` and `/` pickers mutually exclusive.
+   */
+  const detectAtCaret = (next: string, caret: number): boolean => {
+    if (commands.length === 0) {
+      setCommand(undefined)
+      return false
+    }
+    const state = detectCommand(next, caret)
+    setCommand(state)
+    return state !== undefined
+  }
+
+  /**
+   * Replace the leading `/token` with `/name ` and place the caret after the
+   * trailing space. Any already-typed arguments (text after the first space)
+   * are preserved — the before/after splice mirrors insertMention.
+   */
+  const insertCommand = (cmd: CommandInfo) => {
+    const firstSpace = text.indexOf(" ")
+    const rest = firstSpace === -1 ? "" : text.slice(firstSpace + 1)
+    const head = "/" + cmd.name + " "
+    pendingCursor.current = head.length
+    setText(head + rest)
+    closeCommand()
+  }
+
+  return {
+    command,
+    filtered,
+    activeIndex,
+    setActiveIndex,
+    detectAtCaret,
+    closeCommand,
+    insertCommand,
+  }
+}

--- a/webview/src/protocol.ts
+++ b/webview/src/protocol.ts
@@ -200,6 +200,16 @@ export type FileSearchHit = { path: string; name: string }
 export type DirEntry = { name: string; path: string; kind: "file" | "folder" }
 
 /**
+ * One opencode custom command surfaced to the `/` picker. The host strips the
+ * `template` (it is expanded server-side by `session.command`) and keeps only
+ * what the picker renders + needs. `takesArguments` drives the smart run UX: a
+ * template containing `$ARGUMENTS` waits for the user to type args, otherwise
+ * the command runs the moment it is selected. `agent` is a display-only hint;
+ * the agent/model actually used are read host-side from prefs at run time.
+ */
+export type CommandInfo = { name: string; description?: string; agent?: string; takesArguments: boolean }
+
+/**
  * Status snapshot of the optional semantic index — Phase 6 of the
  * workspace-context plan. `disabled` is the default; flipping
  * `opencui.indexing.semantic.enabled` true plus configuring a real
@@ -368,6 +378,7 @@ export type Outbound =
   | { type: "connected"; connected: boolean; error?: string }
   | { type: "selection"; selection: Selection }
   | { type: "contextUsage"; usage?: ContextUsage }
+  | { type: "commands"; commands: CommandInfo[] }
   | { type: "conversations"; conversations: ConversationSummary[]; activeID?: string }
   | { type: "restore"; conversationID: string; messages: ChatMessage[]; reviewHunks?: Record<string, ReviewHunkState> }
   | { type: "context"; ref: EditorContextRef }
@@ -416,6 +427,7 @@ export type Outbound =
 export type Inbound =
   | { type: "mounted" }
   | { type: "send"; text: string; mentions?: string[]; attachments?: Attachment[]; conversationMentions?: string[] }
+  | { type: "runCommand"; command: string; arguments: string }
   | { type: "editMessage"; id: string; text: string; mentions?: string[]; attachments?: Attachment[]; conversationMentions?: string[] }
   | { type: "abort" }
   | { type: "newSession" }

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -2588,6 +2588,13 @@ button {
 .promptbox--top .mention-popover {
   top: 26px;
 }
+/* The `/` command picker is a touch wider than the @-file picker (command
+   descriptions need the room) and never shows a horizontal scrollbar — long
+   descriptions ellipsize via .mention-path instead of forcing a scroll. */
+.command-popover {
+  width: min(320px, calc(100% - 16px));
+  overflow-x: hidden;
+}
 .mention-hit {
   display: flex;
   align-items: baseline;


### PR DESCRIPTION
## Summary

Adds a `/` command picker to the chat composer so users can run opencode commands without retyping the template prose. Covers both **custom** commands (`command.list`) and a curated set of **built-in** commands.

- **Trigger:** typing `/` at the start of the input opens a picker (mirroring the `@`-file picker), filtered client-side as you type. `/` mid-string (paths, dates, fractions) never triggers.
- **Smart run UX:** selecting a command whose template uses `$ARGUMENTS` inserts `/name ` and waits for arguments; an argument-less command runs immediately on select.
- **Execution (custom):** runs via `session.command`, which expands the command's `template` server-side (including opencode's `!shell` / `@file` substitutions) and streams the assistant turn through the **existing SSE subscription** — zero new rendering plumbing. The chat bubble shows the typed invocation (`/name args`), never the expansion.
- **Backward compatible:** unknown `/foo` and prose like `/etc/hosts` still send as normal prompts. The `@`-file picker and IME composition are unchanged.

### Built-in commands
`command.list` returns only user-defined custom commands, so opencode's built-ins (like `/compact`) were missing. They're merged into the same picker as synthetic entries and routed host-side to their dedicated session endpoints instead of `session.command`:

| Command | Endpoint | Behavior |
|---|---|---|
| `/compact` | `session.summarize` | streams the summary turn |
| `/init` | `session.init` | streams the codebase-analysis turn; the required `messageID` is generated client-side |
| `/share` | `session.share` | notification with the share URL + Copy Link |
| `/unshare` | `session.unshare` | DELETE; confirmation notification |

A custom command of the same name **shadows** the built-in (dispatched through `session.command` instead). The webview is unchanged for built-ins — they flow through the same `commands` list and `runCommand` message; only the host merges (`withBuiltinCommands`) and routes them.

### How it's wired
- **Host** (`src/chat/view.ts`, `src/chat/builtin-commands.ts`): `refreshCommands` fetches `command.list` on connect + each subscription (re)attach, maps to `CommandInfo` with a host-computed `takesArguments`, merges built-ins, and posts a `commands` Outbound. `handleRunCommand` routes built-ins to `handleBuiltinCommand`; custom commands call `session.command` (note: its `model` is a single string, not the prompt-path object; `arguments` is required).
- **Protocol** (`webview/src/protocol.ts`): new `CommandInfo` type, `commands` Outbound, `runCommand` Inbound.
- **Webview**: new pure helpers `command-tokens.ts` + a small `useCommandPicker` hook; `PromptBox` gains the dropdown, keyboard nav, smart-select, and submit routing; `useChatState` holds `commands` + exposes `runCommand`.

Closes #248.

## Test plan

Verified locally:
- [x] `bun run test` — **859 pass** (51 files). New: `command-tokens.test.ts`, command-picker block in `promptbox.test.tsx`, `builtin-commands.test.ts` (merge precedence + `generateMessageID`), and mock-opencode E2E assertions for `command.list` / `session.command` (incl. the model-is-a-string guard) / `summarize` / `share` / `init`.
- [x] `bun run check-types` (host) — clean.
- [x] `cd webview && bunx tsc --noEmit` — clean.
- [x] `bun run package` — builds cleanly (`dist/extension.js` 142 KB).

Needs manual/visual verification in the Extension Dev Host:
- [ ] Custom: add `.opencode/command/hello.md` (with `$ARGUMENTS` + a `@file`/`!shell` token), type `/`, filter, run — bubble shows the typed invocation, turn streams in.
- [ ] Built-ins: `/compact` summarizes, `/share` shows a URL notification (+ Copy Link), `/unshare` confirms. **`/init` — verify against a live opencode server**, since its `messageID` format is server-defined (we generate a ULID-style id; failure is benign — logged, no turn).
- [ ] Negatives: `/etc/hosts` falls through to a normal prompt; a custom command named `compact` shadows the built-in; `@`-picker and Stop-mid-command still work.

No release in this PR.