### PR TITLE
feat(icons): adopt VS Code codicons for toolbar, picker, and dialog icons

### DIFF
--- a/test/webview/statusbar.test.tsx
+++ b/test/webview/statusbar.test.tsx
@@ -37,6 +37,18 @@ describe("StatusBar", () => {
     expect(screen.getByText("Code Reviewer")).toBeInTheDocument()
   })
 
+  it("renders the new-chat button as a codicon-add glyph", () => {
+    render(<StatusBar {...baseProps} />)
+    const button = screen.getByRole("button", { name: "New chat" })
+    expect(button.querySelector(".codicon-add")).toBeTruthy()
+  })
+
+  it("renders the history button as a codicon-history glyph", () => {
+    render(<StatusBar {...baseProps} />)
+    const button = screen.getByRole("button", { name: /Chat history/ })
+    expect(button.querySelector(".codicon-history")).toBeTruthy()
+  })
+
   it("falls back to 'default' when selection is empty", () => {
     render(<StatusBar {...baseProps} />)
     expect(screen.getAllByText("default").length).toBeGreaterThanOrEqual(1)

--- a/webview/bun.lock
+++ b/webview/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "opencui-webview",
       "dependencies": {
+        "@vscode/codicons": "^0.0.45",
         "katex": "^0.16.46",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -326,6 +327,8 @@
     "@vitest/spy": ["@vitest/spy@4.1.5", "", {}, "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ=="],
 
     "@vitest/utils": ["@vitest/utils@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug=="],
+
+    "@vscode/codicons": ["@vscode/codicons@0.0.45", "", {}, "sha512-1KAZ7XCMagp5Gdrlr4bbbcAqgcIL623iO1wW6rfcSVGAVUQvR0WP7bQx1SbJ11gmV3fdQTSEFIJQ/5C+HuVasw=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/webview/package.json
+++ b/webview/package.json
@@ -7,6 +7,7 @@
     "dev": "vite"
   },
   "dependencies": {
+    "@vscode/codicons": "^0.0.45",
     "katex": "^0.16.46",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/webview/src/components/ImagePreviewModal.tsx
+++ b/webview/src/components/ImagePreviewModal.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from "react"
-import { ICON_SIZE } from "../design-tokens"
 
 type Props = {
   src: { dataUrl: string; filename: string } | null
@@ -42,9 +41,7 @@ export function ImagePreviewModal({ src, onClose }: Props) {
           onClose()
         }}
       >
-        <svg width={ICON_SIZE.lg} height={ICON_SIZE.lg} viewBox="0 0 14 14" aria-hidden="true">
-          <path d="M2 2l10 10M12 2L2 12" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
-        </svg>
+        <span className="codicon codicon-close" aria-hidden="true" />
       </button>
       <img
         className="image-preview-img"

--- a/webview/src/components/ImageThumbnail.tsx
+++ b/webview/src/components/ImageThumbnail.tsx
@@ -1,6 +1,5 @@
 import type { Attachment } from "../protocol"
 import { formatBytes } from "../mention-tokens"
-import { ICON_SIZE } from "../design-tokens"
 
 /** The minimum shape ImageThumbnail needs. `id` is only required when
  *  `onRemove` is wired up (paperclip/paste flow); read-only sent bubbles
@@ -53,9 +52,7 @@ export function ImageThumbnail({ attachment, onPreview, onRemove }: Props) {
             onRemove(attachment.id!)
           }}
         >
-          <svg width={ICON_SIZE.xs} height={ICON_SIZE.xs} viewBox="0 0 8 8" aria-hidden="true">
-            <path d="M1 1l6 6M7 1l-6 6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-          </svg>
+          <span className="codicon codicon-close" aria-hidden="true" />
         </button>
       )}
     </li>

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -979,29 +979,15 @@ function StopIcon() {
 }
 
 function FolderIcon() {
-  return (
-    <svg width={ICON_SIZE.lg} height={ICON_SIZE.lg} viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <path d="M2 4a1 1 0 0 1 1-1h3.5l1.5 1.5H13a1 1 0 0 1 1 1V12a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V4z"
-        stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
-    </svg>
-  )
+  return <span className="codicon codicon-folder" aria-hidden="true" />
 }
 
 function ChatIcon() {
-  return (
-    <svg width={ICON_SIZE.lg} height={ICON_SIZE.lg} viewBox="0 0 16 16" fill="none" aria-hidden="true">
-      <path d="M3 3h10a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1H6l-3 2.5V4a1 1 0 0 1 1-1z"
-        stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
-    </svg>
-  )
+  return <span className="codicon codicon-comment-discussion" aria-hidden="true" />
 }
 
 function ChevronIcon() {
-  return (
-    <svg width={ICON_SIZE.sm} height={ICON_SIZE.sm} viewBox="0 0 16 16" fill="none" aria-hidden="true" className="mention-category-chevron">
-      <path d="M6 4l4 4-4 4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-    </svg>
-  )
+  return <span className="codicon codicon-chevron-right mention-category-chevron" aria-hidden="true" />
 }
 
 /**

--- a/webview/src/components/QuestionDialog.tsx
+++ b/webview/src/components/QuestionDialog.tsx
@@ -127,7 +127,7 @@ function QuestionItem({
                   onClick={() => onToggle(opt.label)}
                 >
                   <span className={`question-option-marker ${multiple ? "square" : "circle"}`} aria-hidden="true">
-                    {checked && (multiple ? "✓" : "●")}
+                    {checked && (multiple ? <span className="codicon codicon-check" /> : "●")}
                   </span>
                   <span className="question-option-text">
                     <span className="question-option-label">{opt.label}</span>

--- a/webview/src/components/StatusBar.tsx
+++ b/webview/src/components/StatusBar.tsx
@@ -99,7 +99,7 @@ export function StatusBar({
         aria-label="New chat"
         title="New chat"
       >
-        <span className="new-chat-icon" aria-hidden="true" />
+        <span className="codicon codicon-add" aria-hidden="true" />
       </button>
       <ChatHistoryMenu
         conversations={conversations}
@@ -197,7 +197,7 @@ function ChatHistoryMenu({
         aria-label="Chat history"
         title={activeTitle ? `Chat history: ${activeTitle}` : "Chat history"}
       >
-        <span className="history-clock" />
+        <span className="codicon codicon-history" aria-hidden="true" />
       </button>
       {open && (
         <div className="history-popover">
@@ -211,7 +211,7 @@ function ChatHistoryMenu({
                 onCreate()
               }}
             >
-              <span className="history-new-icon" aria-hidden="true" />
+              <span className="codicon codicon-add" aria-hidden="true" />
               <span className="history-new-text">New chat</span>
             </button>
           </div>

--- a/webview/src/main.tsx
+++ b/webview/src/main.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import ReactDOM from "react-dom/client"
 import App from "./App"
+import "@vscode/codicons/dist/codicon.css"
 import "./styles.css"
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -519,60 +519,13 @@ button {
 .new-chat-trigger:hover {
   background: var(--hover-bg-pill);
 }
-.new-chat-icon {
-  position: relative;
-  width: 11px;
-  height: 11px;
+.new-chat-trigger .codicon {
+  font-size: 14px;
   opacity: 0.85;
 }
-.new-chat-icon::before,
-.new-chat-icon::after {
-  content: "";
-  position: absolute;
-  background: currentColor;
-  border-radius: 1px;
-}
-.new-chat-icon::before {
-  left: 50%;
-  top: 0;
-  width: 1.6px;
-  height: 100%;
-  transform: translateX(-50%);
-}
-.new-chat-icon::after {
-  top: 50%;
-  left: 0;
-  width: 100%;
-  height: 1.6px;
-  transform: translateY(-50%);
-}
-.history-clock {
-  position: relative;
-  width: 11px;
-  height: 11px;
-  border: 1.4px solid currentColor;
-  border-radius: 50%;
-  opacity: 0.78;
-  box-sizing: border-box;
-}
-.history-clock::before,
-.history-clock::after {
-  content: "";
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  width: 1.2px;
-  border-radius: 1px;
-  background: currentColor;
-  transform-origin: 50% 0;
-}
-.history-clock::before {
-  height: 3.8px;
-  transform: translate(-50%, -0.8px) rotate(180deg);
-}
-.history-clock::after {
-  height: 3px;
-  transform: translate(-50%, -0.8px) rotate(300deg);
+.history-trigger .codicon {
+  font-size: 14px;
+  opacity: 0.8;
 }
 .history-popover {
   position: absolute;
@@ -620,32 +573,9 @@ button {
 .history-new:hover {
   background: color-mix(in srgb, var(--vscode-gitDecoration-addedResourceForeground, #3fb950) 14%, transparent);
 }
-.history-new-icon {
-  position: relative;
+.history-new .codicon {
   flex: 0 0 auto;
-  width: 10px;
-  height: 10px;
-}
-.history-new-icon::before,
-.history-new-icon::after {
-  content: "";
-  position: absolute;
-  background: currentColor;
-  border-radius: 1px;
-}
-.history-new-icon::before {
-  left: 50%;
-  top: 0;
-  width: 1.6px;
-  height: 100%;
-  transform: translateX(-50%);
-}
-.history-new-icon::after {
-  top: 50%;
-  left: 0;
-  width: 100%;
-  height: 1.6px;
-  transform: translateY(-50%);
+  font-size: 13px;
 }
 .history-new-text {
   flex: 0 0 auto;
@@ -1792,6 +1722,7 @@ button {
 }
 .question-option-marker.circle { border-radius: 50%; }
 .question-option-marker.square { border-radius: 3px; }
+.question-option-marker .codicon { font-size: 11px; }
 .question-option.is-checked .question-option-marker {
   border-color: var(--vscode-focusBorder);
   color: var(--vscode-focusBorder);
@@ -2554,6 +2485,9 @@ button {
 .image-preview-close:hover {
   background: rgba(0, 0, 0, 0.85);
 }
+.image-preview-close .codicon {
+  font-size: 16px;
+}
 .attachment-icon {
   width: auto;
   height: 14px;
@@ -2656,6 +2590,9 @@ button {
 }
 .image-thumb-remove:hover {
   background: rgba(0, 0, 0, 0.78);
+}
+.image-thumb-remove .codicon {
+  font-size: 10px;
 }
 .icon-btn.attach-btn {
   display: inline-flex;
@@ -2802,6 +2739,10 @@ button {
 .mention-hit.active .mention-category-meta {
   color: var(--vscode-list-activeSelectionForeground);
   opacity: 0.8;
+}
+.mention-popover .codicon {
+  font-size: 14px;
+  flex-shrink: 0;
 }
 .mention-category-chevron {
   opacity: 0.5;


### PR DESCRIPTION
## Summary

Replaces the three-way icon mix (inline SVG, CSS pseudo-element geometry, unicode glyph) with **VS Code codicons** where it is a clear win. Icons now auto-match the user's active theme, and the fragile hand-built CSS (notably the `.history-clock` faked from two rotated pseudo-elements) is gone. Net **-62 lines**, ~74 of them dead CSS.

Closes #288

## How the font is wired (no host change)

- `@vscode/codicons` added to the webview; `main.tsx` imports `codicon.css`.
- The webview is a single-file Vite build (`assetsInlineLimit: 100000000`), so `codicon.ttf` inlines as a `data:font/ttf;base64,…` URL — verified present in the production `dist/webview` bundle.
- The host CSP already sets `font-src ${cspSource} data:` (`src/chat/view.ts`), so the inlined font passes with **zero host/CSP change**.

## Migrated to codicons

| Icon | Was | Now |
|---|---|---|
| New chat (+) | `.new-chat-icon` pseudo-element bars | `codicon-add` |
| Chat history | `.history-clock` rotated pseudo-elements | `codicon-history` |
| History "New chat" (+) | `.history-new-icon` pseudo-elements | `codicon-add` |
| @-picker folder | inline SVG | `codicon-folder` |
| @-picker past-chats | inline SVG | `codicon-comment-discussion` |
| @-picker chevron | inline SVG | `codicon-chevron-right` |
| Thumbnail / preview close | inline SVG | `codicon-close` |
| Question multi-select check | `✓` glyph | `codicon-check` |

Each codicon is sized via a co-located CSS rule to preserve the previous footprint (e.g. 14px in the 22×22 round buttons), so layout does not shift.

## Deliberately kept as custom SVG

- **Composer Send / Stop** — pixel-tuned inside bespoke circular buttons (documented centering math); already theme via `currentColor`. Codicons would risk regressing the centering for no theming gain.
- **Paperclip** — no clean codicon equivalent.

## Test plan

- [x] `@vscode/codicons` font inlines as a `data:` URL in the production build (verified in `dist/webview/index.html`)
- [x] All seven codicon classes used are present in the bundle
- [x] webview `tsc --noEmit` — clean
- [x] host `check-types` — clean
- [x] `bun run test` — 949 pass (added 2: new-chat → `codicon-add`, history → `codicon-history`)
- [x] `bun run package` — production build succeeds
- [ ] **Visual smoke in the Extension Development Host** (reload the webview): confirm glyph sizing/centering in the status bar, @-picker, image thumbnails, and the multi-select question dialog match the intended look