### PR TITLE
fix(server): recover from opencode crashes and SSE stream loss

### DIFF
--- a/src/chat/stream.ts
+++ b/src/chat/stream.ts
@@ -88,6 +88,14 @@ export type StreamHandlers = {
   onSessionIdle?: () => void
   onSessionBusy?: () => void
   /**
+   * Fired exactly once when the SSE connection ends for any reason other
+   * than a deliberate `Subscription.abort()` — transport error or the server
+   * closing the stream (e.g. the opencode process died). After this fires no
+   * further events will arrive on this subscription; the owner must drop it
+   * and re-subscribe to keep receiving events.
+   */
+  onStreamClosed?: (reason: "error" | "ended") => void
+  /**
    * Optional second routing branch for child (subagent) sessions. The
    * SSE stream is process-wide (`client.global.event()` returns every
    * session's events), so we can listen for child-session lifecycle
@@ -256,11 +264,15 @@ export function subscribeSession(
         if (!payload?.type) continue
         route(payload.type, payload.properties)
       }
+      if (controller.signal.aborted || stopped) return
+      log(`[sse] stream ended for session ${sessionID}`)
+      handlers.onStreamClosed?.("ended")
     } catch (e) {
-      if (controller.signal.aborted) return
+      if (controller.signal.aborted || stopped) return
       log("event stream error", e)
       handlers.onSessionError?.((e as Error).message)
       readyReject(e)
+      handlers.onStreamClosed?.("error")
     }
   })()
 

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -107,6 +107,8 @@ export class ChatView implements vscode.WebviewViewProvider {
   /** Background re-sweeps after a Stop, to catch late orchestrator dispatches. */
   private static readonly ABORT_DRAIN_PASSES = 6
   private static readonly ABORT_DRAIN_INTERVAL_MS = 1000
+  /** Minimum gap between automatic SSE re-attach attempts after stream loss. */
+  private static readonly STREAM_REATTACH_MIN_MS = 10_000
   /**
    * "This turn isn't done yet" defer for opencode/omo continuations.
    * Owns its own timer + signal gating; see {@link ContinuationState}
@@ -1184,11 +1186,23 @@ export class ChatView implements vscode.WebviewViewProvider {
       })
       if (res.error) {
         log("prompt failed", res.error)
+        this.failSend("opencode rejected the prompt; see the output log for details.")
       }
     } catch (e) {
       log("prompt call threw", e)
+      this.failSend((e as Error).message || "Could not reach the opencode server.")
     }
-    // No UI action here — the SSE subscription owns assistant lifecycle.
+    // No further UI action here — the SSE subscription owns assistant lifecycle.
+  }
+
+  /**
+   * A send that never reached opencode produces no SSE events, so nothing
+   * would ever clear the webview's `busy` — unstick it explicitly and tell
+   * the user instead of failing silently into a permanent "Working…".
+   */
+  private failSend(message: string) {
+    this.post({ type: "sessionIdle" })
+    this.surfaceToast({ variant: "error", title: "Send failed", message })
   }
 
   /**
@@ -1271,11 +1285,15 @@ export class ChatView implements vscode.WebviewViewProvider {
         query: { directory: backend.directory },
         body,
       })
-      if (res.error) log("command failed", res.error)
+      if (res.error) {
+        log("command failed", res.error)
+        this.failSend("opencode rejected the command; see the output log for details.")
+      }
     } catch (e) {
       log("command call threw", e)
+      this.failSend((e as Error).message || "Could not reach the opencode server.")
     }
-    // No UI action here — the SSE subscription owns assistant lifecycle.
+    // No further UI action here — the SSE subscription owns assistant lifecycle.
   }
 
   /**
@@ -1634,6 +1652,31 @@ export class ChatView implements vscode.WebviewViewProvider {
     await this.handleSend(trimmed, mentions, attachments, conversationMentions)
   }
 
+  private lastStreamReattachAt = 0
+
+  /**
+   * Best-effort re-subscribe after the SSE stream died. Throttled so a server
+   * that crashes immediately on every boot can't drive a respawn loop —
+   * outside the window the next user action re-attaches lazily instead.
+   */
+  private async reattachAfterStreamLoss() {
+    if (!this.sessionID) return
+    const now = Date.now()
+    if (now - this.lastStreamReattachAt < ChatView.STREAM_REATTACH_MIN_MS) {
+      log("[sse] re-attach throttled; will reconnect on next action")
+      return
+    }
+    this.lastStreamReattachAt = now
+    try {
+      const backend = await this.servers.ensure()
+      if (!this.sessionID || this.subscription) return
+      await this.attachSubscription(backend, this.sessionID)
+      log("[sse] re-attached after stream loss")
+    } catch (e) {
+      log("[sse] re-attach failed; will reconnect on next action", e)
+    }
+  }
+
   private async attachSubscription(backend: Backend, sessionID: string) {
     this.subscription?.abort()
     const subscription = subscribeSession(backend, sessionID, {
@@ -1819,6 +1862,20 @@ export class ChatView implements vscode.WebviewViewProvider {
         subscription.addChildSession(info.id)
         if (!this.subagentTracker) return
         void this.subagentTracker.registerChildSession(info)
+      },
+      onStreamClosed: (reason) => {
+        // No further events will arrive on this subscription. Drop it so the
+        // `!this.subscription` re-attach checks work again (a dead-but-truthy
+        // subscription used to block reconnection forever), unstick the
+        // composer, and try one throttled re-attach — `ensure()` respawns the
+        // server if the process died.
+        if (this.subscription !== subscription) return
+        log(`[sse] stream closed (${reason}); scheduling re-attach`)
+        this.subscription = undefined
+        this.aborting = false
+        this.continuationState.finishPending()
+        this.post({ type: "sessionIdle" })
+        void this.reattachAfterStreamLoss()
       },
     })
     this.subscription = subscription

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,8 @@ export type OpencodeConfigMode = "isolated" | "user"
 type ServerHandle = {
   url: string
   close(): void
+  /** Register a callback fired if the process exits AFTER successful startup. */
+  onExit(listener: () => void): void
 }
 
 export type Backend = {
@@ -80,6 +82,16 @@ export class ServerManager {
     this.client = client
     this.workspace = workspace
     this.configMode = configMode
+    server.onExit(() => {
+      // Only invalidate if this handle is still the active one — a crash
+      // notification from a server we already replaced (restart/dispose)
+      // must not clobber its successor.
+      if (this.server !== server) return
+      log("opencode server exited unexpectedly; clearing cached backend")
+      this.server = undefined
+      this.client = undefined
+      this.workspace = undefined
+    })
     return this.toBackend(server, client)
   }
 
@@ -148,7 +160,7 @@ function bundledBinaryPath(extensionPath: string): string | undefined {
   }
 }
 
-function startOpencodeServer(
+export function startOpencodeServer(
   binaryPath: string,
   options: {
     hostname: string
@@ -177,6 +189,8 @@ function startOpencodeServer(
   return new Promise((resolve, reject) => {
     let output = ""
     let settled = false
+    let started = false
+    const exitListeners: Array<() => void> = []
     const timer = setTimeout(() => {
       if (settled) return
       settled = true
@@ -203,10 +217,12 @@ function startOpencodeServer(
           return
         }
         settled = true
+        started = true
         clearTimeout(timer)
         resolve({
           url: match[1],
           close: () => closeProcess(proc),
+          onExit: (listener) => exitListeners.push(listener),
         })
         return
       }
@@ -217,8 +233,13 @@ function startOpencodeServer(
     })
     proc.on("error", fail)
     proc.on("exit", (code) => {
-      if (settled) return
-      fail(new Error(`Server exited with code ${code}${formatServerOutput(output)}`))
+      if (!settled) {
+        fail(new Error(`Server exited with code ${code}${formatServerOutput(output)}`))
+        return
+      }
+      if (!started) return
+      log(`opencode server process exited (code ${code})`)
+      for (const listener of exitListeners) listener()
     })
   })
 }

--- a/test/host/e2e-mock-opencode.test.ts
+++ b/test/host/e2e-mock-opencode.test.ts
@@ -644,3 +644,36 @@ describe("E2E (mock opencode): child session routing", () => {
     expect(parentIdleCount).toBe(0)
   })
 })
+
+describe("E2E (mock opencode): stream loss detection", () => {
+  it("fires onStreamClosed when the server ends the SSE stream", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const closed: string[] = []
+    const subscription = subscribeSession({ url: server.url, client, directory: "/tmp" }, "ses_test", {
+      onAssistantStart: () => {},
+      onStreamClosed: (reason) => closed.push(reason),
+    })
+    await subscription.ready
+    await server.awaitClient()
+    await server.close()
+    await new Promise((r) => setTimeout(r, 100))
+    // Regression: a dead-but-truthy subscription used to block all
+    // re-attach checks; the owner now learns the stream is gone.
+    expect(closed).toHaveLength(1)
+    subscription.abort()
+  })
+
+  it("does NOT fire onStreamClosed on deliberate abort", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const closed: string[] = []
+    const subscription = subscribeSession({ url: server.url, client, directory: "/tmp" }, "ses_test", {
+      onAssistantStart: () => {},
+      onStreamClosed: (reason) => closed.push(reason),
+    })
+    await subscription.ready
+    await server.awaitClient()
+    subscription.abort()
+    await new Promise((r) => setTimeout(r, 100))
+    expect(closed).toHaveLength(0)
+  })
+})

--- a/test/host/server-handle.test.ts
+++ b/test/host/server-handle.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest"
+import { mkdtempSync, writeFileSync, chmodSync } from "fs"
+import { tmpdir } from "os"
+import { join } from "path"
+import { startOpencodeServer } from "../../src/server"
+
+// A stand-in opencode binary: announces readiness like the real server, then
+// exits shortly after — letting us observe the post-startup exit notification
+// without a real opencode install.
+function fakeBinary(script: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "opencui-fake-opencode-"))
+  const file = join(dir, "opencode")
+  writeFileSync(file, `#!/bin/sh\n${script}\n`)
+  chmodSync(file, 0o755)
+  return file
+}
+
+describe("startOpencodeServer exit notification", () => {
+  it("notifies onExit listeners when the process dies AFTER startup", async () => {
+    const bin = fakeBinary('echo "opencode server listening on http://127.0.0.1:43210"\nsleep 0.2')
+    const handle = await startOpencodeServer(bin, {
+      hostname: "127.0.0.1",
+      port: 43210,
+      timeout: 5000,
+      configMode: "isolated",
+    })
+    expect(handle.url).toBe("http://127.0.0.1:43210")
+    let exits = 0
+    handle.onExit(() => exits++)
+    await new Promise((r) => setTimeout(r, 600))
+    // Regression: the old exit handler returned early once `settled`, so a
+    // post-startup crash was invisible and ensure() served the dead backend.
+    expect(exits).toBe(1)
+  })
+
+  it("rejects (and does not notify) when the process dies BEFORE startup", async () => {
+    const bin = fakeBinary("exit 7")
+    await expect(
+      startOpencodeServer(bin, {
+        hostname: "127.0.0.1",
+        port: 43211,
+        timeout: 5000,
+        configMode: "isolated",
+      }),
+    ).rejects.toThrow(/exited with code 7/)
+  })
+})


### PR DESCRIPTION
## Summary

- **Stale backend**: `startOpencodeServer`'s exit handler returned early once `settled`, so a post-startup crash was invisible — `ServerManager.ensure()` returned the dead backend forever. The handle now exposes `onExit` and the manager invalidates its cache (guarded so a replaced server's late exit can't clobber its successor).
- **Dead subscription**: on SSE error the stream loop ended, but `ChatView.subscription` stayed truthy, so every `!this.subscription` re-attach check was skipped permanently. `subscribeSession` now fires `onStreamClosed` on any non-deliberate stream termination; the view clears the subscription, unsticks the composer, and attempts a throttled (10s) re-attach via `ensure()` — which now respawns a crashed server. Outside the throttle window the next user action re-attaches lazily.
- **Permanent "Working…"**: a `promptAsync` / `session.command` failure was only logged while the webview held `busy: true` forever. Failures now post `sessionIdle` and surface an error toast.

## Test plan

- [x] `bun run test` — 980 passed (4 new: stream-end fires `onStreamClosed`, deliberate abort does not, post-startup exit notifies `onExit` via a fake binary subprocess, pre-startup exit still rejects)
- [x] `bun run check-types` — clean
- [ ] Manual: `kill -9` the opencode process mid-conversation; verify the panel reconnects and the next prompt works (needs live opencode)

Closes #324