### PR TITLE
feat(picker): show file-type codicons in the @ file picker

### DIFF
--- a/test/webview/file-icons.test.ts
+++ b/test/webview/file-icons.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest"
+import { fileTypeCodicon } from "../../webview/src/file-icons"
+
+describe("fileTypeCodicon", () => {
+  it("maps source files to a generic code glyph", () => {
+    for (const n of ["App.tsx", "main.ts", "esbuild.js", "index.html", "styles.css", "server.go", "lib.rs"]) {
+      expect(fileTypeCodicon(n)).toBe("file-code")
+    }
+  })
+
+  it("maps data, docs, and media to their own glyphs", () => {
+    expect(fileTypeCodicon("package.json")).toBe("json")
+    expect(fileTypeCodicon("CHANGELOG.md")).toBe("markdown")
+    expect(fileTypeCodicon("notes.txt")).toBe("file-text")
+    expect(fileTypeCodicon("paper.pdf")).toBe("file-pdf")
+    expect(fileTypeCodicon("logo.png")).toBe("file-media")
+    expect(fileTypeCodicon("icon.svg")).toBe("file-media")
+  })
+
+  it("maps config, archives, db, shell, and notebooks", () => {
+    expect(fileTypeCodicon("vite.config.yaml")).toBe("gear")
+    expect(fileTypeCodicon("tsconfig.toml")).toBe("gear")
+    expect(fileTypeCodicon("bundle.zip")).toBe("file-zip")
+    expect(fileTypeCodicon("data.sqlite")).toBe("database")
+    expect(fileTypeCodicon("setup.sh")).toBe("terminal")
+    expect(fileTypeCodicon("analysis.ipynb")).toBe("notebook")
+  })
+
+  it("treats lock files as locks regardless of their extension", () => {
+    expect(fileTypeCodicon("bun.lock")).toBe("lock")
+    expect(fileTypeCodicon("Cargo.lock")).toBe("lock")
+    expect(fileTypeCodicon("package-lock.json")).toBe("lock")
+    expect(fileTypeCodicon("pnpm-lock.yaml")).toBe("lock")
+  })
+
+  it("recognizes LICENSE by name and dotfile-extensions, and is case-insensitive", () => {
+    expect(fileTypeCodicon("LICENSE")).toBe("law")
+    expect(fileTypeCodicon("license.md")).toBe("law")
+    expect(fileTypeCodicon("LICENCE")).toBe("law")
+    expect(fileTypeCodicon(".env")).toBe("gear")
+    expect(fileTypeCodicon("PACKAGE.JSON")).toBe("json")
+  })
+
+  it("falls back to a plain file glyph for unknown and extensionless names", () => {
+    expect(fileTypeCodicon(".gitignore")).toBe("file")
+    expect(fileTypeCodicon("Makefile")).toBe("file")
+    expect(fileTypeCodicon("data.unknownext")).toBe("file")
+  })
+})

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -23,6 +23,7 @@ import {
 import { ImagePreviewModal } from "./ImagePreviewModal"
 import { ImageThumbnail } from "./ImageThumbnail"
 import { ICON_SIZE } from "../design-tokens"
+import { fileTypeCodicon } from "../file-icons"
 
 // Re-export so existing consumers (tests, integrators) keep working through PromptBox.
 export {
@@ -737,7 +738,9 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
                   }}
                   onMouseEnter={() => setBrowseIndex(i)}
                 >
-                  {entry.kind === "folder" && <FolderIcon />}
+                  {entry.kind === "folder"
+                    ? <FolderIcon />
+                    : <span className={`codicon codicon-${fileTypeCodicon(entry.name)}`} aria-hidden="true" />}
                   <span className="mention-name">{entry.name}</span>
                   {entry.kind === "folder" && <ChevronIcon />}
                 </li>
@@ -761,6 +764,7 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
                 }}
                 onMouseEnter={() => setActiveIndex(i)}
               >
+                <span className={`codicon codicon-${fileTypeCodicon(hit.name)}`} aria-hidden="true" />
                 <span className="mention-name">{hit.name}</span>
                 <span className="mention-path">{hit.path}</span>
               </li>

--- a/webview/src/file-icons.ts
+++ b/webview/src/file-icons.ts
@@ -1,0 +1,65 @@
+/**
+ * Map a file name to a codicon class *suffix* for the @-picker file rows
+ * (callers prepend "codicon-"). Monochrome, theme-colored category icons:
+ * VS Code's colorful per-language icons come from the active file icon theme,
+ * which a webview cannot read, so we ship our own category-level set that
+ * matches the `codicon-folder` already used in the same picker.
+ */
+
+const BY_EXT: Record<string, string> = {
+  // Source / markup / styles — one generic "code file" glyph
+  ts: "file-code", tsx: "file-code", js: "file-code", jsx: "file-code",
+  mjs: "file-code", cjs: "file-code", mts: "file-code", cts: "file-code",
+  html: "file-code", htm: "file-code", xml: "file-code", vue: "file-code",
+  svelte: "file-code", astro: "file-code",
+  css: "file-code", scss: "file-code", sass: "file-code", less: "file-code",
+  py: "file-code", rb: "file-code", go: "file-code", rs: "file-code",
+  java: "file-code", kt: "file-code", c: "file-code", h: "file-code",
+  cpp: "file-code", cc: "file-code", hpp: "file-code", cs: "file-code",
+  php: "file-code", swift: "file-code", lua: "file-code", dart: "file-code",
+  // Structured data
+  json: "json", jsonc: "json",
+  // Docs / text
+  md: "markdown", mdx: "markdown", markdown: "markdown",
+  txt: "file-text", rst: "file-text", log: "file-text",
+  pdf: "file-pdf",
+  // Config formats
+  yaml: "gear", yml: "gear", toml: "gear", ini: "gear", env: "gear",
+  conf: "gear", cfg: "gear", properties: "gear",
+  // Images / media
+  png: "file-media", jpg: "file-media", jpeg: "file-media", gif: "file-media",
+  webp: "file-media", bmp: "file-media", ico: "file-media", svg: "file-media",
+  avif: "file-media", mp4: "file-media", mov: "file-media", webm: "file-media",
+  mp3: "file-media", wav: "file-media",
+  // Archives
+  zip: "file-zip", tar: "file-zip", gz: "file-zip", tgz: "file-zip",
+  rar: "file-zip", "7z": "file-zip", bz2: "file-zip",
+  // Compiled / binary
+  exe: "file-binary", bin: "file-binary", so: "file-binary", dll: "file-binary",
+  o: "file-binary", a: "file-binary", wasm: "file-binary", dylib: "file-binary",
+  // Databases
+  db: "database", sqlite: "database", sql: "database",
+  // Shell scripts
+  sh: "terminal", bash: "terminal", zsh: "terminal", fish: "terminal",
+  // Notebooks
+  ipynb: "notebook",
+}
+
+export function fileTypeCodicon(name: string): string {
+  const lower = name.toLowerCase()
+  // Lock files often carry a .json/.yaml extension we'd otherwise classify by
+  // (package-lock.json, pnpm-lock.yaml, bun.lock, Cargo.lock), so match first.
+  if (lower.endsWith(".lock") || lower === "package-lock.json" || lower === "pnpm-lock.yaml") return "lock"
+  if (
+    lower === "license" ||
+    lower === "licence" ||
+    lower.startsWith("license.") ||
+    lower.startsWith("licence.")
+  )
+    return "law"
+  // `lastIndexOf(".") + 1` gives the whole name when there is no dot (-1 + 1 =
+  // 0), and the part after the leading dot for dotfiles (".env" -> "env"). Both
+  // fall through to the `?? "file"` fallback when unmatched (".gitignore").
+  const ext = lower.slice(lower.lastIndexOf(".") + 1)
+  return BY_EXT[ext] ?? "file"
+}

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -2743,6 +2743,7 @@ button {
 .mention-popover .codicon {
   font-size: 14px;
   flex-shrink: 0;
+  align-self: center;
 }
 .mention-category-chevron {
   opacity: 0.5;
@@ -2803,11 +2804,6 @@ button {
 }
 .mention-browser .mention-hit {
   align-items: center;
-}
-.mention-browser .mention-hit:not(.mention-folder) {
-  /* Indent files so their names line up under folder names, which are pushed
-     right by the folder icon + gap. */
-  padding-left: 32px;
 }
 .mention-folder .mention-name {
   flex: 1;


### PR DESCRIPTION
## Summary

File rows in the `@` picker now lead with a **file-type codicon** instead of plain text, so the list is scannable at a glance. A pure `fileTypeCodicon(name)` maps extension/filename to a category glyph; it matches the `codicon-folder` already used for folders in the same list.

Closes #290

## Why monochrome, not the colorful Explorer icons

The colorful per-language icons in VS Code's Explorer come from the active **file icon theme** (Seti by default), which a webview cannot read — there is no API to resolve a file's themed icon, and the picker is a custom React overlay, not a native TreeView/QuickPick that gets `ThemeIcon.File` for free. So we ship our own theme-colored category set.

## Mapping (fallback `file`)

| Category | Glyph |
|---|---|
| code (ts/js/tsx/html/css/py/go/rs/...) | `file-code` |
| json | `json` · markdown -> `markdown` · text -> `file-text` · pdf -> `file-pdf` |
| images/media | `file-media` · archives -> `file-zip` · binary -> `file-binary` |
| lock files (`*.lock`, `package-lock.json`, `pnpm-lock.yaml`) | `lock` |
| LICENSE | `law` · db/sql -> `database` · shell -> `terminal` · config (yaml/toml/ini/env) -> `gear` · notebook -> `notebook` |

## Layout notes

- Applies to both the `@query` search-hits list and the non-folder rows of the drill-down browser; folders keep `codicon-folder`.
- Browse file rows previously had `padding-left: 32px` to indent names under folder names (files had no icon); that's removed — files now carry a leading icon at the same position as folders, so names line up naturally.
- Reuses the existing `.mention-popover .codicon` sizing (14px) + a new `align-self: center` (only affects the flat search-hits rows, which are the one `align-items: baseline` list; every already-approved icon sits in an `align-items: center` row, so it is a no-op for them).

## Test plan

- [x] `webview tsc --noEmit` — clean
- [x] `bun run test` — 955 pass (added `test/webview/file-icons.test.ts`, 6 cases incl. lockfiles, LICENSE, dotfiles, case-insensitivity, fallback)
- [x] `bun run package` — production build succeeds
- [ ] **Visual smoke in the Extension Dev Host**: type `@` then a query (search-hits list) and drill into a folder (browse list) — confirm file glyphs read right, folders/files align, and the browse indent looks correct