### PR TITLE
chore(release): 1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.4.3] - 2026-06-09
+
+### Fixed
+- Stop now cancels background subagents, not just the main agent. Pressing Stop previously aborted only the active session and any foreground subagents it was blocked on; background subagents and omo orchestrator sessions ran on independently and could keep dispatching new work seconds later. Stop now walks opencode's authoritative session tree (`session.children`, recursively) and aborts every descendant, root first, with a short background re-sweep to catch tasks dispatched while the first sweep is in flight (#310, #311).
+
 ## [1.4.2] - 2026-06-07
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Release v1.4.3: bump package.json to 1.4.3 and add the `[1.4.3]` CHANGELOG section for the Stop background-subagent fix.

Bundles #311 (cancel background subagents on Stop, closing #310).

## Test plan
- [x] `bun run check-types` — clean
- [x] `bun run test` — green on the merged fix
- [ ] Tag v1.4.3 from main → GitHub Release → marketplace publish workflow

Closes #312