### PR TITLE
chore(release): 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-06-27
+
+### Changed
+- The new-chat composer (the input shown on an empty conversation) now opens about a line taller, so there is more room to start typing; the docked composer used during an active conversation keeps its original compact height (#357, #358, #359, #360).
+
 ## [1.5.0] - 2026-06-22
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Cuts the v1.5.1 patch release. Bumps the version and adds a dated CHANGELOG entry for the composer-height work merged since v1.5.0.

- `package.json` — `1.5.0` -> `1.5.1`.
- `CHANGELOG.md` — new `## [1.5.1] - 2026-06-27` section.

Net user-facing change: the new-chat composer opens about a line taller, while the docked composer during an active conversation keeps its original compact height (#357, #358, #359, #360).

Once merged, a `v1.5.1` tag + GitHub Release will trigger `release.yml` to publish to the VS Code Marketplace and Open VSX.

## Test plan

- [x] `bun run test` — 996/996 passing (65 files).
- [x] `bun run check-types` (host) — clean.
- [x] `bun run package` — production build succeeds.
- [x] `bun install` — lockfile unchanged (no dependency change in this release).

Closes #361