### PR TITLE
chore(release): 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-06-02
+
+### Added
+- File-type icons in the `@` file picker: file rows now lead with a category glyph (code, JSON, Markdown, image, lock, archive, ...) so the list is scannable at a glance (#291).
+
+### Changed
+- Icons across the UI - the status bar, the `@` picker, the dialogs, and the image controls - now render from VS Code's built-in **codicon** font, so they follow your active color theme and match the rest of VS Code's chrome, replacing the previous mix of inline SVGs, hand-drawn CSS shapes, and unicode glyphs (#289).
+- The Review card is refined: the disclosure caret and the Keep / Undo actions (and the bulk Keep all / Undo all) are now codicons, a single-file review collapses to one clean row with inline actions instead of repeating the filename, and the card's entry animation was removed so it no longer flashes when the turn re-renders (#293).
+
 ## [1.3.1] - 2026-06-01
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
Release v1.4.0 — UI-wide codicon adoption, file-type icons in the `@` picker, and Review-card refinements.

Bumps `package.json` to 1.4.0 and adds the `[1.4.0]` CHANGELOG section (2026-06-02) covering #289, #291, #293.

Closes #294

## Bundled

| PR | Change |
|----|--------|
| #289 | Adopt VS Code codicons across the UI |
| #291 | File-type icons in the `@` file picker |
| #293 | Refine the Review card |
| #287 | (internal) inline SVG sizes back on the ICON_SIZE token |

## Test plan
- [x] host `check-types` + webview `tsc --noEmit` — clean
- [x] `bun run test` — 955 pass
- [x] `bun run package` — production build succeeds
- [ ] Tag `v1.4.0` from `main` + publish the GitHub Release -> the release workflow ships to VS Code Marketplace + Open VSX