### PR TITLE
fix(chat): clear abort tree per Stop generation and revive drain passes

### DIFF
--- a/src/chat/abort-tree.ts
+++ b/src/chat/abort-tree.ts
@@ -1,0 +1,84 @@
+import type { Backend } from "../server"
+import { log } from "../output"
+
+/**
+ * State for one Stop generation. `aborted` dedupes `session.abort` calls
+ * across every sweep in the generation (the initial sweep plus all drain
+ * passes); `isLive` lets a sweep abandon work the moment the generation is
+ * superseded (the user pressed Stop again or started a new turn).
+ */
+export interface AbortSweepState {
+  aborted: Set<string>
+  isLive: () => boolean
+}
+
+/**
+ * One breadth-first pass over the session subtree rooted at `rootID`,
+ * aborting every session not already aborted this generation. Returns the
+ * number of sessions newly aborted in this pass. `seed` lets the caller
+ * inject child IDs known to the tracker that may not yet show up in
+ * `session.children`.
+ */
+export async function sweepAbortTree(
+  client: Backend["client"],
+  rootID: string,
+  seed: string[],
+  state: AbortSweepState,
+): Promise<number> {
+  let newlyAborted = 0
+  // Per-pass traversal guard, deliberately distinct from `state.aborted`:
+  // drain passes must re-list children of already-aborted nodes to catch
+  // sessions the orchestrator dispatched after the node was first aborted.
+  // Gating traversal on `state.aborted` made every drain pass skip the root
+  // and exit having seen nothing.
+  const visited = new Set<string>()
+  const queue = [rootID, ...seed]
+  while (queue.length) {
+    if (!state.isLive()) break
+    const id = queue.shift()!
+    if (visited.has(id)) continue
+    visited.add(id)
+    if (!state.aborted.has(id)) {
+      state.aborted.add(id)
+      newlyAborted++
+      try {
+        await client.session.abort({ path: { id } })
+      } catch (e) {
+        log("session.abort failed", id, e)
+      }
+    }
+    try {
+      const res = await client.session.children({ path: { id } })
+      for (const child of res.data ?? []) {
+        if (child?.id && !visited.has(child.id)) queue.push(child.id)
+      }
+    } catch (e) {
+      log("session.children failed", id, e)
+    }
+  }
+  return newlyAborted
+}
+
+/**
+ * Re-sweep the subtree until a pass finds no new sessions, catching tasks
+ * the orchestrator dispatches in the window after the initial sweep. Bounded
+ * by iteration count and abandoned the moment the generation is superseded.
+ */
+export async function drainAbortTree(
+  client: Backend["client"],
+  rootID: string,
+  state: AbortSweepState,
+  opts: { passes: number; intervalMs: number },
+): Promise<void> {
+  for (let i = 0; i < opts.passes && state.isLive(); i++) {
+    await delay(opts.intervalMs)
+    if (!state.isLive()) return
+    const found = await sweepAbortTree(client, rootID, [], state)
+    if (found === 0) return
+    log(`[abort] drain pass ${i + 1} aborted ${found} late session(s)`)
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -35,6 +35,7 @@ import { lastUserTurnIndex, redoAction, userMessageText } from "./undo"
 import { migrateConversationsToWorkspace } from "./conversation-store"
 import { ConversationManager } from "./conversation-manager"
 import { ContinuationState } from "./continuation-state"
+import { sweepAbortTree, drainAbortTree } from "./abort-tree"
 import { SubagentDispatch } from "./subagent-dispatch"
 export { summarizePrompt } from "./subagent-dispatch"
 import { relativeToCwd, samePath } from "./paths"
@@ -890,6 +891,10 @@ export class ChatView implements vscode.WebviewViewProvider {
     //      arriving after the abort propagation) can no longer flip
     //      a cancelled row to `error`.
     const gen = ++this.abortGen
+    // Each Stop is a fresh generation: sessions aborted by a PREVIOUS Stop
+    // must be re-abortable, or a second Stop in the same conversation skips
+    // the root entirely and the server keeps generating.
+    this.abortedTree.clear()
     let childSessionIDs: string[] = []
     if (this.subagentTracker) {
       childSessionIDs = await this.subagentTracker.cancelForSession(sessionID)
@@ -915,11 +920,15 @@ export class ChatView implements vscode.WebviewViewProvider {
       // in parallel and hit a race where a child's cancel result reached the
       // still-live parent and spun up a new turn. Settling the parent before
       // its children closes that race.
-      await this.sweepAbortTree(backend.client, sessionID, childSessionIDs, gen)
+      const state = { aborted: this.abortedTree, isLive: () => gen === this.abortGen }
+      await sweepAbortTree(backend.client, sessionID, childSessionIDs, state)
       // The first sweep can miss sessions the orchestrator dispatches while
       // the sweep is in flight. Drain in the background until a sweep finds
       // nothing new (or the user starts a new turn, bumping `abortGen`).
-      void this.drainAbortTree(backend.client, sessionID, gen)
+      void drainAbortTree(backend.client, sessionID, state, {
+        passes: ChatView.ABORT_DRAIN_PASSES,
+        intervalMs: ChatView.ABORT_DRAIN_INTERVAL_MS,
+      })
     } catch (e) {
       log("session.abort failed", e)
     }
@@ -928,9 +937,10 @@ export class ChatView implements vscode.WebviewViewProvider {
   }
 
   /**
-   * Tracks every session id aborted in the current Stop so re-sweeps don't
-   * re-abort the same node and the drain loop can tell when it has gone quiet.
-   * Cleared at the start of each sweep generation.
+   * Session ids aborted in the current Stop generation, shared by the initial
+   * sweep and the background drain so they don't re-abort the same node.
+   * Cleared in `abortCurrent` when a new generation starts — a stale entry
+   * would make the next Stop skip the session entirely.
    */
   private abortedTree = new Set<string>()
   /**
@@ -940,59 +950,6 @@ export class ChatView implements vscode.WebviewViewProvider {
    * the user has since restarted.
    */
   private abortGen = 0
-
-  /**
-   * One breadth-first pass over the session subtree rooted at `rootID`,
-   * aborting every session not already aborted this generation. Returns the
-   * number of sessions newly aborted in this pass. `seed` lets the caller
-   * inject child IDs known to the tracker that may not yet show up in
-   * `session.children`.
-   */
-  private async sweepAbortTree(
-    client: Backend["client"],
-    rootID: string,
-    seed: string[],
-    gen: number,
-  ): Promise<number> {
-    let newlyAborted = 0
-    const queue = [rootID, ...seed]
-    while (queue.length) {
-      if (gen !== this.abortGen) break
-      const id = queue.shift()!
-      if (this.abortedTree.has(id)) continue
-      this.abortedTree.add(id)
-      newlyAborted++
-      try {
-        await client.session.abort({ path: { id } })
-      } catch (e) {
-        log("session.abort failed", id, e)
-      }
-      try {
-        const res = await client.session.children({ path: { id } })
-        for (const child of res.data ?? []) {
-          if (child?.id && !this.abortedTree.has(child.id)) queue.push(child.id)
-        }
-      } catch (e) {
-        log("session.children failed", id, e)
-      }
-    }
-    return newlyAborted
-  }
-
-  /**
-   * Re-sweep the subtree until a pass finds no new sessions, catching tasks
-   * the orchestrator dispatches in the window after the initial sweep. Bounded
-   * by iteration count and abandoned the moment `abortGen` moves on.
-   */
-  private async drainAbortTree(client: Backend["client"], rootID: string, gen: number): Promise<void> {
-    for (let i = 0; i < ChatView.ABORT_DRAIN_PASSES && gen === this.abortGen; i++) {
-      await delay(ChatView.ABORT_DRAIN_INTERVAL_MS)
-      if (gen !== this.abortGen) return
-      const found = await this.sweepAbortTree(client, rootID, [], gen)
-      if (found === 0) return
-      log(`[abort] drain pass ${i + 1} aborted ${found} late session(s)`)
-    }
-  }
 
   private async handleSend(text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) {
     // A new turn supersedes any in-flight abort drain from a prior Stop so it
@@ -2272,10 +2229,6 @@ function findContextLimit(
 
 function numberOrZero(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) ? value : 0
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 function collectSymbolFocus(activeRel: string | undefined, mentions: string[] | undefined): string[] {

--- a/test/host/e2e-mock-opencode.test.ts
+++ b/test/host/e2e-mock-opencode.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest"
 import { createOpencodeClient } from "@opencode-ai/sdk"
 import { startMockOpencode, type MockOpencodeServer } from "./mock-opencode-server"
 import { subscribeSession } from "../../src/chat/stream"
+import { sweepAbortTree, drainAbortTree } from "../../src/chat/abort-tree"
 
 let server: MockOpencodeServer
 
@@ -75,30 +76,80 @@ describe("E2E (mock opencode): SDK ↔ HTTP server", () => {
     expect((res.data ?? []).map((s) => s.id)).toEqual(["ses_child_a", "ses_child_b"])
   })
 
-  it("a recursive children-walk aborts the whole subtree, root first (Stop cancels every descendant)", async () => {
+  it("sweepAbortTree aborts the whole subtree, root first (Stop cancels every descendant)", async () => {
     const client = createOpencodeClient({ baseUrl: server.url })
     // Tree: parent → [a, b]; a → [a1 (orchestrator grandchild)]. A parent-only
     // abort would miss a1 entirely — the bug this guards against.
     server.setChildren("ses_parent", ["ses_child_a", "ses_child_b"])
     server.setChildren("ses_child_a", ["ses_grand_a1"])
 
-    // Mirror ChatView.sweepAbortTree: BFS from the root, abort each node, then
-    // enqueue its children.
-    const aborted = new Set<string>()
-    const queue = ["ses_parent"]
-    while (queue.length) {
-      const id = queue.shift()!
-      if (aborted.has(id)) continue
-      aborted.add(id)
-      await client.session.abort({ path: { id } })
-      const res = await client.session.children({ path: { id } })
-      for (const child of res.data ?? []) if (!aborted.has(child.id)) queue.push(child.id)
-    }
+    const state = { aborted: new Set<string>(), isLive: () => true }
+    const found = await sweepAbortTree(client, "ses_parent", [], state)
 
+    expect(found).toBe(4)
     expect(server.aborts[0]).toBe("ses_parent") // root settles before any child
     expect(new Set(server.aborts)).toEqual(
       new Set(["ses_parent", "ses_child_a", "ses_child_b", "ses_grand_a1"]),
     )
+  })
+
+  it("a re-sweep finds children dispatched after the first sweep without re-aborting settled nodes", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    server.setChildren("ses_parent", ["ses_child_a"])
+
+    const state = { aborted: new Set<string>(), isLive: () => true }
+    expect(await sweepAbortTree(client, "ses_parent", [], state)).toBe(2)
+
+    // Orchestrator dispatches a late background task between sweeps — the
+    // drain regression: a traversal gated on the aborted set would skip the
+    // already-aborted root, never list its children, and miss ses_late.
+    server.setChildren("ses_parent", ["ses_child_a", "ses_late"])
+    expect(await sweepAbortTree(client, "ses_parent", [], state)).toBe(1)
+
+    expect(server.aborts).toEqual(["ses_parent", "ses_child_a", "ses_late"])
+    // Quiet tree → 0, which is what lets drainAbortTree terminate.
+    expect(await sweepAbortTree(client, "ses_parent", [], state)).toBe(0)
+  })
+
+  it("a fresh generation re-aborts a session aborted by a previous Stop", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+
+    // Stop 1 aborts the root; the user sends a new turn in the same session
+    // and presses Stop again. ChatView.abortCurrent starts each generation
+    // with a cleared aborted-set, so the root must be aborted again — the old
+    // ChatView-lifetime set made every Stop after the first a no-op.
+    const stop1 = { aborted: new Set<string>(), isLive: () => true }
+    await sweepAbortTree(client, "ses_parent", [], stop1)
+    const stop2 = { aborted: new Set<string>(), isLive: () => true }
+    expect(await sweepAbortTree(client, "ses_parent", [], stop2)).toBe(1)
+
+    expect(server.aborts).toEqual(["ses_parent", "ses_parent"])
+  })
+
+  it("drainAbortTree aborts sessions dispatched after the initial sweep", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    server.setChildren("ses_parent", [])
+
+    const state = { aborted: new Set<string>(), isLive: () => true }
+    await sweepAbortTree(client, "ses_parent", [], state)
+    expect(server.aborts).toEqual(["ses_parent"])
+
+    server.setChildren("ses_parent", ["ses_late_dispatch"])
+    await drainAbortTree(client, "ses_parent", state, { passes: 3, intervalMs: 5 })
+
+    expect(server.aborts).toEqual(["ses_parent", "ses_late_dispatch"])
+  })
+
+  it("sweepAbortTree abandons the walk when the generation is superseded", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    server.setChildren("ses_parent", ["ses_child_a", "ses_child_b"])
+
+    // Generation dies as soon as the root abort lands (the user sent a new
+    // turn); the children must NOT be aborted out from under the new turn.
+    const state = { aborted: new Set<string>(), isLive: () => server.aborts.length === 0 }
+    await sweepAbortTree(client, "ses_parent", [], state)
+
+    expect(server.aborts).toEqual(["ses_parent"])
   })
 
   it("command.list returns the workspace's commands", async () => {


### PR DESCRIPTION
## Summary

- `ChatView.abortedTree` was never cleared, so the second Stop in a conversation skipped `session.abort` for the root (and every previously aborted child) — the UI showed Stopped while the server kept generating and tools kept mutating disk.
- The same set doubled as the traversal guard, which made every `drainAbortTree` pass skip the already-aborted root before listing its children — the drain (the #311 fix for late orchestrator dispatches) could never find anything and always exited on pass 1.
- Extracted the BFS into `src/chat/abort-tree.ts` with a per-pass `visited` set separate from the per-generation `aborted` set; `abortCurrent` now clears the generation set when it bumps `abortGen`.
- Rewrote the e2e abort test to exercise the real `sweepAbortTree`/`drainAbortTree` (it previously re-implemented the BFS locally, which is why both bugs were invisible to it), plus new regression tests for the two-Stops sequence, late-dispatched children, drain pickup, and generation supersession.

## Test plan

- [x] `bun run test` — 967 passed (4 new tests)
- [x] `bun run check-types` — clean
- [ ] Manual: Stop a turn, send another, Stop again; verify opencode logs a second abort (needs live opencode)

Closes #316