### PR TITLE
chore(deps): bump @opencode-ai/sdk to 1.17.9

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "opencui",
       "dependencies": {
-        "@opencode-ai/sdk": "^1.14.25",
+        "@opencode-ai/sdk": "^1.17.9",
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
@@ -173,7 +173,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.14.33", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-LtP9oLMSxVw47AE562IagIOwxLfHLVjk/CTExkYCYtdjPXTQeU5mjyZDbahilAGeFUen9fFE/R9e933zvjF9sQ=="],
+    "@opencode-ai/sdk": ["@opencode-ai/sdk@1.17.9", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-MHmXEpGPHkg14v1p+cUlIOUxd6DQdSElfau9nqY7tcDI0x5r4Y8D0dKXcyAh0Gc73ptaGW67Vg84nkcV6O27Pw=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.128.0", "", {}, "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ=="],
 

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
     "publish:marketplace": "vsce publish --no-dependencies"
   },
   "dependencies": {
-    "@opencode-ai/sdk": "^1.14.25"
+    "@opencode-ai/sdk": "^1.17.9"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",


### PR DESCRIPTION
## Summary

Bumps `@opencode-ai/sdk` from 1.14.33 to **1.17.9** to track the current opencode CLI release (1.17.9) that users run locally. The SDK is opencui's only runtime coupling to opencode, so keeping it aligned avoids drifting from the server's event and API shapes.

- opencode **1.15.0** restored missing JS SDK event types (session + message events) — directly relevant to opencui's SSE stream normalization.
- **1.16 / 1.17** are additive (server features, MCP fixes) with no consumer-facing API breakage.
- One-line dependency change + lockfile; no source changes required.

## Test plan

- [x] `bun run check-types` — clean (exit 0)
- [x] `bun run test` — 995/995 pass
- [x] `bun run compile` — production build succeeds
- [x] Lockfile resolves `@opencode-ai/sdk@1.17.9`

No release cut.

Closes #353