### PR TITLE
chore(release): 1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.5.3] - 2026-06-29
+
+### Fixed
+- Clicking New chat ("+" or "+ New chat") while already on a fresh, empty "New conversation" no longer stacks a second identical empty chat. It now refreshes the existing empty conversation instead, so repeated clicks stop piling up duplicate "New conversation" entries in the history list. Starting a new chat from a conversation that has messages still creates a fresh one as before (#367, #368).
+- The "+ New chat" icon and label in the chat-history popover are now vertically aligned on the same horizontal line (#367, #368).
+
 ## [1.5.2] - 2026-06-28
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Patch release **v1.5.3**. Bumps `package.json` to `1.5.3` and adds the `## [1.5.3]` CHANGELOG entry.

Since v1.5.2 (both from #367, #368):
- New-chat ("+" / "+ New chat") reuses a fresh, empty "New conversation" instead of stacking a second identical empty chat, so repeated clicks stop piling up duplicates.
- The "+ New chat" icon and label in the chat-history popover are vertically aligned on the same line.

After this merges, the tag `v1.5.3` + GitHub Release are created from `main`, which triggers `release.yml` to publish to the VS Code Marketplace and Open VSX.

## Test plan

- [x] Version bumped to 1.5.3 in `package.json`
- [x] `CHANGELOG.md` `## [1.5.3]` entry added (dated 2026-06-29)
- [x] Underlying change (#368) merged green: `bun run test` 1000 passed, host + webview `tsc` clean, `bun run compile` builds
- [ ] `release.yml` tag-vs-version gate passes and both Marketplace + Open VSX publish steps go green (verified post-tag)

Closes #369