### PR TITLE
perf(webview): memoize markdown render path to cut per-token streaming cost

### DIFF
--- a/webview/src/components/CodeBlock.tsx
+++ b/webview/src/components/CodeBlock.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react"
+import { memo, useEffect, useMemo, useState } from "react"
 import { codeToHtml, type BundledLanguage } from "shiki/bundle/web"
 import { vscode } from "../vscode"
 
@@ -11,7 +11,12 @@ const SUPPORTED = new Set<string>([
   "xml", "docker", "dockerfile", "ini", "diff",
 ])
 
-export function CodeBlock({ code, language }: Props) {
+// While a fenced block streams in, `code` grows on every delta. Debounce the
+// shiki tokenization so it runs once the content settles instead of
+// re-highlighting the whole (immediately superseded) snippet on each token.
+const HIGHLIGHT_DEBOUNCE_MS = 90
+
+function CodeBlockImpl({ code, language }: Props) {
   const [html, setHtml] = useState<string>("")
   const [copied, setCopied] = useState(false)
   const theme = useMemo(() => {
@@ -23,15 +28,18 @@ export function CodeBlock({ code, language }: Props) {
   useEffect(() => {
     let cancelled = false
     const lang = normaliseLang(language)
-    codeToHtml(code, { lang: lang as BundledLanguage, theme })
-      .then((h) => {
-        if (!cancelled) setHtml(h)
-      })
-      .catch(() => {
-        if (!cancelled) setHtml(`<pre><code>${escape(code)}</code></pre>`)
-      })
+    const timer = setTimeout(() => {
+      codeToHtml(code, { lang: lang as BundledLanguage, theme })
+        .then((h) => {
+          if (!cancelled) setHtml(h)
+        })
+        .catch(() => {
+          if (!cancelled) setHtml(`<pre><code>${escape(code)}</code></pre>`)
+        })
+    }, HIGHLIGHT_DEBOUNCE_MS)
     return () => {
       cancelled = true
+      clearTimeout(timer)
     }
   }, [code, language, theme])
 
@@ -80,6 +88,8 @@ export function CodeBlock({ code, language }: Props) {
     </div>
   )
 }
+
+export const CodeBlock = memo(CodeBlockImpl)
 
 function escape(s: string) {
   return s.replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!)

--- a/webview/src/components/Markdown.tsx
+++ b/webview/src/components/Markdown.tsx
@@ -1,4 +1,4 @@
-import { isValidElement, type ReactNode } from "react"
+import { isValidElement, memo, useMemo, type ReactNode } from "react"
 import ReactMarkdown, { type Components } from "react-markdown"
 import remarkGfm from "remark-gfm"
 import remarkBreaks from "remark-breaks"
@@ -178,16 +178,35 @@ function flattenChildren(node: ReactNode): string {
 // as faint red text and keeps going.
 const katexOptions = { strict: "ignore", throwOnError: false } as const
 
-export function Markdown({ text }: Props) {
+// Math is comparatively expensive: normalizeMath's regex passes, the
+// remark-math tokenizer, and the rehype-katex tree walk all re-run on every
+// render of a streaming message. Most chat messages contain no math, so detect
+// the delimiters once and skip the whole math pipeline when there are none.
+// Covers `$…$` / `$$…$$` plus the `\(…\)` / `\[…\]` forms normalizeMath would
+// convert into dollar math. Currency like `$5` trips this too — intentional:
+// the pipeline then escapes it correctly, exactly as before.
+const MATH_HINT = /\$|\\\(|\\\[/
+
+function MarkdownImpl({ text }: Props) {
+  const { source, hasMath } = useMemo(() => {
+    const enveloped = normalizeAgentEnvelopes(text)
+    const math = MATH_HINT.test(enveloped)
+    return { source: math ? normalizeMath(enveloped) : enveloped, hasMath: math }
+  }, [text])
   return (
     <div className="md">
       <ReactMarkdown
-        remarkPlugins={[remarkGfm, remarkBreaks, remarkMath]}
-        rehypePlugins={[[rehypeKatex, katexOptions]]}
+        remarkPlugins={hasMath ? [remarkGfm, remarkBreaks, remarkMath] : [remarkGfm, remarkBreaks]}
+        rehypePlugins={hasMath ? [[rehypeKatex, katexOptions]] : []}
         components={components}
       >
-        {normalizeMath(normalizeAgentEnvelopes(text))}
+        {source}
       </ReactMarkdown>
     </div>
   )
 }
+
+// Memoized on `text` (its only prop): every settled segment above the one
+// currently streaming skips the full remark/rehype re-parse when an unrelated
+// part of the tree re-renders.
+export const Markdown = memo(MarkdownImpl)


### PR DESCRIPTION
## Summary

Cuts the per-token CPU cost of assistant streaming in the webview. The delta coalescer and `MessageView` memo already keep streaming from re-rendering the whole transcript, but the markdown layer underneath re-did O(n) work per token (O(n^2) over a turn) for the actively-streaming bubble. This addresses item 1 of the performance audit.

- **`Markdown` → `React.memo`** keyed on its only prop (`text`), with the `normalizeMath(normalizeAgentEnvelopes(text))` pass memoized on `text`. Settled segments above the streaming one no longer re-run the remark/rehype pipeline when an unrelated part of the tree re-renders.
- **Skip the math pipeline when there's no math.** `normalizeMath` + `remark-math` + `rehype-katex` only run when the text contains `$`, `\(`, or `\[`; `remark-gfm` and `remark-breaks` always run. Most chat messages have no math, so this drops the KaTeX tree walk and regex passes for them. Currency like `$5` still routes through the pipeline and escapes correctly (unchanged behavior).
- **`CodeBlock` → `React.memo` + debounced shiki highlight.** A streaming fenced block grows on every delta; the highlight now fires once the content settles (90ms debounce) instead of re-tokenizing the whole superseded snippet per token. The plain `<pre>` fallback shows until the first highlight resolves.

No behavior change — purely render-path optimization.

## Test plan

- [x] `bun run test` — 65 files / 995 tests pass (includes `markdown.test.tsx`, `codeblock.test.tsx`, `message-view.test.tsx`).
- [x] Webview type-check `cd webview && bunx tsc --noEmit` — clean (exit 0).
- [x] Host type-check `bun run check-types` — clean.
- [x] Production build `bun run compile` — webview vite single-file + host esbuild both succeed.
- [ ] Visual: confirm math, GFM tables, currency, and streaming code blocks still render correctly in the panel (not verified in-editor).

Closes #351