### PR TITLE
fix(history): color "+ New chat" with theme link instead of git-add green

### DIFF
--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -591,8 +591,10 @@ button:focus-visible {
   font-size: 11px;
   font-weight: 600;
 }
-/* "New chat" — small green link-style action so it reads as "create"
-   rather than "select" against the regular history rows below. */
+/* "New chat" — small link-style action so it reads as "create" rather than
+   "select" against the regular history rows below. Uses the theme link color
+   (matches .btn.link / .md a) so it tracks the user's UI accent instead of a
+   hardcoded git-add green. */
 .history-new {
   display: inline-flex;
   align-items: center;
@@ -601,14 +603,14 @@ button:focus-visible {
   border: 0;
   border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--color-diff-add);
+  color: var(--vscode-textLink-foreground);
   font-size: 11px;
   font-weight: 600;
   cursor: pointer;
   transition: background-color 0.12s ease, color 0.12s ease;
 }
 .history-new:hover {
-  background: color-mix(in srgb, var(--color-diff-add) 14%, transparent);
+  background: color-mix(in srgb, var(--vscode-textLink-foreground) 14%, transparent);
 }
 .history-new .codicon {
   flex: 0 0 auto;


### PR DESCRIPTION
## Summary

The Chat history popover's **"+ New chat"** action was colored with `--color-diff-add` — git's added-file green (fallback `#3fb950`). That is a version-control semantic color repurposed as a "create" affordance, so it looked out of place and ignored the user's theme accent.

This swaps the text color and the hover background tint to `--vscode-textLink-foreground`, the same theme link/accent token already used by `.btn.link` and `.md a`. The action stays link-styled (visually distinct from the plain history rows), but now tracks the user's UI color in every theme. The icon-only toolbar New chat button is untouched — it already used `--vscode-foreground`.

## Test plan

- [x] `bunx tsc --noEmit` (webview) — clean, exit 0
- [x] `bun run test test/webview/statusbar.test.tsx` — 40 passed (behavioral tests unaffected; no test asserted the color)
- [ ] Visual: open the Chat history popover and confirm "+ New chat" renders in the theme link color (not green) at rest and on hover, across a light and a dark theme

Closes #363