### PR TITLE
feat(chat): pin the new question to the top when sending

### DIFF
--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -47,6 +47,7 @@ export default function App() {
   const [activeHeaderPopover, setActiveHeaderPopover] = useState<HeaderPopoverID | null>(null)
   const [editingMessageID, setEditingMessageID] = useState<string | null>(null)
   const [bottomDockHeight, setBottomDockHeight] = useState(0)
+  const [messagesHeight, setMessagesHeight] = useState(0)
   // Distance-from-bottom threshold for *re-engaging* stick mode once the
   // user has manually disengaged it. Smaller than the old 80 px because we
   // now use scroll direction, not just position.
@@ -75,6 +76,17 @@ export default function App() {
       top: scrollRef.current.scrollTop,
       stick: stickToBottom.current,
     }
+  }
+  // Sending (or running a command) re-engages stick-to-bottom so the new turn
+  // scrolls its question to the top via the last-turn spacer, even if the user
+  // had scrolled up to read earlier messages.
+  const sendAndPinTop = (...args: Parameters<typeof send>) => {
+    stickToBottom.current = true
+    send(...args)
+  }
+  const runCommandAndPinTop = (...args: Parameters<typeof runCommand>) => {
+    stickToBottom.current = true
+    runCommand(...args)
   }
   const [reviewRequest, setReviewRequest] = useState<{ path: string; key: number }>()
   const openReviewFile = (path: string) => {
@@ -160,10 +172,22 @@ export default function App() {
     return () => observer.disconnect()
   }, [])
 
+  // Measure the scroll viewport so the last-turn spacer (which pins the newest
+  // question to the top) can be sized to roughly one viewport minus the dock.
+  useLayoutEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const update = () => setMessagesHeight(el.clientHeight)
+    update()
+    const observer = new ResizeObserver(update)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
   useLayoutEffect(() => {
     if (!stickToBottom.current) return
     scrollToBottom()
-  }, [bottomDockHeight])
+  }, [bottomDockHeight, messagesHeight])
 
   // Entering/exiting in-place edit swaps a regular user bubble for an absolute
   // overlay. Chromium may treat the overlay's extra scrollable overflow as a
@@ -190,7 +214,10 @@ export default function App() {
     })
   }, [state.conversationID])
 
-  const appStyle = { "--bottom-dock-height": `${bottomDockHeight}px` } as CSSProperties
+  const appStyle = {
+    "--bottom-dock-height": `${bottomDockHeight}px`,
+    "--messages-height": `${messagesHeight}px`,
+  } as CSSProperties
 
   return (
     <div className="app" style={appStyle}>
@@ -220,7 +247,7 @@ export default function App() {
         <PromptBox
           busy={busy}
           aborting={state.aborting}
-          onSend={send}
+          onSend={sendAndPinTop}
           onAbort={abort}
           searchFiles={searchFiles}
           listDir={listDir}
@@ -231,7 +258,7 @@ export default function App() {
           onOpenConversation={openConversation}
           contextUsage={state.contextUsage}
           commands={state.commands}
-          onRunCommand={runCommand}
+          onRunCommand={runCommandAndPinTop}
           inject={state.injectedText}
         />
       )}
@@ -338,7 +365,7 @@ export default function App() {
             <PromptBox
               busy={busy}
               aborting={state.aborting}
-              onSend={send}
+              onSend={sendAndPinTop}
               onAbort={abort}
               searchFiles={searchFiles}
               listDir={listDir}
@@ -348,7 +375,7 @@ export default function App() {
               onOpenConversation={openConversation}
               contextUsage={state.contextUsage}
               commands={state.commands}
-              onRunCommand={runCommand}
+              onRunCommand={runCommandAndPinTop}
               inject={state.injectedText}
             />
           </div>

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -825,6 +825,15 @@ button {
 .turn {
   display: block;
 }
+/* Reserve a roughly viewport-tall slot under the most recent turn so scrolling
+   to the bottom lands its user question at the top of the view (ChatGPT-style),
+   with the answer streaming into the space below. A short or cancelled answer
+   simply leaves blank space here; a long answer outgrows this min-height and
+   scrolls normally with the question sticky-pinned at the top. The height is
+   one scroll viewport minus the docked composer/cards, less a small top gap. */
+.turn:last-child {
+  min-height: calc(var(--messages-height, 0px) - var(--bottom-dock-height, 0px) - 16px);
+}
 /* Chromium / WebKit (VS Code's webview): track blends with the chat background,
    thumb is invisible by default and appears only on hover or while scrolling. */
 .messages::-webkit-scrollbar {


### PR DESCRIPTION
## Summary

Closes #302.

When you send a message, the new question now scrolls to the **top** of the chat (ChatGPT/Claude-style), with the answer streaming into the space below — instead of the old behavior of pinning the view to the bottom.

### How

A roughly viewport-tall **min-height spacer on the last turn** (`.turn:last-child`), so the existing scroll-to-bottom lands the turn's top — the user's question — at the top of the viewport. One mechanism covers all three answer-length cases:

- **Short answer** → the spacer fills the gap; the question stays at the top with blank space below it (confirmed as the desired ChatGPT-style behavior).
- **Cancelled answer** → same; the question stays pinned with the partial answer below, no broken/empty scroll.
- **Long answer** → outgrows the spacer and scrolls normally, with the `position: sticky` question staying visible at the top.

Supporting changes in `App.tsx`:
- Measure the scroll viewport (`ResizeObserver` on `.messages`) into a `--messages-height` CSS var; the spacer is `calc(var(--messages-height) - var(--bottom-dock-height) - 16px)`.
- Re-engage stick-to-bottom on `send` / `runCommand` so the question reaches the top even if the user had scrolled up.
- The existing re-scroll layout effect now also depends on `messagesHeight` so a viewport resize re-pins correctly.

No changes to the sticky-bubble, stick-to-bottom-on-scroll, or edit-scroll-restore logic.

## Test plan

- [x] `cd webview && bunx tsc --noEmit` — clean.
- [x] `bun run check-types` — clean (host untouched).
- [x] `bun run test` — full suite green (**960 tests, 63 files**).
- [x] `bun run compile` — production build succeeds.
- [ ] **Manual smoke (yours to run — the webview can't be driven headlessly):** in the Extension Development Host (`bun run watch`, reload window):
  - Send a message → the new question jumps to the top; the answer streams below it.
  - Send something with a **short** reply → the question stays at the top with blank space down to the composer.
  - Send, then **Stop** mid-stream → the question stays pinned at the top with the partial answer below.
  - Send something with a **long** reply → it scrolls/follows normally and the question stays visible (sticky) at the top.
  - Reopen a conversation from History → shows the last question at the top (expected with this model).

> Note: the `16px` top-gap in the spacer `calc` is the one value that may want a small pixel tweak once seen live — easy to adjust if it looks too tight or too loose.
