### PR TITLE
fix(webview): block Enter-submit while the composer is in Stopping state

### DIFF
--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -104,6 +104,19 @@ describe("PromptBox", () => {
     expect(textarea.value).toBe("")
   })
 
+  it("Enter does NOT submit while aborting, matching the disabled Stopping… button", async () => {
+    const user = userEvent.setup()
+    const onSend = vi.fn()
+    // During the abort drain, assistantDone can clear busy while aborting is
+    // still true — Enter used to slip through and race the in-flight abort.
+    render(<PromptBox busy={false} aborting={true} onSend={onSend} onAbort={vi.fn()} />)
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    await user.type(textarea, "too eager")
+    await user.keyboard("{Enter}")
+    expect(onSend).not.toHaveBeenCalled()
+    expect(textarea.value).toBe("too eager")
+  })
+
   it("Shift+Enter inserts a newline instead of submitting", async () => {
     const user = userEvent.setup()
     const onSend = vi.fn()

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -133,6 +133,10 @@ function extractConversationLabels(text: string | undefined): string[] {
 
 export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles, listDir, attachFile, initial, variant = "send", position = "bottom", conversations, activeConversationID, onOpenConversation, contextUsage, commands = [], onRunCommand, inject }: Props) {
   const { text, setText, ref, backdropRef, pendingCursor } = usePromptText(initial?.text ?? "")
+  // The Send button renders a disabled "Stopping…" while aborting, but Enter
+  // routes through submit() — both must honor the same block, or a prompt
+  // races the in-flight abort and gets its early events dropped.
+  const sendBlocked = busy || aborting
   const [selectedChipStart, setSelectedChipStart] = useState<number | undefined>(undefined)
   const [attachError, setAttachError] = useState<string | undefined>(undefined)
   const [attaching, setAttaching] = useState(false)
@@ -278,8 +282,8 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
   }
 
   const runCommandAndClear = (command: string, args: string) => {
-    // Respect busy on the picker-run path too (submit already guards busy).
-    if (busy || !onRunCommand) return
+    // Respect busy/aborting on the picker-run path too (submit guards both).
+    if (sendBlocked || !onRunCommand) return
     onRunCommand(command, args)
     clearComposer()
   }
@@ -299,7 +303,7 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
     // Route a typed `/name args` to the command path when the name matches a
     // known command. Unknown slashes (and prose like `/etc/hosts`) fall through
     // to a normal prompt send. Edit composers never route (no onRunCommand).
-    if (variant === "send" && !busy && onRunCommand) {
+    if (variant === "send" && !sendBlocked && onRunCommand) {
       const parsed = parseCommandInput(trimmed)
       if (parsed && commands.some((c) => c.name === parsed.name)) {
         runCommandAndClear(parsed.name, parsed.args)
@@ -318,7 +322,7 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
     // so display order in the bubble matches input order: chip-cited
     // files first, pasted images second.
     for (const a of imageAttachments) activeAttachments.push(a)
-    if ((!trimmed && activeAttachments.length === 0) || busy) return
+    if ((!trimmed && activeAttachments.length === 0) || sendBlocked) return
     const allMentions = extractMentions(text, knownMentions.current)
     const fileMentions = allMentions.filter((m) => !knownConversations.current.has(m))
     const convIDs = allMentions


### PR DESCRIPTION
## Summary

- During an abort, `assistantDone` (not gated on `aborting`) sets `busy: false` while `aborting` is still true. The Send button correctly shows a disabled "Stopping…", but `PromptBox.submit` and both slash-command run paths guarded only `busy` — Enter still submitted, racing the in-flight abort: the new turn's early deltas were dropped host-side and the stale `session.idle`'s `wasAborting` branch cancelled the new turn's Main task row.
- All three send paths now share a `sendBlocked = busy || aborting` guard, matching the button.

## Test plan

- [x] `bun run test` — 986 passed (1 new component test: Enter ignored with `busy=false, aborting=true`)
- [x] `bun run check-types` — clean

Closes #332