### PR TITLE
fix(chat): animate the work-panel fold and reduce streaming layout shift

### DIFF
--- a/test/webview/message-view.test.tsx
+++ b/test/webview/message-view.test.tsx
@@ -292,6 +292,24 @@ describe("MessageView (assistant role)", () => {
     expect(screen.getByText(/150 tokens/)).toBeInTheDocument()
   })
 
+  it("keeps the process panel body mounted (clipped) when collapsed", () => {
+    // The grid-clip refactor animates expand/collapse by clipping an
+    // always-mounted body rather than mounting/unmounting it. Guard that the
+    // body stays in the DOM when collapsed, and the container lacks is-open.
+    const msg = {
+      id: "a-proc",
+      role: "assistant",
+      blocks: [
+        { type: "tool", update: { callID: "c1", tool: "read", status: "completed", input: { filePath: "src/foo.ts" } } },
+      ],
+    } as Message
+    const { container } = render(
+      <MessageView message={msg} processOpen={false} processOnly={true} />,
+    )
+    expect(container.querySelector(".process-body")).not.toBeNull()
+    expect(container.querySelector(".process")?.classList.contains("is-open")).toBe(false)
+  })
+
   it("renders markdown in reasoning body when a title is extracted", () => {
     const msg = {
       id: "a-reason-titled",

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -455,12 +455,16 @@ function ProcessPanel({
   const title = pending ? processTitle(blocks) : processSummary(blocks) ?? processTitle(blocks)
 
   return (
-    <div className="process">
-      <button className="process-head" onClick={() => setOpen(!open)}>
+    <div className={`process ${open ? "is-open" : ""}`}>
+      <button className="process-head" onClick={() => setOpen(!open)} aria-expanded={open}>
         <span className="process-title">{title}</span>
         <span className={`process-caret ${open ? "is-open" : ""}`}>›</span>
       </button>
-      {open && <div className="process-body">{renderBlocks(blocks, true, onReviewFile)}</div>}
+      {/* Body stays mounted; the grid wrapper clips it to 0fr when collapsed so
+          expand/collapse animates height instead of snapping. */}
+      <div className="process-body-clip">
+        <div className="process-body">{renderBlocks(blocks, true, onReviewFile)}</div>
+      </div>
     </div>
   )
 }

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -1248,6 +1248,12 @@ button {
   font-size: 10px;
   opacity: 0.5;
   margin-top: 6px;
+  /* Fade in on completion so the line settles in rather than popping. */
+  animation: msg-usage-in 0.2s ease both;
+}
+@keyframes msg-usage-in {
+  from { opacity: 0; }
+  to { opacity: 0.5; }
 }
 
 /* Semantic-index status pill — sits in the status bar / header area. */
@@ -1291,6 +1297,9 @@ button {
 
 .thinking-dots {
   display: inline-block;
+  /* Reserve one line so the bubble doesn't nudge when the dots are replaced by
+     the first streamed token. */
+  min-height: 1.5em;
   padding: 6px 2px;
   color: var(--vscode-foreground);
   font-style: italic;
@@ -1349,8 +1358,24 @@ button {
 .process-caret.is-open {
   transform: rotate(90deg);
 }
-.process-body {
+/* Grid wrapper that clips the body to 0fr when collapsed. Animating
+   grid-template-rows (instead of mount/unmount) makes the fold glide rather
+   than snap. The body stays mounted, so content growth during streaming is not
+   animated — only the open/close toggle is. Mirrors `.review-body-clip`. */
+.process-body-clip {
+  display: grid;
+  grid-template-rows: 0fr;
+  overflow: hidden;
+  transition:
+    grid-template-rows 0.18s ease,
+    margin-top 0.18s ease;
+}
+.process.is-open .process-body-clip {
+  grid-template-rows: 1fr;
   margin-top: 8px;
+}
+.process-body {
+  min-height: 0;
   padding-left: 12px;
   border-left: 1px solid var(--vscode-panel-border);
 }
@@ -2064,6 +2089,13 @@ button {
   .review-body,
   .review-body-clip {
     transition: none;
+  }
+  .process-caret,
+  .process-body-clip {
+    transition: none;
+  }
+  .msg-usage {
+    animation: none;
   }
 }
 /* ===== Prompt box ===== */


### PR DESCRIPTION
Closes #266

## Summary

CSS polish to remove visible jumps in the conversation:

- **Work-panel fold animates** instead of snapping. The body is now always mounted inside a `grid-template-rows: 0fr→1fr` clip wrapper (same technique as `.review-body-clip`), and `.process` toggles `is-open`. Because the body stays mounted, content growth during streaming is *not* animated — only the user's expand/collapse toggle is.
- **`.thinking-dots`** reserves ~one line so the bubble doesn't nudge when the first token replaces it.
- **`.msg-usage`** fades in on completion rather than popping.
- All three respect `prefers-reduced-motion`.

Deliberately **not** adding `scroll-behavior: smooth` to `.messages` — it fights the per-delta `scrollTop` writes that drive stick-to-bottom.

## Test plan

- [x] `bun run test` — 939 pass (+1: collapsed panel keeps its body mounted)
- [x] `cd webview && bunx tsc --noEmit` — clean
- [x] `bun run compile` — builds
- [ ] Manual: toggle the work panel (slides, no snap); thinking→first-token (no jump); reduced-motion (no animation)