### PR TITLE
fix(chat): gate permission/question events while aborting

### DIFF
--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -1755,6 +1755,10 @@ export class ChatView implements vscode.WebviewViewProvider {
         })
       },
       onPermissionNeeded: (perm) => {
+        // Same ignore-while-aborting gate as the other non-terminal events:
+        // a permission raised mid-Stop targets a session being torn down,
+        // and no resolution event exists that would ever clear the dialog.
+        if (this.aborting) return
         this.activePermissions.set(perm.id, perm)
         this.post({
           type: "permission",
@@ -1764,6 +1768,7 @@ export class ChatView implements vscode.WebviewViewProvider {
         })
       },
       onQuestionAsked: (q) => {
+        if (this.aborting) return
         this.activeQuestions.set(q.id, q)
         this.post({
           type: "question",

--- a/test/webview/abort-flow.test.ts
+++ b/test/webview/abort-flow.test.ts
@@ -104,6 +104,29 @@ describe("reducer abort flow", () => {
     expect(after.pendingPermission).toBeUndefined()
   })
 
+  it("aborted also clears a pending question", () => {
+    const withQuestion = reducer(pendingAssistant(), {
+      type: "question",
+      id: "q1",
+      questions: [{ question: "Pick", header: "Pick", options: [{ label: "A", description: "a" }] }],
+    })
+    expect(withQuestion.pendingQuestion?.id).toBe("q1")
+    const after = reducer(withQuestion, { type: "aborted" })
+    expect(after.pendingQuestion).toBeUndefined()
+  })
+
+  it("permission / question racing in DURING aborting are dropped (nothing could ever clear them)", () => {
+    const aborted = reducer(pendingAssistant(), { type: "aborted" })
+    const withPerm = reducer(aborted, { type: "permission", id: "p_late", title: "Allow?" })
+    expect(withPerm).toBe(aborted)
+    const withQuestion = reducer(aborted, {
+      type: "question",
+      id: "q_late",
+      questions: [{ question: "Pick", header: "Pick", options: [{ label: "A", description: "a" }] }],
+    })
+    expect(withQuestion).toBe(aborted)
+  })
+
   it("assistantError on an already-stopped message is suppressed (no red block)", () => {
     const before = pendingAssistant("a1")
     const aborted = reducer(before, { type: "aborted" })

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -318,6 +318,7 @@ export function reducer(state: ChatState, action: Action): ChatState {
         busy: true,
         aborting: true,
         pendingPermission: undefined,
+        pendingQuestion: undefined,
         messages: state.messages.map((m, i) => {
           if (m.role !== "assistant" || !m.pending) return m
           if (i === lastPendingIdx) return { ...m, pending: false, stopped: true }
@@ -343,6 +344,10 @@ export function reducer(state: ChatState, action: Action): ChatState {
     case "continuationPending":
       return { ...state, continuationPending: action.pending }
     case "permission":
+      // Ignore-while-aborting, like the other non-terminal events: there is
+      // no permission-resolved wire event, so a dialog raised mid-Stop could
+      // never be cleared once the session dies.
+      if (state.aborting) return state
       return {
         ...state,
         pendingPermission: { id: action.id, title: action.title, pattern: action.pattern },
@@ -350,6 +355,7 @@ export function reducer(state: ChatState, action: Action): ChatState {
     case "clearPermission":
       return { ...state, pendingPermission: undefined }
     case "question":
+      if (state.aborting) return state
       return {
         ...state,
         pendingQuestion: { id: action.id, questions: action.questions },


### PR DESCRIPTION
## Summary

- `permission.updated` / `question.asked` events were the only session events NOT gated on `aborting` (host and reducer), violating the repo rule that non-terminal events fall under the ignore-while-aborting gate. A permission racing in just after Stop set `pendingPermission` during the abort drain, and with no permission-resolved wire event the dead session's dialog could never be dismissed.
- Host now drops both while `this.aborting` (and doesn't register them in `activePermissions`/`activeQuestions`); reducer drops both while `state.aborting`; `aborted` clears `pendingQuestion` alongside `pendingPermission`.

## Test plan

- [x] `bun run test` — 985 passed (2 new reducer regression tests)
- [x] `bun run check-types` — clean

Closes #330