### PR TITLE
feat(chat): add /provider command to connect & disconnect AI providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,10 @@
         "title": "OpenCode Panel: Manage MCP Servers"
       },
       {
+        "command": "opencui.manageProviders",
+        "title": "OpenCode Panel: Manage AI Providers"
+      },
+      {
         "command": "opencui.server.restart",
         "title": "OpenCode Panel: Restart Backend"
       },

--- a/src/chat/builtin-commands.ts
+++ b/src/chat/builtin-commands.ts
@@ -22,6 +22,7 @@ export const BUILTIN_COMMANDS: ReadonlyArray<CommandInfo> = [
   { name: "share", description: "Create a shareable link for this session", takesArguments: false },
   { name: "unshare", description: "Disable sharing for this session", takesArguments: false },
   { name: "mcp", description: "Manage MCP servers", takesArguments: false },
+  { name: "provider", description: "Manage AI providers", takesArguments: false },
   { name: "undo", description: "Revert the last turn", takesArguments: false },
   { name: "redo", description: "Re-apply the last reverted turn", takesArguments: false },
   { name: "fork", description: "Duplicate this conversation", takesArguments: false },

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -1217,6 +1217,12 @@ export class ChatView implements vscode.WebviewViewProvider {
       await vscode.commands.executeCommand("opencui.manageMcp")
       return
     }
+    // `/provider` opens the native AI-provider management picker — same
+    // no-bubble, no-backend-here contract as `/mcp`.
+    if (command === "provider") {
+      await vscode.commands.executeCommand("opencui.manageProviders")
+      return
+    }
     // `/new` starts a fresh chat — no backend needed (the next prompt creates the
     // session lazily), and it must not post a bubble / Main task.
     if (command === "new") {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import { InlineEdit } from "./inline/edit"
 import { Preferences } from "./preferences"
 import { Picker } from "./picker"
 import { McpManager } from "./mcp/manage"
+import { ProviderManager } from "./provider/manage"
 import { RecentEditsTracker } from "./workspace-context/recent-edits"
 import { IndexManager, readIndexSettings } from "./indexing/index-manager"
 import { AgentTaskStore } from "./agents/task-store"
@@ -35,6 +36,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const inline = new InlineEdit(servers, prefs)
   const picker = new Picker(servers, prefs)
   const mcp = new McpManager(servers)
+  const providers = new ProviderManager(servers, prefs)
 
   context.subscriptions.push(
     vscode.window.registerWebviewViewProvider(ChatView.viewType, chat, {
@@ -51,6 +53,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("opencui.selectModel", () => picker.pickModel()),
     vscode.commands.registerCommand("opencui.selectVariant", () => picker.pickVariantForCurrent()),
     vscode.commands.registerCommand("opencui.manageMcp", () => mcp.run()),
+    vscode.commands.registerCommand("opencui.manageProviders", () => providers.run()),
     vscode.commands.registerCommand("opencui.agents.open", () => showAgentsQuickPick(agentTaskStore!)),
     vscode.commands.registerCommand("opencui.server.restart", async () => {
       status.set("starting", "restarting backend")

--- a/src/provider/manage.ts
+++ b/src/provider/manage.ts
@@ -19,6 +19,9 @@ type ProviderItem = vscode.QuickPickItem & { row?: ProviderRow; connect?: typeof
 type MethodItem = vscode.QuickPickItem & { index: number }
 type ChoiceItem = vscode.QuickPickItem & { choice: ConnectableProvider }
 
+/** Result of awaiting a server-orchestrated ("auto") OAuth callback. */
+type AutoOutcome = { kind: "ok" } | { kind: "cancelled" } | { kind: "failed"; message?: string }
+
 type ProviderState = {
   rows: ProviderRow[]
   /** providerID -> display name, for the connect list. */
@@ -192,46 +195,57 @@ export class ProviderManager {
     try {
       const authRes = await backend.client.provider.oauth.authorize({ path, query, body: { method: methodIndex } })
       if (authRes.error || !authRes.data) {
-        vscode.window.showErrorMessage(`OpenCode Panel: could not start OAuth for "${choice.name}"`)
+        vscode.window.showErrorMessage(
+          `OpenCode Panel: could not start OAuth for "${choice.name}"${suffix(errorText(authRes.error))}`,
+        )
         return
       }
       const authz = authRes.data
       if (authz.url) await vscode.env.openExternal(vscode.Uri.parse(authz.url))
 
       if (authz.method === "auto") {
-        // The local opencode server captures the redirect itself, so the
-        // callback blocks until the user finishes in the browser. Make the
-        // progress cancellable and race the callback against cancellation:
-        // abandoning the flow (closing the browser) would otherwise leave this
-        // notification stuck forever on a callback that never resolves. On
-        // cancel we abort the in-flight request and bail quietly.
+        // Server-orchestrated flow. For device-code providers (e.g. GitHub
+        // Copilot) `instructions` carries a user code ("Enter code: XXXX-XXXX")
+        // the user must type at `url`; the callback then polls server-side until
+        // they finish. Surface that code (and copy it) or the user can't
+        // complete the flow — then block on the callback, cancellably, so
+        // abandoning it doesn't leave the notification stuck forever.
+        const code = deviceCode(authz.instructions)
+        if (code) {
+          await vscode.env.clipboard.writeText(code)
+          void vscode.window.showInformationMessage(
+            `OpenCode Panel: enter code ${code} in your browser to authorize "${choice.name}" (copied to clipboard).`,
+          )
+        }
         const outcome = await vscode.window.withProgress(
           {
             location: vscode.ProgressLocation.Notification,
             cancellable: true,
-            title: `Authorizing "${choice.name}" — finish in your browser, or cancel...`,
+            title: code
+              ? `Authorizing "${choice.name}" — enter code ${code} in your browser, or cancel...`
+              : `Authorizing "${choice.name}" — finish in your browser, or cancel...`,
           },
-          async (_progress, token): Promise<"ok" | "cancelled" | "failed"> => {
+          async (_progress, token): Promise<AutoOutcome> => {
             const controller = new AbortController()
-            const onCancel = new Promise<"cancelled">((resolve) =>
+            const onCancel = new Promise<AutoOutcome>((resolve) =>
               token.onCancellationRequested(() => {
                 controller.abort()
-                resolve("cancelled")
+                resolve({ kind: "cancelled" })
               }),
             )
             const onCallback = backend.client.provider.oauth
               .callback({ path, query, body: { method: methodIndex }, signal: controller.signal })
-              .then((res): "ok" | "failed" => (!res.error && res.data === true ? "ok" : "failed"))
-              .catch((): "failed" => "failed")
+              .then((res): AutoOutcome => (!res.error && res.data === true ? { kind: "ok" } : { kind: "failed", message: errorText(res.error) }))
+              .catch((e): AutoOutcome => (controller.signal.aborted ? { kind: "cancelled" } : { kind: "failed", message: (e as Error).message }))
             return Promise.race([onCallback, onCancel])
           },
         )
-        if (outcome === "cancelled") {
+        if (outcome.kind === "cancelled") {
           vscode.window.showInformationMessage(`OpenCode Panel: connecting "${choice.name}" was cancelled.`)
           return
         }
-        if (outcome !== "ok") {
-          vscode.window.showErrorMessage(`OpenCode Panel: authorization failed for "${choice.name}"`)
+        if (outcome.kind !== "ok") {
+          vscode.window.showErrorMessage(`OpenCode Panel: authorization failed for "${choice.name}"${suffix(outcome.message)}`)
           return
         }
         vscode.window.showInformationMessage(`OpenCode Panel: connected "${choice.name}".`)
@@ -252,7 +266,7 @@ export class ProviderManager {
         body: { method: methodIndex, code: code.trim() },
       })
       if (cbRes.error || cbRes.data !== true) {
-        vscode.window.showErrorMessage(`OpenCode Panel: authorization failed for "${choice.name}"`)
+        vscode.window.showErrorMessage(`OpenCode Panel: authorization failed for "${choice.name}"${suffix(errorText(cbRes.error))}`)
         return
       }
       vscode.window.showInformationMessage(`OpenCode Panel: connected "${choice.name}".`)
@@ -298,4 +312,34 @@ export class ProviderManager {
     )
     if (choice === "Select model") await vscode.commands.executeCommand("opencui.selectModel")
   }
+}
+
+/**
+ * Extract the device/user code from an OAuth "auto" provider's `instructions`.
+ * opencode formats it as "Enter code: XXXX-XXXX" — take the part after the
+ * first colon. Returns "" when there is nothing actionable to show.
+ */
+function deviceCode(instructions: string | undefined): string {
+  const text = instructions?.trim()
+  if (!text) return ""
+  const colon = text.indexOf(":")
+  return colon >= 0 ? text.slice(colon + 1).trim() : text
+}
+
+/** Best-effort message from an SDK error union (BadRequestError, string, ...). */
+function errorText(err: unknown): string | undefined {
+  if (!err) return undefined
+  if (typeof err === "string") return err
+  if (typeof err === "object") {
+    const data = (err as { data?: { message?: string } }).data
+    if (data?.message) return data.message
+    const message = (err as { message?: string }).message
+    if (message) return message
+  }
+  return undefined
+}
+
+/** ": <msg>" when a reason is present, else "" — for appending to a notification. */
+function suffix(message: string | undefined): string {
+  return message ? `: ${message}` : ""
 }

--- a/src/provider/manage.ts
+++ b/src/provider/manage.ts
@@ -1,0 +1,114 @@
+import * as vscode from "vscode"
+import type { ServerManager, Backend } from "../server"
+import type { Preferences } from "../preferences"
+import { log } from "../output"
+import { removableProviders, removeProviderAuth, UNSUPPORTED_HINT, type ProviderRow } from "./provider-format"
+
+type ProviderItem = vscode.QuickPickItem & { row?: ProviderRow }
+
+/**
+ * Native QuickPick for opencode's AI providers, reachable from the Command
+ * Palette (`opencui.manageProviders`) and the `/provider` built-in slash
+ * command. Mirrors `src/mcp/manage.ts`: ensure the backend, fetch over the SDK,
+ * drive everything through QuickPick, surface results via notifications. The
+ * loop re-opens the picker (re-fetching the list) until the user presses Esc.
+ *
+ * v1 is disconnect-only: it lists the authenticated providers
+ * (`provider.list().connected`) and removes a provider's stored credentials.
+ * Connecting / authenticating a provider (opencode's API-key / OAuth flow) is a
+ * separate, larger surface and is intentionally out of scope here.
+ */
+export class ProviderManager {
+  constructor(
+    private servers: ServerManager,
+    private prefs: Preferences,
+  ) {}
+
+  async run() {
+    let backend: Backend
+    try {
+      backend = await this.servers.ensure()
+    } catch (e) {
+      log("provider manage: backend ensure failed", e)
+      vscode.window.showErrorMessage(`OpenCode Panel: ${(e as Error).message}`)
+      return
+    }
+
+    for (;;) {
+      const rows = await this.fetchProviders(backend)
+      if (!rows) return
+      const items: ProviderItem[] = rows.map((row) => ({
+        label: `$(key) ${row.name}`,
+        description: row.removable ? "connected" : "from environment (not removable)",
+        row,
+      }))
+      const picked = await vscode.window.showQuickPick(items, {
+        title: "Manage AI providers",
+        placeHolder: rows.length ? "Select a provider to disconnect" : "No connected providers",
+      })
+      if (!picked || !picked.row) return
+      const row = picked.row
+      if (!row.removable) {
+        vscode.window.showInformationMessage(
+          `OpenCode Panel: "${row.name}" is configured from an environment variable — remove it from your environment or opencode config instead.`,
+        )
+        continue
+      }
+      await this.confirmAndDisconnect(backend, row)
+    }
+  }
+
+  private async fetchProviders(backend: Backend): Promise<ProviderRow[] | undefined> {
+    try {
+      const query = { directory: backend.directory }
+      const [listRes, cfgRes] = await Promise.all([
+        backend.client.provider.list({ query }),
+        backend.client.config.providers({ query }),
+      ])
+      if (listRes.error || !listRes.data) {
+        vscode.window.showErrorMessage("OpenCode Panel: failed to load providers")
+        return undefined
+      }
+      return removableProviders(listRes.data.connected ?? [], cfgRes.data?.providers ?? [])
+    } catch (e) {
+      log("provider.list failed", e)
+      vscode.window.showErrorMessage(`OpenCode Panel: ${(e as Error).message}`)
+      return undefined
+    }
+  }
+
+  private async confirmAndDisconnect(backend: Backend, row: ProviderRow) {
+    const confirm = await vscode.window.showWarningMessage(
+      `Remove stored credentials for "${row.name}"?`,
+      {
+        modal: true,
+        detail: "You'll need to re-authenticate with opencode to use this provider's models again.",
+      },
+      "Remove",
+    )
+    if (confirm !== "Remove") return
+
+    const result = await removeProviderAuth(backend.url, row.id)
+    if (result.kind === "ok") {
+      vscode.window.showInformationMessage(`OpenCode Panel: removed credentials for "${row.name}".`)
+      await this.warnIfActiveModel(row)
+      return
+    }
+    if (result.kind === "unsupported") {
+      const choice = await vscode.window.showWarningMessage(UNSUPPORTED_HINT, "Copy command")
+      if (choice === "Copy command") await vscode.env.clipboard.writeText("opencode auth logout")
+      return
+    }
+    vscode.window.showErrorMessage(`OpenCode Panel: could not remove "${row.name}" — ${result.message}`)
+  }
+
+  /** If the user's selected model belonged to the removed provider, nudge them to pick another. */
+  private async warnIfActiveModel(row: ProviderRow) {
+    if (this.prefs.get().modelProviderID !== row.id) return
+    const choice = await vscode.window.showWarningMessage(
+      `Your selected model used "${row.name}", which is now disconnected. Pick a new model.`,
+      "Select model",
+    )
+    if (choice === "Select model") await vscode.commands.executeCommand("opencui.selectModel")
+  }
+}

--- a/src/provider/manage.ts
+++ b/src/provider/manage.ts
@@ -2,21 +2,40 @@ import * as vscode from "vscode"
 import type { ServerManager, Backend } from "../server"
 import type { Preferences } from "../preferences"
 import { log } from "../output"
-import { removableProviders, removeProviderAuth, UNSUPPORTED_HINT, type ProviderRow } from "./provider-format"
+import {
+  connectableProviders,
+  removableProviders,
+  removeProviderAuth,
+  UNSUPPORTED_HINT,
+  type AuthMethod,
+  type ConnectableProvider,
+  type ProviderRow,
+} from "./provider-format"
 
-type ProviderItem = vscode.QuickPickItem & { row?: ProviderRow }
+/** Sentinel identifying the "Connect a provider" row in the main picker. */
+const CONNECT = Symbol("provider-connect")
+
+type ProviderItem = vscode.QuickPickItem & { row?: ProviderRow; connect?: typeof CONNECT }
+type MethodItem = vscode.QuickPickItem & { index: number }
+type ChoiceItem = vscode.QuickPickItem & { choice: ConnectableProvider }
+
+type ProviderState = {
+  rows: ProviderRow[]
+  /** providerID -> display name, for the connect list. */
+  names: Map<string, string>
+  connected: string[]
+}
 
 /**
  * Native QuickPick for opencode's AI providers, reachable from the Command
  * Palette (`opencui.manageProviders`) and the `/provider` built-in slash
  * command. Mirrors `src/mcp/manage.ts`: ensure the backend, fetch over the SDK,
  * drive everything through QuickPick, surface results via notifications. The
- * loop re-opens the picker (re-fetching the list) until the user presses Esc.
+ * loop re-opens the picker (re-fetching) until the user presses Esc.
  *
- * v1 is disconnect-only: it lists the authenticated providers
- * (`provider.list().connected`) and removes a provider's stored credentials.
- * Connecting / authenticating a provider (opencode's API-key / OAuth flow) is a
- * separate, larger surface and is intentionally out of scope here.
+ * Connect (API key / OAuth) is fully supported by the released SDK. Disconnect
+ * removes stored credentials via an untyped, guarded DELETE — see
+ * `removeProviderAuth` for why.
  */
 export class ProviderManager {
   constructor(
@@ -35,18 +54,26 @@ export class ProviderManager {
     }
 
     for (;;) {
-      const rows = await this.fetchProviders(backend)
-      if (!rows) return
-      const items: ProviderItem[] = rows.map((row) => ({
-        label: `$(key) ${row.name}`,
-        description: row.removable ? "connected" : "from environment (not removable)",
-        row,
-      }))
+      const state = await this.fetchState(backend)
+      if (!state) return
+      const items: ProviderItem[] = [
+        { label: "$(add) Connect a provider", connect: CONNECT, alwaysShow: true },
+        ...state.rows.map((row): ProviderItem => ({
+          label: `$(key) ${row.name}`,
+          description: row.removable ? "connected" : "from environment (not removable)",
+          row,
+        })),
+      ]
       const picked = await vscode.window.showQuickPick(items, {
         title: "Manage AI providers",
-        placeHolder: rows.length ? "Select a provider to disconnect" : "No connected providers",
+        placeHolder: state.rows.length ? "Connect a new provider, or disconnect one" : "Connect a provider to get started",
       })
-      if (!picked || !picked.row) return
+      if (!picked) return
+      if (picked.connect) {
+        await this.connectFlow(backend, state)
+        continue
+      }
+      if (!picked.row) return
       const row = picked.row
       if (!row.removable) {
         vscode.window.showInformationMessage(
@@ -58,7 +85,7 @@ export class ProviderManager {
     }
   }
 
-  private async fetchProviders(backend: Backend): Promise<ProviderRow[] | undefined> {
+  private async fetchState(backend: Backend): Promise<ProviderState | undefined> {
     try {
       const query = { directory: backend.directory }
       const [listRes, cfgRes] = await Promise.all([
@@ -69,13 +96,152 @@ export class ProviderManager {
         vscode.window.showErrorMessage("OpenCode Panel: failed to load providers")
         return undefined
       }
-      return removableProviders(listRes.data.connected ?? [], cfgRes.data?.providers ?? [])
+      const connected = listRes.data.connected ?? []
+      const configProviders = cfgRes.data?.providers ?? []
+      const names = new Map<string, string>()
+      for (const p of listRes.data.all ?? []) names.set(p.id, p.name)
+      for (const p of configProviders) if (!names.has(p.id)) names.set(p.id, p.name)
+      return { rows: removableProviders(connected, configProviders), names, connected }
     } catch (e) {
       log("provider.list failed", e)
       vscode.window.showErrorMessage(`OpenCode Panel: ${(e as Error).message}`)
       return undefined
     }
   }
+
+  // --- Connect ------------------------------------------------------------
+
+  private async connectFlow(backend: Backend, state: ProviderState) {
+    const query = { directory: backend.directory }
+    let methodsByProvider: Record<string, AuthMethod[]>
+    try {
+      const res = await backend.client.provider.auth({ query })
+      if (res.error || !res.data) {
+        vscode.window.showErrorMessage("OpenCode Panel: failed to load provider login methods")
+        return
+      }
+      methodsByProvider = res.data
+    } catch (e) {
+      log("provider.auth failed", e)
+      vscode.window.showErrorMessage(`OpenCode Panel: ${(e as Error).message}`)
+      return
+    }
+
+    const choices = connectableProviders(methodsByProvider, state.names, state.connected)
+    if (choices.length === 0) {
+      vscode.window.showInformationMessage("OpenCode Panel: no providers available to connect.")
+      return
+    }
+    const items: ChoiceItem[] = choices.map((choice) => ({
+      label: `$(plug) ${choice.name}`,
+      description: choice.connected ? "connected — reconnect" : choice.methods.map((m) => m.label).join(", "),
+      choice,
+    }))
+    const pick = await vscode.window.showQuickPick(items, {
+      title: "Connect a provider",
+      placeHolder: "Select a provider to connect",
+    })
+    if (!pick) return
+    const choice = pick.choice
+
+    let methodIndex = 0
+    if (choice.methods.length > 1) {
+      const methodItems: MethodItem[] = choice.methods.map((m, index) => ({ label: m.label, description: m.type, index }))
+      const mPick = await vscode.window.showQuickPick(methodItems, {
+        title: `Connect ${choice.name}`,
+        placeHolder: "Login method",
+      })
+      if (!mPick) return
+      methodIndex = mPick.index
+    }
+    const method = choice.methods[methodIndex]!
+    if (method.type === "api") await this.connectApiKey(backend, choice, method)
+    else await this.connectOAuth(backend, choice, methodIndex)
+  }
+
+  private async connectApiKey(backend: Backend, choice: ConnectableProvider, method: AuthMethod) {
+    const key = await vscode.window.showInputBox({
+      title: `Connect ${choice.name}`,
+      prompt: method.label,
+      password: true,
+      ignoreFocusOut: true,
+      placeHolder: "Paste your API key",
+      validateInput: (v) => (v.trim() ? undefined : "An API key is required"),
+    })
+    if (!key) return
+    try {
+      const res = await backend.client.auth.set({
+        path: { id: choice.id },
+        query: { directory: backend.directory },
+        body: { type: "api", key: key.trim() },
+      })
+      if (res.error) {
+        vscode.window.showErrorMessage(`OpenCode Panel: could not connect "${choice.name}"`)
+        return
+      }
+      vscode.window.showInformationMessage(`OpenCode Panel: connected "${choice.name}".`)
+    } catch (e) {
+      log("auth.set failed", e)
+      vscode.window.showErrorMessage(`OpenCode Panel: ${(e as Error).message}`)
+    }
+  }
+
+  private async connectOAuth(backend: Backend, choice: ConnectableProvider, methodIndex: number) {
+    const query = { directory: backend.directory }
+    const path = { id: choice.id }
+    try {
+      const authRes = await backend.client.provider.oauth.authorize({ path, query, body: { method: methodIndex } })
+      if (authRes.error || !authRes.data) {
+        vscode.window.showErrorMessage(`OpenCode Panel: could not start OAuth for "${choice.name}"`)
+        return
+      }
+      const authz = authRes.data
+      if (authz.url) await vscode.env.openExternal(vscode.Uri.parse(authz.url))
+
+      if (authz.method === "auto") {
+        // The local opencode server captures the redirect itself — block on the
+        // callback while the user finishes in the browser (like MCP authenticate).
+        const cbRes = await vscode.window.withProgress(
+          {
+            location: vscode.ProgressLocation.Notification,
+            cancellable: false,
+            title: `Authorizing "${choice.name}" — finish in your browser...`,
+          },
+          () => backend.client.provider.oauth.callback({ path, query, body: { method: methodIndex } }),
+        )
+        if (cbRes.error || cbRes.data !== true) {
+          vscode.window.showErrorMessage(`OpenCode Panel: authorization failed for "${choice.name}"`)
+          return
+        }
+        vscode.window.showInformationMessage(`OpenCode Panel: connected "${choice.name}".`)
+        return
+      }
+
+      // method === "code": the user authorizes in the browser and pastes a code back.
+      const code = await vscode.window.showInputBox({
+        title: `Connect ${choice.name}`,
+        prompt: authz.instructions || "Paste the authorization code from your browser",
+        ignoreFocusOut: true,
+        validateInput: (v) => (v.trim() ? undefined : "An authorization code is required"),
+      })
+      if (!code) return
+      const cbRes = await backend.client.provider.oauth.callback({
+        path,
+        query,
+        body: { method: methodIndex, code: code.trim() },
+      })
+      if (cbRes.error || cbRes.data !== true) {
+        vscode.window.showErrorMessage(`OpenCode Panel: authorization failed for "${choice.name}"`)
+        return
+      }
+      vscode.window.showInformationMessage(`OpenCode Panel: connected "${choice.name}".`)
+    } catch (e) {
+      log("provider oauth failed", e)
+      vscode.window.showErrorMessage(`OpenCode Panel: ${(e as Error).message}`)
+    }
+  }
+
+  // --- Disconnect ---------------------------------------------------------
 
   private async confirmAndDisconnect(backend: Backend, row: ProviderRow) {
     const confirm = await vscode.window.showWarningMessage(

--- a/src/provider/manage.ts
+++ b/src/provider/manage.ts
@@ -199,17 +199,38 @@ export class ProviderManager {
       if (authz.url) await vscode.env.openExternal(vscode.Uri.parse(authz.url))
 
       if (authz.method === "auto") {
-        // The local opencode server captures the redirect itself — block on the
-        // callback while the user finishes in the browser (like MCP authenticate).
-        const cbRes = await vscode.window.withProgress(
+        // The local opencode server captures the redirect itself, so the
+        // callback blocks until the user finishes in the browser. Make the
+        // progress cancellable and race the callback against cancellation:
+        // abandoning the flow (closing the browser) would otherwise leave this
+        // notification stuck forever on a callback that never resolves. On
+        // cancel we abort the in-flight request and bail quietly.
+        const outcome = await vscode.window.withProgress(
           {
             location: vscode.ProgressLocation.Notification,
-            cancellable: false,
-            title: `Authorizing "${choice.name}" — finish in your browser...`,
+            cancellable: true,
+            title: `Authorizing "${choice.name}" — finish in your browser, or cancel...`,
           },
-          () => backend.client.provider.oauth.callback({ path, query, body: { method: methodIndex } }),
+          async (_progress, token): Promise<"ok" | "cancelled" | "failed"> => {
+            const controller = new AbortController()
+            const onCancel = new Promise<"cancelled">((resolve) =>
+              token.onCancellationRequested(() => {
+                controller.abort()
+                resolve("cancelled")
+              }),
+            )
+            const onCallback = backend.client.provider.oauth
+              .callback({ path, query, body: { method: methodIndex }, signal: controller.signal })
+              .then((res): "ok" | "failed" => (!res.error && res.data === true ? "ok" : "failed"))
+              .catch((): "failed" => "failed")
+            return Promise.race([onCallback, onCancel])
+          },
         )
-        if (cbRes.error || cbRes.data !== true) {
+        if (outcome === "cancelled") {
+          vscode.window.showInformationMessage(`OpenCode Panel: connecting "${choice.name}" was cancelled.`)
+          return
+        }
+        if (outcome !== "ok") {
           vscode.window.showErrorMessage(`OpenCode Panel: authorization failed for "${choice.name}"`)
           return
         }

--- a/src/provider/provider-format.ts
+++ b/src/provider/provider-format.ts
@@ -48,6 +48,43 @@ export function removableProviders(
   return rows
 }
 
+/** A login method for a provider (mirrors the SDK's `ProviderAuthMethod`). */
+export type AuthMethod = { type: string; label: string }
+
+/** A provider the user can connect, with its available login methods. */
+export type ConnectableProvider = {
+  id: string
+  name: string
+  connected: boolean
+  /** In declared order — the array index is the `method` the OAuth endpoints expect. */
+  methods: AuthMethod[]
+}
+
+/**
+ * Build the "connect a provider" list from `provider.auth()` (providerID ->
+ * login methods), the id->name map (from `provider.list().all` /
+ * `config.providers()`), and the connected ids. Providers with no methods are
+ * dropped; already-connected providers stay (so they can re-auth) and are
+ * flagged. Sorted by name. Method order is preserved because the OAuth
+ * `method` field is an index into it.
+ */
+export function connectableProviders(
+  methodsByProvider: Readonly<Record<string, ReadonlyArray<AuthMethod>>>,
+  names: ReadonlyMap<string, string>,
+  connected: ReadonlyArray<string>,
+): ConnectableProvider[] {
+  const connectedSet = new Set(connected)
+  return Object.entries(methodsByProvider)
+    .filter(([, methods]) => methods.length > 0)
+    .map(([id, methods]): ConnectableProvider => ({
+      id,
+      name: names.get(id)?.trim() || id,
+      connected: connectedSet.has(id),
+      methods: methods.map((m) => ({ type: m.type, label: m.label })),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+}
+
 /** The opencode route that removes a provider's stored credentials. */
 export function authDeletePath(id: string): string {
   return `/auth/${encodeURIComponent(id)}`

--- a/src/provider/provider-format.ts
+++ b/src/provider/provider-format.ts
@@ -1,0 +1,85 @@
+/**
+ * Pure helpers for the AI-provider management picker — building the connected
+ * provider rows and performing the credential removal. Kept free of `vscode`
+ * so they unit-test in the node project without the API stub (mirrors
+ * `src/mcp/status-format.ts`).
+ */
+
+/** One authenticated provider, as shown in the picker. */
+export type ProviderRow = {
+  id: string
+  name: string
+  /** opencode config source: "env" | "config" | "custom" | "api" | "unknown". */
+  source: string
+  /** env-var providers can't be removed here (mirrors opencode's `canDisconnect`). */
+  removable: boolean
+}
+
+export type RemoveResult =
+  | { kind: "ok" }
+  | { kind: "unsupported" }
+  | { kind: "error"; message: string }
+
+export const UNSUPPORTED_HINT =
+  "Removing a provider needs a newer opencode — the DELETE /auth/{id} endpoint isn't in your version yet. Update opencode, or run: opencode auth logout"
+
+/**
+ * Merge the authenticated provider ids (`provider.list().connected`) with the
+ * config provider metadata (`config.providers()`) into display rows. A
+ * connected id missing from config keeps its id as the name and is assumed
+ * removable. env-sourced providers are marked non-removable. Sorted by name.
+ */
+export function removableProviders(
+  connected: ReadonlyArray<string>,
+  configProviders: ReadonlyArray<{ id: string; name?: string; source?: string }>,
+): ProviderRow[] {
+  const byId = new Map(configProviders.map((p) => [p.id, p]))
+  const rows = connected.map((id): ProviderRow => {
+    const cfg = byId.get(id)
+    const source = cfg?.source ?? "unknown"
+    return {
+      id,
+      name: cfg?.name?.trim() || id,
+      source,
+      removable: source !== "env",
+    }
+  })
+  rows.sort((a, b) => a.name.localeCompare(b.name))
+  return rows
+}
+
+/** The opencode route that removes a provider's stored credentials. */
+export function authDeletePath(id: string): string {
+  return `/auth/${encodeURIComponent(id)}`
+}
+
+/**
+ * Remove a provider's stored credentials.
+ *
+ * No published `@opencode-ai/sdk` exposes provider-credential removal yet —
+ * the top-level `client.auth.remove` still maps to the MCP route
+ * (`/mcp/{name}/auth`). The provider route `DELETE /auth/{id}` (operationId
+ * `auth.remove`, returns `true`) currently exists only on opencode's `dev`
+ * branch, so we call it untyped via `fetch`. When a published SDK ships it,
+ * replace this with `client.auth.remove({ path: { providerID } })`.
+ *
+ * We only ever pass ids from `provider.list().connected`, so a 404 means the
+ * route is missing (older opencode) — not "no such credential". `fetchImpl` is
+ * injectable so this is unit-testable without a live server.
+ */
+export async function removeProviderAuth(
+  baseUrl: string,
+  id: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<RemoveResult> {
+  const url = baseUrl.replace(/\/+$/, "") + authDeletePath(id)
+  let res: Response
+  try {
+    res = await fetchImpl(url, { method: "DELETE" })
+  } catch (e) {
+    return { kind: "error", message: (e as Error).message }
+  }
+  if (res.ok) return { kind: "ok" }
+  if (res.status === 404) return { kind: "unsupported" }
+  return { kind: "error", message: `HTTP ${res.status}` }
+}

--- a/test/host/builtin-commands.test.ts
+++ b/test/host/builtin-commands.test.ts
@@ -36,7 +36,7 @@ describe("withBuiltinCommands", () => {
   })
 
   it("registers the session-management built-ins", () => {
-    for (const name of ["undo", "redo", "fork", "new", "mcp"]) {
+    for (const name of ["undo", "redo", "fork", "new", "mcp", "provider"]) {
       expect(BUILTIN_COMMAND_NAMES.has(name)).toBe(true)
     }
   })

--- a/test/host/mock-opencode-server.ts
+++ b/test/host/mock-opencode-server.ts
@@ -48,6 +48,10 @@ export type MockOpencodeServer = {
   mcpDisconnectCalls: string[]
   mcpAuthenticateCalls: string[]
   mcpAuthRemoveCalls: string[]
+  /** Records of every provider credential removal (DELETE /auth/{id}). */
+  providerAuthRemoveCalls: string[]
+  /** Toggle the DELETE /auth/{id} route off to simulate an older opencode (404). */
+  setAuthRemoveSupported: (v: boolean) => void
   /** Configure what GET /mcp returns. */
   setMcpStatus: (map: Record<string, { status: string; error?: string }>) => void
   close: () => Promise<void>
@@ -69,6 +73,8 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
   const mcpDisconnectCalls: string[] = []
   const mcpAuthenticateCalls: string[] = []
   const mcpAuthRemoveCalls: string[] = []
+  const providerAuthRemoveCalls: string[] = []
+  let authRemoveSupported = true
   let clientResolver: (() => void) | undefined
 
   const server: Server = createServer((req: IncomingMessage, res: ServerResponse) => {
@@ -272,6 +278,21 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
       return
     }
 
+    // Provider credential removal — the untyped DELETE the ProviderManager
+    // issues. `authRemoveSupported = false` simulates an older opencode whose
+    // server lacks the route (404 → "unsupported" in removeProviderAuth).
+    const authRemoveMatch = path.match(/^\/auth\/([^/]+)$/)
+    if (authRemoveMatch && req.method === "DELETE") {
+      if (!authRemoveSupported) {
+        res.statusCode = 404
+        res.end()
+        return
+      }
+      providerAuthRemoveCalls.push(decodeURIComponent(authRemoveMatch[1]!))
+      reply(res, 200, true)
+      return
+    }
+
     // Health (used by some SDK clients before connecting)
     if (path === "/" && req.method === "GET") {
       reply(res, 200, { ok: true })
@@ -319,6 +340,10 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
     mcpDisconnectCalls,
     mcpAuthenticateCalls,
     mcpAuthRemoveCalls,
+    providerAuthRemoveCalls,
+    setAuthRemoveSupported(v) {
+      authRemoveSupported = v
+    },
     setMcpStatus(map) {
       mcpStatus = map
     },

--- a/test/host/provider-format.test.ts
+++ b/test/host/provider-format.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi } from "vitest"
-import { removableProviders, removeProviderAuth, authDeletePath } from "../../src/provider/provider-format"
+import {
+  removableProviders,
+  removeProviderAuth,
+  authDeletePath,
+  connectableProviders,
+} from "../../src/provider/provider-format"
 
 describe("removableProviders", () => {
   it("merges connected ids with config name/source and sorts by name", () => {
@@ -36,6 +41,44 @@ describe("authDeletePath", () => {
     expect(authDeletePath("https://x/.well-known/opencode")).toBe(
       "/auth/https%3A%2F%2Fx%2F.well-known%2Fopencode",
     )
+  })
+})
+
+describe("connectableProviders", () => {
+  const names = new Map([
+    ["openai", "OpenAI"],
+    ["anthropic", "Anthropic"],
+  ])
+
+  it("lists providers with methods, sorted by name, flagging connected ones", () => {
+    const out = connectableProviders(
+      {
+        openai: [{ type: "api", label: "API Key" }],
+        anthropic: [
+          { type: "oauth", label: "Claude Pro/Max" },
+          { type: "api", label: "API Key" },
+        ],
+      },
+      names,
+      ["anthropic"],
+    )
+    expect(out.map((p) => p.id)).toEqual(["anthropic", "openai"]) // sorted by name
+    expect(out[0]).toEqual({
+      id: "anthropic",
+      name: "Anthropic",
+      connected: true,
+      methods: [
+        { type: "oauth", label: "Claude Pro/Max" },
+        { type: "api", label: "API Key" },
+      ],
+    })
+    expect(out[1]!.connected).toBe(false)
+  })
+
+  it("drops providers with no methods and falls back to the id when unnamed", () => {
+    const out = connectableProviders({ foo: [], bar: [{ type: "api", label: "API Key" }] }, new Map(), [])
+    expect(out.map((p) => p.id)).toEqual(["bar"])
+    expect(out[0]!.name).toBe("bar")
   })
 })
 

--- a/test/host/provider-format.test.ts
+++ b/test/host/provider-format.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from "vitest"
+import { removableProviders, removeProviderAuth, authDeletePath } from "../../src/provider/provider-format"
+
+describe("removableProviders", () => {
+  it("merges connected ids with config name/source and sorts by name", () => {
+    const rows = removableProviders(
+      ["openai", "anthropic"],
+      [
+        { id: "anthropic", name: "Anthropic", source: "config" },
+        { id: "openai", name: "OpenAI", source: "api" },
+      ],
+    )
+    expect(rows.map((r) => r.id)).toEqual(["anthropic", "openai"]) // sorted by name
+    expect(rows[0]).toEqual({ id: "anthropic", name: "Anthropic", source: "config", removable: true })
+    expect(rows.every((r) => r.removable)).toBe(true)
+  })
+
+  it("marks env-sourced providers non-removable", () => {
+    const rows = removableProviders(["openai"], [{ id: "openai", name: "OpenAI", source: "env" }])
+    expect(rows[0]!.removable).toBe(false)
+  })
+
+  it("falls back to the id as name and removable=true when config is missing", () => {
+    const rows = removableProviders(["mystery"], [])
+    expect(rows[0]).toEqual({ id: "mystery", name: "mystery", source: "unknown", removable: true })
+  })
+
+  it("returns [] for no connected providers", () => {
+    expect(removableProviders([], [{ id: "openai", name: "OpenAI", source: "env" }])).toEqual([])
+  })
+})
+
+describe("authDeletePath", () => {
+  it("builds the route and url-encodes the id", () => {
+    expect(authDeletePath("openai")).toBe("/auth/openai")
+    expect(authDeletePath("https://x/.well-known/opencode")).toBe(
+      "/auth/https%3A%2F%2Fx%2F.well-known%2Fopencode",
+    )
+  })
+})
+
+describe("removeProviderAuth", () => {
+  const resp = (status: number) => ({ ok: status >= 200 && status < 300, status })
+
+  it("DELETEs the encoded url and returns ok on 2xx", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(resp(200))
+    const res = await removeProviderAuth("http://127.0.0.1:9/", "openai", fetchImpl as never)
+    expect(res).toEqual({ kind: "ok" })
+    expect(fetchImpl).toHaveBeenCalledWith("http://127.0.0.1:9/auth/openai", { method: "DELETE" })
+  })
+
+  it("maps 404 to unsupported (route missing on older opencode)", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(resp(404))
+    expect(await removeProviderAuth("http://h", "openai", fetchImpl as never)).toEqual({ kind: "unsupported" })
+  })
+
+  it("maps other non-2xx to error with the status", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(resp(500))
+    expect(await removeProviderAuth("http://h", "x", fetchImpl as never)).toEqual({
+      kind: "error",
+      message: "HTTP 500",
+    })
+  })
+
+  it("maps a thrown fetch to error", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"))
+    expect(await removeProviderAuth("http://h", "x", fetchImpl as never)).toEqual({
+      kind: "error",
+      message: "ECONNREFUSED",
+    })
+  })
+
+  it("strips trailing slashes from baseUrl", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(resp(200))
+    await removeProviderAuth("http://h///", "x", fetchImpl as never)
+    expect(fetchImpl).toHaveBeenCalledWith("http://h/auth/x", { method: "DELETE" })
+  })
+})

--- a/test/host/provider-manage.test.ts
+++ b/test/host/provider-manage.test.ts
@@ -175,8 +175,32 @@ describe("ProviderManager.run — connect", () => {
     await makeManager(backend).run()
     expect(openExternal).toHaveBeenCalled()
     expect(backend.client.provider.oauth.authorize).toHaveBeenCalledWith({ path: { id: "anthropic" }, query: QD, body: { method: 0 } })
-    expect(backend.client.provider.oauth.callback).toHaveBeenCalledWith({ path: { id: "anthropic" }, query: QD, body: { method: 0 } })
+    // callback also carries an AbortSignal (cancellable progress), so match loosely.
+    expect(backend.client.provider.oauth.callback).toHaveBeenCalledWith(
+      expect.objectContaining({ path: { id: "anthropic" }, query: QD, body: { method: 0 } }),
+    )
     expect(win.showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("connected"))
+  })
+
+  it("treats an abandoned OAuth (auto) flow as cancelled, not an error", async () => {
+    const backend = makeBackend({
+      all: [{ id: "github-copilot", name: "GitHub Copilot" }],
+      auth: { "github-copilot": [{ type: "oauth", label: "GitHub" }] },
+    })
+    // The callback never resolves — the user closed the browser without finishing.
+    backend.client.provider.oauth.callback = vi.fn(() => new Promise(() => {}))
+    // Simulate the user clicking Cancel on the progress notification.
+    const withProgress = vscode.window.withProgress as unknown as ReturnType<typeof vi.fn>
+    withProgress.mockImplementationOnce((_opts: unknown, task: (p: unknown, t: unknown) => unknown) =>
+      task({ report: vi.fn() }, { isCancellationRequested: false, onCancellationRequested: (cb: () => void) => cb() }),
+    )
+    win.showQuickPick
+      .mockResolvedValueOnce({ connect: true })
+      .mockResolvedValueOnce({ choice: choice("github-copilot", "GitHub Copilot", [{ type: "oauth", label: "GitHub" }]) })
+      .mockResolvedValueOnce(undefined)
+    await makeManager(backend).run()
+    expect(win.showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("cancelled"))
+    expect(win.showErrorMessage).not.toHaveBeenCalled()
   })
 
   it("connects via OAuth (code): prompts for the authorization code", async () => {

--- a/test/host/provider-manage.test.ts
+++ b/test/host/provider-manage.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import * as vscode from "vscode"
+import { ProviderManager } from "../../src/provider/manage"
+import type { ServerManager } from "../../src/server"
+import type { Preferences } from "../../src/preferences"
+
+// Drives ProviderManager end-to-end against a stubbed SDK client + scripted
+// vscode.window prompts + a stubbed global fetch (the removal call is an
+// untyped DELETE, since no published SDK exposes provider-credential removal).
+// showQuickPick / showWarningMessage return values are queued per call in
+// invocation order; the final main-picker call returns undefined to break the
+// run() loop (Esc).
+
+const win = vscode.window as unknown as {
+  showQuickPick: ReturnType<typeof vi.fn>
+  showInformationMessage: ReturnType<typeof vi.fn>
+  showErrorMessage: ReturnType<typeof vi.fn>
+  showWarningMessage: ReturnType<typeof vi.fn>
+}
+const exec = vscode.commands.executeCommand as unknown as ReturnType<typeof vi.fn>
+const writeText = vscode.env.clipboard.writeText as unknown as ReturnType<typeof vi.fn>
+
+function makeBackend(connected: string[], providers: Array<{ id: string; name: string; source: string }>) {
+  return {
+    url: "http://127.0.0.1:1234",
+    directory: "/ws",
+    configMode: "isolated",
+    client: {
+      provider: { list: vi.fn().mockResolvedValue({ data: { connected, all: [], default: {} } }) },
+      config: { providers: vi.fn().mockResolvedValue({ data: { providers, default: {} } }) },
+    },
+  }
+}
+
+function makeManager(backend: unknown, selection: { modelProviderID?: string } = {}) {
+  const servers = { ensure: vi.fn().mockResolvedValue(backend) } as unknown as ServerManager
+  const prefs = { get: vi.fn().mockReturnValue(selection) } as unknown as Preferences
+  return new ProviderManager(servers, prefs)
+}
+
+const row = (id: string, name: string, source: string, removable: boolean) => ({ id, name, source, removable })
+const Q = { query: { directory: "/ws" } }
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  win.showQuickPick.mockReset()
+  win.showInformationMessage.mockReset()
+  win.showErrorMessage.mockReset()
+  win.showWarningMessage.mockReset()
+  exec.mockReset()
+  writeText.mockReset()
+  fetchMock = vi.fn()
+  vi.stubGlobal("fetch", fetchMock)
+})
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("ProviderManager.run", () => {
+  it("lists connected providers and exits when the picker is dismissed", async () => {
+    const backend = makeBackend(["anthropic"], [{ id: "anthropic", name: "Anthropic", source: "config" }])
+    win.showQuickPick.mockResolvedValueOnce(undefined)
+    await makeManager(backend).run()
+    expect(backend.client.provider.list).toHaveBeenCalledWith(Q)
+    const items = win.showQuickPick.mock.calls[0]![0] as Array<{ label: string }>
+    expect(items.map((i) => i.label)).toContain("$(key) Anthropic")
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("disconnects a removable provider after confirm, then re-fetches", async () => {
+    const backend = makeBackend(["anthropic"], [{ id: "anthropic", name: "Anthropic", source: "config" }])
+    win.showQuickPick
+      .mockResolvedValueOnce({ row: row("anthropic", "Anthropic", "config", true) })
+      .mockResolvedValueOnce(undefined)
+    win.showWarningMessage.mockResolvedValueOnce("Remove") // confirm modal
+    fetchMock.mockResolvedValue({ ok: true, status: 200 })
+    await makeManager(backend).run()
+    expect(fetchMock).toHaveBeenCalledWith("http://127.0.0.1:1234/auth/anthropic", { method: "DELETE" })
+    expect(win.showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("removed credentials"))
+    expect(backend.client.provider.list).toHaveBeenCalledTimes(2) // open + after the action
+  })
+
+  it("does nothing when the confirm modal is dismissed", async () => {
+    const backend = makeBackend(["anthropic"], [{ id: "anthropic", name: "Anthropic", source: "config" }])
+    win.showQuickPick
+      .mockResolvedValueOnce({ row: row("anthropic", "Anthropic", "config", true) })
+      .mockResolvedValueOnce(undefined)
+    win.showWarningMessage.mockResolvedValueOnce(undefined) // dismissed
+    await makeManager(backend).run()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("shows the guarded hint + copies the CLI command on a 404 (unsupported)", async () => {
+    const backend = makeBackend(["anthropic"], [{ id: "anthropic", name: "Anthropic", source: "config" }])
+    win.showQuickPick
+      .mockResolvedValueOnce({ row: row("anthropic", "Anthropic", "config", true) })
+      .mockResolvedValueOnce(undefined)
+    win.showWarningMessage
+      .mockResolvedValueOnce("Remove") // confirm
+      .mockResolvedValueOnce("Copy command") // unsupported hint action
+    fetchMock.mockResolvedValue({ ok: false, status: 404 })
+    await makeManager(backend).run()
+    expect(writeText).toHaveBeenCalledWith("opencode auth logout")
+  })
+
+  it("refuses env-sourced providers without confirming or calling fetch", async () => {
+    const backend = makeBackend(["openai"], [{ id: "openai", name: "OpenAI", source: "env" }])
+    win.showQuickPick
+      .mockResolvedValueOnce({ row: row("openai", "OpenAI", "env", false) })
+      .mockResolvedValueOnce(undefined)
+    await makeManager(backend).run()
+    expect(win.showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("environment variable"))
+    expect(win.showWarningMessage).not.toHaveBeenCalled()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("warns + offers the model picker when the active model's provider is removed", async () => {
+    const backend = makeBackend(["anthropic"], [{ id: "anthropic", name: "Anthropic", source: "config" }])
+    win.showQuickPick
+      .mockResolvedValueOnce({ row: row("anthropic", "Anthropic", "config", true) })
+      .mockResolvedValueOnce(undefined)
+    win.showWarningMessage
+      .mockResolvedValueOnce("Remove") // confirm
+      .mockResolvedValueOnce("Select model") // active-model warning action
+    fetchMock.mockResolvedValue({ ok: true, status: 200 })
+    await makeManager(backend, { modelProviderID: "anthropic" }).run()
+    expect(exec).toHaveBeenCalledWith("opencui.selectModel")
+  })
+
+  it("surfaces a provider-fetch failure and stops before showing a picker", async () => {
+    const backend = makeBackend([], [])
+    backend.client.provider.list = vi.fn().mockResolvedValue({ error: { message: "boom" } })
+    await makeManager(backend).run()
+    expect(win.showErrorMessage).toHaveBeenCalled()
+    expect(win.showQuickPick).not.toHaveBeenCalled()
+  })
+})

--- a/test/host/provider-manage.test.ts
+++ b/test/host/provider-manage.test.ts
@@ -203,6 +203,38 @@ describe("ProviderManager.run — connect", () => {
     expect(win.showErrorMessage).not.toHaveBeenCalled()
   })
 
+  it("shows + copies the device code for an OAuth (auto) device flow", async () => {
+    const backend = makeBackend({
+      all: [{ id: "github-copilot", name: "GitHub Copilot" }],
+      auth: { "github-copilot": [{ type: "oauth", label: "GitHub" }] },
+    })
+    backend.client.provider.oauth.authorize = vi
+      .fn()
+      .mockResolvedValue({ data: { url: "https://github.com/login/device", method: "auto", instructions: "Enter code: ABCD-1234" } })
+    win.showQuickPick
+      .mockResolvedValueOnce({ connect: true })
+      .mockResolvedValueOnce({ choice: choice("github-copilot", "GitHub Copilot", [{ type: "oauth", label: "GitHub" }]) })
+      .mockResolvedValueOnce(undefined)
+    await makeManager(backend).run()
+    expect(writeText).toHaveBeenCalledWith("ABCD-1234")
+    expect(win.showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("ABCD-1234"))
+    expect(win.showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("connected"))
+  })
+
+  it("surfaces the real reason when an OAuth (auto) callback fails", async () => {
+    const backend = makeBackend({
+      all: [{ id: "github-copilot", name: "GitHub Copilot" }],
+      auth: { "github-copilot": [{ type: "oauth", label: "GitHub" }] },
+    })
+    backend.client.provider.oauth.callback = vi.fn().mockResolvedValue({ error: { data: { message: "device code expired" } } })
+    win.showQuickPick
+      .mockResolvedValueOnce({ connect: true })
+      .mockResolvedValueOnce({ choice: choice("github-copilot", "GitHub Copilot", [{ type: "oauth", label: "GitHub" }]) })
+      .mockResolvedValueOnce(undefined)
+    await makeManager(backend).run()
+    expect(win.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining("device code expired"))
+  })
+
   it("connects via OAuth (code): prompts for the authorization code", async () => {
     const backend = makeBackend({ all: [{ id: "openai", name: "OpenAI" }], auth: { openai: [{ type: "oauth", label: "ChatGPT" }] } })
     backend.client.provider.oauth.authorize = vi

--- a/test/host/provider-manage.test.ts
+++ b/test/host/provider-manage.test.ts
@@ -5,29 +5,46 @@ import type { ServerManager } from "../../src/server"
 import type { Preferences } from "../../src/preferences"
 
 // Drives ProviderManager end-to-end against a stubbed SDK client + scripted
-// vscode.window prompts + a stubbed global fetch (the removal call is an
-// untyped DELETE, since no published SDK exposes provider-credential removal).
-// showQuickPick / showWarningMessage return values are queued per call in
-// invocation order; the final main-picker call returns undefined to break the
-// run() loop (Esc).
+// vscode.window prompts + a stubbed global fetch (disconnect is an untyped
+// DELETE). showQuickPick / showWarningMessage / showInputBox return values are
+// queued per call in invocation order; the final main-picker call returns
+// undefined to break the run() loop (Esc). The mocks return scripted objects,
+// so the connect row is represented as `{ connect: true }`.
 
 const win = vscode.window as unknown as {
   showQuickPick: ReturnType<typeof vi.fn>
+  showInputBox: ReturnType<typeof vi.fn>
   showInformationMessage: ReturnType<typeof vi.fn>
   showErrorMessage: ReturnType<typeof vi.fn>
   showWarningMessage: ReturnType<typeof vi.fn>
 }
 const exec = vscode.commands.executeCommand as unknown as ReturnType<typeof vi.fn>
 const writeText = vscode.env.clipboard.writeText as unknown as ReturnType<typeof vi.fn>
+const openExternal = vscode.env.openExternal as unknown as ReturnType<typeof vi.fn>
 
-function makeBackend(connected: string[], providers: Array<{ id: string; name: string; source: string }>) {
+type BackendOpts = {
+  connected?: string[]
+  providers?: Array<{ id: string; name: string; source: string }>
+  all?: Array<{ id: string; name: string }>
+  auth?: Record<string, Array<{ type: string; label: string }>>
+}
+
+function makeBackend(opts: BackendOpts = {}) {
   return {
     url: "http://127.0.0.1:1234",
     directory: "/ws",
     configMode: "isolated",
     client: {
-      provider: { list: vi.fn().mockResolvedValue({ data: { connected, all: [], default: {} } }) },
-      config: { providers: vi.fn().mockResolvedValue({ data: { providers, default: {} } }) },
+      provider: {
+        list: vi.fn().mockResolvedValue({ data: { connected: opts.connected ?? [], all: opts.all ?? [], default: {} } }),
+        auth: vi.fn().mockResolvedValue({ data: opts.auth ?? {} }),
+        oauth: {
+          authorize: vi.fn().mockResolvedValue({ data: { url: "https://auth.example/x", method: "auto", instructions: "" } }),
+          callback: vi.fn().mockResolvedValue({ data: true }),
+        },
+      },
+      config: { providers: vi.fn().mockResolvedValue({ data: { providers: opts.providers ?? [], default: {} } }) },
+      auth: { set: vi.fn().mockResolvedValue({ data: true }) },
     },
   }
 }
@@ -39,16 +56,25 @@ function makeManager(backend: unknown, selection: { modelProviderID?: string } =
 }
 
 const row = (id: string, name: string, source: string, removable: boolean) => ({ id, name, source, removable })
+const choice = (id: string, name: string, methods: Array<{ type: string; label: string }>) => ({
+  id,
+  name,
+  connected: false,
+  methods,
+})
 const Q = { query: { directory: "/ws" } }
+const QD = { directory: "/ws" }
 let fetchMock: ReturnType<typeof vi.fn>
 
 beforeEach(() => {
   win.showQuickPick.mockReset()
+  win.showInputBox.mockReset()
   win.showInformationMessage.mockReset()
   win.showErrorMessage.mockReset()
   win.showWarningMessage.mockReset()
   exec.mockReset()
   writeText.mockReset()
+  openExternal.mockReset()
   fetchMock = vi.fn()
   vi.stubGlobal("fetch", fetchMock)
 })
@@ -56,58 +82,49 @@ afterEach(() => {
   vi.unstubAllGlobals()
 })
 
-describe("ProviderManager.run", () => {
-  it("lists connected providers and exits when the picker is dismissed", async () => {
-    const backend = makeBackend(["anthropic"], [{ id: "anthropic", name: "Anthropic", source: "config" }])
+describe("ProviderManager.run — listing & disconnect", () => {
+  it("lists connected providers (after the Connect row) and exits when dismissed", async () => {
+    const backend = makeBackend({ connected: ["anthropic"], providers: [{ id: "anthropic", name: "Anthropic", source: "config" }] })
     win.showQuickPick.mockResolvedValueOnce(undefined)
     await makeManager(backend).run()
     expect(backend.client.provider.list).toHaveBeenCalledWith(Q)
     const items = win.showQuickPick.mock.calls[0]![0] as Array<{ label: string }>
+    expect(items[0]!.label).toContain("Connect a provider")
     expect(items.map((i) => i.label)).toContain("$(key) Anthropic")
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it("disconnects a removable provider after confirm, then re-fetches", async () => {
-    const backend = makeBackend(["anthropic"], [{ id: "anthropic", name: "Anthropic", source: "config" }])
-    win.showQuickPick
-      .mockResolvedValueOnce({ row: row("anthropic", "Anthropic", "config", true) })
-      .mockResolvedValueOnce(undefined)
-    win.showWarningMessage.mockResolvedValueOnce("Remove") // confirm modal
+    const backend = makeBackend({ connected: ["anthropic"], providers: [{ id: "anthropic", name: "Anthropic", source: "config" }] })
+    win.showQuickPick.mockResolvedValueOnce({ row: row("anthropic", "Anthropic", "config", true) }).mockResolvedValueOnce(undefined)
+    win.showWarningMessage.mockResolvedValueOnce("Remove")
     fetchMock.mockResolvedValue({ ok: true, status: 200 })
     await makeManager(backend).run()
     expect(fetchMock).toHaveBeenCalledWith("http://127.0.0.1:1234/auth/anthropic", { method: "DELETE" })
     expect(win.showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("removed credentials"))
-    expect(backend.client.provider.list).toHaveBeenCalledTimes(2) // open + after the action
+    expect(backend.client.provider.list).toHaveBeenCalledTimes(2)
   })
 
   it("does nothing when the confirm modal is dismissed", async () => {
-    const backend = makeBackend(["anthropic"], [{ id: "anthropic", name: "Anthropic", source: "config" }])
-    win.showQuickPick
-      .mockResolvedValueOnce({ row: row("anthropic", "Anthropic", "config", true) })
-      .mockResolvedValueOnce(undefined)
-    win.showWarningMessage.mockResolvedValueOnce(undefined) // dismissed
+    const backend = makeBackend({ connected: ["anthropic"], providers: [{ id: "anthropic", name: "Anthropic", source: "config" }] })
+    win.showQuickPick.mockResolvedValueOnce({ row: row("anthropic", "Anthropic", "config", true) }).mockResolvedValueOnce(undefined)
+    win.showWarningMessage.mockResolvedValueOnce(undefined)
     await makeManager(backend).run()
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it("shows the guarded hint + copies the CLI command on a 404 (unsupported)", async () => {
-    const backend = makeBackend(["anthropic"], [{ id: "anthropic", name: "Anthropic", source: "config" }])
-    win.showQuickPick
-      .mockResolvedValueOnce({ row: row("anthropic", "Anthropic", "config", true) })
-      .mockResolvedValueOnce(undefined)
-    win.showWarningMessage
-      .mockResolvedValueOnce("Remove") // confirm
-      .mockResolvedValueOnce("Copy command") // unsupported hint action
+    const backend = makeBackend({ connected: ["anthropic"], providers: [{ id: "anthropic", name: "Anthropic", source: "config" }] })
+    win.showQuickPick.mockResolvedValueOnce({ row: row("anthropic", "Anthropic", "config", true) }).mockResolvedValueOnce(undefined)
+    win.showWarningMessage.mockResolvedValueOnce("Remove").mockResolvedValueOnce("Copy command")
     fetchMock.mockResolvedValue({ ok: false, status: 404 })
     await makeManager(backend).run()
     expect(writeText).toHaveBeenCalledWith("opencode auth logout")
   })
 
   it("refuses env-sourced providers without confirming or calling fetch", async () => {
-    const backend = makeBackend(["openai"], [{ id: "openai", name: "OpenAI", source: "env" }])
-    win.showQuickPick
-      .mockResolvedValueOnce({ row: row("openai", "OpenAI", "env", false) })
-      .mockResolvedValueOnce(undefined)
+    const backend = makeBackend({ connected: ["openai"], providers: [{ id: "openai", name: "OpenAI", source: "env" }] })
+    win.showQuickPick.mockResolvedValueOnce({ row: row("openai", "OpenAI", "env", false) }).mockResolvedValueOnce(undefined)
     await makeManager(backend).run()
     expect(win.showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("environment variable"))
     expect(win.showWarningMessage).not.toHaveBeenCalled()
@@ -115,23 +132,87 @@ describe("ProviderManager.run", () => {
   })
 
   it("warns + offers the model picker when the active model's provider is removed", async () => {
-    const backend = makeBackend(["anthropic"], [{ id: "anthropic", name: "Anthropic", source: "config" }])
-    win.showQuickPick
-      .mockResolvedValueOnce({ row: row("anthropic", "Anthropic", "config", true) })
-      .mockResolvedValueOnce(undefined)
-    win.showWarningMessage
-      .mockResolvedValueOnce("Remove") // confirm
-      .mockResolvedValueOnce("Select model") // active-model warning action
+    const backend = makeBackend({ connected: ["anthropic"], providers: [{ id: "anthropic", name: "Anthropic", source: "config" }] })
+    win.showQuickPick.mockResolvedValueOnce({ row: row("anthropic", "Anthropic", "config", true) }).mockResolvedValueOnce(undefined)
+    win.showWarningMessage.mockResolvedValueOnce("Remove").mockResolvedValueOnce("Select model")
     fetchMock.mockResolvedValue({ ok: true, status: 200 })
     await makeManager(backend, { modelProviderID: "anthropic" }).run()
     expect(exec).toHaveBeenCalledWith("opencui.selectModel")
   })
 
   it("surfaces a provider-fetch failure and stops before showing a picker", async () => {
-    const backend = makeBackend([], [])
+    const backend = makeBackend()
     backend.client.provider.list = vi.fn().mockResolvedValue({ error: { message: "boom" } })
     await makeManager(backend).run()
     expect(win.showErrorMessage).toHaveBeenCalled()
     expect(win.showQuickPick).not.toHaveBeenCalled()
+  })
+})
+
+describe("ProviderManager.run — connect", () => {
+  it("connects a provider via API key (auth.set)", async () => {
+    const backend = makeBackend({ all: [{ id: "openai", name: "OpenAI" }], auth: { openai: [{ type: "api", label: "API Key" }] } })
+    win.showQuickPick
+      .mockResolvedValueOnce({ connect: true }) // main -> Connect
+      .mockResolvedValueOnce({ choice: choice("openai", "OpenAI", [{ type: "api", label: "API Key" }]) })
+      .mockResolvedValueOnce(undefined) // main reopens -> Esc
+    win.showInputBox.mockResolvedValueOnce("sk-test-123")
+    await makeManager(backend).run()
+    expect(backend.client.auth.set).toHaveBeenCalledWith({
+      path: { id: "openai" },
+      query: QD,
+      body: { type: "api", key: "sk-test-123" },
+    })
+    expect(win.showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("connected"))
+  })
+
+  it("connects via OAuth (auto): opens the browser then callbacks without a code", async () => {
+    const backend = makeBackend({ all: [{ id: "anthropic", name: "Anthropic" }], auth: { anthropic: [{ type: "oauth", label: "Claude Pro/Max" }] } })
+    win.showQuickPick
+      .mockResolvedValueOnce({ connect: true })
+      .mockResolvedValueOnce({ choice: choice("anthropic", "Anthropic", [{ type: "oauth", label: "Claude Pro/Max" }]) })
+      .mockResolvedValueOnce(undefined)
+    await makeManager(backend).run()
+    expect(openExternal).toHaveBeenCalled()
+    expect(backend.client.provider.oauth.authorize).toHaveBeenCalledWith({ path: { id: "anthropic" }, query: QD, body: { method: 0 } })
+    expect(backend.client.provider.oauth.callback).toHaveBeenCalledWith({ path: { id: "anthropic" }, query: QD, body: { method: 0 } })
+    expect(win.showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("connected"))
+  })
+
+  it("connects via OAuth (code): prompts for the authorization code", async () => {
+    const backend = makeBackend({ all: [{ id: "openai", name: "OpenAI" }], auth: { openai: [{ type: "oauth", label: "ChatGPT" }] } })
+    backend.client.provider.oauth.authorize = vi
+      .fn()
+      .mockResolvedValue({ data: { url: "https://auth/x", method: "code", instructions: "Paste the code" } })
+    win.showQuickPick
+      .mockResolvedValueOnce({ connect: true })
+      .mockResolvedValueOnce({ choice: choice("openai", "OpenAI", [{ type: "oauth", label: "ChatGPT" }]) })
+      .mockResolvedValueOnce(undefined)
+    win.showInputBox.mockResolvedValueOnce("the-code")
+    await makeManager(backend).run()
+    expect(backend.client.provider.oauth.callback).toHaveBeenCalledWith({ path: { id: "openai" }, query: QD, body: { method: 0, code: "the-code" } })
+  })
+
+  it("asks which login method when a provider exposes more than one", async () => {
+    const methods = [
+      { type: "oauth", label: "Claude Pro/Max" },
+      { type: "api", label: "API Key" },
+    ]
+    const backend = makeBackend({ all: [{ id: "anthropic", name: "Anthropic" }], auth: { anthropic: methods } })
+    win.showQuickPick
+      .mockResolvedValueOnce({ connect: true })
+      .mockResolvedValueOnce({ choice: choice("anthropic", "Anthropic", methods) })
+      .mockResolvedValueOnce({ index: 1 }) // method picker -> API Key
+      .mockResolvedValueOnce(undefined)
+    win.showInputBox.mockResolvedValueOnce("sk-xyz")
+    await makeManager(backend).run()
+    expect(backend.client.auth.set).toHaveBeenCalledWith({ path: { id: "anthropic" }, query: QD, body: { type: "api", key: "sk-xyz" } })
+  })
+
+  it("reports when no providers are available to connect", async () => {
+    const backend = makeBackend({ auth: {} })
+    win.showQuickPick.mockResolvedValueOnce({ connect: true }).mockResolvedValueOnce(undefined)
+    await makeManager(backend).run()
+    expect(win.showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("no providers available"))
   })
 })

--- a/test/host/provider-remove-integration.test.ts
+++ b/test/host/provider-remove-integration.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, afterEach } from "vitest"
+import { startMockOpencode, type MockOpencodeServer } from "./mock-opencode-server"
+import { removeProviderAuth } from "../../src/provider/provider-format"
+
+// Exercises the one untyped path — a real HTTP DELETE /auth/{id} — against the
+// mock opencode server, since removeProviderAuth bypasses the typed SDK (no
+// published SDK exposes provider-credential removal yet).
+
+describe("removeProviderAuth against a live server", () => {
+  let server: MockOpencodeServer | undefined
+  afterEach(async () => {
+    await server?.close()
+    server = undefined
+  })
+
+  it("DELETEs the credential and records the provider id", async () => {
+    server = await startMockOpencode()
+    const res = await removeProviderAuth(server.url, "anthropic")
+    expect(res).toEqual({ kind: "ok" })
+    expect(server.providerAuthRemoveCalls).toContain("anthropic")
+  })
+
+  it("round-trips a url-encoded custom provider id", async () => {
+    server = await startMockOpencode()
+    const id = "https://x/.well-known/opencode"
+    const res = await removeProviderAuth(server.url, id)
+    expect(res).toEqual({ kind: "ok" })
+    expect(server.providerAuthRemoveCalls).toContain(id)
+  })
+
+  it("maps a missing route to unsupported (older opencode)", async () => {
+    server = await startMockOpencode()
+    server.setAuthRemoveSupported(false)
+    const res = await removeProviderAuth(server.url, "anthropic")
+    expect(res).toEqual({ kind: "unsupported" })
+  })
+})


### PR DESCRIPTION
## Summary

Adds a built-in **`/provider`** slash command + **"OpenCode Panel: Manage AI Providers"** Command-Palette entry that opens a native picker (mirroring `/mcp`, #253). It both **connects** and **disconnects** AI providers.

### Connect (fully supported on released opencode/SDK)
A **"Connect a provider"** row → pick a provider (from `client.provider.auth()`) → pick a login method if it offers more than one → then:
- **API key** → `client.auth.set({ path: { id }, body: { type: "api", key } })`.
- **OAuth** → `client.provider.oauth.authorize({ body: { method } })` opens the browser, then `...oauth.callback(...)` — handling both the server-orchestrated **`auto`** flow (blocks while you finish in the browser, like MCP authenticate) and the **`code`** flow (paste the authorization code).

### Disconnect (gated on opencode dev)
Lists authenticated providers via `client.provider.list().connected`, flags env-var providers (`config.providers().source === "env"`) as **not removable**, and removes a provider's credentials behind a modal confirm. Warns + offers the model picker when you remove the provider backing your selected model.

No published `@opencode-ai/sdk` exposes provider-credential *removal* yet — `client.auth.remove` still maps to the **MCP** route (`/mcp/{name}/auth`) in both 1.14.33 and 1.15.13; the `DELETE /auth/{providerID}` route is opencode-**`dev`**-only. So removal is a single **untyped, guarded** `fetch` (`removeProviderAuth`): on older opencode it 404s → clear "update opencode / `opencode auth logout`" message (Copy action); a `// swap to client.auth.remove(...) when published` note marks the future typed call. **Listing + connect work everywhere today.**

A true opencode custom command (`.md` template) can't do this — it must be a host-routed built-in, like `/mcp`.

## Files
- **NEW** `src/provider/provider-format.ts` (pure: `connectableProviders`, `removableProviders`, `removeProviderAuth`, `authDeletePath`), `src/provider/manage.ts` (`ProviderManager`, mirrors `McpManager`).
- `src/extension.ts`, `package.json` (command), `src/chat/builtin-commands.ts`, `src/chat/view.ts` (`/provider` no-bubble short-circuit).

## Test plan
- [x] `bun run check-types` (host) — clean
- [x] `bun run test` — **925 passed** (58 files; new `provider-format` / `provider-manage` / `provider-remove-integration` cover connect + disconnect)
- [x] webview `tsc --noEmit` — clean
- [x] `bun run compile` — production build OK
- [ ] Manual: `/provider` → Connect a provider (API key + OAuth auto/code); disconnect → confirm → removed; env-var provider not-removable; older opencode → guarded hint; removing the active model's provider → warning + Select model.

Closes #260