### PR TITLE
feat(composer): raise default chatbox height to ~3 rows

### DIFF
--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -23,9 +23,9 @@ describe("PromptBox", () => {
     expect((screen.getByRole("textbox") as HTMLTextAreaElement).rows).toBe(1)
   })
 
-  it("keeps the send composer at two rows", () => {
+  it("keeps the send composer at three rows", () => {
     render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} />)
-    expect((screen.getByRole("textbox") as HTMLTextAreaElement).rows).toBe(2)
+    expect((screen.getByRole("textbox") as HTMLTextAreaElement).rows).toBe(3)
   })
 
   it("applies bottom composer chrome only to the send composer", () => {

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -668,7 +668,7 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
         <textarea
           ref={ref}
           value={text}
-          rows={variant === "edit" ? 1 : 2}
+          rows={variant === "edit" ? 1 : 3}
           placeholder="/ for commands, @ for files, Enter to send"
           onChange={(e) => updateText(e.target.value, e.target.selectionStart ?? e.target.value.length)}
           onKeyDown={onKeyDown}

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -2221,7 +2221,7 @@ button:focus-visible {
 }
 .promptbox textarea {
   width: 100%;
-  min-height: 48px;
+  min-height: 64px;
   /* Hard upper bound mirrors the JS TEXTAREA_MAX_HEIGHT in PromptBox.tsx —
      once the scroll height exceeds the cap, the textarea's own vertical
      scrollbar takes over rather than letting the input keep eating chat


### PR DESCRIPTION
## Summary

Makes the default chat composer a little taller. The resting send composer floored at `min-height: 48px` with `rows={2}` (~two lines); this raises it to `64px` / `rows={3}` (~three lines) so both the docked bottom composer and the empty-state centered one give more room to type before the box's internal scrollbar kicks in.

- `webview/src/styles.css` — `.promptbox textarea` `min-height: 48px` -> `64px`.
- `webview/src/components/PromptBox.tsx` — send-variant `rows={2}` -> `rows={3}` (edit variant stays at 1).
- `test/webview/promptbox.test.tsx` — updated the row-count assertion (2 -> 3).

Scoped to the send composer only: the in-place message-edit composer keeps its own `min-height: 24px` override, and the `--message-max-height` / `TEXTAREA_MAX_HEIGHT` cap and auto-grow behavior are untouched.

## Test plan

- [x] `bun run test` — 995/995 passing (65 files), including the updated row-count assertion.
- [x] `bun run check-types` (host) — clean.
- [x] `cd webview && bunx tsc --noEmit` — clean.
- [x] `bun run package` — production build succeeds.
- [ ] Visual: reload the extension and confirm the empty composer rests at ~3 lines and still auto-grows/caps as before. Easy to dial up/down by adjusting the single `min-height` value if a different height is preferred.

Closes #357