### PR TITLE
chore(release): cut v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-05-30
+
 ### Added
 - MCP (Model Context Protocol) server management. A native QuickPick — reachable from the Command Palette (**OpenCode Panel: Manage MCP Servers**) and by typing `/mcp` in the chat composer — lists every configured server with a status icon (connected / disabled / failed / needs auth / needs client registration) and inline error detail, fetched via the SDK's `client.mcp.status`. From it you can **add** a server (a multi-step prompt for a local command or remote URL → `mcp.add`), **connect** / **disconnect** (`mcp.connect` / `mcp.disconnect`), **authenticate** a server that needs OAuth (`mcp.auth.authenticate`, where the local opencode server opens the browser and finalizes the flow itself — no code pasting), **remove** stored OAuth credentials (`mcp.auth.remove`), and copy a failed server's error. Status is re-fetched on open and after every action, since the SDK has no MCP push event. `/mcp` opens the picker without posting a chat turn; `mcp.add` is session-scoped (it is not written to your opencode config).
 - `/undo`, `/redo`, `/fork`, and `/new` session slash commands in the `/` picker, matching opencode's own built-in slash set. **`/undo`** reverts the last turn (`session.revert`), drops it from the transcript, and restores its prompt text into the composer so you can edit and resend; **`/redo`** re-applies it (`session.unrevert` / `session.revert`). **`/fork`** duplicates the current session into a new conversation (`session.fork`) — copying the history and switching to it — so you can branch and continue independently. **`/new`** starts a fresh chat. Like the other built-ins these post no chat turn. `/redo` is in-memory (it does not survive a window reload), and any new turn or conversation switch clears it.
+
+Closes #252, #254.
 
 ## [1.0.0] - 2026-05-30
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
Cuts **v1.1.0**.

Bumps `package.json` to 1.1.0 and rolls the CHANGELOG `[Unreleased]` block into `## [1.1.0]`.

## Included since v1.0.0
- **MCP server management** — native picker + `/mcp` (#253, closes #252)
- **`/undo` · `/redo` · `/fork` · `/new`** session commands (#255, closes #254)
- **README screenshots** refreshed (#257)

## Verified locally
- [x] `bun run check-types` — clean
- [x] `bun run test` — 898 passed (55 files)
- [x] `bun run package` — production build OK

Once merged, tagging `v1.1.0` + publishing the GitHub Release triggers the Marketplace + Open VSX publish workflow.

Closes #258