### PR TITLE
fix(review): anchor pure-deletion hunk undo after line N with separator newline

### DIFF
--- a/src/chat/diff.ts
+++ b/src/chat/diff.ts
@@ -240,6 +240,16 @@ export function findHunkInFile(
   current: string,
   hunk: Pick<ReviewDiffHunk, "newText" | "newStart" | "newCount" | "leadingContext" | "trailingContext">,
 ): { start: number; end: number } | undefined {
+  // Pure-deletion hunks (`+N,0`): per unified-diff convention the anchor is
+  // AFTER line N, so the restore point is the start of line N+1 — offset of
+  // line index N, not N-1. (N=0, deletion at the very top, yields offset 0.)
+  // Without this, the generic newStart-1 anchoring below matched the empty
+  // candidate one line too early.
+  if (hunk.newText === "" && hunk.newCount === 0) {
+    const offset = lineToByteOffset(current, hunk.newStart)
+    return { start: offset, end: offset }
+  }
+
   // Primary: line-anchored exact match. We try a few variants because opencode
   // and the editor may disagree on trailing-newline normalization.
   if (hunk.newStart > 0) {

--- a/src/chat/fs-ops.ts
+++ b/src/chat/fs-ops.ts
@@ -442,11 +442,20 @@ async function undoUpdate(
       silent,
     )
   }
+  // A zero-width match means we're re-inserting a deleted block at a line
+  // boundary. `hunk.oldText` is newline-JOINED (no trailing separator), so
+  // add the one the join dropped: trailing mid-file, leading when appending
+  // to a file that doesn't end in a newline.
+  let restored = hunk.oldText
+  if (located.start === located.end) {
+    if (located.start < current.length) restored = `${restored}\n`
+    else if (current.length > 0 && !current.endsWith("\n")) restored = `\n${restored}`
+  }
   const edit = new vscode.WorkspaceEdit()
   edit.replace(
     existing,
     new vscode.Range(doc.positionAt(located.start), doc.positionAt(located.end)),
-    hunk.oldText,
+    restored,
   )
   const ok = await vscode.workspace.applyEdit(edit)
   if (!ok) {

--- a/test/host/review-actions.test.ts
+++ b/test/host/review-actions.test.ts
@@ -267,6 +267,46 @@ describe("reviewHunk: moved files", () => {
   })
 })
 
+describe("reviewHunk: undo of context-free deletion hunks", () => {
+  beforeEach(() => {
+    ;(vscode.workspace.applyEdit as ReturnType<typeof vi.fn>).mockImplementation(
+      async (edit: unknown) => {
+        const ops = (edit as { edits?: Array<{ uri: vscode.Uri; range: vscode.Range; text: string }> }).edits
+        if (!ops) return true
+        for (const op of [...ops].reverse()) {
+          const entry = files.get(op.uri.fsPath)
+          if (!entry) continue
+          const start = offsetFromPosition(entry.content, op.range.start)
+          const end = offsetFromPosition(entry.content, op.range.end)
+          entry.content = entry.content.slice(0, start) + op.text + entry.content.slice(end)
+        }
+        return true
+      },
+    )
+  })
+
+  it("restores deleted lines at their original position with the separator newline", async () => {
+    // Original: line1..line5. opencode deleted line3+line4 (no context lines).
+    files.set("/workspace/a.ts", { content: "line1\nline2\nline5\n" })
+    const patch = "@@ -3,2 +2,0 @@\n-line3\n-line4"
+    const { change, hunk } = makeChange({ path: "a.ts", patch })
+    const outcome = await reviewHunk(change, hunk, "rejected", { silent: true })
+    expect(outcome.status).toBe("applied")
+    // Regression: the old anchor put the block one line early and glued it
+    // to the following line ("line1\nline3\nline4line2\n…").
+    expect(files.get("/workspace/a.ts")?.content).toBe("line1\nline2\nline3\nline4\nline5\n")
+  })
+
+  it("restores a deleted trailing block at EOF of a newline-terminated file", async () => {
+    files.set("/workspace/b.ts", { content: "line1\nline2\n" })
+    const patch = "@@ -3,1 +2,0 @@\n-line3"
+    const { change, hunk } = makeChange({ path: "b.ts", patch })
+    const outcome = await reviewHunk(change, hunk, "rejected", { silent: true })
+    expect(outcome.status).toBe("applied")
+    expect(files.get("/workspace/b.ts")?.content).toBe("line1\nline2\nline3")
+  })
+})
+
 describe("reviewHunk: moved files with edits", () => {
   // Mirror WorkspaceEdit.replace onto the in-memory file map so the content
   // revert is observable (the shared applyEdit mock just returns true).

--- a/test/host/review-undo.test.ts
+++ b/test/host/review-undo.test.ts
@@ -169,6 +169,33 @@ describe("findHunkInFile: safe location for repeated text blocks", () => {
     })
     expect(result).toBeDefined()
   })
+
+  it("anchors a pure-deletion hunk (+N,0) AFTER line N, not at line N", () => {
+    // line3/line4 were deleted after line2: `@@ -3,2 +2,0 @@`. The restore
+    // point is the start of line 3 — the old newStart-1 anchoring put it at
+    // the start of line 2, one line too early.
+    const file = "line1\nline2\nline5\n"
+    const result = findHunkInFile(file, {
+      newText: "",
+      newStart: 2,
+      newCount: 0,
+      leadingContext: [],
+      trailingContext: [],
+    })
+    expect(result).toEqual({ start: 12, end: 12 })
+  })
+
+  it("anchors a deletion at the very top (+0,0) at offset 0", () => {
+    const file = "line2\nline3\n"
+    const result = findHunkInFile(file, {
+      newText: "",
+      newStart: 0,
+      newCount: 0,
+      leadingContext: [],
+      trailingContext: [],
+    })
+    expect(result).toEqual({ start: 0, end: 0 })
+  })
 })
 
 describe("splitReviewDiff round-trip with findHunkInFile", () => {


### PR DESCRIPTION
## Summary

- Undoing a context-free deletion hunk (`@@ -5,3 +4,0 @@`) re-inserted the deleted lines one line above their original position AND glued them to the following line: `findHunkInFile` anchored at `newStart - 1` (where the empty candidate trivially matches) instead of after line N, and `undoUpdate` inserted `hunk.oldText` (newline-joined, no trailing separator) verbatim.
- `findHunkInFile` now special-cases `newText === "" && newCount === 0` to anchor at the start of line N+1 (offset 0 for `+0,0`); `undoUpdate` adds the separator newline on zero-width insertions — trailing mid-file, leading when appending to a file without a trailing newline. The legacy `findHunkText("")` path is unchanged (still offset 0).
- `undoMove` delegates to `undoUpdate`, so move-with-deletion hunks benefit too.

## Test plan

- [x] `bun run test` — 991 passed (4 new: anchor-after-N, top-of-file anchor, mid-file round-trip restore, EOF restore)
- [x] `bun run check-types` — clean

Closes #336