### PR TITLE
fix(composer): scope taller height to the new-chat composer

### DIFF
--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -23,8 +23,13 @@ describe("PromptBox", () => {
     expect((screen.getByRole("textbox") as HTMLTextAreaElement).rows).toBe(1)
   })
 
-  it("keeps the send composer at three rows", () => {
+  it("keeps the docked (bottom) send composer at two rows", () => {
     render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} />)
+    expect((screen.getByRole("textbox") as HTMLTextAreaElement).rows).toBe(2)
+  })
+
+  it("gives the empty-state (top) composer an extra row", () => {
+    render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} position="top" />)
     expect((screen.getByRole("textbox") as HTMLTextAreaElement).rows).toBe(3)
   })
 

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -668,7 +668,7 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
         <textarea
           ref={ref}
           value={text}
-          rows={variant === "edit" ? 1 : 3}
+          rows={variant === "edit" ? 1 : position === "top" ? 3 : 2}
           placeholder="/ for commands, @ for files, Enter to send"
           onChange={(e) => updateText(e.target.value, e.target.selectionStart ?? e.target.value.length)}
           onKeyDown={onKeyDown}

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -2173,6 +2173,14 @@ button:focus-visible {
      is the same width as the docked one. */
   padding: var(--composer-edge-gap) 12px 4px;
 }
+/* The empty-state ("new chat") composer rests one line taller than the docked
+   bottom composer: nothing else is on screen yet, so a roomier input reads as
+   the primary call to action. The docked composer keeps the original 48px floor
+   so it doesn't crowd the conversation above it. Mirrors the rows={3} the
+   component sets for position="top". */
+.promptbox--top textarea {
+  min-height: 64px;
+}
 .promptbox-input {
   background: var(--vscode-input-background);
   border: 1px solid var(--vscode-input-border, transparent);
@@ -2221,7 +2229,7 @@ button:focus-visible {
 }
 .promptbox textarea {
   width: 100%;
-  min-height: 64px;
+  min-height: 48px;
   /* Hard upper bound mirrors the JS TEXTAREA_MAX_HEIGHT in PromptBox.tsx —
      once the scroll height exceeds the cap, the textarea's own vertical
      scrollbar takes over rather than letting the input keep eating chat


### PR DESCRIPTION
## Summary

Follow-up to #358. That PR made the chat composer ~3 rows tall, which is right for the empty-state "new chat" composer but also grew the docked bottom composer used during an active conversation. This scopes the taller size to the empty-state composer only; the docked one returns to its original compact height.

- `webview/src/styles.css` — base `.promptbox textarea` `min-height` back to `48px`; new `.promptbox--top textarea { min-height: 64px }` override keeps the empty-state composer taller.
- `webview/src/components/PromptBox.tsx` — `rows` is now position-keyed: `3` for `position="top"`, `2` for the docked composer (`1` still for edit).
- `test/webview/promptbox.test.tsx` — assert the docked composer is 2 rows and add coverage that the top composer is 3.

Net effect: new chat = roomier ~3-row input; ongoing conversation = original compact ~2-row docked input. The in-place message-edit composer (its own `min-height: 24px`) and the max-height cap / auto-grow are untouched.

## Test plan

- [x] `bun run test` — 996/996 passing (65 files), including the new docked=2 / top=3 row assertions.
- [x] `bun run check-types` (host) — clean.
- [x] `cd webview && bunx tsc --noEmit` — clean.
- [x] `bun run package` — production build succeeds.
- [ ] Visual: new chat rests at ~3 lines; after the first message the docked composer sits at the original ~2 lines; both still auto-grow and cap as before.

Closes #359