### PR TITLE
perf(chat): memoize MessageView and coalesce stream deltas per frame

### DIFF
--- a/test/webview/delta-coalescer.test.ts
+++ b/test/webview/delta-coalescer.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest"
+import { createDeltaCoalescer } from "../../webview/src/delta-coalescer"
+import type { Action } from "../../webview/src/hooks/useChatState"
+
+// A manually-driven requestAnimationFrame so tests flush on demand.
+function manualRaf() {
+  let cb: (() => void) | null = null
+  const raf = (fn: () => void) => {
+    cb = fn
+  }
+  const tick = () => {
+    const c = cb
+    cb = null
+    c?.()
+  }
+  return { raf, tick }
+}
+
+describe("createDeltaCoalescer", () => {
+  it("merges consecutive same-id textDeltas into one dispatch", () => {
+    const dispatched: Action[] = []
+    const { raf, tick } = manualRaf()
+    const c = createDeltaCoalescer((a) => dispatched.push(a), raf)
+    c.enqueue({ type: "textDelta", id: "a1", delta: "Hel" } as Action)
+    c.enqueue({ type: "textDelta", id: "a1", delta: "lo" } as Action)
+    c.enqueue({ type: "textDelta", id: "a1", delta: " world" } as Action)
+    expect(dispatched).toHaveLength(0) // nothing dispatched until the frame fires
+    tick()
+    expect(dispatched).toEqual([{ type: "textDelta", id: "a1", delta: "Hello world" }])
+  })
+
+  it("does not merge deltas for different message ids", () => {
+    const dispatched: Action[] = []
+    const { raf, tick } = manualRaf()
+    const c = createDeltaCoalescer((a) => dispatched.push(a), raf)
+    c.enqueue({ type: "textDelta", id: "a1", delta: "x" } as Action)
+    c.enqueue({ type: "textDelta", id: "a2", delta: "y" } as Action)
+    tick()
+    expect(dispatched).toEqual([
+      { type: "textDelta", id: "a1", delta: "x" },
+      { type: "textDelta", id: "a2", delta: "y" },
+    ])
+  })
+
+  it("does not merge textDelta with reasoningDelta", () => {
+    const dispatched: Action[] = []
+    const { raf, tick } = manualRaf()
+    const c = createDeltaCoalescer((a) => dispatched.push(a), raf)
+    c.enqueue({ type: "textDelta", id: "a1", delta: "x" } as Action)
+    c.enqueue({ type: "reasoningDelta", id: "a1", delta: "y" } as Action)
+    tick()
+    expect(dispatched).toHaveLength(2)
+  })
+
+  it("preserves order when a tool interleaves two text deltas", () => {
+    const dispatched: Action[] = []
+    const { raf, tick } = manualRaf()
+    const c = createDeltaCoalescer((a) => dispatched.push(a), raf)
+    c.enqueue({ type: "textDelta", id: "a1", delta: "before" } as Action)
+    c.enqueue({ type: "tool", id: "a1", update: { callID: "c", tool: "read", status: "running" } } as Action)
+    c.enqueue({ type: "textDelta", id: "a1", delta: "after" } as Action)
+    tick()
+    expect(dispatched.map((a) => a.type)).toEqual(["textDelta", "tool", "textDelta"])
+    expect((dispatched[0] as { delta: string }).delta).toBe("before")
+    expect((dispatched[2] as { delta: string }).delta).toBe("after")
+  })
+
+  it("schedules one frame per burst and re-arms after a flush", () => {
+    const dispatched: Action[] = []
+    let rafCalls = 0
+    let cb: (() => void) | null = null
+    const raf = (fn: () => void) => {
+      rafCalls++
+      cb = fn
+    }
+    const c = createDeltaCoalescer((a) => dispatched.push(a), raf)
+    c.enqueue({ type: "textDelta", id: "a1", delta: "a" } as Action)
+    c.enqueue({ type: "textDelta", id: "a1", delta: "b" } as Action)
+    expect(rafCalls).toBe(1) // both queued under a single scheduled frame
+    cb?.()
+    c.enqueue({ type: "textDelta", id: "a1", delta: "c" } as Action)
+    expect(rafCalls).toBe(2) // a fresh frame is scheduled only after the prior flush
+  })
+})

--- a/test/webview/same-message-view-props.test.ts
+++ b/test/webview/same-message-view-props.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest"
+import { sameMessageViewProps } from "../../webview/src/components/MessageView"
+import type { Message } from "../../webview/src/hooks/useChatState"
+import type { AgentsStatusInfo } from "../../webview/src/protocol"
+
+const msg = { id: "a1", role: "assistant", blocks: [] } as Message
+const base = { message: msg, processOpen: false, processOnly: false }
+
+describe("sameMessageViewProps", () => {
+  it("returns true when render-affecting props are identical", () => {
+    expect(sameMessageViewProps({ ...base }, { ...base })).toBe(true)
+  })
+
+  it("ignores differing function props — they are fresh closures every render", () => {
+    expect(
+      sameMessageViewProps(
+        { ...base, onEditMessage: () => {}, onReviewFile: () => {} },
+        { ...base, onEditMessage: () => {}, onReviewFile: () => {} },
+      ),
+    ).toBe(true)
+  })
+
+  it("returns false when the message object identity changes (a delta landed)", () => {
+    expect(sameMessageViewProps(base, { ...base, message: { ...msg } as Message })).toBe(false)
+  })
+
+  it("returns false when busy flips", () => {
+    expect(sameMessageViewProps({ ...base, busy: false }, { ...base, busy: true })).toBe(false)
+  })
+
+  it("returns false when agentActivity changes", () => {
+    expect(
+      sameMessageViewProps(
+        { ...base, agentActivity: undefined },
+        { ...base, agentActivity: { total: 1, running: 1 } as AgentsStatusInfo },
+      ),
+    ).toBe(false)
+  })
+})

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react"
+import { memo, useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react"
 import type { Block, Message } from "../hooks/useChatState"
 import type { AgentsStatusInfo, Attachment, ConversationSummary, DirEntry, FileSearchHit } from "../protocol"
 import { findMentionRanges, makeAttachmentLabel } from "../mention-tokens"
@@ -24,23 +24,7 @@ import { AgentActivity } from "./AgentActivity"
  */
 type EditPhase = "view" | "editing"
 
-export function MessageView({
-  message,
-  processOpen,
-  processOnly,
-  busy,
-  onReviewFile,
-  onEditMessage,
-  onBeginEdit,
-  onEndEdit,
-  onRetry,
-  agentActivity,
-  searchFiles,
-  listDir,
-  attachFile,
-  conversations,
-  activeConversationID,
-}: {
+type MessageViewProps = {
   message: Message
   processOpen: boolean
   processOnly: boolean
@@ -56,7 +40,48 @@ export function MessageView({
   attachFile?: () => Promise<{ attachments: Attachment[]; error?: string }>
   conversations?: ConversationSummary[]
   activeConversationID?: string
-}) {
+}
+
+/**
+ * Render-affecting props only. Function props are intentionally excluded —
+ * `useChatState` returns fresh closures every render and `App` passes inline
+ * arrows, so comparing them would defeat the memo on every keystroke/delta.
+ * The reducer preserves object identity for messages it didn't touch
+ * (`appendToLastBlock`/`upsertTool` slice the array and replace one index), so
+ * `message` identity is a reliable "did this row change" signal — which lets a
+ * streaming turn re-render without dragging the whole transcript with it.
+ */
+export function sameMessageViewProps(prev: MessageViewProps, next: MessageViewProps): boolean {
+  return (
+    prev.message === next.message &&
+    prev.processOpen === next.processOpen &&
+    prev.processOnly === next.processOnly &&
+    prev.busy === next.busy &&
+    prev.agentActivity === next.agentActivity &&
+    prev.conversations === next.conversations &&
+    prev.activeConversationID === next.activeConversationID
+  )
+}
+
+export const MessageView = memo(MessageViewComponent, sameMessageViewProps)
+
+function MessageViewComponent({
+  message,
+  processOpen,
+  processOnly,
+  busy,
+  onReviewFile,
+  onEditMessage,
+  onBeginEdit,
+  onEndEdit,
+  onRetry,
+  agentActivity,
+  searchFiles,
+  listDir,
+  attachFile,
+  conversations,
+  activeConversationID,
+}: MessageViewProps) {
   if (message.role === "user") {
     return (
       <UserMessageView

--- a/webview/src/delta-coalescer.ts
+++ b/webview/src/delta-coalescer.ts
@@ -1,0 +1,52 @@
+import type { Action } from "./hooks/useChatState"
+
+type Raf = (cb: () => void) => void
+
+/**
+ * Coalesces high-frequency streaming deltas into one dispatch burst per
+ * animation frame. opencode posts each `textDelta`/`reasoningDelta` as its own
+ * `postMessage`, and each becomes a separate React render; under a fast stream
+ * that is the dominant render cost.
+ *
+ * Consecutive deltas for the SAME message id and kind are merged into one
+ * action; every other action — and any delta for a different id/kind — is kept
+ * in arrival order so a `tool`/`patch`/`assistantDone` that arrives mid-stream
+ * still lands between the right text and is never reordered. React 18 batches
+ * the per-frame dispatch loop into a single render.
+ *
+ * `raf` is injectable so tests can flush synchronously.
+ */
+export function createDeltaCoalescer(
+  dispatch: (action: Action) => void,
+  raf: Raf = (cb) => requestAnimationFrame(cb),
+) {
+  const queue: Action[] = []
+  let scheduled = false
+
+  function flush() {
+    scheduled = false
+    const batch = queue.splice(0)
+    for (const action of batch) dispatch(action)
+  }
+
+  function enqueue(action: Action) {
+    const last = queue[queue.length - 1]
+    if (
+      (action.type === "textDelta" || action.type === "reasoningDelta") &&
+      last !== undefined &&
+      last.type === action.type &&
+      last.id === action.id
+    ) {
+      // Merge into a fresh object so we never mutate the original event.
+      queue[queue.length - 1] = { ...last, delta: last.delta + action.delta }
+    } else {
+      queue.push(action)
+    }
+    if (!scheduled) {
+      scheduled = true
+      raf(flush)
+    }
+  }
+
+  return { enqueue, flush }
+}

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -1,5 +1,6 @@
 import { useEffect, useReducer, useRef } from "react"
 import { vscode } from "../vscode"
+import { createDeltaCoalescer } from "../delta-coalescer"
 import type {
   AgentsStatusInfo,
   Attachment,
@@ -64,7 +65,7 @@ export type ChatState = {
   injectedText?: { text: string; nonce: number }
 }
 
-type Action =
+export type Action =
   | Outbound
   | { type: "reset" }
   | { type: "clearPermission" }
@@ -365,6 +366,10 @@ export function useChatState() {
   const nextRequestID = useRef(1)
 
   useEffect(() => {
+    // Streaming deltas are coalesced to one render per frame; request/response
+    // messages below resolve their pending refs immediately (order-independent)
+    // and bypass the queue.
+    const coalescer = createDeltaCoalescer(dispatch)
     const off = vscode.onMessage((msg) => {
       if (msg.type === "fileSearchResult") {
         const resolver = fileSearchPending.current.get(msg.requestID)
@@ -390,7 +395,7 @@ export function useChatState() {
         }
         return
       }
-      dispatch(msg as Action)
+      coalescer.enqueue(msg as Action)
     })
     vscode.post({ type: "mounted" })
     return off


### PR DESCRIPTION
Closes #264

## Summary

While an assistant answer streams, the chat panel was re-rendering the **entire** transcript on every text delta. Two causes, two fixes:

- **No memoization.** `MessageView` is now wrapped in `React.memo` with a custom comparator (`sameMessageViewProps`) that compares only render-affecting props and **ignores the always-fresh function props** (`useChatState` returns new closures each render; `App` passes inline arrows). The reducer already preserves object identity for messages it didn't touch, so a streaming turn re-renders on its own without dragging completed messages with it.
- **One render per delta.** A new `delta-coalescer` merges consecutive same-id `textDelta`/`reasoningDelta` and flushes once per `requestAnimationFrame`, **preserving event order** relative to `tool`/`patch`/`assistantDone` (a tool arriving mid-stream still lands between the right text). Request/response messages (`fileSearchResult`, etc.) keep their immediate path.

No change to what the conversation displays — purely how often it renders.

## Test plan

- [x] `bun run test` — 938 pass (+10: 5 coalescer, 5 comparator)
- [x] `bun run check-types` (host) + `cd webview && bunx tsc --noEmit` — clean
- [x] `bun run compile` — webview + host bundles build
- [ ] Manual: stream a long answer in a long conversation; only the live message updates (React DevTools highlight-updates), no stutter