### PR TITLE
docs: remove README link to gitignored CLAUDE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ bun install
 bun run watch         # esbuild + vite single-file
 ```
 
-Open the folder in VS Code and press `F5` to launch an Extension Development Host. See [CLAUDE.md](./CLAUDE.md) for architecture notes and the test layout.
+Open the folder in VS Code and press `F5` to launch an Extension Development Host.
 
 ## License
 


### PR DESCRIPTION
## Summary

Removes the trailing "See [CLAUDE.md](./CLAUDE.md) for architecture notes and the test layout." sentence from the Develop section of `README.md`. `CLAUDE.md` is gitignored / untracked in this repo, so the relative link 404s on GitHub. The preceding F5 dev-host instruction is kept.

## Test plan

- [x] Docs-only change — no source, build, or test paths touched.
- [x] Verified the diff is a single line and the remaining sentence reads correctly.

Closes #347