### PR TITLE
chore: remove unused visibleReviewDocument helper and Collector type

### DIFF
--- a/src/chat/fs-ops.ts
+++ b/src/chat/fs-ops.ts
@@ -48,11 +48,6 @@ export async function openFileDocument(relPath: string, root?: string) {
   return vscode.workspace.openTextDocument(uri)
 }
 
-export function visibleReviewDocument(relPath: string) {
-  const uris = new Set(workspaceFileUriCandidates(relPath).map(({ uri }) => uri.toString()))
-  return vscode.window.visibleTextEditors.find((editor) => uris.has(editor.document.uri.toString()))?.document
-}
-
 export async function workspaceFileUri(relPath: string, root?: string) {
   const existing = await existingWorkspaceFileUri(relPath, root)
   if (existing) return existing

--- a/src/workspace-context/types.ts
+++ b/src/workspace-context/types.ts
@@ -29,5 +29,3 @@ export type CollectorOutput = {
 export type CollectorInput = {
   workspace: WorkspaceRoot
 }
-
-export type Collector = (input: CollectorInput) => Promise<CollectorOutput>


### PR DESCRIPTION
## Summary

Removes two symbols that are exported but referenced nowhere in `src/`, `webview/src/`, or `test/`:

- `visibleReviewDocument()` (`src/chat/fs-ops.ts`) — orphaned helper, zero callers.
- `Collector` type (`src/workspace-context/types.ts`) — unused alias (`CollectorInput` / `CollectorOutput` stay in use).

### Scope notes

- `ALWAYS_EXCLUDE` / `SECRET_LIKE` (`src/indexing/ignore.ts`) were initially suspected dead, but `defaultIgnoreMatcher()` consumes them locally — reverted and left untouched. They are over-exported, not dead; that cosmetic cleanup is deliberately out of scope. The build caught the misclassification before commit.
- The stale `chat/review-render.ts` reference in `CLAUDE.md` was corrected locally too, but `CLAUDE.md` is gitignored in this repo, so it is not part of this diff.

## Test plan

- [x] `bun run check-types` — clean (host `tsc --noEmit`).
- [x] `bun run test` — 65 files, 995 tests pass.
- [x] `bun run package` — production build (webview vite + esbuild) succeeds.
- [x] `tsc` raised no `TS2304` on removal, confirming no remaining references.
- [x] No behavior change.

Closes #345