### PR TITLE
docs(license): update copyright holder to Haoyang Zeng

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Arthur Zeng
+Copyright (c) 2026 Haoyang Zeng
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

Update the MIT `LICENSE` copyright holder from "Arthur Zeng" to "Haoyang Zeng", matching the VS Code Marketplace publisher `haoyangzeng` referenced elsewhere in the project. Single-line change; `grep` confirms no other tracked file references the old name.

## Test plan

- [x] `grep -rn "Arthur Zeng"` returns no remaining matches.
- [x] `LICENSE` line 3 reads `Copyright (c) 2026 Haoyang Zeng`.
- [x] No code paths touched — text-only change, no build/test impact.

Closes #349