### PR TITLE
perf(webview): memoize turn grouping and message-list scans

### DIFF
--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useRef, useState, type CSSProperties } from "react"
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties } from "react"
 import { useChatState } from "./hooks/useChatState"
 import type { Message } from "./hooks/useChatState"
 import type { Attachment } from "./protocol"
@@ -125,11 +125,17 @@ export default function App() {
     }
   }
 
-  const busy = state.busy || state.messages.some((m) => m.pending)
-  const activeProcessID = state.messages.findLast((m) => m.role === "assistant" && m.pending)?.id
-  const agentActivityMessageID = (state.agentsStatus?.total ?? 0) > 0
-    ? activeProcessID ?? state.messages.findLast((m) => m.role === "assistant")?.id
-    : undefined
+  const { busy, activeProcessID, agentActivityMessageID } = useMemo(() => {
+    const busy = state.busy || state.messages.some((m) => m.pending)
+    const activeProcessID = state.messages.findLast((m) => m.role === "assistant" && m.pending)?.id
+    const agentActivityMessageID = (state.agentsStatus?.total ?? 0) > 0
+      ? activeProcessID ?? state.messages.findLast((m) => m.role === "assistant")?.id
+      : undefined
+    return { busy, activeProcessID, agentActivityMessageID }
+  }, [state.messages, state.busy, state.agentsStatus?.total])
+  // Rebuild the turn structure only when the message list actually changes,
+  // not on every coalesced streaming frame.
+  const turns = useMemo(() => groupTurns(state.messages), [state.messages])
 
   useEffect(() => {
     if (editingMessageID) setActiveHeaderPopover(null)
@@ -258,7 +264,7 @@ export default function App() {
           }
         }}
       >
-        {groupTurns(state.messages).map((turn) => (
+        {turns.map((turn) => (
           <div className="turn" key={turn.key}>
             {turn.user && (
               <MessageView


### PR DESCRIPTION
## Summary

Closes #298.

`App.tsx` re-walked the full message list on every render — including every coalesced streaming frame:

- `groupTurns(state.messages)` ran inline in JSX (O(N) rebuild of the turn structure each render).
- `busy` / `activeProcessID` / `agentActivityMessageID` each scanned `state.messages` (`.some` / `.findLast`) on every render.

These inputs only change when `state.messages` changes, so the work was redundant during streaming.

### What changed

- Wrapped `groupTurns(state.messages)` in `useMemo` keyed on `state.messages` (which `MessageView`'s existing `memo` already relies on for stable identity).
- Wrapped the three derivations in one `useMemo` keyed on `[state.messages, state.busy, state.agentsStatus?.total]`.

`groupTurns` itself is untouched, so the dedicated `test/webview/group-turns.test.ts` continues to pin the grouping behavior. Memoization with correct deps cannot change rendered output — it only skips recomputation when the message array is referentially unchanged (the reducer produces a fresh array on every real change).

### Deferred (kept out to stay focused)

The plan's optional `PromptBox` / `StatusBar` filter memos were left out: those derivations feed into effects and only run while a menu is open (not the streaming hot path), so the risk/benefit didn't justify bundling them here.

## Test plan

- [x] `bun run test` — full suite green (**961 tests, 63 files**), including `group-turns.test.ts`.
- [x] `cd webview && bunx tsc --noEmit` — clean.
- [x] `bun run check-types` — clean (host untouched).
- [ ] Manual smoke (Extension Development Host): long conversation streams smoothly; turn grouping, per-turn sticky bubbles, review card, and agent-activity attribution render identically.
