### PR TITLE
refactor(chat): extract message reducer from view.ts

### DIFF
--- a/src/chat/message-reducer.ts
+++ b/src/chat/message-reducer.ts
@@ -1,0 +1,217 @@
+import type {
+  ChatBlock,
+  ChatMessage,
+  Outbound,
+  ReviewChangeActor,
+  ReviewHunkState,
+  ToolUpdate as WireToolUpdate,
+} from "../protocol"
+
+export interface ReducerState {
+  messages: ChatMessage[]
+  reviewHunks: Record<string, ReviewHunkState>
+}
+
+/**
+ * Result of reducing one Outbound message into the local chat state. `save` and
+ * `syncDecorations` tell the caller which side effects to run (persist the
+ * active conversation, re-sync review decorations) — the reducer itself stays
+ * pure so each variant can be tested in isolation. A `null` return means the
+ * message is not a local-state mutation and should be ignored here.
+ */
+export interface ReduceResult extends ReducerState {
+  save: boolean
+  syncDecorations: boolean
+}
+
+export function reduceLocal(state: ReducerState, msg: Outbound): ReduceResult | null {
+  const { messages, reviewHunks } = state
+  const keep = { messages, reviewHunks }
+  switch (msg.type) {
+    case "restore":
+      return {
+        messages: msg.messages.map((m) => ({ ...m, pending: false })),
+        reviewHunks: msg.reviewHunks ?? {},
+        save: false,
+        syncDecorations: true,
+      }
+    case "clear":
+      return { messages: [], reviewHunks: {}, save: true, syncDecorations: false }
+    case "userMessage": {
+      const blocks: ChatBlock[] = []
+      if (msg.attachments) {
+        for (const a of msg.attachments) {
+          blocks.push({
+            type: "attachment",
+            mime: a.mime,
+            filename: a.filename,
+            dataUrl: a.dataUrl,
+            bytes: a.bytes,
+          })
+        }
+      }
+      blocks.push({ type: "text", text: msg.text })
+      return {
+        ...keep,
+        messages: [
+          ...messages,
+          {
+            id: msg.id,
+            role: "user",
+            blocks,
+            ref: msg.ref,
+            backendID: msg.backendID,
+            mentions: msg.mentions,
+            conversationMentions: msg.conversationMentions,
+          },
+        ],
+        save: true,
+        syncDecorations: false,
+      }
+    }
+    case "userMessageBackendID":
+      return {
+        ...keep,
+        messages: messages.map((m) => (m.id === msg.id ? { ...m, backendID: msg.backendID } : m)),
+        save: true,
+        syncDecorations: false,
+      }
+    case "userMessageContext":
+      return {
+        ...keep,
+        messages: messages.map((m) => (m.id === msg.id ? { ...m, context: msg.context } : m)),
+        save: true,
+        syncDecorations: false,
+      }
+    case "assistantStart":
+      return {
+        ...keep,
+        messages: [...messages, { id: msg.id, role: "assistant", blocks: [], pending: true }],
+        save: true,
+        syncDecorations: false,
+      }
+    case "textDelta":
+      return {
+        ...keep,
+        messages: appendText(messages, msg.id, "text", msg.delta),
+        save: true,
+        syncDecorations: false,
+      }
+    case "reasoningDelta":
+      return {
+        ...keep,
+        messages: appendText(messages, msg.id, "reasoning", msg.delta),
+        save: true,
+        syncDecorations: false,
+      }
+    case "tool":
+      return {
+        ...keep,
+        messages: upsertTool(messages, msg.id, msg.update, msg.actor),
+        save: true,
+        syncDecorations: true,
+      }
+    case "patch":
+      return {
+        ...keep,
+        messages: messages.map((m) =>
+          m.id === msg.id
+            ? { ...m, blocks: [...m.blocks, { type: "patch", files: msg.files, diff: msg.diff, actor: msg.actor }] }
+            : m,
+        ),
+        save: true,
+        syncDecorations: true,
+      }
+    case "reviewHunkState": {
+      const next = { ...reviewHunks }
+      if (msg.state) next[msg.key] = msg.state
+      else delete next[msg.key]
+      return { messages, reviewHunks: next, save: true, syncDecorations: true }
+    }
+    case "assistantError":
+      return {
+        ...keep,
+        messages: messages.map((m) => (m.id === msg.id ? { ...m, error: msg.message, pending: false } : m)),
+        save: true,
+        syncDecorations: false,
+      }
+    case "assistantDone":
+      return {
+        ...keep,
+        messages: messages.map((m) => (m.id === msg.id ? { ...m, pending: false, usage: msg.usage } : m)),
+        save: true,
+        syncDecorations: false,
+      }
+    case "aborted": {
+      // Only the LAST pending assistant in the turn carries the Stopped badge;
+      // intermediate ones just clear pending. Otherwise multi-step turns
+      // (subtasks, retries) show several Stopped badges per abort.
+      let lastPendingIdx = -1
+      messages.forEach((m, i) => {
+        if (m.role === "assistant" && m.pending) lastPendingIdx = i
+      })
+      return {
+        ...keep,
+        messages: messages.map((m, i) => {
+          if (m.role !== "assistant" || !m.pending) return m
+          if (i === lastPendingIdx) return { ...m, pending: false, stopped: true }
+          return { ...m, pending: false }
+        }),
+        save: true,
+        syncDecorations: false,
+      }
+    }
+    case "sessionIdle":
+      return {
+        ...keep,
+        messages: messages.map((m) =>
+          m.role === "assistant" && m.pending ? { ...m, pending: false } : m,
+        ),
+        save: true,
+        syncDecorations: false,
+      }
+  }
+  return null
+}
+
+function appendText(
+  messages: ChatMessage[],
+  id: string,
+  kind: "text" | "reasoning",
+  delta: string,
+): ChatMessage[] {
+  return messages.map((message) => {
+    if (message.id !== id) return message
+    const last = message.blocks[message.blocks.length - 1]
+    if (last?.type === kind) {
+      return {
+        ...message,
+        blocks: [...message.blocks.slice(0, -1), { type: kind, text: last.text + delta }],
+      }
+    }
+    return { ...message, blocks: [...message.blocks, { type: kind, text: delta }] }
+  })
+}
+
+function upsertTool(
+  messages: ChatMessage[],
+  id: string,
+  update: WireToolUpdate,
+  actor?: ReviewChangeActor,
+): ChatMessage[] {
+  return messages.map((message) => {
+    if (message.id !== id) return message
+    const existing = message.blocks.findIndex((b) => b.type === "tool" && b.update.callID === update.callID)
+    if (existing >= 0) {
+      const blocks = message.blocks.slice()
+      const prev = blocks[existing]
+      blocks[existing] = {
+        type: "tool",
+        update,
+        actor: actor ?? (prev.type === "tool" ? prev.actor : undefined),
+      }
+      return { ...message, blocks }
+    }
+    return { ...message, blocks: [...message.blocks, { type: "tool", update, actor }] }
+  })
+}

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -18,16 +18,13 @@ import { getWorkspaceRoots, primaryWorkspaceRoot } from "../workspace-root"
 import type { WorkspaceInfo } from "../protocol"
 import type {
   Attachment,
-  ChatBlock,
   ChatMessage,
   CommandInfo,
   ContextUsage,
   Inbound,
   Outbound,
-  ToolUpdate as WireToolUpdate,
   Selection,
   ReviewChange,
-  ReviewChangeActor,
   ReviewHunkState,
 } from "../protocol"
 import { BUILTIN_COMMAND_NAMES, withBuiltinCommands, generateMessageID } from "./builtin-commands"
@@ -38,6 +35,7 @@ import { ContinuationState } from "./continuation-state"
 import { SubagentDispatch } from "./subagent-dispatch"
 export { summarizePrompt } from "./subagent-dispatch"
 import { relativeToCwd, samePath } from "./paths"
+import { reduceLocal } from "./message-reducer"
 import { isTextReviewPath, reviewKey, splitReviewDiff } from "./diff"
 import { extractChanges, reviewChanges } from "./review-changes"
 import { reviewAllForPath } from "./review-actions"
@@ -406,126 +404,12 @@ export class ChatView implements vscode.WebviewViewProvider {
   }
 
   private applyLocal(msg: Outbound) {
-    switch (msg.type) {
-      case "restore":
-        this.messages = msg.messages.map((m) => ({ ...m, pending: false }))
-        this.reviewHunks = msg.reviewHunks ?? {}
-        this.queueReviewDecorationsSync()
-        return
-      case "clear":
-        this.messages = []
-        this.reviewHunks = {}
-        this.saveActive()
-        return
-      case "userMessage": {
-        const blocks: ChatBlock[] = []
-        if (msg.attachments) {
-          for (const a of msg.attachments) {
-            blocks.push({
-              type: "attachment",
-              mime: a.mime,
-              filename: a.filename,
-              dataUrl: a.dataUrl,
-              bytes: a.bytes,
-            })
-          }
-        }
-        blocks.push({ type: "text", text: msg.text })
-        this.messages = [
-          ...this.messages,
-          {
-            id: msg.id,
-            role: "user",
-            blocks,
-            ref: msg.ref,
-            backendID: msg.backendID,
-            mentions: msg.mentions,
-            conversationMentions: msg.conversationMentions,
-          },
-        ]
-        this.saveActive()
-        return
-      }
-      case "userMessageBackendID":
-        this.messages = this.messages.map((m) =>
-          m.id === msg.id ? { ...m, backendID: msg.backendID } : m,
-        )
-        this.saveActive()
-        return
-      case "userMessageContext":
-        this.messages = this.messages.map((m) =>
-          m.id === msg.id ? { ...m, context: msg.context } : m,
-        )
-        this.saveActive()
-        return
-      case "assistantStart":
-        this.messages = [...this.messages, { id: msg.id, role: "assistant", blocks: [], pending: true }]
-        this.saveActive()
-        return
-      case "textDelta":
-        this.messages = appendText(this.messages, msg.id, "text", msg.delta)
-        this.saveActive()
-        return
-      case "reasoningDelta":
-        this.messages = appendText(this.messages, msg.id, "reasoning", msg.delta)
-        this.saveActive()
-        return
-      case "tool":
-        this.messages = upsertTool(this.messages, msg.id, msg.update, msg.actor)
-        this.saveActive()
-        this.queueReviewDecorationsSync()
-        return
-      case "patch":
-        this.messages = this.messages.map((m) =>
-          m.id === msg.id
-            ? { ...m, blocks: [...m.blocks, { type: "patch", files: msg.files, diff: msg.diff, actor: msg.actor }] }
-            : m,
-        )
-        this.saveActive()
-        this.queueReviewDecorationsSync()
-        return
-      case "reviewHunkState":
-        this.reviewHunks = { ...this.reviewHunks }
-        if (msg.state) this.reviewHunks[msg.key] = msg.state
-        else delete this.reviewHunks[msg.key]
-        this.saveActive()
-        this.queueReviewDecorationsSync()
-        return
-      case "assistantError":
-        this.messages = this.messages.map((m) =>
-          m.id === msg.id ? { ...m, error: msg.message, pending: false } : m,
-        )
-        this.saveActive()
-        return
-      case "assistantDone":
-        this.messages = this.messages.map((m) =>
-          m.id === msg.id ? { ...m, pending: false, usage: msg.usage } : m,
-        )
-        this.saveActive()
-        return
-      case "aborted": {
-        // Only the LAST pending assistant in the turn carries the Stopped
-        // badge; intermediate ones just clear pending. Otherwise multi-step
-        // turns (subtasks, retries) show several Stopped badges per abort.
-        let lastPendingIdx = -1
-        this.messages.forEach((m, i) => {
-          if (m.role === "assistant" && m.pending) lastPendingIdx = i
-        })
-        this.messages = this.messages.map((m, i) => {
-          if (m.role !== "assistant" || !m.pending) return m
-          if (i === lastPendingIdx) return { ...m, pending: false, stopped: true }
-          return { ...m, pending: false }
-        })
-        this.saveActive()
-        return
-      }
-      case "sessionIdle":
-        this.messages = this.messages.map((m) =>
-          m.role === "assistant" && m.pending ? { ...m, pending: false } : m,
-        )
-        this.saveActive()
-        return
-    }
+    const next = reduceLocal({ messages: this.messages, reviewHunks: this.reviewHunks }, msg)
+    if (!next) return
+    this.messages = next.messages
+    this.reviewHunks = next.reviewHunks
+    if (next.save) this.saveActive()
+    if (next.syncDecorations) this.queueReviewDecorationsSync()
   }
 
   private postSelection() {
@@ -2208,44 +2092,3 @@ function collectSymbolFocus(activeRel: string | undefined, mentions: string[] | 
   return out
 }
 
-function appendText(
-  messages: ChatMessage[],
-  id: string,
-  kind: "text" | "reasoning",
-  delta: string,
-): ChatMessage[] {
-  return messages.map((message) => {
-    if (message.id !== id) return message
-    const last = message.blocks[message.blocks.length - 1]
-    if (last?.type === kind) {
-      return {
-        ...message,
-        blocks: [...message.blocks.slice(0, -1), { type: kind, text: last.text + delta }],
-      }
-    }
-    return { ...message, blocks: [...message.blocks, { type: kind, text: delta }] }
-  })
-}
-
-function upsertTool(
-  messages: ChatMessage[],
-  id: string,
-  update: WireToolUpdate,
-  actor?: ReviewChangeActor,
-): ChatMessage[] {
-  return messages.map((message) => {
-    if (message.id !== id) return message
-    const existing = message.blocks.findIndex((b) => b.type === "tool" && b.update.callID === update.callID)
-    if (existing >= 0) {
-      const blocks = message.blocks.slice()
-      const prev = blocks[existing]
-      blocks[existing] = {
-        type: "tool",
-        update,
-        actor: actor ?? (prev.type === "tool" ? prev.actor : undefined),
-      }
-      return { ...message, blocks }
-    }
-    return { ...message, blocks: [...message.blocks, { type: "tool", update, actor }] }
-  })
-}

--- a/test/host/message-reducer.test.ts
+++ b/test/host/message-reducer.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest"
+import { reduceLocal, type ReducerState } from "../../src/chat/message-reducer"
+import type { ChatMessage, Outbound } from "../../src/protocol"
+
+function state(messages: ChatMessage[] = [], reviewHunks: ReducerState["reviewHunks"] = {}): ReducerState {
+  return { messages, reviewHunks }
+}
+
+const assistantPending = (id: string): ChatMessage => ({ id, role: "assistant", blocks: [], pending: true })
+
+describe("reduceLocal", () => {
+  it("returns null for a message that is not a local-state mutation", () => {
+    expect(reduceLocal(state(), { type: "sessionBusy" } as Outbound)).toBeNull()
+  })
+
+  it("restore hydrates messages (pending cleared) + reviewHunks, syncs decorations, no save", () => {
+    const msg: Outbound = {
+      type: "restore",
+      conversationID: "c1",
+      messages: [assistantPending("a1")],
+      reviewHunks: { k1: { decision: "accepted" } as never },
+    }
+    const next = reduceLocal(state(), msg)
+    expect(next).not.toBeNull()
+    expect(next!.messages[0]?.pending).toBe(false)
+    expect(next!.reviewHunks).toEqual({ k1: { decision: "accepted" } })
+    expect(next!.save).toBe(false)
+    expect(next!.syncDecorations).toBe(true)
+  })
+
+  it("clear empties messages + reviewHunks and saves", () => {
+    const next = reduceLocal(state([assistantPending("a1")], { k: {} as never }), { type: "clear" })
+    expect(next).toMatchObject({ messages: [], reviewHunks: {}, save: true, syncDecorations: false })
+  })
+
+  it("userMessage appends a user bubble with attachments before the text block", () => {
+    const msg: Outbound = {
+      type: "userMessage",
+      id: "u1",
+      text: "hi",
+      attachments: [{ mime: "image/png", filename: "a.png", dataUrl: "data:...", bytes: 3 }],
+    }
+    const next = reduceLocal(state(), msg)!
+    const blocks = next.messages[0]!.blocks
+    expect(blocks[0]).toMatchObject({ type: "attachment", filename: "a.png" })
+    expect(blocks[1]).toMatchObject({ type: "text", text: "hi" })
+    expect(next.save).toBe(true)
+  })
+
+  it("userMessageBackendID stamps the backendID on the matching message", () => {
+    const next = reduceLocal(state([{ id: "u1", role: "user", blocks: [] }]), {
+      type: "userMessageBackendID",
+      id: "u1",
+      backendID: "b1",
+    })!
+    expect(next.messages[0]!.backendID).toBe("b1")
+  })
+
+  it("assistantStart appends a pending assistant message", () => {
+    const next = reduceLocal(state(), { type: "assistantStart", id: "a1" })!
+    expect(next.messages[0]).toMatchObject({ id: "a1", role: "assistant", pending: true })
+  })
+
+  it("textDelta appends/merges into a trailing text block", () => {
+    let s = state([{ id: "a1", role: "assistant", blocks: [] }])
+    s = reduceLocal(s, { type: "textDelta", id: "a1", delta: "He" })!
+    s = reduceLocal(s, { type: "textDelta", id: "a1", delta: "llo" })!
+    expect(s.messages[0]!.blocks).toEqual([{ type: "text", text: "Hello" }])
+  })
+
+  it("tool upserts by callID and requests a decoration sync", () => {
+    const update = { callID: "t1", name: "edit" } as never
+    const next = reduceLocal(state([{ id: "a1", role: "assistant", blocks: [] }]), {
+      type: "tool",
+      id: "a1",
+      update,
+    })!
+    expect(next.messages[0]!.blocks[0]).toMatchObject({ type: "tool" })
+    expect(next.syncDecorations).toBe(true)
+  })
+
+  it("patch appends a patch block and requests a decoration sync", () => {
+    const next = reduceLocal(state([{ id: "a1", role: "assistant", blocks: [] }]), {
+      type: "patch",
+      id: "a1",
+      files: ["x.ts"],
+      diff: "@@",
+    })!
+    expect(next.messages[0]!.blocks[0]).toMatchObject({ type: "patch", files: ["x.ts"] })
+    expect(next.syncDecorations).toBe(true)
+  })
+
+  it("reviewHunkState sets and deletes by key without touching messages", () => {
+    const msgs = [{ id: "a1", role: "assistant" as const, blocks: [] }]
+    const set = reduceLocal(state(msgs), { type: "reviewHunkState", key: "k1", state: { decision: "accepted" } as never })!
+    expect(set.reviewHunks).toEqual({ k1: { decision: "accepted" } })
+    expect(set.messages).toBe(msgs)
+    const cleared = reduceLocal(set, { type: "reviewHunkState", key: "k1" })!
+    expect(cleared.reviewHunks).toEqual({})
+  })
+
+  it("assistantError sets the error and clears pending", () => {
+    const next = reduceLocal(state([assistantPending("a1")]), {
+      type: "assistantError",
+      id: "a1",
+      message: "boom",
+    })!
+    expect(next.messages[0]).toMatchObject({ error: "boom", pending: false })
+  })
+
+  it("assistantDone clears pending and records usage", () => {
+    const usage = { input: 1, output: 2 } as never
+    const next = reduceLocal(state([assistantPending("a1")]), { type: "assistantDone", id: "a1", usage })!
+    expect(next.messages[0]).toMatchObject({ pending: false, usage })
+  })
+
+  it("aborted marks only the LAST pending assistant as stopped", () => {
+    const next = reduceLocal(state([assistantPending("a1"), assistantPending("a2")]), { type: "aborted" })!
+    expect(next.messages[0]!.pending).toBe(false)
+    expect(next.messages[0]!.stopped).toBeUndefined()
+    expect(next.messages[1]).toMatchObject({ pending: false, stopped: true })
+  })
+
+  it("sessionIdle clears pending on assistant messages without stopping them", () => {
+    const next = reduceLocal(state([assistantPending("a1")]), { type: "sessionIdle" })!
+    expect(next.messages[0]!.pending).toBe(false)
+    expect(next.messages[0]!.stopped).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

First of three planned low-risk extractions to bring `src/chat/view.ts` back down from its 2251-line regrowth (it is now larger than the 1700-line monolith it was originally split out of).

`ChatView.applyLocal` was a ~120-line reducer switch over 14 `Outbound` variants, mixing pure state transforms with side effects (`saveActive`, `queueReviewDecorationsSync`). This moves the transforms into a new pure module:

- **`src/chat/message-reducer.ts`** — `reduceLocal({ messages, reviewHunks }, msg)` returns the next state plus `save` / `syncDecorations` flags, or `null` for non-local-mutation messages. The file-local `appendText` / `upsertTool` helpers moved here too.
- **`applyLocal`** is now a 6-line adapter: apply the returned state, run the flagged side effects.
- Net: `view.ts` −164 lines; three now-unused protocol imports dropped.

No behavior change — the side-effect flags reproduce exactly which effects each variant ran before (e.g. `restore` syncs decorations but does not save; `tool`/`patch`/`reviewHunkState` do both).

## Test plan

- [x] `bun run test` — 975 passing (was 961; +14 new `message-reducer.test.ts` covering each variant in isolation)
- [x] `bun run check-types` — clean
- [x] `bun run compile` — host + webview build green
- [ ] Manual: stream a turn, abort mid-stream, accept/reject a review hunk, switch conversations (restore) — verify chat state + review decorations behave as before

Closes #308