### PR TITLE
fix(file-search): invalidate @-picker cache on file create/delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.4.2] - 2026-06-07
+
+### Fixed
+- The `@` file picker now reflects file creates and deletes immediately. Previously the workspace file index was cached for up to 30 seconds with no invalidation, so newly created files were missing from the picker and deleted files lingered (and failed to read when mentioned). The cache is now dropped as soon as a file is created or deleted, and on any workspace-folder change (#306).
+
 ## [1.4.1] - 2026-06-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import { IndexManager, readIndexSettings } from "./indexing/index-manager"
 import { AgentTaskStore } from "./agents/task-store"
 import { showAgentsQuickPick } from "./agents/quickpick"
 import { getOutputChannel, log } from "./output"
+import { initFileSearch } from "./file-search"
 
 let servers: ServerManager | undefined
 let recentEdits: RecentEditsTracker | undefined
@@ -26,6 +27,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const indexSettings = readIndexSettings(vscode.workspace.getConfiguration("opencui"))
   indexManager = new IndexManager(indexSettings)
   agentTaskStore = new AgentTaskStore(context.workspaceState)
+  initFileSearch(context)
   context.subscriptions.push(
     { dispose: () => recentEdits?.dispose() },
     { dispose: () => void indexManager?.stop() },

--- a/src/file-search.ts
+++ b/src/file-search.ts
@@ -9,6 +9,28 @@ let cache: FileSearchHit[] | undefined
 let cacheLoadedAt = 0
 const CACHE_TTL_MS = 30_000
 
+function invalidateCache(): void {
+  cache = undefined
+  cacheLoadedAt = 0
+}
+
+/**
+ * Wire cache invalidation to the workspace lifecycle. The 30s TTL alone lets
+ * the @-picker show files that were just deleted (still listed, then fail to
+ * read) and miss freshly created ones for up to 30s. A FileSystemWatcher on
+ * create/delete and a workspace-folder-change listener drop the stale index
+ * immediately. Registered once from activate(); disposables go on the context.
+ */
+export function initFileSearch(context: vscode.ExtensionContext): void {
+  const watcher = vscode.workspace.createFileSystemWatcher("**/*")
+  watcher.onDidCreate(invalidateCache)
+  watcher.onDidDelete(invalidateCache)
+  context.subscriptions.push(
+    watcher,
+    vscode.workspace.onDidChangeWorkspaceFolders(invalidateCache),
+  )
+}
+
 async function loadFiles(): Promise<FileSearchHit[]> {
   const now = Date.now()
   if (cache && now - cacheLoadedAt < CACHE_TTL_MS) return cache

--- a/test/host/file-search.test.ts
+++ b/test/host/file-search.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest"
-import { rankHits, dirEntriesFrom } from "../../src/file-search"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import * as vscode from "vscode"
+import { rankHits, dirEntriesFrom, initFileSearch, searchWorkspaceFiles } from "../../src/file-search"
 
 const fixtures = [
   { path: "src/foo.ts", name: "foo.ts" },
@@ -103,6 +104,47 @@ describe("rankHits", () => {
       expect(out[0]?.path).toBe("src/foo.ts")
       expect(out[1]?.path).toBe("src/bar.ts")
     })
+  })
+})
+
+describe("cache invalidation", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function uri(p: string) {
+    return vscode.Uri.file(`/workspace/${p}`)
+  }
+
+  it("drops the cached index when the watcher fires create/delete", async () => {
+    const created: Array<() => void> = []
+    const deleted: Array<() => void> = []
+    vi.spyOn(vscode.workspace, "createFileSystemWatcher").mockReturnValue({
+      onDidCreate: (cb: () => void) => (created.push(cb), { dispose: vi.fn() }),
+      onDidDelete: (cb: () => void) => (deleted.push(cb), { dispose: vi.fn() }),
+      onDidChange: () => ({ dispose: vi.fn() }),
+      dispose: vi.fn(),
+    } as unknown as vscode.FileSystemWatcher)
+
+    const findFiles = vi.spyOn(vscode.workspace, "findFiles")
+    findFiles.mockResolvedValue([uri("a.ts")] as never)
+
+    initFileSearch({ subscriptions: [] } as unknown as vscode.ExtensionContext)
+
+    const first = await searchWorkspaceFiles("")
+    expect(first.map((h) => h.path)).toEqual(["a.ts"])
+
+    // A second file now exists, but within the 30s TTL the cache still serves
+    // the stale listing.
+    findFiles.mockResolvedValue([uri("a.ts"), uri("b.ts")] as never)
+    const cached = await searchWorkspaceFiles("")
+    expect(cached.map((h) => h.path)).toEqual(["a.ts"])
+
+    // The watcher fires → cache is dropped → the fresh listing is loaded.
+    deleted.forEach((cb) => cb())
+    const fresh = await searchWorkspaceFiles("")
+    expect(fresh.map((h) => h.path)).toEqual(["a.ts", "b.ts"])
+    expect(findFiles).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/test/host/setup.ts
+++ b/test/host/setup.ts
@@ -91,6 +91,13 @@ vi.mock("vscode", () => {
       getConfiguration: vi.fn(() => ({ get: vi.fn() })),
       openTextDocument: vi.fn(),
       applyEdit: vi.fn().mockResolvedValue(true),
+      findFiles: vi.fn().mockResolvedValue([]),
+      createFileSystemWatcher: vi.fn(() => ({
+        onDidCreate: vi.fn(() => ({ dispose: vi.fn() })),
+        onDidDelete: vi.fn(() => ({ dispose: vi.fn() })),
+        onDidChange: vi.fn(() => ({ dispose: vi.fn() })),
+        dispose: vi.fn(),
+      })),
       asRelativePath: vi.fn((uri: Uri | string) => {
         const fsPath = typeof uri === "string" ? uri : uri.fsPath
         return fsPath.replace(/^\/workspace\//, "").replace(/^\/workspace$/, "")


### PR DESCRIPTION
## Summary

Fixes a stale-cache bug in the `@` file picker found during a codebase bug sweep. `src/file-search.ts` cached the workspace file index behind a 30s TTL with no `FileSystemWatcher` and no reset on workspace-folder change, so within that window:

- newly created files were missing from the picker,
- deleted files lingered and failed to read when mentioned,
- a workspace-folder change could serve a stale listing from the previous folder set.

`initFileSearch(context)` (called from `activate`) now registers a create/delete `FileSystemWatcher` and an `onDidChangeWorkspaceFolders` listener that drop the cache immediately. Disposables are owned by the extension context.

Also bumps the version to **1.4.2** and adds the changelog entry for release.

## Test plan

- [x] `bun run check-types` clean
- [x] `bun run test` — 961 pass (added a host test asserting the cache refreshes after the watcher fires; +1 from 960)
- [x] New test `cache invalidation > drops the cached index when the watcher fires create/delete`

Closes #306