### PR TITLE
fix(chat): constrain wide images and long error tokens to the message column

### DIFF
--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -1201,6 +1201,10 @@ button {
   padding: 6px 10px;
   border-radius: var(--radius);
   margin-top: 6px;
+  /* Long spaceless errors (file paths, URLs) must break inside the column
+     rather than overflow it — this block is outside `.md`, so it needs its
+     own wrap rule. */
+  overflow-wrap: anywhere;
 }
 /* "Stopped" is a user action, not a failure — render as a quiet grey footer
    note (small italic text with a leading bullet dot), no chip background,
@@ -1447,6 +1451,14 @@ button {
   border: 0;
   border-top: 1px solid var(--vscode-panel-border);
   margin: 12px 0;
+}
+/* Assistant-emitted images carry their intrinsic pixel width. Without a cap a
+   wide image paints past the column and is clipped on the right by
+   `.messages { overflow-x: hidden }` (same failure mode as overflowing text).
+   Scale to the column and keep the aspect ratio. */
+.md img {
+  max-width: 100%;
+  height: auto;
 }
 .md table {
   border-collapse: collapse;


### PR DESCRIPTION
Closes #274

## Summary

Deep audit of every content format rendered in a conversation — prose, code blocks, inline code, tables, display/inline math, blockquotes, lists, links, diff hunks, tool-trace rows, images, errors — for the same overflow/clip class fixed in #270 (text under the right scrollbar) and #272 (code blocks in the work panel). Everything scrolls or wraps correctly **except two** unconstrained surfaces, both fixed here:

1. **Markdown images** — there was no `.md img` rule and `Markdown.tsx` does not override `img`, so an assistant-emitted `![](url)` painted at its intrinsic pixel width and was clipped on the right by `.messages { overflow-x: hidden }`. Added `.md img { max-width: 100%; height: auto }` (scale to column, preserve aspect ratio).
2. **Error block** — `.msg-error` lives outside `.md`, so it inherited no wrap rule; a long spaceless error (e.g. `ENOENT … /very/long/path.ts`) overflowed. Added `overflow-wrap: anywhere`.

Code blocks, tables, and display math already scroll horizontally and are untouched. Inline math (a pathologically long `$…$`) remains a known minor edge, called out in #274 and left as-is.

## Test plan

- [x] `bun run compile` — production-shape webview bundle builds clean.
- [x] `bun run test` — 942/942 pass (CSS-only change; no behavioral assertion possible in jsdom, which does not simulate image intrinsic sizing — matches #271/#273).
- [ ] Visual (needs a running instance): an assistant image scales to the sidebar width instead of clipping; a long single-token error wraps. CSS-only and strictly more constraining, so the change is safe and reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)