### PR TITLE
fix(review): stop undoMove truncating moved files to one hunk's fragment

### DIFF
--- a/src/chat/fs-ops.ts
+++ b/src/chat/fs-ops.ts
@@ -387,33 +387,39 @@ async function undoMove(
     )
   }
   const { uri: fromUri } = await findExistingWorkspaceFile(change.path, root, { preferAbsolute: change.absolutePath })
-  if (!fromUri) {
+  const restored = await existingWorkspaceFileUri(change.oldPath, root)
+  if (fromUri) {
+    if (restored) {
+      return reportConflict(
+        change.oldPath,
+        `Cannot restore move target: ${change.oldPath} already exists.`,
+        silent,
+      )
+    }
+    const toUri = await workspaceFileUri(change.oldPath, root)
+    try {
+      await vscode.workspace.fs.rename(fromUri, toUri, { overwrite: false })
+    } catch (e) {
+      return reportConflict(
+        change.path,
+        `Could not undo move of ${change.path}: ${(e as Error).message ?? "unknown error"}.`,
+        silent,
+      )
+    }
+  } else if (!restored) {
     return reportMissing(change.path, `${change.path} is no longer present; cannot move back.`, silent)
   }
-  const toExisting = await existingWorkspaceFileUri(change.oldPath, root)
-  if (toExisting) {
-    return reportConflict(
-      change.oldPath,
-      `Cannot restore move target: ${change.oldPath} already exists.`,
-      silent,
-    )
-  }
-  const toUri = await workspaceFileUri(change.oldPath, root)
-  try {
-    await vscode.workspace.fs.rename(fromUri, toUri, { overwrite: false })
-    // If the move was accompanied by edits, restore the old content too.
-    if (hunk.oldText) {
-      const data = new TextEncoder().encode(hunk.oldText)
-      await vscode.workspace.fs.writeFile(toUri, data)
-    }
+  // else: an earlier hunk of this move already renamed the file back — only
+  // this hunk's content revert remains.
+
+  if (!hunk.oldText && !hunk.newText) {
     return { status: "applied" }
-  } catch (e) {
-    return reportConflict(
-      change.path,
-      `Could not undo move of ${change.path}: ${(e as Error).message ?? "unknown error"}.`,
-      silent,
-    )
   }
+  // Revert the edits carried by the move with the same ranged replace as a
+  // plain update. Writing `hunk.oldText` as the whole file (the previous
+  // behavior) truncated everything outside the hunk — oldText is one hunk's
+  // fragment, not the original file.
+  return undoUpdate({ ...change, path: change.oldPath, absolutePath: undefined }, hunk, root, silent)
 }
 
 async function undoUpdate(

--- a/test/host/review-actions.test.ts
+++ b/test/host/review-actions.test.ts
@@ -267,6 +267,60 @@ describe("reviewHunk: moved files", () => {
   })
 })
 
+describe("reviewHunk: moved files with edits", () => {
+  // Mirror WorkspaceEdit.replace onto the in-memory file map so the content
+  // revert is observable (the shared applyEdit mock just returns true).
+  beforeEach(() => {
+    ;(vscode.workspace.applyEdit as ReturnType<typeof vi.fn>).mockImplementation(
+      async (edit: unknown) => {
+        const ops = (edit as { edits?: Array<{ uri: vscode.Uri; range: vscode.Range; text: string }> }).edits
+        if (!ops) return true
+        for (const op of [...ops].reverse()) {
+          const entry = files.get(op.uri.fsPath)
+          if (!entry) continue
+          const start = offsetFromPosition(entry.content, op.range.start)
+          const end = offsetFromPosition(entry.content, op.range.end)
+          entry.content = entry.content.slice(0, start) + op.text + entry.content.slice(end)
+        }
+        return true
+      },
+    )
+  })
+
+  it("Undo: reverts only the hunk's lines and keeps the rest of the file intact", async () => {
+    files.set("/workspace/new-name.ts", { content: "line1\nEDITED\nline3\nline4\n" })
+    const patch = "@@ -2,1 +2,1 @@\n-ORIGINAL\n+EDITED"
+    const { change, hunk } = makeChange({
+      path: "new-name.ts",
+      kind: "moved",
+      patch,
+      oldPath: "old-name.ts",
+    })
+    const outcome = await reviewHunk(change, hunk, "rejected", { silent: true })
+    expect(outcome.status).toBe("applied")
+    expect(renames[0]?.from.fsPath).toBe("/workspace/new-name.ts")
+    expect(renames[0]?.to.fsPath).toBe("/workspace/old-name.ts")
+    // The regression: the old code wrote hunk.oldText as the WHOLE file,
+    // destroying line1/line3/line4.
+    expect(files.get("/workspace/old-name.ts")?.content).toBe("line1\nORIGINAL\nline3\nline4\n")
+  })
+
+  it("Undo: a later hunk applies its content revert after an earlier hunk already renamed the file back", async () => {
+    files.set("/workspace/old-name.ts", { content: "line1\nEDITED\nline3\n" })
+    const patch = "@@ -2,1 +2,1 @@\n-ORIGINAL\n+EDITED"
+    const { change, hunk } = makeChange({
+      path: "new-name.ts",
+      kind: "moved",
+      patch,
+      oldPath: "old-name.ts",
+    })
+    const outcome = await reviewHunk(change, hunk, "rejected", { silent: true })
+    expect(outcome.status).toBe("applied")
+    expect(renames).toHaveLength(0)
+    expect(files.get("/workspace/old-name.ts")?.content).toBe("line1\nORIGINAL\nline3\n")
+  })
+})
+
 describe("reviewAllForPath: multi-tool turn", () => {
   // `applyEdit` in the shared mock just returns `true`; for these tests we need
   // it to actually mutate the on-disk file map so chained undos see the


### PR DESCRIPTION
## Summary

- `undoMove` renamed the file back and then overwrote the ENTIRE file with `hunk.oldText` — one hunk's fragment, not the original content. Undoing a hunk of a move-with-edits truncated the file to that fragment (data loss).
- It now reverts only the hunk via the same line-anchored ranged replace as `undoUpdate`, delegating after the rename step.
- Sequential per-hunk undo for moves also works now: if an earlier hunk already renamed the file back, a later hunk's undo applies its content revert at the restored path instead of failing with "missing".

## Test plan

- [x] `bun run test` — 973 passed (2 new regression tests: content preservation outside the hunk, second-hunk undo after rename)
- [x] `bun run check-types` — clean

Closes #320