### PR TITLE
fix(mentions): resolve @file mentions across all workspace folders

### DIFF
--- a/src/chat/prompt-builder.ts
+++ b/src/chat/prompt-builder.ts
@@ -5,6 +5,7 @@ import type { ChatMessage } from "../protocol"
 import type { WorkspaceRoot } from "../workspace-root"
 import type { PromptContextBlock } from "../workspace-context/types"
 import { log } from "../output"
+import { stripWorkspaceFolderPrefix } from "./paths"
 
 export const DEFAULT_MENTION_MAX_BYTES = 200_000
 export const DEFAULT_CONVERSATION_MAX_BYTES = 100_000
@@ -83,8 +84,8 @@ export async function readMentions(
   if (!mentions || mentions.length === 0) {
     return { bytes: {}, capped: [], failed: [] }
   }
-  const folder = vscode.workspace.workspaceFolders?.[0]
-  if (!folder) return { bytes: {}, capped: [], failed: [] }
+  const folders = vscode.workspace.workspaceFolders ?? []
+  if (!folders.length) return { bytes: {}, capped: [], failed: [] }
   const seen = new Set<string>()
   const blocks: string[] = []
   const bytes: Record<string, { included: number; original: number }> = {}
@@ -98,9 +99,8 @@ export async function readMentions(
       capped.push(rel)
       continue
     }
-    const uri = path.isAbsolute(rel) ? vscode.Uri.file(rel) : vscode.Uri.joinPath(folder.uri, rel)
     try {
-      const buf = await vscode.workspace.fs.readFile(uri)
+      const buf = await readFirstCandidate(rel, folders)
       const remaining = maxBytes - totalBytes
       if (remaining <= 0) {
         capped.push(rel)
@@ -121,6 +121,39 @@ export async function readMentions(
   }
   const block = blocks.length > 0 ? ["Files attached:", ...blocks].join("\n") : undefined
   return { block, bytes, capped, failed }
+}
+
+/**
+ * Resolve a mention path against every workspace folder and return the first
+ * readable file. Exact paths are tried before folder-name-stripped variants:
+ * in multi-root workspaces `asRelativePath` (the source of picker paths)
+ * prefixes the owning folder's name, so `folderB/src/x.ts` must resolve
+ * inside folder B — but a real subdirectory that happens to share the folder
+ * name must still win.
+ */
+async function readFirstCandidate(
+  rel: string,
+  folders: readonly vscode.WorkspaceFolder[],
+): Promise<Uint8Array> {
+  const candidates: vscode.Uri[] = []
+  if (path.isAbsolute(rel)) {
+    candidates.push(vscode.Uri.file(rel))
+  } else {
+    for (const folder of folders) candidates.push(vscode.Uri.joinPath(folder.uri, rel))
+    for (const folder of folders) {
+      const stripped = stripWorkspaceFolderPrefix(folder.uri.fsPath, rel)
+      if (stripped) candidates.push(vscode.Uri.joinPath(folder.uri, stripped))
+    }
+  }
+  let lastError: unknown
+  for (const uri of candidates) {
+    try {
+      return await vscode.workspace.fs.readFile(uri)
+    } catch (e) {
+      lastError = e
+    }
+  }
+  throw lastError ?? new Error(`no candidate for ${rel}`)
 }
 
 export type ConversationMentionResult = {

--- a/test/host/build-prompt.test.ts
+++ b/test/host/build-prompt.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest"
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import * as vscode from "vscode"
 import { buildPrompt, readMentions } from "../../src/chat/prompt-builder"
 import type { WorkspaceRoot } from "../../src/workspace-root"
@@ -131,5 +131,65 @@ describe("readMentions", () => {
     )
     const out = await readMentions(["styles.css"])
     expect(out.block).toContain("```css")
+  })
+})
+
+describe("readMentions: multi-root workspaces", () => {
+  // asRelativePath prefixes the owning folder's name in multi-root setups,
+  // so a mention arrives as "folderB/src/x.ts". The old code resolved it
+  // against folder 0 only → /workspace/folderB/src/x.ts → ENOENT, and the
+  // file silently never reached the prompt.
+  const original = vscode.workspace.workspaceFolders
+
+  beforeEach(() => {
+    vi.mocked(vscode.workspace.fs.readFile).mockReset()
+    ;(vscode.workspace as { workspaceFolders: unknown }).workspaceFolders = [
+      { uri: vscode.Uri.file("/repos/folderA"), name: "folderA", index: 0 },
+      { uri: vscode.Uri.file("/repos/folderB"), name: "folderB", index: 1 },
+    ]
+  })
+
+  afterEach(() => {
+    ;(vscode.workspace as { workspaceFolders: unknown }).workspaceFolders = original
+  })
+
+  it("resolves a folder-prefixed mention inside the owning folder", async () => {
+    const attempted: string[] = []
+    vi.mocked(vscode.workspace.fs.readFile).mockImplementation(async (uri: vscode.Uri) => {
+      attempted.push(uri.fsPath)
+      if (uri.fsPath === "/repos/folderB/src/x.ts") {
+        return new TextEncoder().encode("const b = 2\n")
+      }
+      throw new Error("ENOENT")
+    })
+    const out = await readMentions(["folderB/src/x.ts"])
+    expect(out.failed).toEqual([])
+    expect(out.block).toContain("@folderB/src/x.ts")
+    expect(out.block).toContain("const b = 2")
+    expect(attempted).toContain("/repos/folderB/src/x.ts")
+  })
+
+  it("prefers the exact path over the folder-name-stripped variant", async () => {
+    // folderA really contains a subdirectory named folderA — the exact path
+    // must win over stripping the prefix.
+    vi.mocked(vscode.workspace.fs.readFile).mockImplementation(async (uri: vscode.Uri) => {
+      if (uri.fsPath === "/repos/folderA/folderA/x.ts") {
+        return new TextEncoder().encode("nested")
+      }
+      if (uri.fsPath === "/repos/folderA/x.ts") {
+        return new TextEncoder().encode("stripped")
+      }
+      throw new Error("ENOENT")
+    })
+    const out = await readMentions(["folderA/x.ts"])
+    expect(out.block).toContain("nested")
+    expect(out.block).not.toContain("stripped")
+  })
+
+  it("records the mention as failed when no folder has the file", async () => {
+    vi.mocked(vscode.workspace.fs.readFile).mockRejectedValue(new Error("ENOENT"))
+    const out = await readMentions(["folderB/missing.ts"])
+    expect(out.failed).toEqual(["folderB/missing.ts"])
+    expect(out.block).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

- In multi-root workspaces, every relative `@file` mention failed to read: `asRelativePath` prefixes the owning folder's name (`folderB/src/x.ts`), but `readMentions` resolved only against `workspaceFolders[0]`, producing `/repos/folderA/folderB/src/x.ts` → ENOENT → the file content silently never reached the prompt.
- `readMentions` now tries the exact relative path under every workspace folder first, then the folder-name-stripped variant per folder (same approach as `workspaceFileUriCandidates` in fs-ops). Exact-before-stripped keeps a real subdirectory that shares the folder's name winning over the stripped variant.
- Single-root behavior is unchanged (one candidate, identical read-call counts — existing tests pass unmodified).

## Test plan

- [x] `bun run test` — 979 passed (3 new multi-root tests: owning-folder resolution, exact-over-stripped preference, all-fail → `failed`)
- [x] `bun run check-types` — clean
- [ ] Manual: open a multi-root workspace, mention a file from the second folder, verify content lands in the prompt (needs live opencode)

Closes #322