### PR TITLE
chore(build): skip redundant install per compile; drop dead code

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
     "compile": "bun run build:webview && node esbuild.js",
     "watch": "bun run build:webview && node esbuild.js --watch",
     "package": "bun run build:webview && node esbuild.js --production",
-    "build:webview": "cd webview && bun install --silent && bun run build",
+    "build:webview": "cd webview && bun install --frozen-lockfile --silent && bun run build",
     "check-types": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/src/chat/paths.ts
+++ b/src/chat/paths.ts
@@ -40,14 +40,6 @@ export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
 }
 
-export function escapeHtml(value: string) {
-  return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-}
-
 export function unique(items: string[]) {
   return [...new Set(items)]
 }

--- a/src/file-search.ts
+++ b/src/file-search.ts
@@ -21,11 +21,6 @@ async function loadFiles(): Promise<FileSearchHit[]> {
   return cache
 }
 
-export function invalidateFileCache() {
-  cache = undefined
-  cacheLoadedAt = 0
-}
-
 export async function searchWorkspaceFiles(query: string): Promise<FileSearchHit[]> {
   const all = await loadFiles()
   const recent = getRecentlyOpenedPaths()

--- a/test/host/diff-utils.test.ts
+++ b/test/host/diff-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { samePath, normalizePath, isRecord, escapeHtml, unique } from "../../src/chat/paths"
+import { samePath, normalizePath, isRecord, unique } from "../../src/chat/paths"
 import {
   isTextReviewPath,
   countDiff,
@@ -108,14 +108,6 @@ describe("unique / isRecord", () => {
     expect(isRecord("x")).toBe(false)
     expect(isRecord(42)).toBe(false)
     expect(isRecord({})).toBe(true)
-  })
-})
-
-describe("escapeHtml", () => {
-  it("escapes &, <, >, and double quotes (single quotes pass through)", () => {
-    expect(escapeHtml(`<script>alert("y" & x)</script>`)).toBe(
-      "&lt;script&gt;alert(&quot;y&quot; &amp; x)&lt;/script&gt;",
-    )
   })
 })
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "allowImportingTsExtensions": false,
-    "noEmit": true
+    "noEmit": true,
+    "incremental": true
   },
   "include": ["src/**/*", "webview/src/protocol.ts"],
   "exclude": ["webview/src/**", "!webview/src/protocol.ts", "dist", "out", "node_modules"]


### PR DESCRIPTION
## Summary

Closes #300. Build-speed + dead-code cleanup, all low-risk.

- **`build:webview` → `--frozen-lockfile`.** It re-ran `bun install` (re-resolving deps) on every `compile` / `watch` / `package`. `webview/bun.lock` is committed, so a frozen install skips resolution — near-instant when `node_modules` already matches, and fails loudly only on genuine lockfile drift. Verified: `bun run compile` succeeds against the current lockfile.
- **Removed dead `invalidateFileCache()`** (`src/file-search.ts`) — zero callers across `src/`, `webview/`, `test/`. The 30s TTL cache is unaffected.
- **Removed dead `escapeHtml()`** (`src/chat/paths.ts`) — no production callers (the old standalone-panel renderer that used it is gone); its only consumer was a self-test in `diff-utils.test.ts`, removed alongside it.
- **`incremental: true`** in the root `tsconfig.json` for faster repeat `check-types`. `*.tsbuildinfo` is already gitignored.

## Test plan

- [x] `bun run test` — green (**960 tests** — one fewer, the removed `escapeHtml` self-test; 63 files).
- [x] `bun run check-types` — clean (writes `out/tsconfig.tsbuildinfo`, gitignored).
- [x] `cd webview && bunx tsc --noEmit` — clean.
- [x] `bun run compile` — production build succeeds with `--frozen-lockfile`, faster steady-state.
