### PR TITLE
perf(chat): debounce per-token conversation persistence

### DIFF
--- a/src/chat/conversation-manager.ts
+++ b/src/chat/conversation-manager.ts
@@ -19,6 +19,9 @@ export type ActiveSnapshot = {
   reviewHunks: Record<string, ReviewHunkState>
 }
 
+/** Debounce window for the streaming hot path's disk writes. */
+const PERSIST_DEBOUNCE_MS = 300
+
 /**
  * Workspace-state-backed list of saved conversations. Owns the
  * conversation array, the active-conversation-id pointer, and the
@@ -30,6 +33,8 @@ export type ActiveSnapshot = {
 export class ConversationManager {
   private conversations: SavedConversation[]
   private activeID: string
+  private pendingPersist?: ReturnType<typeof setTimeout>
+  private disposed = false
 
   constructor(private context: vscode.ExtensionContext) {
     this.conversations = context.workspaceState.get<SavedConversation[]>(CONVERSATIONS_KEY) ?? []
@@ -164,5 +169,50 @@ export class ConversationManager {
   async persist(): Promise<void> {
     await this.context.workspaceState.update(CONVERSATIONS_KEY, this.conversations)
     await this.context.workspaceState.update(ACTIVE_CONVERSATION_KEY, this.activeID)
+  }
+
+  /**
+   * Debounced disk write for the streaming hot path. `saveActiveSnapshot`
+   * already updated the in-memory state synchronously, so this only
+   * coalesces the expensive workspaceState serialization. Non-resetting
+   * trailing edge: an already-pending timer is left to fire rather than
+   * pushed back, so inter-write latency stays capped at PERSIST_DEBOUNCE_MS
+   * even through an unbroken token stream — and `persist()` always writes
+   * the latest `this.conversations`, so a late-firing timer is never stale.
+   */
+  schedulePersist(): void {
+    if (this.disposed || this.pendingPersist) return
+    this.pendingPersist = setTimeout(() => {
+      this.pendingPersist = undefined
+      if (this.disposed) return
+      void this.persist()
+    }, PERSIST_DEBOUNCE_MS)
+  }
+
+  /**
+   * Cancel any pending debounced write and persist the latest state now.
+   * Called at every conversation boundary, at turn end, and on shutdown so
+   * a debounced tail is never lost.
+   */
+  async flushPersist(): Promise<void> {
+    this.clearPending()
+    await this.persist()
+  }
+
+  private clearPending(): void {
+    if (this.pendingPersist) {
+      clearTimeout(this.pendingPersist)
+      this.pendingPersist = undefined
+    }
+  }
+
+  /**
+   * Stop accepting debounced writes. Guards against a stray timer firing
+   * after the owning ChatView (and its context) is torn down. Callers that
+   * need the tail on disk must `flushPersist()` first.
+   */
+  dispose(): void {
+    this.disposed = true
+    this.clearPending()
   }
 }

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -242,7 +242,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.manager.setActiveID(conversation.id)
     this.messages = []
     this.reviewHunks = {}
-    await this.manager.persist()
+    await this.manager.flushPersist()
     this.sendConversationState()
     this.post({ type: "contextUsage", usage: undefined })
     if (this.taskStore) this.postAgentsStatus(this.taskStore.list())
@@ -276,6 +276,20 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.aborting = false
     this.taskStoreUnsub?.dispose()
     this.taskStoreUnsub = undefined
+    // Write any debounced tail before the view (and its context) goes away,
+    // then stop accepting further debounced writes so a late timer can't fire
+    // after teardown.
+    void this.manager.flushPersist()
+    this.manager.dispose()
+  }
+
+  /**
+   * Flush any debounced conversation write to disk. Awaited from the
+   * extension's `deactivate()` so a graceful shutdown mid-stream loses
+   * nothing beyond the in-flight token.
+   */
+  flushPersist(): Promise<void> {
+    return this.manager.flushPersist()
   }
 
   private post(msg: Outbound) {
@@ -340,7 +354,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.resetSessionState()
     this.manager.setActiveID(id)
     this.applyActiveSnapshot()
-    await this.manager.persist()
+    await this.manager.flushPersist()
     this.sendConversationState()
     this.post({ type: "contextUsage", usage: undefined })
     if (this.sessionID) void this.refreshContextUsage()
@@ -349,7 +363,7 @@ export class ChatView implements vscode.WebviewViewProvider {
 
   private async renameConversation(id: string, title: string) {
     this.manager.rename(id, title)
-    await this.manager.persist()
+    await this.manager.flushPersist()
     this.postConversationsList()
   }
 
@@ -366,13 +380,13 @@ export class ChatView implements vscode.WebviewViewProvider {
       this.resetSessionState()
       this.manager.setActiveID(this.manager.summaries()[0]!.id)
       this.applyActiveSnapshot()
-      await this.manager.persist()
+      await this.manager.flushPersist()
       this.sendConversationState()
       this.post({ type: "contextUsage", usage: undefined })
       if (this.sessionID) void this.refreshContextUsage()
       return
     }
-    await this.manager.persist()
+    await this.manager.flushPersist()
     this.postConversationsList()
   }
 
@@ -382,7 +396,7 @@ export class ChatView implements vscode.WebviewViewProvider {
       messages: this.messages,
       reviewHunks: this.reviewHunks,
     })
-    void this.manager.persist()
+    this.manager.schedulePersist()
   }
 
   private updateTitleFromPrompt(text: string) {
@@ -940,7 +954,7 @@ export class ChatView implements vscode.WebviewViewProvider {
       }
       this.sessionID = created.data.id
       this.manager.updateActive((conversation) => ({ ...conversation, sessionID: this.sessionID }))
-      void this.manager.persist()
+      await this.manager.flushPersist()
       log("created session", this.sessionID)
       await this.attachSubscription(backend, this.sessionID)
     } else if (!this.subscription) {
@@ -1167,7 +1181,7 @@ export class ChatView implements vscode.WebviewViewProvider {
       }
       this.sessionID = created.data.id
       this.manager.updateActive((conversation) => ({ ...conversation, sessionID: this.sessionID }))
-      void this.manager.persist()
+      await this.manager.flushPersist()
       log("created session", this.sessionID)
       await this.attachSubscription(backend, this.sessionID)
     } else if (!this.subscription) {
@@ -1312,7 +1326,7 @@ export class ChatView implements vscode.WebviewViewProvider {
       }
       this.sessionID = created.data.id
       this.manager.updateActive((conversation) => ({ ...conversation, sessionID: this.sessionID }))
-      void this.manager.persist()
+      await this.manager.flushPersist()
       await this.attachSubscription(backend, this.sessionID)
     } else if (!this.subscription) {
       await this.attachSubscription(backend, this.sessionID)
@@ -1491,7 +1505,7 @@ export class ChatView implements vscode.WebviewViewProvider {
       this.manager.setActiveID(conversation.id)
       this.manager.updateActive((c) => ({ ...c, sessionID: forked.id, messages: copied, reviewHunks: copiedHunks }))
       this.applyActiveSnapshot()
-      await this.manager.persist()
+      await this.manager.flushPersist()
       this.sendConversationState()
       this.post({ type: "contextUsage", usage: undefined })
       await this.attachSubscription(backend, forked.id)
@@ -1710,6 +1724,7 @@ export class ChatView implements vscode.WebviewViewProvider {
           }
           this.subagentDispatch.clearMainTaskID()
           this.post({ type: "sessionIdle" })
+          void this.manager.flushPersist()
           return
         }
         if (this.continuationState.hasGate()) {
@@ -1722,6 +1737,7 @@ export class ChatView implements vscode.WebviewViewProvider {
         }
         this.subagentDispatch.clearMainTaskID()
         this.post({ type: "sessionIdle" })
+        void this.manager.flushPersist()
       },
       onChildSessionEvent: (event) => {
         if (this.aborting) return
@@ -1742,7 +1758,7 @@ export class ChatView implements vscode.WebviewViewProvider {
       },
       onSessionTitleUpdate: (title) => {
         this.manager.rename(this.manager.getActiveID(), title)
-        void this.manager.persist()
+        this.manager.schedulePersist()
         this.postConversationsList()
       },
       onChildSessionDiscovered: (info) => {
@@ -2090,19 +2106,38 @@ type ContextUsageProvider = {
   models?: Record<string, { limit?: { context?: number } } | undefined>
 }
 
+// Provider metadata (model context limits) changes only when the user edits
+// their opencode config, but readContextUsage runs after every turn. Cache it
+// per backend with a short TTL so the indicator stops re-fetching it each turn.
+type CachedProviders = { providers: ContextUsageProvider[]; at: number }
+const providersCache = new Map<string, CachedProviders>()
+const PROVIDERS_CACHE_MS = 5 * 60 * 1000
+
+async function fetchProviders(backend: Backend): Promise<ContextUsageProvider[]> {
+  const now = Date.now()
+  const cached = providersCache.get(backend.url)
+  if (cached && now - cached.at < PROVIDERS_CACHE_MS) return cached.providers
+  const res = await backend.client.config.providers()
+  if (res.error) {
+    if (cached) return cached.providers
+    throw new Error(`config.providers failed: ${JSON.stringify(res.error)}`)
+  }
+  const providers = (res.data as { providers?: ContextUsageProvider[] } | undefined)?.providers ?? []
+  providersCache.set(backend.url, { providers, at: now })
+  return providers
+}
+
 async function readContextUsage(backend: Backend, sessionID: string): Promise<ContextUsage | undefined> {
-  const [messagesRes, providersRes] = await Promise.all([
+  const [messagesRes, providers] = await Promise.all([
     backend.client.session.messages({
       path: { id: sessionID },
       query: { directory: backend.directory, limit: 100 },
     }),
-    backend.client.config.providers(),
+    fetchProviders(backend),
   ])
   if (messagesRes.error) throw new Error(`session.messages failed: ${JSON.stringify(messagesRes.error)}`)
-  if (providersRes.error) throw new Error(`config.providers failed: ${JSON.stringify(providersRes.error)}`)
 
   const messages = (messagesRes.data ?? []) as ContextUsageMessage[]
-  const providers = ((providersRes.data as { providers?: ContextUsageProvider[] } | undefined)?.providers ?? [])
   return contextUsageFromMessages(messages, providers)
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ let servers: ServerManager | undefined
 let recentEdits: RecentEditsTracker | undefined
 let indexManager: IndexManager | undefined
 let agentTaskStore: AgentTaskStore | undefined
+let chatView: ChatView | undefined
 
 export async function activate(context: vscode.ExtensionContext) {
   log("activating OpenCode Panel")
@@ -33,6 +34,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const prefs = new Preferences(context.globalState)
   const status = new StatusBar(context, prefs)
   const chat = new ChatView(context, servers, prefs, recentEdits, indexManager, agentTaskStore)
+  chatView = chat
   const inline = new InlineEdit(servers, prefs)
   const picker = new Picker(servers, prefs)
   const mcp = new McpManager(servers)
@@ -76,5 +78,8 @@ export async function activate(context: vscode.ExtensionContext) {
 }
 
 export async function deactivate() {
+  // Flush any debounced conversation write before the host tears down so a
+  // graceful shutdown mid-stream persists the full transcript.
+  await chatView?.flushPersist()
   await servers?.dispose()
 }

--- a/test/host/conversation-manager-persist.test.ts
+++ b/test/host/conversation-manager-persist.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { ConversationManager } from "../../src/chat/conversation-manager"
+import { CONVERSATIONS_KEY } from "../../src/chat/conversation-store"
+
+type Store = Map<string, unknown>
+
+function fakeContext() {
+  const store: Store = new Map()
+  const update = vi.fn((key: string, value: unknown) => {
+    if (value === undefined) store.delete(key)
+    else store.set(key, value)
+    return Promise.resolve()
+  })
+  const workspaceState = {
+    get: <T>(key: string, def?: T): T => (store.has(key) ? (store.get(key) as T) : (def as T)),
+    update,
+    keys: () => [...store.keys()],
+  }
+  return { context: { workspaceState } as never, store, update }
+}
+
+type Snapshot = Parameters<ConversationManager["saveActiveSnapshot"]>[0]
+
+// Cumulative assistant messages m0..m{n-1}, simulating a growing stream.
+function snap(count: number, pending = false): Snapshot {
+  const messages = Array.from({ length: count }, (_, i) => ({
+    id: `m${i}`,
+    role: "assistant",
+    blocks: [],
+    pending,
+  }))
+  return { sessionID: "s1", messages, reviewHunks: {} } as unknown as Snapshot
+}
+
+function activeMessages(store: Store): Array<{ id: string }> {
+  const conversations = store.get(CONVERSATIONS_KEY) as Array<{ messages: Array<{ id: string }> }>
+  return conversations[0]!.messages
+}
+
+describe("ConversationManager debounced persistence", () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it("constructing the manager does not write to disk", () => {
+    const { context, update } = fakeContext()
+    new ConversationManager(context)
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  it("coalesces rapid schedulePersist calls into a single write of the latest state", async () => {
+    const { context, store, update } = fakeContext()
+    const manager = new ConversationManager(context)
+
+    for (let i = 1; i <= 50; i++) {
+      manager.saveActiveSnapshot(snap(i))
+      manager.schedulePersist()
+    }
+    // Nothing hits disk until the debounce window elapses.
+    expect(update).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(300)
+
+    // One persist == two workspaceState.update calls (conversations + active id).
+    expect(update).toHaveBeenCalledTimes(2)
+    // The single coalesced write holds the latest state, not a stale prefix.
+    const messages = activeMessages(store)
+    expect(messages).toHaveLength(50)
+    expect(messages.at(-1)!.id).toBe("m49")
+  })
+
+  it("flushPersist writes immediately and cancels the pending timer", async () => {
+    const { context, update } = fakeContext()
+    const manager = new ConversationManager(context)
+
+    manager.saveActiveSnapshot(snap(1))
+    manager.schedulePersist()
+    await manager.flushPersist()
+    expect(update).toHaveBeenCalledTimes(2) // wrote synchronously, no timer wait
+
+    update.mockClear()
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(update).not.toHaveBeenCalled() // the pending timer was cancelled by the flush
+  })
+
+  it("a timer firing after dispose is a no-op", async () => {
+    const { context, update } = fakeContext()
+    const manager = new ConversationManager(context)
+
+    manager.saveActiveSnapshot(snap(1))
+    manager.schedulePersist()
+    manager.dispose()
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  it("a re-schedule mid-window does not push the 300ms deadline out", async () => {
+    const { context, update } = fakeContext()
+    const manager = new ConversationManager(context)
+
+    manager.saveActiveSnapshot(snap(1))
+    manager.schedulePersist()
+    await vi.advanceTimersByTimeAsync(200)
+    manager.saveActiveSnapshot(snap(2))
+    manager.schedulePersist() // non-resetting: must not delay the original deadline
+    expect(update).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(100) // now 300ms after the first schedule
+    expect(update).toHaveBeenCalledTimes(2)
+  })
+
+  it("a lifecycle flush after a stream persists the final transcript; reload re-stamps pending:false", async () => {
+    const { context } = fakeContext()
+    const manager = new ConversationManager(context)
+
+    for (let i = 1; i <= 5; i++) {
+      manager.saveActiveSnapshot(snap(i, true)) // streaming snapshots are pending
+      manager.schedulePersist()
+    }
+    await manager.flushPersist() // stands in for the sessionIdle / boundary flush
+
+    // A fresh manager hydrates exactly what was persisted, with pending cleared.
+    const reloaded = new ConversationManager(context)
+    const restored = reloaded.loadActiveSnapshot()
+    expect(restored.messages.map((m) => m.id)).toEqual(["m0", "m1", "m2", "m3", "m4"])
+    expect(restored.messages.every((m) => m.pending === false)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #296.

During assistant streaming, the host persisted the **entire conversation history to disk on every streamed token**. The `textDelta` reducer (`view.ts`) called `saveActive()` → `manager.persist()` (fire-and-forget, no debounce), and `persist()` runs `workspaceState.update(CONVERSATIONS_KEY, this.conversations)` — re-serializing all chats and all messages, dozens of times per second on a fast stream. This was the dominant backend cost during streaming on long conversations.

### What changed

- **Debounced disk write** (`conversation-manager.ts`): new `schedulePersist()` (300ms, **non-resetting** trailing edge — an already-pending timer is left to fire, so inter-write latency is capped at 300ms even through an unbroken stream), `flushPersist()` (cancel pending + write now), `clearPending()`, and `dispose()` (disarm so a late timer can't fire post-teardown). The in-memory `saveActiveSnapshot()` stays synchronous, so state is always current and only the serialization is coalesced.
- **Hot path** uses `schedulePersist()`; **every boundary flushes**: conversation create/select/rename/delete/fork, the three `session.create` sessionID stamps (upgraded from racy `void persist()` to `await flushPersist()` so a chat can't orphan), turn end (`onSessionIdle`, both branches), `dispose()`, and — the one awaitable shutdown hook — `extension.ts deactivate()`.
- **Providers cache**: `config.providers()` (re-fetched every turn for the context indicator, though it changes only on config edits) is cached per backend with a 5-minute TTL, falling back to the last value on error.

### Durability (no message loss)

| Scenario | Covered by | Residual risk |
|---|---|---|
| Graceful `deactivate()` mid-stream | `await chatView.flushPersist()` | ~none |
| View disposed / panel closed | best-effort `dispose()` flush; window-close also hits deactivate | ≤300ms, standalone panel-close only |
| Webview reload | host ChatView not disposed; in-memory state survives | none |
| Hard kill / crash | impossible to cover (no JS runs) | ≤300ms of one turn |

A dropped tail never yields a stuck "pending" bubble — `loadActiveSnapshot` re-stamps `pending:false`.

### Out of scope

Rewriting `appendText`/`upsertTool` to mutate in place: once the disk write is debounced the residual in-memory `.map()` is negligible, and in-place mutation would break the reducer's immutable-array contract.

## Test plan

- [x] `bun run test` — full suite green (**961 tests, 63 files**), including the new `test/host/conversation-manager-persist.test.ts` (6 tests: coalescing into one write of the latest state, immediate flush + timer cancel, post-dispose no-op, non-resetting deadline, lifecycle-flush durability + `pending:false` re-stamp, no-write-on-construct).
- [x] `bun run check-types` — clean (host).
- [x] `cd webview && bunx tsc --noEmit` — clean (webview untouched by this PR).
- [x] `bun run compile` — production build succeeds.
- [ ] Manual smoke (Extension Development Host): stream a long reply → switch conversations → reload window → full transcript persists; Stop mid-stream → partial reply reloads as a settled turn; close + reopen window mid-stream → no lost messages beyond the last <300ms.
