### PR TITLE
chore(release): cut v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-06-01
+
+### Changed
+- The bottom composer, the review card, and the permission/question dialogs now stack in a single absolutely-positioned bottom dock above the scroll area; `.messages` reserves the dock's measured height (`--bottom-dock-height`) so nothing hides behind the floating composer, and a dialog that co-occurs with pending changes no longer drops under it (#277).
+- The review card is restyled as a floating card - rounded border, input background, drop shadow, entry animation, and a fading connector toward the composer - with normalized head/file row heights, a CSS-drawn disclosure chevron, and right-aligned bulk actions (#277). Its top and bottom padding is symmetric and the header hover shares the file-row hover color, so the head and the list read as one surface (#279).
+- `MessageView` is memoized and stream deltas are coalesced per animation frame, cutting layout thrash while a turn streams (#265).
+- The work-panel fold is animated and streaming layout shift during a turn is reduced (#267).
+
+### Fixed
+- The answer is split from the process/thinking section deterministically instead of by prose heuristics (#269).
+- Message text is inset 12px so it lines up with the composer width (#271).
+- Code blocks in the work panel scroll horizontally instead of stretching the message column (#273).
+- Wide images and long unbroken error tokens are constrained to the message column instead of overflowing it (#275).
+
 ## [1.2.0] - 2026-05-31
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Cuts **v1.3.0**. Bumps `package.json` 1.2.0 -> 1.3.0 and adds the `[1.3.0]` CHANGELOG entry covering the chat-panel polish merged since v1.2.0 (#265, #267, #269, #271, #273, #275, #277, #279).

Merging this and publishing the `v1.3.0` GitHub Release triggers `.github/workflows/release.yml`, which type-checks, tests, builds, packages the `.vsix`, and publishes to the VS Code Marketplace + Open VSX.

## Release gates (run locally)

- [x] `bun run check-types` - clean
- [x] `bun run test` - 942 passed (60 files)
- [x] `bun run package` - production build OK
- [x] `bunx @vscode/vsce package --no-dependencies` - packaged `opencui-1.3.0.vsix`, version correct

Closes #280
