### PR TITLE
chore(release): 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-06-22
+
+### Changed
+- The assistant message renderer is memoized on the streaming hot path. Markdown is no longer re-parsed from scratch on every streamed token, the KaTeX math pipeline is skipped entirely for messages that contain no math, and syntax highlighting is debounced so a code block is tokenized once its content settles instead of on every delta. Long replies stream with noticeably less CPU (#351, #352).
+- Updated the bundled opencode SDK to 1.17.9, tracking the current opencode release. This keeps the extension aligned with the event and API shapes of the opencode server users run locally; opencode 1.15.0 also restored the session and message event types the chat stream relies on (#353, #354).
+
 ## [1.4.4] - 2026-06-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Cuts the **1.5.0** release. Bumps `package.json` 1.4.4 to 1.5.0 and adds the CHANGELOG entry for the two user-facing changes that landed since v1.4.4:

- **Streaming-render memoization** — markdown is no longer re-parsed on every token, the math pipeline is skipped when a message has no math, and code highlighting is debounced until a block settles (#351, #352).
- **opencode SDK bumped to 1.17.9** — tracks the current opencode release users run locally (#353, #354).

Merging this lands the version bump on `main`; the `v1.5.0` tag + GitHub Release are created afterward, which triggers the publish workflow (VS Code Marketplace + Open VSX). The workflow's tag-vs-`package.json` guard passes because the bump is on `main` first.

## Test plan

- [x] `bun run check-types` — clean (exit 0)
- [x] `bun run test` — 995/995 pass
- [x] `bun run package` — production build succeeds
- [x] `bunx @vscode/vsce package --no-dependencies` — packages cleanly (2.3 MB, 23 files)

Closes #355