### PR TITLE
fix(chat): balance the review card's top/bottom padding

### DIFF
--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -1833,7 +1833,11 @@ button {
   --review-file-text-line: var(--review-file-target-height);
   position: relative;
   margin: 0 12px;
-  padding: 4px 6px 5px;
+  /* Keep top and bottom padding equal. Each row already centers its own text,
+     so symmetric padding is what makes the card read as vertically balanced;
+     splitting it (4/5 or 5/4) leaves a visibly lopsided gap above vs below the
+     list. */
+  padding: 4px 6px;
   border: var(--bubble-border-width) solid var(--vscode-panel-border);
   border-radius: var(--radius);
   background: var(--color-bg-input);
@@ -1877,7 +1881,9 @@ button {
   transition: background-color 0.12s ease;
 }
 .review-head:hover {
-  background: var(--hover-bg-icon);
+  /* Same hover color as the file rows so the head and the list read as one
+     surface; the head keeps its own (sub-width) shape. */
+  background: var(--hover-bg-row);
 }
 .review-bulk-actions {
   display: inline-flex;
@@ -2104,7 +2110,7 @@ button {
   transition: background-color 0.12s ease;
 }
 .review-file:hover {
-  background: var(--vscode-list-hoverBackground);
+  background: var(--hover-bg-row);
 }
 .review-file.is-selected {
   /* Use the neutral "inactive selection" token rather than the saturated blue


### PR DESCRIPTION
## Summary

Balances the Review card's vertical padding so the top and bottom are symmetric, and unifies the header hover color with the file rows.

**Padding.** A pixel measurement of the rendered card showed `padding: 4px 6px 5px` - 4px above the header, 5px below the last file row. The header (22px) and file rows (24px) each center their own text, so the unequal padding was the whole asymmetry (the card read bottom-heavy). Changed to `4px 6px` (equal top/bottom). Pure box-model, so it holds regardless of font or which files are listed.

**Hover.** `.review-head:hover` used `--hover-bg-icon` (toolbar hover) while the rows used the list-hover color. Both now use `--hover-bg-row` - shared color, each keeps its own shape.

## Test plan

- [x] `bun run check-types` (host) - clean
- [x] `cd webview && bunx tsc --noEmit` - no new errors (3 pre-existing)
- [x] `bun run test` - 942 passed (60 files)
- [x] `bun run build:webview` - built
- [x] Verified by pixel-measuring the rendered card: top gap == bottom gap

Closes #278
