### PR TITLE
fix(chat): reuse empty New conversation on repeat New-chat clicks; align "+ New chat"

### DIFF
--- a/src/chat/conversation-manager.ts
+++ b/src/chat/conversation-manager.ts
@@ -70,6 +70,34 @@ export class ConversationManager {
     return conversation
   }
 
+  /**
+   * Whether a conversation is an untouched "New conversation": still the
+   * default title with no messages. Such a chat is a reuse candidate for the
+   * New-chat action.
+   */
+  private isUntouchedNew(c: SavedConversation): boolean {
+    return c.title === "New conversation" && c.messages.length === 0
+  }
+
+  /**
+   * Backing for the New-chat action ("+" / "+ New chat"). If the active
+   * conversation is already an untouched "New conversation", reuse it — bump
+   * its created/updated time and move it to the front (`reused: true`) —
+   * instead of stacking a second identical empty chat. This is what keeps
+   * repeated New-chat clicks from piling up duplicate empty conversations.
+   * Otherwise add a fresh one (`reused: false`).
+   */
+  addOrReuseEmpty(title: string): { conversation: SavedConversation; reused: boolean } {
+    const active = this.conversations.find((c) => c.id === this.activeID)
+    if (active && this.isUntouchedNew(active)) {
+      const now = Date.now()
+      const refreshed: SavedConversation = { ...active, createdAt: now, updatedAt: now }
+      this.conversations = [refreshed, ...this.conversations.filter((c) => c.id !== refreshed.id)]
+      return { conversation: refreshed, reused: true }
+    }
+    return { conversation: this.add(title), reused: false }
+  }
+
   getMessages(id: string): ChatMessage[] | undefined {
     const conv = this.conversations.find((c) => c.id === id)
     if (!conv) return undefined

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -261,7 +261,10 @@ export class ChatView implements vscode.WebviewViewProvider {
 
   async createConversation() {
     this.resetSessionState()
-    const conversation = this.manager.add("New conversation")
+    // Reuse the active chat if it is already an untouched "New conversation"
+    // so repeated New-chat clicks refresh that empty chat instead of piling
+    // up duplicates.
+    const { conversation } = this.manager.addOrReuseEmpty("New conversation")
     this.manager.setActiveID(conversation.id)
     this.messages = []
     this.reviewHunks = {}

--- a/test/host/conversation-manager-reuse.test.ts
+++ b/test/host/conversation-manager-reuse.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { ConversationManager } from "../../src/chat/conversation-manager"
+import type { ActiveSnapshot } from "../../src/chat/conversation-manager"
+
+function fakeContext() {
+  const store = new Map<string, unknown>()
+  const workspaceState = {
+    get: <T>(key: string, def?: T): T => (store.has(key) ? (store.get(key) as T) : (def as T)),
+    update: vi.fn((key: string, value: unknown) => {
+      if (value === undefined) store.delete(key)
+      else store.set(key, value)
+      return Promise.resolve()
+    }),
+    keys: () => [...store.keys()],
+  }
+  return { context: { workspaceState } as never }
+}
+
+function withMessage(): ActiveSnapshot {
+  return {
+    messages: [{ id: "m0", role: "user", blocks: [], pending: false }],
+    reviewHunks: {},
+  } as unknown as ActiveSnapshot
+}
+
+describe("ConversationManager.addOrReuseEmpty", () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it("reuses the active untouched New conversation instead of stacking a duplicate", () => {
+    const { context } = fakeContext()
+    const manager = new ConversationManager(context)
+    const originalID = manager.getActiveID()
+    expect(manager.summaries()).toHaveLength(1)
+
+    const { conversation, reused } = manager.addOrReuseEmpty("New conversation")
+
+    expect(reused).toBe(true)
+    expect(conversation.id).toBe(originalID)
+    expect(manager.summaries()).toHaveLength(1) // no duplicate empty chat
+  })
+
+  it("bumps the reused conversation's timestamp so it re-sorts to the top", () => {
+    let now = 1_000
+    vi.spyOn(Date, "now").mockImplementation(() => now)
+    const { context } = fakeContext()
+    const manager = new ConversationManager(context)
+    const before = manager.summaries()[0]!.updatedAt
+
+    now = 5_000
+    const { conversation, reused } = manager.addOrReuseEmpty("New conversation")
+
+    expect(reused).toBe(true)
+    expect(conversation.createdAt).toBe(5_000)
+    expect(manager.summaries()[0]!.updatedAt).toBe(5_000)
+    expect(manager.summaries()[0]!.updatedAt).toBeGreaterThan(before)
+  })
+
+  it("adds a fresh conversation when the active one already has messages", () => {
+    const { context } = fakeContext()
+    const manager = new ConversationManager(context)
+    manager.saveActiveSnapshot(withMessage())
+
+    const { conversation, reused } = manager.addOrReuseEmpty("New conversation")
+
+    expect(reused).toBe(false)
+    expect(conversation.id).not.toBe(manager.getActiveID())
+    expect(manager.summaries()).toHaveLength(2)
+  })
+
+  it("adds a fresh conversation when the active one was renamed off the default title", () => {
+    const { context } = fakeContext()
+    const manager = new ConversationManager(context)
+    manager.rename(manager.getActiveID(), "Planning notes")
+
+    const { reused } = manager.addOrReuseEmpty("New conversation")
+
+    expect(reused).toBe(false)
+    expect(manager.summaries()).toHaveLength(2)
+  })
+})

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -594,7 +594,11 @@ button:focus-visible {
 /* "New chat" — small link-style action so it reads as "create" rather than
    "select" against the regular history rows below. Uses the theme link color
    (matches .btn.link / .md a) so it tracks the user's UI accent instead of a
-   hardcoded git-add green. */
+   hardcoded git-add green.
+   `line-height: 1` collapses the icon (13px) and label (11px) onto a single
+   tight line box so they center on the same horizontal line instead of each
+   sitting at its own default-line-height box centre (see .status-indicator and
+   .review-bulk-action for the same glyph-pair alignment treatment). */
 .history-new {
   display: inline-flex;
   align-items: center;
@@ -606,6 +610,7 @@ button:focus-visible {
   color: var(--vscode-textLink-foreground);
   font-size: 11px;
   font-weight: 600;
+  line-height: 1;
   cursor: pointer;
   transition: background-color 0.12s ease, color 0.12s ease;
 }


### PR DESCRIPTION
## Summary

Two fixes to the New-chat affordance (toolbar "+" and the "+ New chat" action in the chat-history popover):

1. **No more duplicate empty chats.** New-chat always called `ConversationManager.add("New conversation")`, so clicking it while already sitting on a fresh, untouched "New conversation" (default title + no messages) stacked a second identical empty chat — repeated clicks piled up duplicates. New `ConversationManager.addOrReuseEmpty()` reuses the active chat when it is still an untouched "New conversation" (bumps its created/updated time and re-sorts it to the front) instead of adding another; otherwise it adds a fresh one. `createConversation()` now routes through it. Both entry points ("+" and "+ New chat") post the same `createConversation` message, so both are covered.

2. **"+ New chat" vertical alignment.** The 13px "+" icon and 11px label sat on mismatched default line boxes, so flex `align-items: center` centered them by differing box centres and the glyph pair did not rest on the same horizontal line. `line-height: 1` collapses them onto one tight line box — the same glyph-pair alignment treatment the codebase documents for `.status-indicator` and uses in `.review-bulk-action`.

## Test plan

- [x] New unit tests `test/host/conversation-manager-reuse.test.ts` — reuse when active is untouched (no duplicate, timestamp bumped, re-sorted), fresh add when active has messages or was renamed (4 tests)
- [x] `bun run test` — 1000 passed (66 files), incl. the mock-opencode E2E that exercises `createConversation`
- [x] `bun run check-types` (host) and webview `tsc --noEmit` — both clean (exit 0)
- [x] `bun run compile` — webview + host build succeeds
- [ ] Visual: in the history popover, confirm repeated New-chat clicks do not add duplicate empty chats, and that "+ New chat" icon + label sit on the same horizontal line

Closes #367