### PR TITLE
fix(agents): reconcile callID-keyed and Main rows after reload

### DIFF
--- a/src/agents/subagent-tracker.ts
+++ b/src/agents/subagent-tracker.ts
@@ -423,15 +423,17 @@ export class SubagentTracker {
    */
   async reconcile(backend: Backend, parentSessionID: string): Promise<void> {
     const conversationID = this.getConversationID()
+    // Snapshot synchronously at attach time: rows a new turn creates AFTER
+    // this point (fresh Main row, fresh dispatches) are never candidates,
+    // so the late-resolving status fetch below can't wrongly settle them.
     const candidates = this.store
       .list()
       .filter(
         (t) =>
-          t.kind === "subagent" &&
+          (t.kind === "subagent" || t.kind === "main") &&
           t.conversationID === conversationID &&
           t.sessionID === parentSessionID &&
-          (t.status === "running" || t.status === "waiting") &&
-          t.childSessionID,
+          (t.status === "running" || t.status === "waiting"),
       )
     if (candidates.length === 0) return
     let statuses: Record<string, { type?: string } | undefined> = {}
@@ -446,7 +448,27 @@ export class SubagentTracker {
     }
     const now = Date.now()
     for (const task of candidates) {
-      const childSid = task.childSessionID!
+      if (task.kind === "main") {
+        // A stale Main row only settles via its own session.idle — which a
+        // reload mid-turn may have swallowed. If the parent is idle (or
+        // forgotten), settle it here; if it's still busy, the live turn's
+        // session.idle will do it.
+        const parentStatus = statuses[parentSessionID]
+        if (!parentStatus || parentStatus.type === "idle") {
+          await this.store.update(task.id, { status: "completed", updatedAt: now })
+          log(`[subagent-tracker] reconcile ${task.id} main row, parent idle/absent → completed`)
+        }
+        continue
+      }
+      if (!task.childSessionID) {
+        // callID-keyed row from before the reload/switch. The in-memory
+        // dispatch map that could ever update it is gone, and markSessionIdle
+        // is main-only — nothing can settle it later. Close it out now.
+        await this.store.update(task.id, { status: "completed", updatedAt: now })
+        log(`[subagent-tracker] reconcile ${task.id} callID-keyed orphan → completed`)
+        continue
+      }
+      const childSid = task.childSessionID
       const childStatus = statuses[childSid]
       if (!childStatus) {
         // Server has no record of this session — it ended (or was

--- a/test/host/subagent-tracker.test.ts
+++ b/test/host/subagent-tracker.test.ts
@@ -509,6 +509,59 @@ describe("SubagentTracker.reconcile", () => {
     expect(store.get(seed.id)!.status).toBe("completed")
   })
 
+  it("completes callID-keyed orphan rows (no childSessionID) — nothing can ever settle them post-reload", async () => {
+    const { tracker, store } = setupTracker()
+    const seed: AgentTask = {
+      id: "subagent:ses_parent:c_orphan",
+      kind: "subagent",
+      conversationID: "conv1",
+      sessionID: "ses_parent",
+      callID: "c_orphan",
+      title: "metadata never arrived",
+      status: "running",
+      startedAt: 1,
+      updatedAt: 1,
+    }
+    await store.upsert(seed)
+    // Even with the parent still busy: the dispatch map is gone post-reload.
+    await tracker.reconcile(mockBackend({ ses_parent: { type: "busy" } }), "ses_parent")
+    expect(store.get(seed.id)!.status).toBe("completed")
+  })
+
+  it("completes a stale Main row when the parent session is idle", async () => {
+    const { tracker, store } = setupTracker()
+    const seed: AgentTask = {
+      id: "main:conv1:ses_parent:turn1",
+      kind: "main",
+      conversationID: "conv1",
+      sessionID: "ses_parent",
+      title: "old turn",
+      status: "running",
+      startedAt: 1,
+      updatedAt: 1,
+    }
+    await store.upsert(seed)
+    await tracker.reconcile(mockBackend({ ses_parent: { type: "idle" } }), "ses_parent")
+    expect(store.get(seed.id)!.status).toBe("completed")
+  })
+
+  it("leaves a Main row running while the parent session is still busy (live turn settles it)", async () => {
+    const { tracker, store } = setupTracker()
+    const seed: AgentTask = {
+      id: "main:conv1:ses_parent:turn2",
+      kind: "main",
+      conversationID: "conv1",
+      sessionID: "ses_parent",
+      title: "live turn",
+      status: "running",
+      startedAt: 1,
+      updatedAt: 1,
+    }
+    await store.upsert(seed)
+    await tracker.reconcile(mockBackend({ ses_parent: { type: "busy" } }), "ses_parent")
+    expect(store.get(seed.id)!.status).toBe("running")
+  })
+
   it("skips reconcile for rows whose conversationID does NOT match (cross-conversation safety)", async () => {
     const { tracker, store } = setupTracker({ conversationID: "conv1" })
     const seed: AgentTask = {


### PR DESCRIPTION
## Summary

- `reconcile()` required `t.childSessionID`, so after a window reload two row classes stayed `running` forever in the Agents popover (persisted in workspaceState):
  - **callID-keyed rows** (`subagent:<sess>:<callID>`, child never discovered pre-reload) — the in-memory dispatch map is gone, `markSessionIdle` is main-only, nothing could ever settle them. Now settled as `completed` unconditionally at reconcile time.
  - **Main rows** — only their own `session.idle` settles them, which the reload swallowed. Now settled when the parent session reports idle/absent; left alone while the parent is busy (the live turn's idle handles it).
- Candidates are snapshotted synchronously at attach time, so rows a new turn creates after re-attach can't be wrongly settled by the late-resolving status fetch.
- Scope remains conversation+session-bound: each window runs its own opencode server, so foreign sessions always read "absent" — widening would kill another window's live rows.

## Test plan

- [x] `bun run test` — 994 passed (3 new reconcile tests)
- [x] `bun run check-types` — clean

Closes #338