### PR TITLE
chore: remove dead .welcome CSS from the webview

### DIFF
--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -908,35 +908,6 @@ button:focus-visible {
   background: transparent;
 }
 
-.welcome {
-  text-align: center;
-  padding: 16px 10px 0;
-}
-.welcome-title { font-size: 18px; font-weight: 600; opacity: 0.7; }
-.welcome-sub { font-size: 12px; margin-top: 6px; opacity: 0.55; }
-.welcome-suggestions {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: 6px;
-  max-width: 320px;
-  margin: 18px auto 0;
-}
-.welcome-suggestion {
-  padding: 7px 10px;
-  border: 1px solid var(--vscode-panel-border);
-  border-radius: var(--radius);
-  background: var(--vscode-editorWidget-background);
-  color: var(--vscode-foreground);
-  font-size: 12px;
-  text-align: left;
-  opacity: 0.85;
-}
-.welcome-suggestion:hover {
-  background: var(--hover-bg-row);
-  opacity: 1;
-}
-
 .msg {
   margin-bottom: var(--message-gap);
 }


### PR DESCRIPTION
## Summary

Removes the orphaned `.welcome*` rules from `webview/src/styles.css`. They styled the welcome / onboarding screen that was removed in #211 when the start-conversation composer moved to the top of the panel; nothing has referenced them since. A repo-wide search finds `welcome` only in these CSS definitions.

29 lines deleted, no behavior change.

Closes #371

## Test plan

- [x] Repo-wide grep confirms no `welcome` class references remain outside the deleted block
- [x] `bun run check-types` — clean
- [x] `bun run compile` — webview vite build succeeds (521 modules transformed)
- [x] `bun run test` — 1000 passed (66 files)
- [x] Reviewed diff: only the `.welcome*` block removed; collapses cleanly to `.msg`
