### PR TITLE
chore(release): 1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.5.2] - 2026-06-28
+
+### Changed
+- The "+ New chat" action in the chat-history popover now uses the theme's link/accent color instead of a hardcoded git-add green, so it matches the rest of the UI across light and dark themes (#363, #364).
+
 ## [1.5.1] - 2026-06-27
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Patch release **v1.5.2**. Bumps `package.json` to `1.5.2` and adds the `## [1.5.2]` CHANGELOG entry.

Since v1.5.1, one user-facing change:
- The "+ New chat" action in the chat-history popover now uses the theme's link/accent color (`--vscode-textLink-foreground`) instead of a hardcoded git-add green, so it matches the rest of the UI across themes (#363, #364).

After this merges, the tag `v1.5.2` + GitHub Release are created from `main`, which triggers `release.yml` to publish to the VS Code Marketplace and Open VSX.

## Test plan

- [x] Version bumped to 1.5.2 in `package.json`
- [x] `CHANGELOG.md` `## [1.5.2]` entry added (dated 2026-06-28)
- [x] webview `tsc --noEmit` clean and StatusBar tests pass (verified on the underlying #364 change)
- [ ] `release.yml` tag-vs-version gate passes and both Marketplace + Open VSX publish steps go green (verified post-tag)

Closes #365