### PR TITLE
fix(chat): let terminal tool closures and patches through the abort gate

### DIFF
--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -1726,7 +1726,12 @@ export class ChatView implements vscode.WebviewViewProvider {
         this.post({ type: "reasoningDelta", id: webviewID, delta })
       },
       onTool: (mid, update) => {
-        if (this.aborting) return
+        // While aborting, drop in-flight churn but let TERMINAL closures
+        // through: a tool that finished (or errored) before the abort
+        // propagated must not persist as "running" forever. Only for
+        // messages we already know — never mint a new bubble mid-abort.
+        const terminal = update.status === "completed" || update.status === "error"
+        if (this.aborting && (!terminal || !this.messageMap.has(mid))) return
         // Forward to the subagent tracker FIRST so the store is
         // up-to-date before any downstream consumer (continuation gate,
         // popover snapshot) reads from it. `forwardToolForSubagentTracking`
@@ -1738,7 +1743,9 @@ export class ChatView implements vscode.WebviewViewProvider {
         this.post({ type: "tool", id: webviewID, update: wire })
       },
       onPatch: (mid, files, diff) => {
-        if (this.aborting) return
+        // Patches describe disk mutations that ALREADY happened — dropping
+        // them while aborting just hides real changes from the Review panel.
+        if (this.aborting && !this.messageMap.has(mid)) return
         const webviewID = this.messageMap.get(mid) ?? this.ensureWebviewID(mid)
         this.post({
           type: "patch",

--- a/test/webview/abort-flow.test.ts
+++ b/test/webview/abort-flow.test.ts
@@ -41,7 +41,7 @@ describe("reducer abort flow", () => {
     expect(msg.blocks.find((b) => b.type === "text" && b.text.includes("leftover"))).toBeUndefined()
   })
 
-  it("reasoningDelta / tool / patch during aborting are also dropped", () => {
+  it("reasoningDelta / non-terminal tool during aborting are also dropped", () => {
     const before = pendingAssistant()
     const aborted = reducer(before, { type: "aborted" })
     const after1 = reducer(aborted, { type: "reasoningDelta", id: "a1", delta: "x" })
@@ -52,8 +52,30 @@ describe("reducer abort flow", () => {
       update: { callID: "c1", tool: "read", status: "running" },
     })
     expect(after2).toBe(aborted)
-    const after3 = reducer(aborted, { type: "patch", id: "a1", files: ["foo.ts"], diff: "@@" })
-    expect(after3).toBe(aborted)
+  })
+
+  it("terminal tool closure during aborting IS applied (no perpetual 'running' block)", () => {
+    const before = reducer(pendingAssistant(), {
+      type: "tool",
+      id: "a1",
+      update: { callID: "c1", tool: "read", status: "running" },
+    })
+    const aborted = reducer(before, { type: "aborted" })
+    const after = reducer(aborted, {
+      type: "tool",
+      id: "a1",
+      update: { callID: "c1", tool: "read", status: "completed" },
+    })
+    const msg = after.messages.find((m) => m.id === "a1")!
+    const tool = msg.blocks.find((b) => b.type === "tool")
+    expect(tool?.type === "tool" && tool.update.status).toBe("completed")
+  })
+
+  it("patch during aborting IS applied (the disk mutation already happened)", () => {
+    const aborted = reducer(pendingAssistant(), { type: "aborted" })
+    const after = reducer(aborted, { type: "patch", id: "a1", files: ["foo.ts"], diff: "@@" })
+    const msg = after.messages.find((m) => m.id === "a1")!
+    expect(msg.blocks.find((b) => b.type === "patch")).toBeDefined()
   })
 
   it("textDelta when NOT aborting still appends normally (control test)", () => {

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -258,10 +258,20 @@ export function reducer(state: ChatState, action: Action): ChatState {
         messages: appendToLastBlock(state.messages, action.id, "reasoning", action.delta),
       }
     case "tool":
-      if (state.aborting) return state
+      // Drop in-flight churn while aborting, but apply TERMINAL closures —
+      // a tool that finished before the abort propagated must not render
+      // as "running" forever (mirrors the host-side gate).
+      if (
+        state.aborting &&
+        action.update.status !== "completed" &&
+        action.update.status !== "error"
+      ) {
+        return state
+      }
       return { ...state, messages: upsertTool(state.messages, action.id, action.update, action.actor) }
     case "patch":
-      if (state.aborting) return state
+      // Patches describe disk mutations that already happened; hiding them
+      // while aborting only desyncs the Review panel from reality.
       return {
         ...state,
         messages: state.messages.map((m) =>


### PR DESCRIPTION
## Summary

- A tool in flight at Stop never received its `completed`/`error` closure: host `onTool`/`onPatch` and the reducer's `tool`/`patch` cases dropped everything while `aborting`. The closure is also what gets persisted, so the tool block stayed `running` forever — including after window reload. Patches (real disk mutations) were hidden from the Review panel.
- Terminal tool updates and patch events now pass the abort gate on both host and reducer. Non-terminal tool churn and text/reasoning deltas stay dropped. Neither side mints a new assistant bubble mid-abort (host forwards only for known message IDs).
- CLAUDE.md self-contradicted ("drops tool/patch events. tool and patch are intentionally NOT dropped"); the abort-state paragraph now describes the implemented behavior. Also removed the stale `escapeHtml` reference (no such helper exists in `paths.ts`).

## Test plan

- [x] `bun run test` — 983 passed (terminal-closure-applied and patch-applied regression tests added; the old "tool/patch dropped" assertion narrowed to non-terminal updates)
- [x] `bun run check-types` — clean

Closes #328