### PR TITLE
fix(agents): settle Main task row when deferred idle resolves by timer

### DIFF
--- a/src/chat/continuation-state.ts
+++ b/src/chat/continuation-state.ts
@@ -53,6 +53,13 @@ export class ContinuationState {
     private deps: {
       post: (msg: Outbound) => void
       activeSubagentCount: () => number
+      /**
+       * Full idle settlement, not just the webview post — must also settle
+       * the task store and clear the per-turn Main task ID, or the deferred
+       * path leaves the turn's Main row `running` forever (persisted, so it
+       * survives reload) and the next turn shows two running Main rows.
+       */
+      emitIdle: () => void
     },
   ) {}
 
@@ -139,7 +146,7 @@ export class ContinuationState {
       log(`[continuation] timer (${source}) resolved; emitting sessionIdle`)
       this.deferActive = false
       this.deps.post({ type: "continuationPending", pending: false })
-      this.deps.post({ type: "sessionIdle" })
+      this.deps.emitIdle()
     }, delay)
   }
 

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -176,12 +176,29 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.continuationState = new ContinuationState({
       post: (msg) => this.post(msg),
       activeSubagentCount: () => this.subagentDispatch.activeSubagentCount(),
+      emitIdle: () => this.settleSessionIdle(),
     })
     this.applyActiveSnapshot()
     void this.manager.persist()
     if (this.taskStore) {
       this.taskStoreUnsub = this.taskStore.onDidChange((tasks) => this.postAgentsStatus(tasks))
     }
+  }
+
+  /**
+   * The full end-of-turn settlement: settle the session's task rows, drop
+   * the per-turn Main task ID, tell the webview, persist. Shared by the
+   * direct `session.idle` path and ContinuationState's deferred-idle timers —
+   * the deferred path once posted only `sessionIdle`, leaving the Main row
+   * `running` in workspaceState forever.
+   */
+  private settleSessionIdle() {
+    if (this.sessionID && this.taskStore) {
+      void this.taskStore.markSessionIdle(this.sessionID)
+    }
+    this.subagentDispatch.clearMainTaskID()
+    this.post({ type: "sessionIdle" })
+    void this.manager.flushPersist()
   }
 
   private postAgentsStatus(tasks: AgentTask[]) {
@@ -1770,12 +1787,7 @@ export class ChatView implements vscode.WebviewViewProvider {
           return
         }
         this.continuationState.finishPending()
-        if (this.sessionID && this.taskStore) {
-          void this.taskStore.markSessionIdle(this.sessionID)
-        }
-        this.subagentDispatch.clearMainTaskID()
-        this.post({ type: "sessionIdle" })
-        void this.manager.flushPersist()
+        this.settleSessionIdle()
       },
       onChildSessionEvent: (event) => {
         if (this.aborting) return

--- a/test/host/continuation-state.test.ts
+++ b/test/host/continuation-state.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { ContinuationState } from "../../src/chat/continuation-state"
+import type { Outbound } from "../../src/protocol"
+
+describe("ContinuationState deferred idle", () => {
+  let posts: Outbound[]
+  let emitIdleCalls: number
+  let subagents: number
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    posts = []
+    emitIdleCalls = 0
+    subagents = 0
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function make() {
+    return new ContinuationState({
+      post: (msg) => posts.push(msg),
+      activeSubagentCount: () => subagents,
+      emitIdle: () => emitIdleCalls++,
+    })
+  }
+
+  it("structural defer + grace timer runs the FULL idle settlement, not just a webview post", () => {
+    const cs = make()
+    subagents = 1
+    cs.beginDefer("sessionIdle")
+    expect(posts).toEqual([{ type: "continuationPending", pending: true }])
+
+    // Subagent settles; ChatView calls collapseToGraceIfSettled.
+    subagents = 0
+    cs.collapseToGraceIfSettled()
+    expect(emitIdleCalls).toBe(0)
+
+    vi.advanceTimersByTime(10_000)
+    // The settlement callback is what marks the task store idle and clears
+    // the Main task ID — the regression was posting sessionIdle directly.
+    expect(emitIdleCalls).toBe(1)
+    expect(posts).toEqual([
+      { type: "continuationPending", pending: true },
+      { type: "continuationPending", pending: false },
+    ])
+  })
+
+  it("toast-only defer settles via emitIdle when the cap expires", () => {
+    const cs = make()
+    cs.markSignal("toast")
+    expect(cs.hasGate()).toBe(true)
+
+    cs.beginDefer("sessionIdle")
+    vi.advanceTimersByTime(120_000)
+    expect(emitIdleCalls).toBe(1)
+  })
+
+  it("timer no-ops while subagents are still active", () => {
+    const cs = make()
+    cs.markSignal("toast")
+    cs.beginDefer("sessionIdle")
+    subagents = 1
+    vi.advanceTimersByTime(120_000)
+    expect(emitIdleCalls).toBe(0)
+  })
+
+  it("finishPending cancels the deferred settlement", () => {
+    const cs = make()
+    cs.markSignal("toast")
+    cs.beginDefer("sessionIdle")
+    cs.finishPending()
+    vi.advanceTimersByTime(120_000)
+    expect(emitIdleCalls).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

- The deferred-idle path (`continuationState.hasGate()` true at `session.idle`) returned early before `taskStore.markSessionIdle` / `clearMainTaskID`, and the defer's timers (`subagents-settled` grace, `toast-cap`) only posted `{type:"sessionIdle"}` to the webview — the task store was never settled, leaving the turn's Main row `running` in workspaceState permanently (it survives reload; the Agents pill spins forever and the next prompt shows two running Main rows).
- `ContinuationState` now requires an `emitIdle` dep that performs the full settlement; ChatView wires it to a new shared `settleSessionIdle()` used by both the direct and deferred paths.
- Added the first test coverage for `ContinuationState` (fake-timer tests for structural defer + grace, toast-cap, still-active no-op, and cancellation).

## Test plan

- [x] `bun run test` — 971 passed (4 new)
- [x] `bun run check-types` — clean
- [ ] Manual: run an omo turn that dispatches a subagent, let it settle, verify the Agents pill goes idle ~10s after the last subagent finishes (needs live opencode)

Closes #318