### PR TITLE
chore(release): cut v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-05-30
+
+### Added
+- Slash-command picker in the chat composer. Typing `/` at the start of the input opens a picker (mirroring the `@`-file picker) listing the workspace's opencode commands, filtered as you type. Selecting a command whose template uses `$ARGUMENTS` inserts `/name ` and waits for arguments; an argument-less command runs immediately. Running a custom command calls the SDK's `session.command`, which expands the command template server-side (including opencode's own `!shell` / `@file` substitutions) and streams the assistant turn through the existing SSE subscription — so it renders exactly like a normal prompt, and the chat shows the typed invocation rather than the expanded template. The command list is fetched via `command.list` on connect and on each subscription (re)attach; unknown `/foo` and prose like `/etc/hosts` still send as normal prompts.
+- opencode's built-in commands in the same picker, since `command.list` returns only user-defined custom commands. `/compact` (summarize and compact the session), `/init` (analyze the codebase and write `AGENTS.md`), `/share`, and `/unshare` are merged in as synthetic entries and routed host-side to their dedicated session endpoints; `/share` surfaces the share URL through a notification with a Copy Link action. A custom command of the same name shadows the built-in.
+
+Closes #248.
+
 ## [0.10.1] - 2026-05-29
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "0.10.1",
+  "version": "1.0.0",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
## Summary

First stable release. Bumps `package.json` to **1.0.0** and adds the `## [1.0.0]` CHANGELOG entry.

Headline change since 0.10.1: the **slash-command picker** for opencode commands — custom commands (`command.list` → `session.command`) plus built-ins (`/compact`, `/init`, `/share`, `/unshare`) routed to their dedicated session endpoints (merged in #249).

## Test plan
- [x] `bun run test` — 859 pass (51 files)
- [x] `bun run check-types` (host) + `cd webview && bunx tsc --noEmit` — clean
- [x] `bun run package` — builds cleanly
- [x] `package.json` version = 1.0.0

On merge: tag `v1.0.0` from `main` → GitHub Release → publish workflow → VS Code Marketplace + Open VSX.

Closes #250.