### PR TITLE
fix(webview): dismiss open QuestionDialog on conversation switch

### DIFF
--- a/test/webview/question-flow.test.ts
+++ b/test/webview/question-flow.test.ts
@@ -51,4 +51,21 @@ describe("reducer — question flow", () => {
     const closed = reducer(opened, { type: "clearQuestion", id: "que_1" })
     expect(closed.pendingQuestion).toBeUndefined()
   })
+
+  it("restore (conversation switch) dismisses an open question, like pendingPermission", () => {
+    const opened = reducer(initialChatState, {
+      type: "question",
+      id: "que_1",
+      questions: [question],
+    })
+    const switched = reducer(opened, {
+      type: "restore",
+      conversationID: "conv_b",
+      messages: [],
+    })
+    // The host already dropped the old session's activeQuestions without
+    // posting questionResolved — without this clear, A's dialog renders
+    // forever in conversation B.
+    expect(switched.pendingQuestion).toBeUndefined()
+  })
 })

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -181,6 +181,10 @@ export function reducer(state: ChatState, action: Action): ChatState {
         messages: action.messages,
         reviewHunks: action.reviewHunks ?? {},
         pendingPermission: undefined,
+        // The host drops the old session's activeQuestions without posting
+        // questionResolved on switch, so a question left open here would
+        // render forever in the new conversation's dock.
+        pendingQuestion: undefined,
         injectedText: undefined,
       }
     case "context":


### PR DESCRIPTION
## Summary

- `restore` (posted on conversation switch) reset `pendingPermission` but not `pendingQuestion`. Host-side `resetSessionState` clears `activeQuestions` without any `questionResolved` post and tears down the old SSE subscription, so nothing else could ever dismiss the dialog — conversation A's question stayed rendered in conversation B, and replying hit a dropped id.
- `restore` now clears `pendingQuestion` alongside `pendingPermission`.

## Test plan

- [x] `bun run test` — 981 passed (1 new reducer regression test)
- [x] `bun run check-types` — clean

Closes #326