### PR TITLE
fix(chat): let code blocks in the work panel scroll horizontally

### DIFF
--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -1367,6 +1367,10 @@ button {
 .process-body-clip {
   display: grid;
   grid-template-rows: 0fr;
+  /* Constrain the column to the panel width (not max-content) so a wide code
+     line can't inflate the body past the panel and get clipped — inner code
+     blocks then scroll horizontally on their own. Mirrors `.review-body`. */
+  grid-template-columns: minmax(0, 1fr);
   overflow: hidden;
   transition:
     grid-template-rows 0.18s ease,
@@ -1378,6 +1382,7 @@ button {
 }
 .process-body {
   min-height: 0;
+  min-width: 0;
   padding-left: 12px;
   border-left: 1px solid var(--vscode-panel-border);
 }


### PR DESCRIPTION
Closes #272

## Summary

Regression from #267. The work-panel body was wrapped in a CSS grid to animate the fold, but with no `grid-template-columns` the column defaulted to `auto` = max-content. A wide code line (e.g. a README markdown preview) inflated the body past the panel; the clip's `overflow: hidden` cut it, and the code block's own `overflow-x: auto` never triggered — so it couldn't scroll.

Fix: `grid-template-columns: minmax(0, 1fr)` on `.process-body-clip` (+ `min-width: 0` on `.process-body`), mirroring `.review-body`. The body stays at panel width and inner code blocks scroll horizontally on their own.

## Test plan

- [x] `bun run test` — 942 pass (CSS-only)
- [x] `bun run compile` — builds
- [ ] Visual: expand a work panel with a wide code block; it scrolls sideways instead of being clipped