### PR TITLE
fix(chat): restore v1.4.3 single-volley Stop sweep semantics

### DIFF
--- a/src/chat/abort-tree.ts
+++ b/src/chat/abort-tree.ts
@@ -18,6 +18,16 @@ export interface AbortSweepState {
  * number of sessions newly aborted in this pass. `seed` lets the caller
  * inject child IDs known to the tracker that may not yet show up in
  * `session.children`.
+ *
+ * Traversal is gated on `state.aborted` itself: a session aborted this
+ * generation is neither re-aborted NOR re-listed, so a re-sweep over a
+ * fully swept tree terminates at the root and touches nothing. This is
+ * deliberate (and a revert of #317's visited/aborted split): a sweep that
+ * re-listed children of aborted nodes kept shooting down every session
+ * that appeared under the root for the whole drain window — opencode's
+ * own post-abort children (title/summary/compaction agents) and follow-up
+ * work started through paths that don't bump the generation. Stop must be
+ * one volley, then silence.
  */
 export async function sweepAbortTree(
   client: Backend["client"],
@@ -26,31 +36,22 @@ export async function sweepAbortTree(
   state: AbortSweepState,
 ): Promise<number> {
   let newlyAborted = 0
-  // Per-pass traversal guard, deliberately distinct from `state.aborted`:
-  // drain passes must re-list children of already-aborted nodes to catch
-  // sessions the orchestrator dispatched after the node was first aborted.
-  // Gating traversal on `state.aborted` made every drain pass skip the root
-  // and exit having seen nothing.
-  const visited = new Set<string>()
   const queue = [rootID, ...seed]
   while (queue.length) {
     if (!state.isLive()) break
     const id = queue.shift()!
-    if (visited.has(id)) continue
-    visited.add(id)
-    if (!state.aborted.has(id)) {
-      state.aborted.add(id)
-      newlyAborted++
-      try {
-        await client.session.abort({ path: { id } })
-      } catch (e) {
-        log("session.abort failed", id, e)
-      }
+    if (state.aborted.has(id)) continue
+    state.aborted.add(id)
+    newlyAborted++
+    try {
+      await client.session.abort({ path: { id } })
+    } catch (e) {
+      log("session.abort failed", id, e)
     }
     try {
       const res = await client.session.children({ path: { id } })
       for (const child of res.data ?? []) {
-        if (child?.id && !visited.has(child.id)) queue.push(child.id)
+        if (child?.id && !state.aborted.has(child.id)) queue.push(child.id)
       }
     } catch (e) {
       log("session.children failed", id, e)
@@ -60,9 +61,12 @@ export async function sweepAbortTree(
 }
 
 /**
- * Re-sweep the subtree until a pass finds no new sessions, catching tasks
- * the orchestrator dispatches in the window after the initial sweep. Bounded
- * by iteration count and abandoned the moment the generation is superseded.
+ * Bounded re-sweep safety net carried over from the original design. With
+ * traversal gated on `state.aborted`, a pass after a COMPLETE initial sweep
+ * stops at the already-aborted root and returns 0 immediately — the drain
+ * only matters for sessions seeded late into a sweep that was still
+ * mid-walk. It must never become a window that aborts sessions spawned
+ * after Stop (see `sweepAbortTree`).
  */
 export async function drainAbortTree(
   client: Backend["client"],

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -941,9 +941,10 @@ export class ChatView implements vscode.WebviewViewProvider {
       // its children closes that race.
       const state = { aborted: this.abortedTree, isLive: () => gen === this.abortGen }
       await sweepAbortTree(backend.client, sessionID, childSessionIDs, state)
-      // The first sweep can miss sessions the orchestrator dispatches while
-      // the sweep is in flight. Drain in the background until a sweep finds
-      // nothing new (or the user starts a new turn, bumping `abortGen`).
+      // Bounded safety net from the original design: with traversal gated on
+      // the aborted set, a pass after a complete sweep terminates at the root
+      // and goes quiet. Stop is one volley — the drain must NOT re-hunt the
+      // tree, or it kills sessions spawned after Stop (see sweepAbortTree).
       void drainAbortTree(backend.client, sessionID, state, {
         passes: ChatView.ABORT_DRAIN_PASSES,
         intervalMs: ChatView.ABORT_DRAIN_INTERVAL_MS,

--- a/test/host/e2e-mock-opencode.test.ts
+++ b/test/host/e2e-mock-opencode.test.ts
@@ -93,22 +93,23 @@ describe("E2E (mock opencode): SDK ↔ HTTP server", () => {
     )
   })
 
-  it("a re-sweep finds children dispatched after the first sweep without re-aborting settled nodes", async () => {
+  it("a re-sweep over a fully swept tree is silent — post-Stop sessions are NOT hunted down", async () => {
     const client = createOpencodeClient({ baseUrl: server.url })
     server.setChildren("ses_parent", ["ses_child_a"])
 
     const state = { aborted: new Set<string>(), isLive: () => true }
     expect(await sweepAbortTree(client, "ses_parent", [], state)).toBe(2)
 
-    // Orchestrator dispatches a late background task between sweeps — the
-    // drain regression: a traversal gated on the aborted set would skip the
-    // already-aborted root, never list its children, and miss ses_late.
-    server.setChildren("ses_parent", ["ses_child_a", "ses_late"])
-    expect(await sweepAbortTree(client, "ses_parent", [], state)).toBe(1)
-
-    expect(server.aborts).toEqual(["ses_parent", "ses_child_a", "ses_late"])
-    // Quiet tree → 0, which is what lets drainAbortTree terminate.
+    // A new session appears under the root right after Stop: opencode's own
+    // title/summary/compaction children, or follow-up work that doesn't bump
+    // the generation. The #317 visited/aborted split re-listed children of
+    // aborted nodes and shot these down for the whole drain window — the
+    // regression vs v1.4.3. Original semantics: traversal terminates at the
+    // already-aborted root and the late session survives.
+    server.setChildren("ses_parent", ["ses_child_a", "ses_post_stop"])
     expect(await sweepAbortTree(client, "ses_parent", [], state)).toBe(0)
+
+    expect(server.aborts).toEqual(["ses_parent", "ses_child_a"])
   })
 
   it("a fresh generation re-aborts a session aborted by a previous Stop", async () => {
@@ -126,7 +127,7 @@ describe("E2E (mock opencode): SDK ↔ HTTP server", () => {
     expect(server.aborts).toEqual(["ses_parent", "ses_parent"])
   })
 
-  it("drainAbortTree aborts sessions dispatched after the initial sweep", async () => {
+  it("drainAbortTree does NOT abort sessions dispatched after a completed sweep", async () => {
     const client = createOpencodeClient({ baseUrl: server.url })
     server.setChildren("ses_parent", [])
 
@@ -134,10 +135,12 @@ describe("E2E (mock opencode): SDK ↔ HTTP server", () => {
     await sweepAbortTree(client, "ses_parent", [], state)
     expect(server.aborts).toEqual(["ses_parent"])
 
+    // Stop is one volley: once the initial sweep covered the tree, the drain
+    // must go quiet, not keep killing whatever spawns under the root next.
     server.setChildren("ses_parent", ["ses_late_dispatch"])
     await drainAbortTree(client, "ses_parent", state, { passes: 3, intervalMs: 5 })
 
-    expect(server.aborts).toEqual(["ses_parent", "ses_late_dispatch"])
+    expect(server.aborts).toEqual(["ses_parent"])
   })
 
   it("sweepAbortTree abandons the walk when the generation is superseded", async () => {


### PR DESCRIPTION
## Summary

Field-reported regression: Stop misbehaves on `main` but works on `v1.4.3`. Root cause is #317's visited/aborted split in `sweepAbortTree`: drain passes re-listed children of already-aborted nodes, so for ~6 seconds after Stop (6 passes x 1 s) a background loop aborted every NEW session that appeared under the conversation root — opencode's internal title/summary/compaction child sessions, omo post-abort wrap-up sessions, and follow-up work started through paths that don't bump `abortGen` (only `handleSend` bumps it; `session.command` slash-command work does not).

This PR restores the original v1.4.3 sweep semantics exactly: traversal is gated on the generation's `aborted` set itself, so each session is aborted at most once per Stop and a re-sweep over a fully swept tree terminates at the root without touching anything. Stop is one abort volley, then silence. The only piece of #317 kept is the minimal fix for the original bug: `abortedTree.clear()` at the start of each Stop generation, so a second Stop in the same conversation still re-aborts the whole tree (#316). `drainAbortTree` stays as the original bounded safety net; with the restored gating it goes quiet immediately after a complete sweep.

Test changes pin the restored behavior:
- re-sweep over a fully swept tree performs zero aborts and returns 0; a session appearing under the root after Stop survives
- `drainAbortTree` does NOT abort sessions dispatched after a completed sweep
- kept: root-first full-subtree abort, second-Stop re-abort with a fresh generation, isLive abandon

## Test plan

- [x] `bun run test` — 995/995 passing
- [x] `bun run check-types` — clean
- [x] `cd webview && bunx tsc --noEmit` — only the two pre-existing errors (`findLast`, `MessageView.tsx`)
- [ ] Manual: Stop during an omo run on this build behaves like v1.4.3 (single volley; no post-Stop kills)

Closes #342