### PR TITLE
feat(mcp): manage MCP servers from a native picker and /mcp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- MCP (Model Context Protocol) server management. A native QuickPick — reachable from the Command Palette (**OpenCode Panel: Manage MCP Servers**) and by typing `/mcp` in the chat composer — lists every configured server with a status icon (connected / disabled / failed / needs auth / needs client registration) and inline error detail, fetched via the SDK's `client.mcp.status`. From it you can **add** a server (a multi-step prompt for a local command or remote URL → `mcp.add`), **connect** / **disconnect** (`mcp.connect` / `mcp.disconnect`), **authenticate** a server that needs OAuth (`mcp.auth.authenticate`, where the local opencode server opens the browser and finalizes the flow itself — no code pasting), **remove** stored OAuth credentials (`mcp.auth.remove`), and copy a failed server's error. Status is re-fetched on open and after every action, since the SDK has no MCP push event. `/mcp` opens the picker without posting a chat turn; `mcp.add` is session-scoped (it is not written to your opencode config).
+
 ## [1.0.0] - 2026-05-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -81,6 +81,10 @@
         "title": "OpenCode Panel: Select Model"
       },
       {
+        "command": "opencui.manageMcp",
+        "title": "OpenCode Panel: Manage MCP Servers"
+      },
+      {
         "command": "opencui.server.restart",
         "title": "OpenCode Panel: Restart Backend"
       },

--- a/src/chat/builtin-commands.ts
+++ b/src/chat/builtin-commands.ts
@@ -21,6 +21,7 @@ export const BUILTIN_COMMANDS: ReadonlyArray<CommandInfo> = [
   { name: "init", description: "Analyze the codebase and write AGENTS.md", takesArguments: false },
   { name: "share", description: "Create a shareable link for this session", takesArguments: false },
   { name: "unshare", description: "Disable sharing for this session", takesArguments: false },
+  { name: "mcp", description: "Manage MCP servers", takesArguments: false },
 ]
 
 export const BUILTIN_COMMAND_NAMES: ReadonlySet<string> = new Set(BUILTIN_COMMANDS.map((c) => c.name))

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -1198,6 +1198,14 @@ export class ChatView implements vscode.WebviewViewProvider {
    * through a VS Code notification.
    */
   private async handleBuiltinCommand(command: string) {
+    // `/mcp` opens the native MCP management picker — it is NOT a session turn,
+    // so it posts no user bubble / Main task and does not ensure a backend here
+    // (the command's own handler does). Delegating to the registered command
+    // keeps a single source of truth for the picker.
+    if (command === "mcp") {
+      await vscode.commands.executeCommand("opencui.manageMcp")
+      return
+    }
     let backend: Backend
     try {
       backend = await this.servers.ensure()

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { ChatView } from "./chat/view"
 import { InlineEdit } from "./inline/edit"
 import { Preferences } from "./preferences"
 import { Picker } from "./picker"
+import { McpManager } from "./mcp/manage"
 import { RecentEditsTracker } from "./workspace-context/recent-edits"
 import { IndexManager, readIndexSettings } from "./indexing/index-manager"
 import { AgentTaskStore } from "./agents/task-store"
@@ -33,6 +34,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const chat = new ChatView(context, servers, prefs, recentEdits, indexManager, agentTaskStore)
   const inline = new InlineEdit(servers, prefs)
   const picker = new Picker(servers, prefs)
+  const mcp = new McpManager(servers)
 
   context.subscriptions.push(
     vscode.window.registerWebviewViewProvider(ChatView.viewType, chat, {
@@ -48,6 +50,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("opencui.selectAgent", () => picker.pickAgent()),
     vscode.commands.registerCommand("opencui.selectModel", () => picker.pickModel()),
     vscode.commands.registerCommand("opencui.selectVariant", () => picker.pickVariantForCurrent()),
+    vscode.commands.registerCommand("opencui.manageMcp", () => mcp.run()),
     vscode.commands.registerCommand("opencui.agents.open", () => showAgentsQuickPick(agentTaskStore!)),
     vscode.commands.registerCommand("opencui.server.restart", async () => {
       status.set("starting", "restarting backend")

--- a/src/mcp/manage.ts
+++ b/src/mcp/manage.ts
@@ -1,0 +1,260 @@
+import * as vscode from "vscode"
+import type { McpStatus, McpLocalConfig, McpRemoteConfig } from "@opencode-ai/sdk"
+import type { ServerManager, Backend } from "../server"
+import { log } from "../output"
+import {
+  actionsFor,
+  parseCommand,
+  statusError,
+  statusIcon,
+  statusLabel,
+  validateServerName,
+  type McpAction,
+} from "./status-format"
+
+/** Sentinel identifying the "Add MCP server" row in the main picker. */
+const ADD = Symbol("mcp-add")
+
+type ServerItem = vscode.QuickPickItem & { server?: string; add?: typeof ADD }
+type ActionItem = vscode.QuickPickItem & { action: McpAction }
+type TypeItem = vscode.QuickPickItem & { value: "local" | "remote" }
+
+/**
+ * Native QuickPick UI for opencode's MCP (Model Context Protocol) servers,
+ * reachable from the Command Palette (`opencui.manageMcp`) and the `/mcp`
+ * built-in slash command. Mirrors `src/picker.ts`: ensure the backend, fetch
+ * over the SDK, drive everything through QuickPick / InputBox, surface results
+ * via notifications.
+ *
+ * Status is poll-based — the SDK has no MCP push event — so `run()` re-fetches
+ * the list on open and after every action (the loop re-opens the picker until
+ * the user presses Esc).
+ */
+export class McpManager {
+  constructor(private servers: ServerManager) {}
+
+  async run() {
+    let backend: Backend
+    try {
+      backend = await this.servers.ensure()
+    } catch (e) {
+      log("mcp manage: backend ensure failed", e)
+      vscode.window.showErrorMessage(`OpenCode Panel: ${(e as Error).message}`)
+      return
+    }
+
+    for (;;) {
+      const statusMap = await this.fetchStatus(backend)
+      if (!statusMap) return
+      const names = Object.keys(statusMap).sort()
+      const items: ServerItem[] = [
+        { label: "$(add) Add MCP server", add: ADD, alwaysShow: true },
+        ...names.map((name): ServerItem => {
+          const st = statusMap[name]!
+          return {
+            label: `${statusIcon(st)} ${name}`,
+            description: statusLabel(st),
+            detail: statusError(st),
+            server: name,
+          }
+        }),
+      ]
+      const picked = await vscode.window.showQuickPick(items, {
+        title: "Manage MCP servers",
+        placeHolder: names.length
+          ? "Select a server to manage, or add one"
+          : "No MCP servers — add one to get started",
+      })
+      if (!picked) return
+      if (picked.add) {
+        await this.addServer(backend, new Set(names))
+        continue
+      }
+      if (picked.server) await this.serverActions(backend, picked.server, statusMap[picked.server]!)
+    }
+  }
+
+  private async fetchStatus(backend: Backend): Promise<Record<string, McpStatus> | undefined> {
+    try {
+      const res = await backend.client.mcp.status({ query: { directory: backend.directory } })
+      if (res.error || !res.data) {
+        vscode.window.showErrorMessage("OpenCode Panel: failed to load MCP status")
+        return undefined
+      }
+      return res.data
+    } catch (e) {
+      log("mcp.status failed", e)
+      vscode.window.showErrorMessage(`OpenCode Panel: ${(e as Error).message}`)
+      return undefined
+    }
+  }
+
+  /** Multi-step Add flow: name → type → command|url → `mcp.add`. */
+  private async addServer(backend: Backend, existing: Set<string>) {
+    const name = await vscode.window.showInputBox({
+      title: "Add MCP server (1/3)",
+      prompt: "Server name",
+      placeHolder: "e.g. github",
+      validateInput: (v) => validateServerName(v, existing),
+    })
+    if (!name) return
+    const serverName = name.trim()
+
+    const type = await vscode.window.showQuickPick<TypeItem>(
+      [
+        { label: "$(server-process) local", description: "Run a command (stdio server)", value: "local" },
+        { label: "$(globe) remote", description: "Connect to an HTTP URL", value: "remote" },
+      ],
+      { title: "Add MCP server (2/3)", placeHolder: "Connection type" },
+    )
+    if (!type) return
+
+    let config: McpLocalConfig | McpRemoteConfig
+    if (type.value === "local") {
+      const command = await vscode.window.showInputBox({
+        title: "Add MCP server (3/3)",
+        prompt: "Command to run",
+        placeHolder: "e.g. npx -y @modelcontextprotocol/server-github",
+        validateInput: (v) => (parseCommand(v).length === 0 ? "A command is required" : undefined),
+      })
+      if (!command) return
+      config = { type: "local", command: parseCommand(command), enabled: true }
+    } else {
+      const url = await vscode.window.showInputBox({
+        title: "Add MCP server (3/3)",
+        prompt: "Server URL",
+        placeHolder: "https://example.com/mcp",
+        validateInput: (v) => {
+          try {
+            new URL(v.trim())
+            return undefined
+          } catch {
+            return "Enter a valid URL"
+          }
+        },
+      })
+      if (!url) return
+      config = { type: "remote", url: url.trim(), enabled: true }
+    }
+
+    try {
+      const res = await backend.client.mcp.add({
+        body: { name: serverName, config },
+        query: { directory: backend.directory },
+      })
+      if (res.error) {
+        vscode.window.showErrorMessage(
+          `OpenCode Panel: could not add "${serverName}" — ${errorMessage(res.error)}`,
+        )
+        return
+      }
+      const st = res.data?.[serverName]
+      const suffix = st ? ` (${statusLabel(st)})` : ""
+      // `mcp.add` registers the server for the running session only — it is NOT
+      // written to opencode.json, so it is gone after a server restart.
+      vscode.window.showInformationMessage(
+        `OpenCode Panel: added "${serverName}"${suffix} for this session. Add it to your opencode config to make it permanent.`,
+      )
+    } catch (e) {
+      log("mcp.add failed", e)
+      vscode.window.showErrorMessage(`OpenCode Panel: ${(e as Error).message}`)
+    }
+  }
+
+  /** Second picker: the actions valid for this server's status, then dispatch. */
+  private async serverActions(backend: Backend, name: string, status: McpStatus) {
+    const items: ActionItem[] = actionsFor(status).map((action) => ({ label: actionLabel(action), action }))
+    const picked = await vscode.window.showQuickPick(items, {
+      title: `${name} — ${statusLabel(status)}`,
+      placeHolder: "Choose an action",
+    })
+    if (!picked) return
+    await this.runAction(backend, name, status, picked.action)
+  }
+
+  private async runAction(backend: Backend, name: string, status: McpStatus, action: McpAction) {
+    const query = { directory: backend.directory }
+    try {
+      switch (action) {
+        case "connect": {
+          const res = await vscode.window.withProgress(
+            { location: vscode.ProgressLocation.Notification, cancellable: false, title: `Connecting "${name}"...` },
+            () => backend.client.mcp.connect({ path: { name }, query }),
+          )
+          if (res.error) vscode.window.showErrorMessage(`OpenCode Panel: could not connect "${name}"`)
+          return
+        }
+        case "disconnect": {
+          const res = await backend.client.mcp.disconnect({ path: { name }, query })
+          if (res.error) vscode.window.showErrorMessage(`OpenCode Panel: could not disconnect "${name}"`)
+          return
+        }
+        case "authenticate": {
+          // The opencode server (a local subprocess) opens the browser and
+          // captures the OAuth redirect itself, then returns the new status —
+          // so this is one blocking call, no URI handler / code paste needed.
+          const res = await vscode.window.withProgress(
+            {
+              location: vscode.ProgressLocation.Notification,
+              cancellable: false,
+              title: `Authenticating "${name}" — finish in your browser...`,
+            },
+            () => backend.client.mcp.auth.authenticate({ path: { name }, query }),
+          )
+          if (res.error || !res.data) {
+            vscode.window.showErrorMessage(`OpenCode Panel: authentication failed for "${name}"`)
+            return
+          }
+          vscode.window.showInformationMessage(`OpenCode Panel: "${name}" is now ${statusLabel(res.data)}`)
+          return
+        }
+        case "signout": {
+          const res = await backend.client.mcp.auth.remove({ path: { name }, query })
+          // 404 = nothing stored (e.g. a local server) — informational, not an error.
+          if (res.error) {
+            vscode.window.showInformationMessage(`OpenCode Panel: no stored OAuth credentials for "${name}"`)
+            return
+          }
+          vscode.window.showInformationMessage(`OpenCode Panel: removed OAuth credentials for "${name}"`)
+          return
+        }
+        case "showError": {
+          const err = statusError(status) ?? "Unknown error"
+          const choice = await vscode.window.showErrorMessage(`OpenCode Panel: "${name}" — ${err}`, "Copy")
+          if (choice === "Copy") await vscode.env.clipboard.writeText(err)
+          return
+        }
+      }
+    } catch (e) {
+      log(`mcp action ${action} failed`, e)
+      vscode.window.showErrorMessage(`OpenCode Panel: ${(e as Error).message}`)
+    }
+  }
+}
+
+function actionLabel(action: McpAction): string {
+  switch (action) {
+    case "connect":
+      return "$(plug) Connect"
+    case "disconnect":
+      return "$(debug-disconnect) Disconnect"
+    case "authenticate":
+      return "$(key) Authenticate"
+    case "signout":
+      return "$(sign-out) Remove OAuth credentials"
+    case "showError":
+      return "$(error) Show error"
+  }
+}
+
+/** Best-effort message extraction from an SDK error union (e.g. BadRequestError). */
+function errorMessage(err: unknown): string {
+  if (typeof err === "string") return err
+  if (err && typeof err === "object") {
+    const data = (err as { data?: { message?: string } }).data
+    if (data?.message) return data.message
+    const message = (err as { message?: string }).message
+    if (message) return message
+  }
+  return "bad request"
+}

--- a/src/mcp/status-format.ts
+++ b/src/mcp/status-format.ts
@@ -1,0 +1,92 @@
+/**
+ * Pure helpers for the MCP management picker — status presentation, the
+ * per-status action set, and Add-flow input parsing/validation. Kept free of
+ * `vscode` so they unit-test in the node project without the API stub
+ * (mirrors `src/chat/paths.ts`).
+ */
+import type { McpStatus } from "@opencode-ai/sdk"
+
+/**
+ * Actions a server can offer, gated by its current status (see `actionsFor`).
+ * `manage.ts` maps each to a QuickPick label and an SDK call.
+ */
+export type McpAction = "connect" | "disconnect" | "authenticate" | "signout" | "showError"
+
+/** Codicon for the server row, chosen to read like a traffic light at a glance. */
+export function statusIcon(status: McpStatus): string {
+  switch (status.status) {
+    case "connected":
+      return "$(pass-filled)"
+    case "disabled":
+      return "$(circle-slash)"
+    case "failed":
+      return "$(error)"
+    case "needs_auth":
+      return "$(key)"
+    case "needs_client_registration":
+      return "$(warning)"
+  }
+}
+
+/** One-line human status for the row description. */
+export function statusLabel(status: McpStatus): string {
+  switch (status.status) {
+    case "connected":
+      return "connected"
+    case "disabled":
+      return "disabled"
+    case "failed":
+      return `failed: ${status.error}`
+    case "needs_auth":
+      return "needs auth"
+    case "needs_client_registration":
+      return "needs client registration"
+  }
+}
+
+/** The error string for the statuses that carry one, else undefined. */
+export function statusError(status: McpStatus): string | undefined {
+  if (status.status === "failed" || status.status === "needs_client_registration") return status.error
+  return undefined
+}
+
+/**
+ * Which actions to offer for a server in this state.
+ *   - connected → disconnect; remove OAuth creds (no-op/404 for non-OAuth servers).
+ *   - disabled  → connect (force it on at runtime).
+ *   - failed    → connect (retry); show the error.
+ *   - needs_auth → authenticate; connect; remove creds (to re-auth).
+ *   - needs_client_registration → only show the error (needs a clientId in config; not fixable here).
+ */
+export function actionsFor(status: McpStatus): McpAction[] {
+  switch (status.status) {
+    case "connected":
+      return ["disconnect", "signout"]
+    case "disabled":
+      return ["connect"]
+    case "failed":
+      return ["connect", "showError"]
+    case "needs_auth":
+      return ["authenticate", "connect", "signout"]
+    case "needs_client_registration":
+      return ["showError"]
+  }
+}
+
+/**
+ * Split a typed command string into an argv array for `McpLocalConfig.command`.
+ * Plain whitespace split — quoted args with embedded spaces are not supported;
+ * complex commands belong in the opencode config file.
+ */
+export function parseCommand(input: string): string[] {
+  return input.trim().split(/\s+/).filter(Boolean)
+}
+
+/** Validate a new server name against the existing set. Returns the error or undefined. */
+export function validateServerName(name: string, existing: Set<string>): string | undefined {
+  const trimmed = name.trim()
+  if (!trimmed) return "Name is required"
+  if (/\s/.test(trimmed)) return "Name cannot contain spaces"
+  if (existing.has(trimmed)) return `A server named "${trimmed}" already exists`
+  return undefined
+}

--- a/test/host/e2e-mock-opencode.test.ts
+++ b/test/host/e2e-mock-opencode.test.ts
@@ -112,6 +112,74 @@ describe("E2E (mock opencode): SDK ↔ HTTP server", () => {
   })
 })
 
+describe("E2E (mock opencode): MCP management", () => {
+  it("mcp.status returns the configured server map", async () => {
+    server.setMcpStatus({
+      github: { status: "connected" },
+      linear: { status: "needs_auth" },
+      postgres: { status: "failed", error: "ECONNREFUSED" },
+    })
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const res = await client.mcp.status({ query: { directory: "/tmp" } })
+    expect(res.error).toBeUndefined()
+    expect(res.data?.github?.status).toBe("connected")
+    expect(res.data?.linear?.status).toBe("needs_auth")
+    expect(res.data?.postgres?.status).toBe("failed")
+  })
+
+  it("mcp.add records a local config with a string[] command", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const res = await client.mcp.add({
+      query: { directory: "/tmp" },
+      body: { name: "gh", config: { type: "local", command: ["npx", "-y", "server-github"], enabled: true } },
+    })
+    expect(res.error).toBeUndefined()
+    expect(res.data?.gh?.status).toBe("connected")
+    expect(server.mcpAddCalls).toHaveLength(1)
+    const body = server.mcpAddCalls[0]!.body as { name?: string; config?: { type?: string; command?: unknown } }
+    expect(body.name).toBe("gh")
+    expect(body.config?.type).toBe("local")
+    expect(body.config?.command).toEqual(["npx", "-y", "server-github"])
+  })
+
+  it("mcp.add records a remote config with a url", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    await client.mcp.add({
+      query: { directory: "/tmp" },
+      body: { name: "remote1", config: { type: "remote", url: "https://example.com/mcp", enabled: true } },
+    })
+    const body = server.mcpAddCalls.at(-1)!.body as { config?: { type?: string; url?: string } }
+    expect(body.config?.type).toBe("remote")
+    expect(body.config?.url).toBe("https://example.com/mcp")
+  })
+
+  it("mcp.connect and mcp.disconnect return booleans and record the name", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const connected = await client.mcp.connect({ path: { name: "github" }, query: { directory: "/tmp" } })
+    const disconnected = await client.mcp.disconnect({ path: { name: "github" }, query: { directory: "/tmp" } })
+    expect(connected.data).toBe(true)
+    expect(disconnected.data).toBe(true)
+    expect(server.mcpConnectCalls).toEqual(["github"])
+    expect(server.mcpDisconnectCalls).toEqual(["github"])
+  })
+
+  it("mcp.auth.authenticate returns a status and records the name", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const res = await client.mcp.auth.authenticate({ path: { name: "linear" }, query: { directory: "/tmp" } })
+    expect(res.error).toBeUndefined()
+    expect(res.data?.status).toBe("connected")
+    expect(server.mcpAuthenticateCalls).toEqual(["linear"])
+  })
+
+  it("mcp.auth.remove reports success and records the name", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const res = await client.mcp.auth.remove({ path: { name: "linear" }, query: { directory: "/tmp" } })
+    expect(res.error).toBeUndefined()
+    expect(res.data?.success).toBe(true)
+    expect(server.mcpAuthRemoveCalls).toEqual(["linear"])
+  })
+})
+
 describe("E2E (mock opencode): subscribeSession streaming", () => {
   it("forwards onAssistantStart on first message.updated event", async () => {
     const client = createOpencodeClient({ baseUrl: server.url })

--- a/test/host/mcp-manage.test.ts
+++ b/test/host/mcp-manage.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import * as vscode from "vscode"
+import { McpManager } from "../../src/mcp/manage"
+import type { ServerManager } from "../../src/server"
+
+// Drives McpManager end-to-end against a stubbed SDK client + scripted
+// vscode.window prompts (no real VS Code, no real opencode). showQuickPick /
+// showInputBox return values are queued per call in invocation order; the final
+// main-picker call returns undefined to break the run() loop (Esc).
+
+const win = vscode.window as unknown as {
+  showQuickPick: ReturnType<typeof vi.fn>
+  showInputBox: ReturnType<typeof vi.fn>
+  showInformationMessage: ReturnType<typeof vi.fn>
+  showErrorMessage: ReturnType<typeof vi.fn>
+  showWarningMessage: ReturnType<typeof vi.fn>
+}
+const writeText = (vscode.env.clipboard.writeText as unknown) as ReturnType<typeof vi.fn>
+
+type McpStub = {
+  status: ReturnType<typeof vi.fn>
+  add: ReturnType<typeof vi.fn>
+  connect: ReturnType<typeof vi.fn>
+  disconnect: ReturnType<typeof vi.fn>
+  auth: { authenticate: ReturnType<typeof vi.fn>; remove: ReturnType<typeof vi.fn> }
+}
+
+function makeMcp(overrides: Partial<McpStub> = {}): McpStub {
+  return {
+    status: vi.fn().mockResolvedValue({ data: {} }),
+    add: vi.fn().mockResolvedValue({ data: {} }),
+    connect: vi.fn().mockResolvedValue({ data: true }),
+    disconnect: vi.fn().mockResolvedValue({ data: true }),
+    auth: {
+      authenticate: vi.fn().mockResolvedValue({ data: { status: "connected" } }),
+      remove: vi.fn().mockResolvedValue({ data: { success: true } }),
+    },
+    ...overrides,
+  }
+}
+
+function makeManager(mcp: McpStub) {
+  const backend = { url: "http://127.0.0.1:1", directory: "/ws", client: { mcp }, configMode: "isolated" }
+  const servers = { ensure: vi.fn().mockResolvedValue(backend) } as unknown as ServerManager
+  return new McpManager(servers)
+}
+
+const Q = { directory: "/ws" }
+
+beforeEach(() => {
+  // Clear history + queued once-values for the prompt fns (leave withProgress's
+  // setup impl, which runs the task, intact).
+  win.showQuickPick.mockReset()
+  win.showInputBox.mockReset()
+  win.showInformationMessage.mockReset()
+  win.showErrorMessage.mockReset()
+  win.showWarningMessage.mockReset()
+  writeText.mockReset()
+})
+
+describe("McpManager.run", () => {
+  it("exits immediately when the main picker is dismissed", async () => {
+    const mcp = makeMcp({ status: vi.fn().mockResolvedValue({ data: { github: { status: "connected" } } }) })
+    win.showQuickPick.mockResolvedValueOnce(undefined)
+    await makeManager(mcp).run()
+    expect(mcp.status).toHaveBeenCalledTimes(1)
+    expect(mcp.disconnect).not.toHaveBeenCalled()
+  })
+
+  it("disconnects a connected server, then re-fetches status", async () => {
+    const mcp = makeMcp({ status: vi.fn().mockResolvedValue({ data: { github: { status: "connected" } } }) })
+    win.showQuickPick
+      .mockResolvedValueOnce({ server: "github" })
+      .mockResolvedValueOnce({ action: "disconnect" })
+      .mockResolvedValueOnce(undefined)
+    await makeManager(mcp).run()
+    expect(mcp.disconnect).toHaveBeenCalledWith({ path: { name: "github" }, query: Q })
+    expect(mcp.status).toHaveBeenCalledTimes(2) // initial open + after the action
+  })
+
+  it("authenticates a needs_auth server via the server-orchestrated flow", async () => {
+    const mcp = makeMcp({ status: vi.fn().mockResolvedValue({ data: { linear: { status: "needs_auth" } } }) })
+    win.showQuickPick
+      .mockResolvedValueOnce({ server: "linear" })
+      .mockResolvedValueOnce({ action: "authenticate" })
+      .mockResolvedValueOnce(undefined)
+    await makeManager(mcp).run()
+    expect(mcp.auth.authenticate).toHaveBeenCalledWith({ path: { name: "linear" }, query: Q })
+    expect(win.showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("connected"))
+  })
+
+  it("removes OAuth credentials on sign out", async () => {
+    const mcp = makeMcp({ status: vi.fn().mockResolvedValue({ data: { linear: { status: "needs_auth" } } }) })
+    win.showQuickPick
+      .mockResolvedValueOnce({ server: "linear" })
+      .mockResolvedValueOnce({ action: "signout" })
+      .mockResolvedValueOnce(undefined)
+    await makeManager(mcp).run()
+    expect(mcp.auth.remove).toHaveBeenCalledWith({ path: { name: "linear" }, query: Q })
+  })
+
+  it("adds a local server, splitting the command into argv", async () => {
+    const mcp = makeMcp({ add: vi.fn().mockResolvedValue({ data: { gh: { status: "connected" } } }) })
+    win.showInputBox
+      .mockResolvedValueOnce("gh") // name
+      .mockResolvedValueOnce("npx -y server-github") // command
+    win.showQuickPick
+      .mockResolvedValueOnce({ add: true }) // main -> Add
+      .mockResolvedValueOnce({ value: "local" }) // type
+      .mockResolvedValueOnce(undefined) // main reopens -> Esc
+    await makeManager(mcp).run()
+    expect(mcp.add).toHaveBeenCalledWith({
+      body: { name: "gh", config: { type: "local", command: ["npx", "-y", "server-github"], enabled: true } },
+      query: Q,
+    })
+    expect(win.showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("permanent"))
+  })
+
+  it("adds a remote server with the entered url", async () => {
+    const mcp = makeMcp()
+    win.showInputBox
+      .mockResolvedValueOnce("remote1") // name
+      .mockResolvedValueOnce("https://example.com/mcp") // url
+    win.showQuickPick
+      .mockResolvedValueOnce({ add: true })
+      .mockResolvedValueOnce({ value: "remote" })
+      .mockResolvedValueOnce(undefined)
+    await makeManager(mcp).run()
+    expect(mcp.add).toHaveBeenCalledWith({
+      body: { name: "remote1", config: { type: "remote", url: "https://example.com/mcp", enabled: true } },
+      query: Q,
+    })
+  })
+
+  it("aborts the Add flow when the name prompt is cancelled", async () => {
+    const mcp = makeMcp()
+    win.showInputBox.mockResolvedValueOnce(undefined) // cancel at name
+    win.showQuickPick
+      .mockResolvedValueOnce({ add: true })
+      .mockResolvedValueOnce(undefined)
+    await makeManager(mcp).run()
+    expect(mcp.add).not.toHaveBeenCalled()
+  })
+
+  it("shows and copies a failed server's error", async () => {
+    const mcp = makeMcp({
+      status: vi.fn().mockResolvedValue({ data: { postgres: { status: "failed", error: "ECONNREFUSED" } } }),
+    })
+    win.showQuickPick
+      .mockResolvedValueOnce({ server: "postgres" })
+      .mockResolvedValueOnce({ action: "showError" })
+      .mockResolvedValueOnce(undefined)
+    win.showErrorMessage.mockResolvedValueOnce("Copy")
+    await makeManager(mcp).run()
+    expect(writeText).toHaveBeenCalledWith("ECONNREFUSED")
+  })
+
+  it("surfaces a status-fetch failure and stops before showing a picker", async () => {
+    const mcp = makeMcp({ status: vi.fn().mockResolvedValue({ error: { message: "boom" } }) })
+    await makeManager(mcp).run()
+    expect(win.showErrorMessage).toHaveBeenCalled()
+    expect(win.showQuickPick).not.toHaveBeenCalled()
+  })
+})

--- a/test/host/mcp-status-format.test.ts
+++ b/test/host/mcp-status-format.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest"
+import type { McpStatus } from "@opencode-ai/sdk"
+import {
+  actionsFor,
+  parseCommand,
+  statusError,
+  statusIcon,
+  statusLabel,
+  validateServerName,
+} from "../../src/mcp/status-format"
+
+const STATUSES: McpStatus[] = [
+  { status: "connected" },
+  { status: "disabled" },
+  { status: "failed", error: "ECONNREFUSED" },
+  { status: "needs_auth" },
+  { status: "needs_client_registration", error: "no clientId" },
+]
+
+describe("statusIcon", () => {
+  it("returns a distinct codicon per status", () => {
+    const icons = STATUSES.map(statusIcon)
+    expect(new Set(icons).size).toBe(STATUSES.length)
+    expect(icons.every((i) => i.startsWith("$("))).toBe(true)
+  })
+})
+
+describe("statusLabel", () => {
+  it("renders a human label, inlining the error for failed", () => {
+    expect(statusLabel({ status: "connected" })).toBe("connected")
+    expect(statusLabel({ status: "disabled" })).toBe("disabled")
+    expect(statusLabel({ status: "needs_auth" })).toBe("needs auth")
+    expect(statusLabel({ status: "failed", error: "boom" })).toBe("failed: boom")
+    expect(statusLabel({ status: "needs_client_registration", error: "x" })).toBe("needs client registration")
+  })
+})
+
+describe("statusError", () => {
+  it("returns the error only for the statuses that carry one", () => {
+    expect(statusError({ status: "failed", error: "boom" })).toBe("boom")
+    expect(statusError({ status: "needs_client_registration", error: "x" })).toBe("x")
+    expect(statusError({ status: "connected" })).toBeUndefined()
+    expect(statusError({ status: "needs_auth" })).toBeUndefined()
+    expect(statusError({ status: "disabled" })).toBeUndefined()
+  })
+})
+
+describe("actionsFor", () => {
+  it("offers status-appropriate actions", () => {
+    expect(actionsFor({ status: "connected" })).toEqual(["disconnect", "signout"])
+    expect(actionsFor({ status: "disabled" })).toEqual(["connect"])
+    expect(actionsFor({ status: "failed", error: "x" })).toEqual(["connect", "showError"])
+    expect(actionsFor({ status: "needs_auth" })).toEqual(["authenticate", "connect", "signout"])
+    expect(actionsFor({ status: "needs_client_registration", error: "x" })).toEqual(["showError"])
+  })
+
+  it("only offers authenticate when a server needs auth", () => {
+    for (const st of STATUSES) {
+      const hasAuth = actionsFor(st).includes("authenticate")
+      expect(hasAuth).toBe(st.status === "needs_auth")
+    }
+  })
+})
+
+describe("parseCommand", () => {
+  it("splits on whitespace and drops empties", () => {
+    expect(parseCommand("npx -y @scope/server")).toEqual(["npx", "-y", "@scope/server"])
+    expect(parseCommand("  spaced   out  ")).toEqual(["spaced", "out"])
+    expect(parseCommand("")).toEqual([])
+    expect(parseCommand("   ")).toEqual([])
+  })
+})
+
+describe("validateServerName", () => {
+  const existing = new Set(["github"])
+  it("rejects empty, spaced, and duplicate names", () => {
+    expect(validateServerName("", existing)).toMatch(/required/i)
+    expect(validateServerName("   ", existing)).toMatch(/required/i)
+    expect(validateServerName("my server", existing)).toMatch(/spaces/i)
+    expect(validateServerName("github", existing)).toMatch(/already exists/i)
+  })
+  it("accepts a fresh single-token name", () => {
+    expect(validateServerName("linear", existing)).toBeUndefined()
+    expect(validateServerName("  linear  ", existing)).toBeUndefined()
+  })
+})

--- a/test/host/mock-opencode-server.ts
+++ b/test/host/mock-opencode-server.ts
@@ -38,6 +38,14 @@ export type MockOpencodeServer = {
   setSessionStatus: (sessionID: string, status: { type: "idle" | "busy" | "retry" } | undefined) => void
   /** Number of times GET /session/status has been called. */
   statusPollCount: () => number
+  /** Records of every mcp.add body, and the server name for each lifecycle/auth call. */
+  mcpAddCalls: Array<{ body: unknown }>
+  mcpConnectCalls: string[]
+  mcpDisconnectCalls: string[]
+  mcpAuthenticateCalls: string[]
+  mcpAuthRemoveCalls: string[]
+  /** Configure what GET /mcp returns. */
+  setMcpStatus: (map: Record<string, { status: string; error?: string }>) => void
   close: () => Promise<void>
 }
 
@@ -49,6 +57,12 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
   let commands: Array<Record<string, unknown>> = []
   const sessionStatuses = new Map<string, { type: "idle" | "busy" | "retry" }>()
   let statusPolls = 0
+  let mcpStatus: Record<string, { status: string; error?: string }> = {}
+  const mcpAddCalls: Array<{ body: unknown }> = []
+  const mcpConnectCalls: string[] = []
+  const mcpDisconnectCalls: string[] = []
+  const mcpAuthenticateCalls: string[] = []
+  const mcpAuthRemoveCalls: string[] = []
   let clientResolver: (() => void) | undefined
 
   const server: Server = createServer((req: IncomingMessage, res: ServerResponse) => {
@@ -197,6 +211,44 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
       return
     }
 
+    // MCP management. Order matters: the /auth/authenticate route must be
+    // checked before the bare /auth route below.
+    if (path === "/mcp" && req.method === "GET") {
+      reply(res, 200, mcpStatus)
+      return
+    }
+    if (path === "/mcp" && req.method === "POST") {
+      const body = (await readBody(req)) as { name?: string }
+      mcpAddCalls.push({ body })
+      if (body?.name) mcpStatus[body.name] = { status: "connected" }
+      reply(res, 200, mcpStatus)
+      return
+    }
+    const mcpAuthenticateMatch = path.match(/^\/mcp\/([^/]+)\/auth\/authenticate$/)
+    if (mcpAuthenticateMatch && req.method === "POST") {
+      mcpAuthenticateCalls.push(mcpAuthenticateMatch[1]!)
+      reply(res, 200, { status: "connected" })
+      return
+    }
+    const mcpAuthMatch = path.match(/^\/mcp\/([^/]+)\/auth$/)
+    if (mcpAuthMatch && req.method === "DELETE") {
+      mcpAuthRemoveCalls.push(mcpAuthMatch[1]!)
+      reply(res, 200, { success: true })
+      return
+    }
+    const mcpConnectMatch = path.match(/^\/mcp\/([^/]+)\/connect$/)
+    if (mcpConnectMatch && req.method === "POST") {
+      mcpConnectCalls.push(mcpConnectMatch[1]!)
+      reply(res, 200, true)
+      return
+    }
+    const mcpDisconnectMatch = path.match(/^\/mcp\/([^/]+)\/disconnect$/)
+    if (mcpDisconnectMatch && req.method === "POST") {
+      mcpDisconnectCalls.push(mcpDisconnectMatch[1]!)
+      reply(res, 200, true)
+      return
+    }
+
     // Health (used by some SDK clients before connecting)
     if (path === "/" && req.method === "GET") {
       reply(res, 200, { ok: true })
@@ -236,6 +288,14 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
     },
     statusPollCount() {
       return statusPolls
+    },
+    mcpAddCalls,
+    mcpConnectCalls,
+    mcpDisconnectCalls,
+    mcpAuthenticateCalls,
+    mcpAuthRemoveCalls,
+    setMcpStatus(map) {
+      mcpStatus = map
     },
     async close() {
       for (const c of sseClients) c.end()

--- a/test/host/setup.ts
+++ b/test/host/setup.ts
@@ -81,6 +81,11 @@ vi.mock("vscode", () => {
     ViewColumn: { One: 1, Two: 2, Three: 3 },
     StatusBarAlignment: { Left: 1, Right: 2 },
     QuickPickItemKind: { Separator: -1, Default: 0 },
+    ProgressLocation: { SourceControl: 1, Window: 10, Notification: 15 },
+    env: {
+      clipboard: { writeText: vi.fn(), readText: vi.fn() },
+      openExternal: vi.fn(),
+    },
     workspace: {
       workspaceFolders: [{ uri: Uri.file("/workspace") }],
       getConfiguration: vi.fn(() => ({ get: vi.fn() })),
@@ -127,6 +132,11 @@ vi.mock("vscode", () => {
       showErrorMessage: vi.fn(),
       showTextDocument: vi.fn(),
       showQuickPick: vi.fn(),
+      showInputBox: vi.fn(),
+      // Run the progress task immediately and return its result (the SDK call).
+      withProgress: vi.fn((_opts: unknown, task: (p: unknown, t: unknown) => unknown) =>
+        task({ report: vi.fn() }, { isCancellationRequested: false, onCancellationRequested: vi.fn() }),
+      ),
       createStatusBarItem: vi.fn((_align?: unknown, _priority?: number) => {
         const item: Record<string, unknown> = {
           text: "",


### PR DESCRIPTION
## Summary

Adds MCP (Model Context Protocol) server management to OpenCode Panel. opencode can attach local/remote MCP tool servers and exposes a full management surface over the SDK (`client.mcp.*`), but the panel had no way to use it — you had to drop to the opencode CLI/TUI.

A native VS Code **QuickPick** (mirroring the agent/model pickers — native for management, webview only for chat) lists every server with a status icon and lets you add / connect / disconnect / authenticate / sign out. Reachable two ways:

- Command Palette → **OpenCode Panel: Manage MCP Servers** (`opencui.manageMcp`)
- Typing **`/mcp`** in the chat composer (a built-in slash command that routes to the same command — opens the picker, posts no chat turn)

### How it works
- **Status is poll-based** — the SDK `Event` union has no `EventMcp*`, so the picker re-fetches `mcp.status` on open and after every action (the `run()` loop re-opens until Esc).
- **OAuth is one call.** Because the opencode server is a local subprocess, `mcp.auth.authenticate` opens the browser and captures the loopback redirect itself, then returns the new status — no `registerUriHandler`, no pasting a code (mirrors `opencode auth login`).
- **`mcp.add` is session-scoped** ("add dynamically") — not written to `opencode.json`; the success toast says so.
- Zero webview/protocol/React changes beyond one entry in the built-in command list.

### Files
- New `src/mcp/status-format.ts` (pure: icon/label/error, the per-status action state machine, command parse, name validation) and `src/mcp/manage.ts` (`McpManager`: `run` loop, `addServer` multi-step, `serverActions` dispatch).
- `src/extension.ts` registers `opencui.manageMcp`; `package.json` contributes it.
- `src/chat/builtin-commands.ts` adds `/mcp`; `src/chat/view.ts` routes it to the command (no bubble / Main task).

## Test plan
- [x] `bun run test` — **882 pass** (+23 new): pure-helper tests, a stub-driven `McpManager` end-to-end host test (connect/disconnect/authenticate/sign-out/add-local/add-remote/show-error/cancel/error paths), and mock-opencode-server MCP routes + SDK-contract e2e assertions.
- [x] `bun run check-types` (host) — clean.
- [x] `cd webview && bunx tsc --noEmit` — clean.
- [x] `bun run compile` — host + webview build OK.
- [ ] Manual (needs a live opencode + a real MCP server): list renders with icons; `/mcp` opens the picker with no chat bubble; disconnect/connect flip status; add local/remote; `needs_auth` → Authenticate → browser → connected; Sign out → `needs_auth`; bad config → error toast.

Closes #252.