### PR TITLE
fix(chat): keep legacy active-conversation pointer through migration

### DIFF
--- a/src/chat/conversation-store.ts
+++ b/src/chat/conversation-store.ts
@@ -29,9 +29,17 @@ export async function migrateConversationsToWorkspace(context: vscode.ExtensionC
   if (context.workspaceState.get<boolean>(MIGRATED_TO_WORKSPACE_KEY, false)) return
   const legacy = context.globalState.get<SavedConversation[]>(CONVERSATIONS_KEY)
   if (legacy && legacy.length) {
-    await context.workspaceState.update(CONVERSATIONS_KEY, legacy)
     const legacyActive = context.globalState.get<string>(ACTIVE_CONVERSATION_KEY)
-    if (legacyActive) await context.workspaceState.update(ACTIVE_CONVERSATION_KEY, legacyActive)
+    // Issue BOTH workspaceState writes before the first await: the caller
+    // constructs ConversationManager (which reads both keys synchronously)
+    // without awaiting this function, and only the synchronous cache write
+    // of an update that has already STARTED is visible to it. Awaiting the
+    // conversations write before starting the active-pointer write meant the
+    // manager fell back to conversations[0] and persisted that over the
+    // legacy pointer — with globalState already cleared, unrecoverably.
+    const writes = [context.workspaceState.update(CONVERSATIONS_KEY, legacy)]
+    if (legacyActive) writes.push(context.workspaceState.update(ACTIVE_CONVERSATION_KEY, legacyActive))
+    await Promise.all(writes)
     await context.globalState.update(CONVERSATIONS_KEY, undefined)
     await context.globalState.update(ACTIVE_CONVERSATION_KEY, undefined)
   }

--- a/test/host/migrate-conversations.test.ts
+++ b/test/host/migrate-conversations.test.ts
@@ -74,6 +74,23 @@ describe("migrateConversationsToWorkspace", () => {
     expect(globalState.store.has("opencui.conversations")).toBe(false) // never had it
   })
 
+  it("makes BOTH keys visible to a synchronous read before the first await settles", () => {
+    // ChatView constructs ConversationManager (which synchronously reads both
+    // keys) immediately after calling the migration WITHOUT awaiting it.
+    // Memento.update populates its cache synchronously — but only for updates
+    // that have already started. The regression: the active-pointer write
+    // used to start only after the conversations write resolved, so the
+    // manager fell back to conversations[0] and clobbered the legacy pointer.
+    const { context, workspaceState } = fakeContext({
+      "opencui.conversations": [{ id: "c1" }, { id: "c2" }],
+      "opencui.activeConversation": "c2",
+    })
+    void migrateConversationsToWorkspace(context)
+    // Synchronous read, no await: both keys must already be in the cache.
+    expect(workspaceState.store.get("opencui.conversations")).toEqual([{ id: "c1" }, { id: "c2" }])
+    expect(workspaceState.store.get("opencui.activeConversation")).toBe("c2")
+  })
+
   it("leaves the migration flag unset when a data write rejects", async () => {
     const globalStore: Map<string, unknown> = new Map([["opencui.conversations", [{ id: "c1" }]]])
     const workspaceStore: Map<string, unknown> = new Map()


### PR DESCRIPTION
## Summary

- `migrateConversationsToWorkspace` awaited the `CONVERSATIONS_KEY` write before starting the `ACTIVE_CONVERSATION_KEY` write. `ConversationManager` (constructed immediately after the un-awaited migration call) reads both keys synchronously — it saw the migrated conversations but not the active pointer, fell back to `conversations[0].id`, and the subsequent `persist()` overwrote the legacy pointer. With globalState cleared by the migration, the value was unrecoverable.
- Both workspaceState writes now start before the first `await` (`Promise.all`), so `Memento.update`'s synchronous cache population covers the constructor's reads for both keys.

## Test plan

- [x] `bun run test` — 987 passed (1 new regression test: synchronous read of both keys immediately after the un-awaited call)
- [x] `bun run check-types` — clean

Closes #334