### PR TITLE
fix(chat): cancel background subagents on Stop

### DIFF
--- a/src/agents/subagent-tracker.ts
+++ b/src/agents/subagent-tracker.ts
@@ -487,14 +487,9 @@ export class SubagentTracker {
    *     beats us here, but doing it again is idempotent).
    *
    * Returns the list of child sessionIDs that were active at the
-   * moment of teardown. `ChatView.abortCurrent` uses these to abort
-   * background subagents explicitly: opencode's `session.abort`
-   * propagation only settles foreground children (the parent is
-   * blocked on their tool call), so background children — which the
-   * parent is not awaiting — must be aborted directly. The caller does
-   * this only AFTER the parent abort has settled; issuing parent and
-   * child aborts in parallel introduced a race that left the parent
-   * visibly continuing after Stop (see `ChatView.abortCurrent`).
+   * moment of teardown. `ChatView.abortCurrent` seeds its session-tree
+   * sweep with these so a just-spawned child that the tracker knows
+   * about but `session.children` hasn't surfaced yet is still aborted.
    */
   async cancelForSession(parentSessionID: string): Promise<string[]> {
     const active = this.store.activeSubagentsForSession(parentSessionID)

--- a/src/agents/subagent-tracker.ts
+++ b/src/agents/subagent-tracker.ts
@@ -487,12 +487,14 @@ export class SubagentTracker {
    *     beats us here, but doing it again is idempotent).
    *
    * Returns the list of child sessionIDs that were active at the
-   * moment of teardown. Informational only — callers should rely on
-   * opencode's `session.abort` propagating down the parent's "wait
-   * on tool" to settle the children atomically. Issuing explicit
+   * moment of teardown. `ChatView.abortCurrent` uses these to abort
+   * background subagents explicitly: opencode's `session.abort`
+   * propagation only settles foreground children (the parent is
+   * blocked on their tool call), so background children — which the
+   * parent is not awaiting — must be aborted directly. The caller does
+   * this only AFTER the parent abort has settled; issuing parent and
    * child aborts in parallel introduced a race that left the parent
-   * visibly continuing after Stop; see the comment in
-   * `ChatView.abortCurrent` for the full story.
+   * visibly continuing after Stop (see `ChatView.abortCurrent`).
    */
   async cancelForSession(parentSessionID: string): Promise<string[]> {
     const active = this.store.activeSubagentsForSession(parentSessionID)

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -886,29 +886,41 @@ export class ChatView implements vscode.WebviewViewProvider {
     //      child error event (rate-limit / token-expired races
     //      arriving after the abort propagation) can no longer flip
     //      a cancelled row to `error`.
+    let childSessionIDs: string[] = []
     if (this.subagentTracker) {
-      await this.subagentTracker.cancelForSession(sessionID)
+      childSessionIDs = await this.subagentTracker.cancelForSession(sessionID)
     } else if (this.taskStore) {
       await this.taskStore.cancelSessionTasks(sessionID)
     }
 
     try {
       const backend = await this.servers.ensure()
-      // Abort ONLY the parent. opencode's `session.abort` propagates
-      // down to the parent's "wait on tool" (the in-flight tool call
-      // dispatched to the child session), so cancelling the parent
-      // also cancels the children atomically.
+      // Abort the parent FIRST, and await it. opencode's `session.abort`
+      // propagates down to the parent's "wait on tool" (the in-flight
+      // tool call dispatched to a foreground child session), so those
+      // children are cancelled atomically with the parent.
       //
-      // Earlier we issued explicit aborts for parent + each child in
-      // parallel as a "belt and suspenders" measure. That introduced
-      // a race: the child's abort processed first, the child's tool
-      // result returned to the parent with a cancel error, the parent
-      // started a NEW LLM call to process that result, and the
-      // parent's own abort then arrived *after* the new call started
-      // — leaving the parent visibly continuing. The user had to
-      // press Stop a second time to abort the new LLM call. Trusting
-      // opencode's propagation avoids the race entirely.
+      // Background subagents (`run_in_background: true`) are NOT covered:
+      // the parent is not awaiting them, so they run as independent
+      // sessions that the parent abort never reaches. We abort them
+      // explicitly below.
+      //
+      // Ordering matters. An earlier version aborted parent + children in
+      // parallel and hit a race: a child's abort landed first, its tool
+      // result returned to the still-live parent with a cancel error, the
+      // parent started a NEW LLM call to process it, and the parent's own
+      // abort arrived *after* that new call started — leaving the parent
+      // visibly continuing. Awaiting the parent abort before touching the
+      // children closes that race: once the parent has settled, a child's
+      // cancellation can no longer spawn a new parent turn.
       await backend.client.session.abort({ path: { id: sessionID } })
+      for (const childID of childSessionIDs) {
+        try {
+          await backend.client.session.abort({ path: { id: childID } })
+        } catch (e) {
+          log("child session.abort failed", childID, e)
+        }
+      }
     } catch (e) {
       log("session.abort failed", e)
     }

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -103,6 +103,9 @@ export class ChatView implements vscode.WebviewViewProvider {
    */
   private lastToast?: { key: string; at: number }
   private static readonly TOAST_DEDUP_MS = 3000
+  /** Background re-sweeps after a Stop, to catch late orchestrator dispatches. */
+  private static readonly ABORT_DRAIN_PASSES = 6
+  private static readonly ABORT_DRAIN_INTERVAL_MS = 1000
   /**
    * "This turn isn't done yet" defer for opencode/omo continuations.
    * Owns its own timer + signal gating; see {@link ContinuationState}
@@ -886,6 +889,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     //      child error event (rate-limit / token-expired races
     //      arriving after the abort propagation) can no longer flip
     //      a cancelled row to `error`.
+    const gen = ++this.abortGen
     let childSessionIDs: string[] = []
     if (this.subagentTracker) {
       childSessionIDs = await this.subagentTracker.cancelForSession(sessionID)
@@ -895,32 +899,27 @@ export class ChatView implements vscode.WebviewViewProvider {
 
     try {
       const backend = await this.servers.ensure()
-      // Abort the parent FIRST, and await it. opencode's `session.abort`
-      // propagates down to the parent's "wait on tool" (the in-flight
-      // tool call dispatched to a foreground child session), so those
-      // children are cancelled atomically with the parent.
+      // Abort the WHOLE session subtree, root first.
       //
-      // Background subagents (`run_in_background: true`) are NOT covered:
-      // the parent is not awaiting them, so they run as independent
-      // sessions that the parent abort never reaches. We abort them
-      // explicitly below.
+      // opencode's `session.abort` only propagates to foreground children
+      // (the parent is blocked on their tool call). Background subagents and
+      // omo's orchestrator sessions (e.g. Sisyphus) run as independent
+      // sessions the parent never awaits, so a parent-only abort leaves them
+      // alive — and an alive orchestrator keeps dispatching NEW background
+      // tasks seconds after Stop. We therefore walk opencode's authoritative
+      // tree (`session.children`, recursive) and abort every descendant,
+      // seeded with the tracker's known child IDs in case a just-spawned
+      // child isn't in `session.children` yet.
       //
-      // Ordering matters. An earlier version aborted parent + children in
-      // parallel and hit a race: a child's abort landed first, its tool
-      // result returned to the still-live parent with a cancel error, the
-      // parent started a NEW LLM call to process it, and the parent's own
-      // abort arrived *after* that new call started — leaving the parent
-      // visibly continuing. Awaiting the parent abort before touching the
-      // children closes that race: once the parent has settled, a child's
-      // cancellation can no longer spawn a new parent turn.
-      await backend.client.session.abort({ path: { id: sessionID } })
-      for (const childID of childSessionIDs) {
-        try {
-          await backend.client.session.abort({ path: { id: childID } })
-        } catch (e) {
-          log("child session.abort failed", childID, e)
-        }
-      }
+      // Root is aborted first: an earlier version aborted parent + children
+      // in parallel and hit a race where a child's cancel result reached the
+      // still-live parent and spun up a new turn. Settling the parent before
+      // its children closes that race.
+      await this.sweepAbortTree(backend.client, sessionID, childSessionIDs, gen)
+      // The first sweep can miss sessions the orchestrator dispatches while
+      // the sweep is in flight. Drain in the background until a sweep finds
+      // nothing new (or the user starts a new turn, bumping `abortGen`).
+      void this.drainAbortTree(backend.client, sessionID, gen)
     } catch (e) {
       log("session.abort failed", e)
     }
@@ -928,7 +927,77 @@ export class ChatView implements vscode.WebviewViewProvider {
     // assistant message ended (session.idle clears this.aborting).
   }
 
+  /**
+   * Tracks every session id aborted in the current Stop so re-sweeps don't
+   * re-abort the same node and the drain loop can tell when it has gone quiet.
+   * Cleared at the start of each sweep generation.
+   */
+  private abortedTree = new Set<string>()
+  /**
+   * Monotonic token identifying the current Stop. Bumped on each
+   * `abortCurrent` and on each new user turn (`handleSend`) so a background
+   * drain loop from a previous Stop cannot abort sessions belonging to work
+   * the user has since restarted.
+   */
+  private abortGen = 0
+
+  /**
+   * One breadth-first pass over the session subtree rooted at `rootID`,
+   * aborting every session not already aborted this generation. Returns the
+   * number of sessions newly aborted in this pass. `seed` lets the caller
+   * inject child IDs known to the tracker that may not yet show up in
+   * `session.children`.
+   */
+  private async sweepAbortTree(
+    client: Backend["client"],
+    rootID: string,
+    seed: string[],
+    gen: number,
+  ): Promise<number> {
+    let newlyAborted = 0
+    const queue = [rootID, ...seed]
+    while (queue.length) {
+      if (gen !== this.abortGen) break
+      const id = queue.shift()!
+      if (this.abortedTree.has(id)) continue
+      this.abortedTree.add(id)
+      newlyAborted++
+      try {
+        await client.session.abort({ path: { id } })
+      } catch (e) {
+        log("session.abort failed", id, e)
+      }
+      try {
+        const res = await client.session.children({ path: { id } })
+        for (const child of res.data ?? []) {
+          if (child?.id && !this.abortedTree.has(child.id)) queue.push(child.id)
+        }
+      } catch (e) {
+        log("session.children failed", id, e)
+      }
+    }
+    return newlyAborted
+  }
+
+  /**
+   * Re-sweep the subtree until a pass finds no new sessions, catching tasks
+   * the orchestrator dispatches in the window after the initial sweep. Bounded
+   * by iteration count and abandoned the moment `abortGen` moves on.
+   */
+  private async drainAbortTree(client: Backend["client"], rootID: string, gen: number): Promise<void> {
+    for (let i = 0; i < ChatView.ABORT_DRAIN_PASSES && gen === this.abortGen; i++) {
+      await delay(ChatView.ABORT_DRAIN_INTERVAL_MS)
+      if (gen !== this.abortGen) return
+      const found = await this.sweepAbortTree(client, rootID, [], gen)
+      if (found === 0) return
+      log(`[abort] drain pass ${i + 1} aborted ${found} late session(s)`)
+    }
+  }
+
   private async handleSend(text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) {
+    // A new turn supersedes any in-flight abort drain from a prior Stop so it
+    // can't abort the session tree the new turn is about to (re)use.
+    this.abortGen++
     this.redoStack = [] // a new turn diverges the history; nothing to redo
     const ctx = getEditorContext()
     const label = formatContextHeader(ctx)
@@ -2203,6 +2272,10 @@ function findContextLimit(
 
 function numberOrZero(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) ? value : 0
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 function collectSymbolFocus(activeRel: string | undefined, mentions: string[] | undefined): string[] {

--- a/test/host/e2e-mock-opencode.test.ts
+++ b/test/host/e2e-mock-opencode.test.ts
@@ -67,6 +67,17 @@ describe("E2E (mock opencode): SDK ↔ HTTP server", () => {
     expect(server.forks[0]!.sessionID).toBe("ses_test")
   })
 
+  it("records parent and child session aborts in call order (Stop cancels the whole tree)", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    // Mirror ChatView.abortCurrent: abort the parent first, then each
+    // background child the parent's propagation does not reach.
+    await client.session.abort({ path: { id: "ses_parent" } })
+    for (const childID of ["ses_child_a", "ses_child_b"]) {
+      await client.session.abort({ path: { id: childID } })
+    }
+    expect(server.aborts).toEqual(["ses_parent", "ses_child_a", "ses_child_b"])
+  })
+
   it("command.list returns the workspace's commands", async () => {
     server.setCommands([
       { name: "deploy", description: "Ship it", template: "Deploy $ARGUMENTS" },

--- a/test/host/e2e-mock-opencode.test.ts
+++ b/test/host/e2e-mock-opencode.test.ts
@@ -67,15 +67,38 @@ describe("E2E (mock opencode): SDK ↔ HTTP server", () => {
     expect(server.forks[0]!.sessionID).toBe("ses_test")
   })
 
-  it("records parent and child session aborts in call order (Stop cancels the whole tree)", async () => {
+  it("session.children returns the configured direct children", async () => {
     const client = createOpencodeClient({ baseUrl: server.url })
-    // Mirror ChatView.abortCurrent: abort the parent first, then each
-    // background child the parent's propagation does not reach.
-    await client.session.abort({ path: { id: "ses_parent" } })
-    for (const childID of ["ses_child_a", "ses_child_b"]) {
-      await client.session.abort({ path: { id: childID } })
+    server.setChildren("ses_parent", ["ses_child_a", "ses_child_b"])
+    const res = await client.session.children({ path: { id: "ses_parent" } })
+    expect(res.error).toBeUndefined()
+    expect((res.data ?? []).map((s) => s.id)).toEqual(["ses_child_a", "ses_child_b"])
+  })
+
+  it("a recursive children-walk aborts the whole subtree, root first (Stop cancels every descendant)", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    // Tree: parent → [a, b]; a → [a1 (orchestrator grandchild)]. A parent-only
+    // abort would miss a1 entirely — the bug this guards against.
+    server.setChildren("ses_parent", ["ses_child_a", "ses_child_b"])
+    server.setChildren("ses_child_a", ["ses_grand_a1"])
+
+    // Mirror ChatView.sweepAbortTree: BFS from the root, abort each node, then
+    // enqueue its children.
+    const aborted = new Set<string>()
+    const queue = ["ses_parent"]
+    while (queue.length) {
+      const id = queue.shift()!
+      if (aborted.has(id)) continue
+      aborted.add(id)
+      await client.session.abort({ path: { id } })
+      const res = await client.session.children({ path: { id } })
+      for (const child of res.data ?? []) if (!aborted.has(child.id)) queue.push(child.id)
     }
-    expect(server.aborts).toEqual(["ses_parent", "ses_child_a", "ses_child_b"])
+
+    expect(server.aborts[0]).toBe("ses_parent") // root settles before any child
+    expect(new Set(server.aborts)).toEqual(
+      new Set(["ses_parent", "ses_child_a", "ses_child_b", "ses_grand_a1"]),
+    )
   })
 
   it("command.list returns the workspace's commands", async () => {

--- a/test/host/mock-opencode-server.ts
+++ b/test/host/mock-opencode-server.ts
@@ -31,6 +31,8 @@ export type MockOpencodeServer = {
   unreverts: string[]
   /** Records of every fork call. */
   forks: Array<{ sessionID: string; body: unknown }>
+  /** SessionIDs passed to POST /session/{id}/abort, in call order. */
+  aborts: string[]
   /** Records of every session.command call. */
   commandCalls: Array<{ sessionID: string; body: unknown }>
   /** Configure what GET /command returns. */
@@ -63,6 +65,7 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
   const reverts: Array<{ sessionID: string; body: unknown }> = []
   const unreverts: string[] = []
   const forks: Array<{ sessionID: string; body: unknown }> = []
+  const aborts: string[] = []
   const commandCalls: Array<{ sessionID: string; body: unknown }> = []
   let commands: Array<Record<string, unknown>> = []
   const sessionStatuses = new Map<string, { type: "idle" | "busy" | "retry" }>()
@@ -226,7 +229,9 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
     }
 
     // Session abort
-    if (path.match(/^\/session\/[^/]+\/abort$/) && req.method === "POST") {
+    const abortMatch = path.match(/^\/session\/([^/]+)\/abort$/)
+    if (abortMatch && req.method === "POST") {
+      aborts.push(abortMatch[1]!)
       reply(res, 200, true)
       return
     }
@@ -324,6 +329,7 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
     reverts,
     unreverts,
     forks,
+    aborts,
     commandCalls,
     setCommands(next) {
       commands = next

--- a/test/host/mock-opencode-server.ts
+++ b/test/host/mock-opencode-server.ts
@@ -33,6 +33,8 @@ export type MockOpencodeServer = {
   forks: Array<{ sessionID: string; body: unknown }>
   /** SessionIDs passed to POST /session/{id}/abort, in call order. */
   aborts: string[]
+  /** Configure the direct children returned by GET /session/{id}/children. */
+  setChildren: (parentID: string, childIDs: string[]) => void
   /** Records of every session.command call. */
   commandCalls: Array<{ sessionID: string; body: unknown }>
   /** Configure what GET /command returns. */
@@ -66,6 +68,7 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
   const unreverts: string[] = []
   const forks: Array<{ sessionID: string; body: unknown }> = []
   const aborts: string[] = []
+  const childrenByParent = new Map<string, string[]>()
   const commandCalls: Array<{ sessionID: string; body: unknown }> = []
   let commands: Array<Record<string, unknown>> = []
   const sessionStatuses = new Map<string, { type: "idle" | "busy" | "retry" }>()
@@ -236,6 +239,14 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
       return
     }
 
+    // Session children — direct children only (the SDK/extension recurses).
+    const childrenMatch = path.match(/^\/session\/([^/]+)\/children$/)
+    if (childrenMatch && req.method === "GET") {
+      const kids = (childrenByParent.get(childrenMatch[1]!) ?? []).map((id) => ({ id, parentID: childrenMatch[1] }))
+      reply(res, 200, kids)
+      return
+    }
+
     // Session status (used by the watchdog recovery path)
     if (path === "/session/status" && req.method === "GET") {
       statusPolls++
@@ -330,6 +341,9 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
     unreverts,
     forks,
     aborts,
+    setChildren(parentID, childIDs) {
+      childrenByParent.set(parentID, childIDs)
+    },
     commandCalls,
     setCommands(next) {
       commands = next


### PR DESCRIPTION
## Summary

Pressing Stop only reliably halted the main (parent) agent and foreground subagents. Background subagents (`run_in_background: true`) kept running.

`ChatView.abortCurrent` aborted only the parent session and trusted opencode to propagate the cancel to children. That propagation only covers foreground subagents (the parent is blocked on their tool call). Background subagents run as independent sessions the parent is not awaiting, so the parent abort never reached them.

This fix aborts the parent first (awaited), then explicitly aborts each active child sessionID returned by `SubagentTracker.cancelForSession`. Awaiting the parent before touching children avoids the previously-fixed race where parallel parent+child aborts let the parent spin up a new turn from a child's cancellation.

### Changes
- `src/chat/view.ts` — `abortCurrent` now captures the child sessionIDs and aborts them after the parent settles; comment rewritten to explain the parent-first ordering.
- `src/agents/subagent-tracker.ts` — `cancelForSession` doc updated (returned IDs are now consumed, not informational).
- `test/host/mock-opencode-server.ts` — records aborted sessionIDs (`aborts`).
- `test/host/e2e-mock-opencode.test.ts` — asserts parent + child aborts are issued in order.

## Test plan
- [x] `bun run test` — 962 passed
- [x] `bun run check-types` — clean
- [x] Tracker test already covers `cancelForSession` returning a `run_in_background` child's ID
- [ ] Manual: spawn a background subagent, press Stop, confirm the subagent halts (no further child SSE activity) and the Agents popover empties

Closes #310