### PR TITLE
chore(release): 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-06-04
+
+### Added
+- The newest question now pins to the top of the chat when you send it, so the answer streams in just below it instead of being pushed off-screen as it grows. Short or cancelled answers leave the question parked at the top, ChatGPT-style (#303).
+
+### Changed
+- Conversation history is persisted with a short debounce instead of re-writing the entire history to disk on every streamed token. The in-memory state stays current on every event and a flush still runs at every turn boundary and on shutdown, so nothing is lost - only the redundant per-token disk writes during long replies are gone (#297).
+- The chat view memoizes turn grouping and the message-list scans that ran on every streaming frame, trimming re-render work on the hot path (#299).
+- Builds are faster: the webview dependency install is skipped when the lockfile is unchanged (`--frozen-lockfile`), and confirmed-dead code was removed (#301).
+
 ## [1.4.0] - 2026-06-02
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
Release v1.4.1 — pin the new question to the top on send, plus streaming-persistence, render, and build optimizations.

Bumps `package.json` to 1.4.1 and adds the `[1.4.1]` CHANGELOG section (2026-06-04).

Closes #304

## Bundled

| PR | Change |
|----|--------|
| #303 | Pin the new question to the top of the chat when sending |
| #297 | Debounce per-token conversation persistence |
| #299 | Memoize turn grouping and message-list scans |
| #301 | Skip redundant webview install per compile; drop dead code |

## Test plan
- [x] host `check-types` (`tsc --noEmit`) — clean
- [x] `bun run test` — 960 pass (63 files)
- [x] `bun run package` — production build succeeds
- [ ] Tag `v1.4.1` from `main` + publish the GitHub Release → `release.yml` ships to VS Code Marketplace + Open VSX