### PR TITLE
chore(release): cut v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-05-31
+
+### Added
+- `/provider` command + **OpenCode Panel: Manage AI Providers** picker (mirroring `/mcp`) to connect and disconnect AI providers. **Connect** lists every provider that exposes a login method (`client.provider.auth()`) and runs it — an **API key** (`client.auth.set`) or **OAuth** (`client.provider.oauth.authorize` → browser → `...oauth.callback`), handling both the server-orchestrated **device-code** flow (e.g. GitHub Copilot — the user code from the authorize `instructions` is shown and copied to the clipboard, under a cancellable "waiting" progress so an abandoned flow can't hang) and the **paste-a-code** flow. **Disconnect** lists authenticated providers (`client.provider.list().connected`), marks env-var providers as non-removable, and removes a provider's stored credentials behind a confirm — warning when you disconnect the model you currently have selected. Connect works on released opencode; credential removal uses the `DELETE /auth/{id}` route (currently opencode `dev`) and degrades gracefully with a clear hint (and `opencode auth logout`) on versions that lack it.
+
+Closes #260.
+
 ## [1.1.0] - 2026-05-30
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
Cuts **v1.2.0**. Bumps `package.json` to 1.2.0 and rolls the CHANGELOG `[Unreleased]` block into `## [1.2.0]`.

## Included since v1.1.0
- **`/provider`** — connect & disconnect AI providers, with device-code OAuth handling (#261, closes #260)

## Verified locally
- [x] `bun run check-types` — clean
- [x] `bun run test` — 928 passed (58 files)
- [x] `bun run package` — production build OK

Once merged, tagging `v1.2.0` + publishing the GitHub Release triggers the Marketplace + Open VSX publish workflow.

Closes #262