### PR TITLE
fix(chat): six correctness fixes from extension audit

### DIFF
--- a/src/chat/stream.ts
+++ b/src/chat/stream.ts
@@ -678,10 +678,14 @@ export function subscribeSession(
       seenAssistantMessages.add(messageID)
       handlers.onAssistantStart?.(messageID)
     }
-    if (p.field === "text") {
+    // Guard `typeof p.delta === "string"` (same as onPartUpdated guards
+    // part.text): a malformed/empty delta would otherwise throw on
+    // `p.delta.length`, propagate out of the SSE reader loop, and tear down the
+    // live subscription mid-turn.
+    if (p.field === "text" && typeof p.delta === "string") {
       handlers.onTextDelta(messageID, p.delta)
       seenLen.set(partID, (seenLen.get(partID) ?? 0) + p.delta.length)
-    } else if (p.field === "reasoning") {
+    } else if (p.field === "reasoning" && typeof p.delta === "string") {
       handlers.onReasoningDelta?.(messageID, p.delta)
       seenLen.set(partID, (seenLen.get(partID) ?? 0) + p.delta.length)
     }

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -1184,16 +1184,23 @@ export class ChatView implements vscode.WebviewViewProvider {
     // promptAsync's { providerID, modelID } object.
     const model = sel.modelProviderID && sel.modelID ? `${sel.modelProviderID}/${sel.modelID}` : undefined
     log("command dispatch", { sessionID: this.sessionID, command, agent: sel.agent ?? "default", model: model ?? "default" })
+    const body = {
+      command,
+      arguments: args,
+      ...(sel.agent ? { agent: sel.agent } : {}),
+      ...(model ? { model } : {}),
+    }
+    if (sel.modelVariant) {
+      // `variant` is a top-level field the command endpoint accepts (same as
+      // promptAsync in handleSend); the bundled SDK types don't expose it yet.
+      // Without this, custom /commands silently run at the model's default effort.
+      ;(body as unknown as { variant?: string }).variant = sel.modelVariant
+    }
     try {
       const res = await backend.client.session.command({
         path: { id: this.sessionID },
         query: { directory: backend.directory },
-        body: {
-          command,
-          arguments: args,
-          ...(sel.agent ? { agent: sel.agent } : {}),
-          ...(model ? { model } : {}),
-        },
+        body,
       })
       if (res.error) log("command failed", res.error)
     } catch (e) {
@@ -1659,6 +1666,22 @@ export class ChatView implements vscode.WebviewViewProvider {
       onToast: (toast) => this.surfaceToast(toast),
       onSessionError: (message) => {
         log("session error", message)
+        // A parent session.error that isn't mirrored by an assistant-message
+        // error (that case is handled in onAssistantEnd) would otherwise fail
+        // silently AND let the trailing session.idle's markSessionIdle sweep the
+        // Agents-popover Main row to "completed". Settle the Main task first so
+        // the terminal guard protects its status, then surface the failure.
+        // A server-side abort ("Aborted") settles quietly — mirroring the chat
+        // bubble's Stopped convention — instead of flashing a red toast.
+        const classified = classifyTerminal(message)
+        void this.subagentDispatch.recordMainTaskFinish(classified.status, classified.error)
+        if (classified.status === "error") {
+          this.surfaceToast({
+            variant: "error",
+            title: "Session error",
+            message: message || "The session reported an error.",
+          })
+        }
       },
       onSessionBusy: () => {
         // A new busy state means continuation (if any) took over — cancel

--- a/test/host/e2e-mock-opencode.test.ts
+++ b/test/host/e2e-mock-opencode.test.ts
@@ -102,6 +102,24 @@ describe("E2E (mock opencode): SDK ↔ HTTP server", () => {
     expect(body.model).toBe("openai/gpt-5")
   })
 
+  it("session.command forwards a top-level variant the SDK type does not declare", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    // handleRunCommand sends `variant` as a top-level field (like promptAsync).
+    // The SDK's SessionCommandData.body doesn't declare it, so it's cast on.
+    // This guards that the SDK doesn't strip the unknown field before the wire —
+    // the whole effort-on-/commands fix depends on it surviving serialization.
+    const commandBody = { command: "deploy", arguments: "prod", model: "openai/gpt-5" }
+    ;(commandBody as unknown as { variant?: string }).variant = "high"
+    await client.session.command({
+      path: { id: "ses_test" },
+      query: { directory: "/tmp" },
+      body: commandBody,
+    })
+    expect(server.commandCalls).toHaveLength(1)
+    const recorded = server.commandCalls[0]!.body as { variant?: string }
+    expect(recorded.variant).toBe("high")
+  })
+
   it("session.summarize (the /compact endpoint) round-trips", async () => {
     const client = createOpencodeClient({ baseUrl: server.url })
     const res = await client.session.summarize({

--- a/test/host/stream-part-delta.test.ts
+++ b/test/host/stream-part-delta.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { createOpencodeClient } from "@opencode-ai/sdk"
+import { startMockOpencode, type MockOpencodeServer } from "./mock-opencode-server"
+import { subscribeSession } from "../../src/chat/stream"
+
+let server: MockOpencodeServer
+
+beforeEach(async () => {
+  server = await startMockOpencode()
+})
+
+afterEach(async () => {
+  await server.close()
+})
+
+function makeBackend() {
+  const client = createOpencodeClient({ baseUrl: server.url })
+  return { url: server.url, client, directory: "/tmp" }
+}
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+describe("subscribeSession message.part.delta guard", () => {
+  it("a malformed delta (missing/non-string `delta`) does not throw or tear down the subscription", async () => {
+    const textDeltas: string[] = []
+    let sessionErrors = 0
+    const backend = makeBackend()
+
+    const subscription = subscribeSession(
+      backend,
+      "ses_test",
+      {
+        onTextDelta: (_id, delta) => textDeltas.push(delta),
+        onSessionError: () => sessionErrors++,
+      },
+      // Long watchdog so it can't interfere with the assertions.
+      { watchdogMs: 10_000 },
+    )
+    await subscription.ready
+    await server.awaitClient()
+
+    // field=text but no `delta`: before the guard this threw on `p.delta.length`,
+    // propagated out of the SSE reader loop, and killed the live subscription.
+    server.push({
+      type: "message.part.delta",
+      sessionID: "ses_test",
+      messageID: "msg_a",
+      partID: "p1",
+      field: "text",
+    })
+    await wait(20)
+
+    // A subsequent VALID delta must still be delivered — proves the stream survived.
+    server.push({
+      type: "message.part.delta",
+      sessionID: "ses_test",
+      messageID: "msg_a",
+      partID: "p1",
+      field: "text",
+      delta: "hello",
+    })
+    await wait(20)
+
+    subscription.abort()
+    expect(sessionErrors).toBe(0)
+    expect(textDeltas).toEqual(["hello"])
+  })
+})

--- a/test/webview/abort-flow.test.ts
+++ b/test/webview/abort-flow.test.ts
@@ -101,6 +101,30 @@ describe("reducer abort flow", () => {
     expect(msg.pending).toBe(false)
   })
 
+  it("assistantStart while aborting is dropped (no stray empty bubble)", () => {
+    const before = pendingAssistant("a1")
+    const aborted = reducer(before, { type: "aborted" })
+    // A late message.start races in after Stop.
+    const after = reducer(aborted, { type: "assistantStart", id: "a2" })
+    expect(after).toBe(aborted) // reference-equal: reducer returned the same state
+    expect(after.messages.filter((m) => m.role === "assistant")).toHaveLength(1)
+  })
+
+  it("restore after aborted clears aborting + continuationPending (composer recovers)", () => {
+    // Repro: user presses Stop, then switches conversations before the old
+    // session's sessionIdle (the only thing that clears `aborting`) arrives.
+    // Without the restore reset, `aborting` strands and PromptBox stays disabled.
+    const aborted = reducer(pendingAssistant("a1"), { type: "aborted" })
+    const pending = reducer(aborted, { type: "continuationPending", pending: true })
+    expect(pending.aborting).toBe(true)
+    expect(pending.continuationPending).toBe(true)
+    const restored = reducer(pending, { type: "restore", conversationID: "c2", messages: [] })
+    expect(restored.aborting).toBe(false)
+    expect(restored.continuationPending).toBe(false)
+    expect(restored.busy).toBe(false)
+    expect(restored.conversationID).toBe("c2")
+  })
+
   it("multiple pending assistants in a turn: only the LAST one gets the Stopped badge", () => {
     // Build a state with two pending assistants in the same turn (e.g. a
     // subtask intermediate step + the final answer).

--- a/test/webview/statusbar.test.tsx
+++ b/test/webview/statusbar.test.tsx
@@ -113,6 +113,15 @@ describe("StatusBar", () => {
     expect(items[1]!.textContent).toMatch(/default/i)
   })
 
+  it("trigger shows the Effort segment with 'default' even when no variant is set", () => {
+    // Discoverability: the collapsed bar must always advertise Effort (like
+    // Model/Agent), not hide it until a variant is picked.
+    render(<StatusBar {...baseProps} selection={{ model: "openai/gpt-5.5" }} />)
+    const trigger = screen.getByRole("button", { name: /change agent, model, and effort/i })
+    expect(trigger.textContent).toMatch(/Effort/)
+    expect(trigger.textContent).toMatch(/default/)
+  })
+
   it("renders the New chat icon button and fires onCreateConversation", async () => {
     const user = userEvent.setup()
     const onCreateConversation = vi.fn()

--- a/webview/src/components/StatusBar.tsx
+++ b/webview/src/components/StatusBar.tsx
@@ -358,13 +358,9 @@ function SelectorMenu({
       >
         <span className="selector-prefix">Model</span>
         <span className="selector-primary">{prettyModel}</span>
-        {variant && (
-          <>
-            <span className="selector-sep">·</span>
-            <span className="selector-prefix">Effort</span>
-            <span className="selector-variant">{variant}</span>
-          </>
-        )}
+        <span className="selector-sep">·</span>
+        <span className="selector-prefix">Effort</span>
+        <span className="selector-variant">{variant ?? "default"}</span>
         <span className="selector-sep">·</span>
         <span className="selector-prefix">Agent</span>
         <span className="selector-secondary">{prettyAgent}</span>

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -169,6 +169,13 @@ export function reducer(state: ChatState, action: Action): ChatState {
       return {
         ...state,
         busy: false,
+        // A conversation switch invalidates any in-flight abort/continuation:
+        // the old session's SSE subscription is torn down, so its `sessionIdle`
+        // (the only thing that clears `aborting`) never arrives. Without this,
+        // a stranded `aborting` leaves the new conversation's composer disabled
+        // ("Stopping…") with no way to recover but a window reload.
+        aborting: false,
+        continuationPending: false,
         contextUsage: undefined,
         conversationID: action.conversationID,
         messages: action.messages,
@@ -226,6 +233,10 @@ export function reducer(state: ChatState, action: Action): ChatState {
         ),
       }
     case "assistantStart":
+      // Mirror the textDelta/tool/patch gates: a late message.start racing in
+      // after Stop must not append a fresh pending assistant bubble (it would
+      // render with no Stopped badge once sessionIdle clears its pending flag).
+      if (state.aborting) return state
       return {
         ...state,
         busy: true,


### PR DESCRIPTION
## Summary

Six confirmed, low-risk correctness bugs found in a read-only audit of the extension. Each fix is small and independent.

1. **Composer deadlock after Stop → switch conversation** (high) — `webview/src/hooks/useChatState.ts` `restore` now clears `aborting`/`continuationPending`. Switching conversations tears down the old SSE subscription, so its `sessionIdle` (the only thing that cleared `aborting`) never arrived — `PromptBox` checks `aborting` before `busy` and rendered a disabled "Stopping…" button, deadlocking the new conversation's composer until a window reload.
2. **Custom `/commands` ignore the effort setting** (medium) — `src/chat/view.ts` `handleRunCommand` now sets the top-level `variant` on the `session.command` body (the endpoint accepts it; `handleSend` already did). Custom slash commands previously ran at the model's default reasoning effort.
3. **Parent `session.error` is silent** (medium) — `onSessionError` now surfaces a toast and settles the Agents-popover Main task (a server-side abort settles quietly), instead of only logging and letting the trailing idle sweep the row to "completed".
4. **`assistantStart` not gated while aborting** (medium) — the reducer now drops a late `message.start` after Stop, mirroring the `textDelta`/`tool`/`patch` gates, so no stray empty assistant bubble appears.
5. **`onPartDelta` can throw and kill the SSE stream** (medium) — now guards `typeof p.delta === "string"` (like its sibling `onPartUpdated`). `route()` has no per-event try/catch, so an unguarded `p.delta.length` threw out of the reader loop and tore down the live subscription.
6. **Effort selector hidden in the default state** (low) — `StatusBar` now always renders the Effort segment with `variant ?? "default"`, matching Model/Agent, so the control is discoverable before a selection.

Lower-severity findings (server lifecycle, path-guard, polish) are catalogued for follow-up PRs.

## Test plan

- [x] `bun run check-types` (host) — clean
- [x] `cd webview && bunx tsc --noEmit` — clean (the 3 errors previously noted in CLAUDE.md no longer reproduce on this tree)
- [x] `bun run test` — 947 passed (61 files), +5 new tests:
  - reducer: `restore` after `aborted` clears `aborting`/`continuationPending`; `assistantStart` is a reference-equal no-op while aborting
  - host E2E: `session.command` carries a top-level `variant` through the SDK (guards the cast)
  - stream: a malformed `message.part.delta` (missing `delta`) neither throws nor tears down the subscription
- [ ] Manual smoke in the Extension Development Host (needs a human; webview does not hot-reload — reload the window after build):
  - Stop a turn, immediately switch conversations → composer usable
  - Effort = high, run a custom `/command` → resulting message records `info.variant`
  - Status bar shows `Effort default` before any selection

Closes #282