### PR TITLE
fix(icons): put inline SVG sizes back on the ICON_SIZE token

### DIFF
--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -980,7 +980,7 @@ function StopIcon() {
 
 function FolderIcon() {
   return (
-    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <svg width={ICON_SIZE.lg} height={ICON_SIZE.lg} viewBox="0 0 16 16" fill="none" aria-hidden="true">
       <path d="M2 4a1 1 0 0 1 1-1h3.5l1.5 1.5H13a1 1 0 0 1 1 1V12a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V4z"
         stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
     </svg>
@@ -989,7 +989,7 @@ function FolderIcon() {
 
 function ChatIcon() {
   return (
-    <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <svg width={ICON_SIZE.lg} height={ICON_SIZE.lg} viewBox="0 0 16 16" fill="none" aria-hidden="true">
       <path d="M3 3h10a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1H6l-3 2.5V4a1 1 0 0 1 1-1z"
         stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
     </svg>
@@ -998,7 +998,7 @@ function ChatIcon() {
 
 function ChevronIcon() {
   return (
-    <svg width="10" height="10" viewBox="0 0 16 16" fill="none" aria-hidden="true" className="mention-category-chevron">
+    <svg width={ICON_SIZE.sm} height={ICON_SIZE.sm} viewBox="0 0 16 16" fill="none" aria-hidden="true" className="mention-category-chevron">
       <path d="M6 4l4 4-4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
     </svg>
   )

--- a/webview/src/design-tokens.ts
+++ b/webview/src/design-tokens.ts
@@ -7,9 +7,10 @@
  */
 
 /**
- * Icon-pixel sizes for inline SVG icons. Maps to the four visual scales the
- * UI actually uses, no more. If you need a new size, prefer extending this
- * scale (e.g. `xl: 18`) rather than inlining a literal.
+ * Icon-pixel sizes for inline SVG icons. These scales cover every inline SVG
+ * in the webview. CSS-drawn icons (pseudo-element shapes, codicon glyphs) size
+ * themselves in styles.css and may sit outside this scale. If an SVG needs a
+ * new size, extend this scale (e.g. `xl: 18`) rather than inlining a literal.
  */
 export const ICON_SIZE = {
   /** Tiny X buttons (thumbnail remove, stop-square inside send button). */


### PR DESCRIPTION
## Summary

Three inline SVGs in `PromptBox.tsx` hardcoded their pixel sizes, bypassing the `ICON_SIZE` token that `design-tokens.ts` exists to enforce (its own doc says a stray `width={11}` should be "a compile error"):

- `FolderIcon` `width="14"` → `ICON_SIZE.lg`
- `ChatIcon` `width="14"` → `ICON_SIZE.lg`
- `ChevronIcon` `width="10"` → `ICON_SIZE.sm`

14 and 10 are the exact sizes these already rendered, so there is **no visual change** — this just restores the single-source-of-truth invariant the other six inline SVGs already follow.

Also corrected the token doc: it claimed "the four visual scales the UI actually uses, no more," but CSS-drawn icons (`.new-chat-icon`, `.history-clock`) use an off-scale 11px. The comment now scopes itself to inline SVGs and notes CSS-drawn icons size themselves.

Closes #286

## Test plan

- [x] `bunx tsc --noEmit` (webview) — clean
- [x] `bun run test` — 947/947 pass
- [x] No rendered-pixel change (literals replaced with tokens of identical value)
- [ ] Visual smoke in the Extension Development Host (folder/chat/chevron icons in the @-picker unchanged)