### PR TITLE
feat(review): refine the Review card

### DIFF
--- a/test/webview/review-attribution-render.test.tsx
+++ b/test/webview/review-attribution-render.test.tsx
@@ -50,8 +50,8 @@ describe("ReviewPanel: subagent attribution stays on the tooltip", () => {
     // No `.review-file-actor` element — the old badge is gone.
     expect(container.querySelector(".review-file-actor")).toBeNull()
     // The row title tooltip still carries the attribution so power users can hover.
-    const row = container.querySelector(".review-file") as HTMLElement
-    expect(row.title).toContain("Modified by: explore")
+    const head = container.querySelector(".review-head") as HTMLElement
+    expect(head.title).toContain("Modified by: explore")
   })
 
   it("keeps tooltip clean (just the path) for main-agent changes", () => {
@@ -66,8 +66,8 @@ describe("ReviewPanel: subagent attribution stays on the tooltip", () => {
     ]
     const { container } = render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
     expect(container.querySelector(".review-file-actor")).toBeNull()
-    const row = container.querySelector(".review-file") as HTMLElement
-    expect(row.title).toBe("src/foo.ts")
+    const head = container.querySelector(".review-head") as HTMLElement
+    expect(head.title).toBe("src/foo.ts")
   })
 
   it("lists multiple subagents in the tooltip when more than one touched the file", () => {
@@ -88,9 +88,9 @@ describe("ReviewPanel: subagent attribution stays on the tooltip", () => {
       ]),
     ]
     const { container } = render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
-    const row = container.querySelector(".review-file") as HTMLElement
-    expect(row.title).toContain("explore")
-    expect(row.title).toContain("hephaestus")
+    const head = container.querySelector(".review-head") as HTMLElement
+    expect(head.title).toContain("explore")
+    expect(head.title).toContain("hephaestus")
   })
 
   it("still collapses main + subagent edits onto one row (no duplicate visible attribution)", () => {
@@ -111,9 +111,9 @@ describe("ReviewPanel: subagent attribution stays on the tooltip", () => {
       ]),
     ]
     const { container } = render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
-    expect(container.querySelectorAll(".review-file")).toHaveLength(1)
+    expect(container.querySelectorAll(".review-head")).toHaveLength(1)
     expect(container.querySelector(".review-file-actor")).toBeNull()
-    const row = container.querySelector(".review-file") as HTMLElement
-    expect(row.title).toContain("Modified by: hephaestus")
+    const head = container.querySelector(".review-head") as HTMLElement
+    expect(head.title).toContain("Modified by: hephaestus")
   })
 })

--- a/test/webview/review-panel.test.tsx
+++ b/test/webview/review-panel.test.tsx
@@ -60,7 +60,7 @@ describe("ReviewPanel", () => {
     expect(container.firstChild).toBeNull()
   })
 
-  it("shows single-file collapsed header for one pending change", () => {
+  it("shows a single-row header for one pending change", () => {
     const messages = [
       editMessage("m1", {
         filePath: "src/foo.ts",
@@ -71,8 +71,9 @@ describe("ReviewPanel", () => {
     ]
     const { container } = render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
     expect(screen.getByText("Review")).toBeInTheDocument()
-    // foo.ts appears in both the header summary and the row file-name
-    expect(screen.getAllByText("foo.ts").length).toBeGreaterThanOrEqual(2)
+    // The single-file card is one row: the filename shows once (no duplicate
+    // body row), with inline Keep/Undo in the header.
+    expect(screen.getByText("foo.ts")).toBeInTheDocument()
     expect(container.querySelector(".review-stat.add")?.textContent).toBe("+1")
     expect(container.querySelector(".review-stat.del")?.textContent).toBe("-1")
   })
@@ -101,11 +102,10 @@ describe("ReviewPanel", () => {
     expect(container.querySelector(".review-stat.del")?.textContent).toBe("-1")
   })
 
-  it("applies kind-created class to row for new files", () => {
+  it("applies the kind-created class for a new file", () => {
     const messages = [createMessage("m1", { filePath: "new.ts", content: "line1\nline2\nline3" })]
     const { container } = render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
-    const row = container.querySelector(".review-file.kind-created")
-    expect(row).not.toBeNull()
+    expect(container.querySelector(".kind-created")).not.toBeNull()
   })
 
   it("disambiguates same-basename paths in row labels", () => {
@@ -153,7 +153,7 @@ describe("ReviewPanel", () => {
     expect(onReviewAllInChange).toHaveBeenCalledWith(expect.any(String), "foo.ts", "rejected")
   })
 
-  it("calls onSelectPath and onOpenReviewChange when row is clicked (selection)", async () => {
+  it("calls onSelectPath and onOpenReviewChange when the single-file header is clicked", async () => {
     const user = userEvent.setup()
     const onSelectPath = vi.fn()
     const onOpenReviewChange = vi.fn()
@@ -168,8 +168,8 @@ describe("ReviewPanel", () => {
         onOpenReviewChange={onOpenReviewChange}
       />,
     )
-    const row = container.querySelector(".review-file") as HTMLElement
-    await user.click(row)
+    const head = container.querySelector(".review-head") as HTMLElement
+    await user.click(head)
     expect(onSelectPath).toHaveBeenCalledWith("foo.ts")
     expect(onOpenReviewChange).toHaveBeenCalled()
   })
@@ -188,10 +188,11 @@ describe("ReviewPanel", () => {
     expect(container.firstChild).toBeNull()
   })
 
-  it("toggles the panel via the header button", async () => {
+  it("toggles the panel via the header button (multi-file)", async () => {
     const user = userEvent.setup()
     const messages = [
-      editMessage("m1", { filePath: "foo.ts", patch: "@@\n+a", additions: 1, deletions: 0 }),
+      editMessage("m1", { filePath: "a.ts", patch: "@@\n+a", additions: 1, deletions: 0 }),
+      editMessage("m2", { filePath: "b.ts", patch: "@@\n+b", additions: 1, deletions: 0 }),
     ]
     const { container } = render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
     const header = container.querySelector(".review-head") as HTMLButtonElement
@@ -279,7 +280,7 @@ describe("ReviewPanel", () => {
       editMessage("m2", { filePath: "new.ts", patch: "@@\n+x", additions: 1, deletions: 0 }),
     ]
     const { container } = render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
-    expect(container.querySelector(".review-file.kind-created")).not.toBeNull()
-    expect(container.querySelector(".review-file.kind-updated")).toBeNull()
+    expect(container.querySelector(".kind-created")).not.toBeNull()
+    expect(container.querySelector(".kind-updated")).toBeNull()
   })
 })

--- a/webview/src/components/ReviewPanel.tsx
+++ b/webview/src/components/ReviewPanel.tsx
@@ -74,8 +74,15 @@ export function ReviewPanel({
   return (
     <div className={`review-panel ${open ? "" : "is-collapsed"}`}>
       <div className="review-head-row">
-        <button className="review-head" onClick={() => setOpen(!open)} aria-expanded={open}>
-          <span className={`review-caret ${open ? "is-open" : ""}`}>›</span>
+        <button
+          className={`review-head${isSingle ? ` kind-${onlyChange!.kind}` : ""}`}
+          onClick={() => (isSingle ? selectChange(onlyChange!) : setOpen(!open))}
+          aria-expanded={isSingle ? undefined : open}
+          title={isSingle ? actorTooltip(onlyChange!) : undefined}
+        >
+          {!isSingle && (
+            <span className={`review-caret codicon codicon-chevron-right ${open ? "is-open" : ""}`} aria-hidden="true" />
+          )}
           <span className="review-title">{isSingle ? "Review" : "Review changes"}</span>
           <span className="review-summary" title={onlyChange?.path}>
             {onlyChange ? (displayNames.get(onlyChange.path) ?? basename(onlyChange.path)) : `${pendingChanges.length} files`}
@@ -83,81 +90,108 @@ export function ReviewPanel({
           <span className="review-stat add">+{additions}</span>
           <span className="review-stat del">-{deletions}</span>
         </button>
-        {!isSingle && (
-          <div className="review-bulk-actions">
-            <button
-              className="review-bulk-action accept"
-              onClick={(event) => { stopHead(event); bulkAct("accepted") }}
-              onKeyDown={stopHead}
-              title={`Keep changes in all ${pendingChanges.length} files`}
-              aria-label="Keep all changes"
-            >
-              Keep all
-            </button>
-            <button
-              className="review-bulk-action reject"
-              onClick={(event) => { stopHead(event); bulkAct("rejected") }}
-              onKeyDown={stopHead}
-              title={`Undo changes in all ${pendingChanges.length} files`}
-              aria-label="Undo all changes"
-            >
-              Undo all
-            </button>
-          </div>
-        )}
-      </div>
-      <div className="review-body-clip" aria-hidden={!open}>
-        <div className="review-body">
-          <div className="review-files">
-            {pendingChanges.map(({ change }) => {
-              const isSelected = change.source === selected.source && change.path === selected.path
-              const stop = (event: MouseEvent | KeyboardEvent) => event.stopPropagation()
-              const act = (action: ReviewHunkState) => {
-                onReviewAllInChange?.(change.source, change.path, action)
-              }
-              return (
-                <div
-                  key={`${change.source}:${change.path}`}
-                  className={`review-file kind-${change.kind} ${isSelected ? "is-selected" : ""}`}
-                  onClick={() => selectChange(change)}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter" || event.key === " ") {
-                      event.preventDefault()
-                      selectChange(change)
-                    }
-                  }}
-                  role="button"
-                  tabIndex={0}
-                  title={actorTooltip(change)}
-                >
-                  <span className="review-file-kind" aria-label={kindLabel(change.kind)}>{kindLetter(change.kind)}</span>
-                  <span className="review-file-name">{displayNames.get(change.path) ?? basename(change.path)}</span>
-                  <span className="review-file-stat add">+{change.additions}</span>
-                  <span className="review-file-stat del">-{change.deletions}</span>
-                  <button
-                    className="review-file-action accept"
-                    onClick={(event) => { stop(event); act("accepted") }}
-                    onKeyDown={stop}
-                    aria-label={`Keep changes in ${basename(change.path)}`}
-                    title="Keep all changes in this file"
-                  >
-                    Keep
-                  </button>
-                  <button
-                    className="review-file-action reject"
-                    onClick={(event) => { stop(event); act("rejected") }}
-                    onKeyDown={stop}
-                    aria-label={`Undo changes in ${basename(change.path)}`}
-                    title="Undo all changes in this file"
-                  >
-                    Undo
-                  </button>
-                </div>
-              )
-            })}
-          </div>
+        <div className="review-bulk-actions">
+          {isSingle ? (
+            <>
+              <button
+                className="review-bulk-action accept"
+                onClick={(event) => { stopHead(event); onReviewAllInChange?.(onlyChange!.source, onlyChange!.path, "accepted") }}
+                onKeyDown={stopHead}
+                title="Keep all changes in this file"
+                aria-label={`Keep changes in ${basename(onlyChange!.path)}`}
+              >
+                <span className="codicon codicon-check" aria-hidden="true" />
+              </button>
+              <button
+                className="review-bulk-action reject"
+                onClick={(event) => { stopHead(event); onReviewAllInChange?.(onlyChange!.source, onlyChange!.path, "rejected") }}
+                onKeyDown={stopHead}
+                title="Undo all changes in this file"
+                aria-label={`Undo changes in ${basename(onlyChange!.path)}`}
+              >
+                <span className="codicon codicon-discard" aria-hidden="true" />
+              </button>
+            </>
+          ) : (
+            <>
+              <button
+                className="review-bulk-action accept"
+                onClick={(event) => { stopHead(event); bulkAct("accepted") }}
+                onKeyDown={stopHead}
+                title={`Keep changes in all ${pendingChanges.length} files`}
+                aria-label="Keep all changes"
+              >
+                <span className="codicon codicon-check" aria-hidden="true" />
+                Keep all
+              </button>
+              <button
+                className="review-bulk-action reject"
+                onClick={(event) => { stopHead(event); bulkAct("rejected") }}
+                onKeyDown={stopHead}
+                title={`Undo changes in all ${pendingChanges.length} files`}
+                aria-label="Undo all changes"
+              >
+                <span className="codicon codicon-discard" aria-hidden="true" />
+                Undo all
+              </button>
+            </>
+          )}
         </div>
       </div>
+      {!isSingle && (
+        <div className="review-body-clip" aria-hidden={!open}>
+          <div className="review-body">
+            <div className="review-files">
+              {pendingChanges.map(({ change }) => {
+                const isSelected = change.source === selected.source && change.path === selected.path
+                const stop = (event: MouseEvent | KeyboardEvent) => event.stopPropagation()
+                const act = (action: ReviewHunkState) => {
+                  onReviewAllInChange?.(change.source, change.path, action)
+                }
+                return (
+                  <div
+                    key={`${change.source}:${change.path}`}
+                    className={`review-file kind-${change.kind} ${isSelected ? "is-selected" : ""}`}
+                    onClick={() => selectChange(change)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault()
+                        selectChange(change)
+                      }
+                    }}
+                    role="button"
+                    tabIndex={0}
+                    title={actorTooltip(change)}
+                  >
+                    <span className="review-file-kind" aria-label={kindLabel(change.kind)}>{kindLetter(change.kind)}</span>
+                    <span className="review-file-name">{displayNames.get(change.path) ?? basename(change.path)}</span>
+                    <span className="review-file-stat add">+{change.additions}</span>
+                    <span className="review-file-stat del">-{change.deletions}</span>
+                    <button
+                      className="review-file-action accept"
+                      onClick={(event) => { stop(event); act("accepted") }}
+                      onKeyDown={stop}
+                      aria-label={`Keep changes in ${basename(change.path)}`}
+                      title="Keep all changes in this file"
+                    >
+                      <span className="codicon codicon-check" aria-hidden="true" />
+                    </button>
+                    <button
+                      className="review-file-action reject"
+                      onClick={(event) => { stop(event); act("rejected") }}
+                      onKeyDown={stop}
+                      aria-label={`Undo changes in ${basename(change.path)}`}
+                      title="Undo all changes in this file"
+                    >
+                      <span className="codicon codicon-discard" aria-hidden="true" />
+                    </button>
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -1773,7 +1773,6 @@ button {
   border-radius: var(--radius);
   background: var(--color-bg-input);
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.22);
-  animation: review-panel-in 0.16s ease;
 }
 .review-panel::after {
   content: "";
@@ -1827,6 +1826,7 @@ button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 4px;
   flex: 0 0 auto;
   height: var(--review-head-target-height);
   padding: 0 7px;
@@ -1852,31 +1852,19 @@ button {
 .review-bulk-action:focus-visible {
   outline: 1px solid var(--vscode-focusBorder);
 }
-.review-caret {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+.review-bulk-action .codicon {
+  font-size: 13px;
+}
+/* The caret is a codicon glyph; the descendant selector outweighs the codicon
+   base `font` shorthand so this size and the rotation actually apply. */
+.review-head .review-caret {
   flex: 0 0 12px;
   width: 12px;
-  height: var(--review-head-target-height);
   color: var(--vscode-descriptionForeground);
-  line-height: 1;
-  font-size: 0;
+  font-size: 14px;
   transition: transform 0.16s ease;
 }
-.review-caret::before {
-  content: "";
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  width: 5px;
-  height: 5px;
-  border-right: 1.5px solid currentColor;
-  border-bottom: 1.5px solid currentColor;
-  transform: translate(-50%, -50%) rotate(-45deg);
-}
-.review-caret.is-open {
+.review-head .review-caret.is-open {
   transform: rotate(90deg);
 }
 .review-title,
@@ -1956,6 +1944,9 @@ button {
 .review-file-action:focus-visible {
   opacity: 1;
   outline: 1px solid var(--vscode-focusBorder);
+}
+.review-file-action .codicon {
+  font-size: 13px;
 }
 @media (hover: none) {
   .review-file-action { opacity: 1; }
@@ -2105,22 +2096,7 @@ button {
   font-size: 13px;
   font-weight: 600;
 }
-.review-file-stat.add { grid-area: add; }
-.review-file-stat.del { grid-area: del; }
-@keyframes review-panel-in {
-  from {
-    opacity: 0;
-    transform: translateY(6px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
 @media (prefers-reduced-motion: reduce) {
-  .review-panel {
-    animation: none;
-  }
   .review-caret,
   .review-body,
   .review-body-clip {


### PR DESCRIPTION
## Summary

Polishes the Review card docked above the composer. Net effect: less hand-rolled CSS, icons consistent with the rest of the codicon work, and a cleaner single-file layout.

Closes #292

## Changes

1. **Caret -> codicon.** The disclosure caret was a rotated `::before` border-box plus a dead `>` glyph hidden with `font-size: 0`. Replaced with `codicon-chevron-right` that rotates 90deg on open — same fragile-pseudo-element cleanup as #289.
2. **Action buttons -> codicons.** Per-file Keep/Undo are now icon-only `codicon-check` / `codicon-discard`; bulk Keep all / Undo all pair the glyph with their label. Mirrors VS Code's SCM. **All `aria-label`s preserved**, so the buttons keep their accessible names.
3. **Single-file one-liner (behavior change).** A single-file review used to show the filename twice — head summary + a body row. It's now a single row: the header carries the filename + stats + always-visible inline Keep/Undo, no separate body. Removes the duplication and the hover-to-act step. The change kind (M/U/D/R) is carried as a class on the header.
4. **Dropped the entry animation.** `animation: review-panel-in` sat directly on `.review-panel`, which `CLAUDE.md` forbids ('they flash visibly when React remounts on prop changes') — the panel unmounts at zero pending changes and remounts on the next edit, so the fade could replay mid-turn. Removed it and its now-dead `prefers-reduced-motion` guard.
5. **Deduped CSS.** `.review-file-stat.add/.del { grid-area }` was declared twice verbatim; removed one pair.

## Tests

Updated the review tests that pinned the old single-file head+row structure (filename-twice assertion, `.review-file` row selectors, single-file collapse toggle) to the new one-row design + `.review-head` tooltip. Multi-file behavior is unchanged; action-button tests pass untouched because they query by `aria-label`.

- [x] webview `tsc --noEmit` — clean
- [x] `bun run test` — 955 pass (review-panel + review-attribution-render updated)
- [x] `bun run package` — production build; all three review codicons present in the bundle
- [ ] **Visual smoke in the Extension Dev Host**: trigger edits to see the card. Check (a) single file = one clean row with inline Keep/Undo, (b) multi-file caret rotates open/closed, (c) per-file Keep/Undo icons appear on row hover, (d) bulk Keep all/Undo all show glyph+label