### PR TITLE
refactor(chat): extract pure helpers and builtin runners from ChatView

### DIFF
--- a/src/agents/subagent-tracker.ts
+++ b/src/agents/subagent-tracker.ts
@@ -9,22 +9,7 @@ import {
   subagentTaskID,
   subagentTaskIDByChildSession,
 } from "./task-store"
-
-/**
- * Set of tool names that count as "dispatching a subagent". Mirrors
- * `TARGET_TOOLS2` in oh-my-opencode source. Kept in sync with
- * `SUBAGENT_TOOLS` in `chat/view.ts` — the export there is the public
- * spelling used by tests; this internal copy avoids a circular import
- * between view.ts and this file.
- */
-const SUBAGENT_DISPATCH_TOOLS: ReadonlySet<string> = new Set([
-  "task",
-  "Task",
-  "task_tool",
-  "delegate_task",
-  "call_omo_agent",
-  "background_task",
-])
+import { SUBAGENT_TOOLS } from "./summary"
 
 export type SubagentSubscription = {
   addChildSession: (sessionID: string) => void
@@ -124,7 +109,7 @@ export class SubagentTracker {
   }
 
   static isSubagentDispatchTool(toolName: string): boolean {
-    return SUBAGENT_DISPATCH_TOOLS.has(toolName)
+    return SUBAGENT_TOOLS.has(toolName)
   }
 
   /**
@@ -132,7 +117,7 @@ export class SubagentTracker {
    * to dispatch tools and updates the AgentTask accordingly.
    */
   async handleToolUpdate(update: ToolUpdate, messageID?: string): Promise<void> {
-    if (!SUBAGENT_DISPATCH_TOOLS.has(update.tool)) return
+    if (!SUBAGENT_TOOLS.has(update.tool)) return
     const parentSessionID = this.getParentSessionID()
     if (!parentSessionID) {
       log(`[subagent-tracker] skip ${update.tool}:${update.callID} — no parent sessionID yet`)

--- a/src/agents/summary.ts
+++ b/src/agents/summary.ts
@@ -1,0 +1,95 @@
+import type { ToolUpdate } from "../chat/stream"
+import type { AgentsStatusInfo, AgentsTaskInfo } from "../protocol"
+import {
+  ATTENTION_STATUSES,
+  isAttentionStatus,
+  type AgentTask,
+  type AttentionStatus,
+} from "./task-store"
+
+/**
+ * Tool names that represent dispatching a subagent. Mirrors
+ * `TASK_TOOLS` + `TARGET_TOOLS2` from oh-my-opencode's source plus the
+ * omo background-task and delegate-task families:
+ *   - `task` / `Task` / `task_tool` — opencode's built-in task tool (and
+ *     omo's `delegateTask` which is registered under the name `task`).
+ *   - `delegate_task` — defensive: if a future omo version re-registers
+ *     this with its lowercase name we still catch it.
+ *   - `call_omo_agent` — omo's parallel subagent dispatcher used by the
+ *     deep-agent stack (Hephaestus / Sisyphus / Prometheus).
+ *   - `background_task` — omo's pure background dispatcher, used by
+ *     Hephaestus prompts for fire-and-forget worker tasks.
+ * `SubagentTracker.isSubagentDispatchTool` consults this same set.
+ */
+export const SUBAGENT_TOOLS: ReadonlySet<string> = new Set([
+  "task",
+  "Task",
+  "task_tool",
+  "delegate_task",
+  "call_omo_agent",
+  "background_task",
+])
+
+export function isSubagentTool(toolName: string): boolean {
+  return SUBAGENT_TOOLS.has(toolName)
+}
+
+export function summarizeAgentTasks(
+  tasks: AgentTask[],
+  conversationID?: string,
+): AgentsStatusInfo {
+  const scoped = conversationID
+    ? tasks.filter((task) => task.conversationID === conversationID)
+    : tasks
+
+  // The popover shows ONLY currently-active work — main tasks and any
+  // subagents whose status is in ATTENTION_STATUSES. `completed` and
+  // `cancelled` rows are dropped so the popover reflects "what's happening
+  // right now," not a per-chat history. A second user prompt gets its own
+  // main row (see mainTaskID's per-turn keying); the prior turn's row is
+  // settled and filtered out.
+  const counts: Record<AttentionStatus, number> = Object.fromEntries(
+    ATTENTION_STATUSES.map((status) => [status, 0]),
+  ) as Record<AttentionStatus, number>
+  const items: AgentsTaskInfo[] = []
+  for (const task of scoped) {
+    if (!isAttentionStatus(task.status)) continue
+    counts[task.status] += 1
+    items.push({
+      id: task.id,
+      kind: task.kind,
+      title: task.title,
+      status: task.status,
+      error: task.error,
+      startedAt: task.startedAt,
+      updatedAt: task.updatedAt,
+      subagent: task.kind === "subagent" ? task.subagent : undefined,
+      category: task.kind === "subagent" ? task.category : undefined,
+      model: task.kind === "subagent" ? task.model : undefined,
+    })
+  }
+  // Stable order: main tasks first (the user's prompt anchor), then
+  // subagents by startedAt asc. Within each kind, chronological order
+  // is what makes "scrolling back through the turn" make sense.
+  items.sort((a, b) => {
+    if (a.kind !== b.kind) return a.kind === "main" ? -1 : 1
+    return a.startedAt - b.startedAt
+  })
+  return {
+    running: counts.running,
+    waiting: counts.waiting,
+    error: counts.error,
+    total: counts.running + counts.waiting + counts.error,
+    tasks: items,
+  }
+}
+
+export function taskTitleFromUpdate(update: ToolUpdate): string {
+  const input = update.input
+  if (input && typeof input === "object") {
+    const description = (input as Record<string, unknown>).description
+    if (typeof description === "string" && description.trim()) return description.trim()
+  }
+  if (update.title && update.title.trim()) return update.title.trim()
+  return "Background agent"
+}

--- a/src/agents/task-store.ts
+++ b/src/agents/task-store.ts
@@ -79,7 +79,7 @@ export const ACTIVE_STATUSES: ReadonlyArray<AgentTaskStatus> = ["running", "wait
 /**
  * Statuses the Agents popover shows. Active work plus `error` so a
  * failed task stays visible until the user starts the next turn. Exported
- * so call sites (e.g. `summarizeAgentTasks` in `src/chat/view.ts`) iterate
+ * so call sites (e.g. `summarizeAgentTasks` in `src/agents/summary.ts`) iterate
  * the same set and `isAttentionStatus` narrows the union, instead of
  * duplicating the membership check inline.
  */

--- a/src/chat/builtin-runners.ts
+++ b/src/chat/builtin-runners.ts
@@ -1,0 +1,333 @@
+import * as vscode from "vscode"
+import type { Backend } from "../server"
+import type { Preferences } from "../preferences"
+import type { ChatMessage, Outbound, ReviewHunkState } from "../protocol"
+import type { ConversationManager } from "./conversation-manager"
+import { generateMessageID } from "./builtin-commands"
+import { lastUserTurnIndex, redoAction, userMessageText } from "./undo"
+import { log } from "../output"
+
+/**
+ * Everything the built-in runners need from ChatView, as closures so the
+ * view's fields stay private (same pattern as {@link SubagentDispatch}).
+ * The runners never cache session state across awaits beyond a single
+ * command's execution — each `run*` re-reads through these accessors.
+ */
+export type BuiltinRunnerDeps = {
+  prefs: Preferences
+  manager: ConversationManager
+  getSessionID: () => string | undefined
+  setSessionID: (id: string) => void
+  hasSubscription: () => boolean
+  attachSubscription: (backend: Backend, sessionID: string) => Promise<void>
+  /** Post the typed-invocation bubble and key the Agents popover for the turn. */
+  beginBuiltinTurn: (display: string) => Promise<void>
+  post: (msg: Outbound) => void
+  getMessages: () => ChatMessage[]
+  setMessages: (messages: ChatMessage[]) => void
+  /** Live array — runners push/pop in place; ChatView owns reassignment. */
+  getRedoStack: () => ChatMessage[][]
+  getReviewHunks: () => Record<string, ReviewHunkState>
+  clearReviewHunks: () => void
+  saveActive: () => void
+  sendConversationState: () => void
+  queueReviewDecorationsSync: () => void
+  resetSessionState: () => void
+  applyActiveSnapshot: () => void
+  refreshContextUsage: (backend: Backend) => Promise<void>
+}
+
+/**
+ * Implementations of the opencode built-in slash commands that run against
+ * a backend session endpoint. `/compact` and `/init` run a server-side turn
+ * (rendered via the existing SSE subscription); `/share` and `/unshare` are
+ * one-shot actions surfaced through a VS Code notification; `/undo`, `/redo`
+ * and `/fork` mutate local conversation state around a server revert/fork.
+ *
+ * ChatView handles `/mcp`, `/provider` and `/new` itself (they are not
+ * session turns and must not ensure a backend), then delegates here.
+ */
+export class BuiltinRunners {
+  constructor(private deps: BuiltinRunnerDeps) {}
+
+  async run(command: string, backend: Backend): Promise<void> {
+    switch (command) {
+      case "compact":
+        return this.runCompact(backend)
+      case "init":
+        return this.runInit(backend)
+      case "share":
+        return this.runShare(backend)
+      case "unshare":
+        return this.runUnshare(backend)
+      case "undo":
+        return this.runUndo(backend)
+      case "redo":
+        return this.runRedo(backend)
+      case "fork":
+        return this.runFork(backend)
+    }
+  }
+
+  private async runCompact(backend: Backend) {
+    const sessionID = this.deps.getSessionID()
+    if (!sessionID) {
+      void vscode.window.showInformationMessage("Nothing to compact yet.")
+      return
+    }
+    if (!this.deps.hasSubscription()) await this.deps.attachSubscription(backend, sessionID)
+    await this.deps.beginBuiltinTurn("/compact")
+    const sel = this.deps.prefs.get()
+    const body = sel.modelProviderID && sel.modelID ? { providerID: sel.modelProviderID, modelID: sel.modelID } : undefined
+    try {
+      const res = await backend.client.session.summarize({
+        path: { id: sessionID },
+        query: { directory: backend.directory },
+        body,
+      })
+      if (res.error) log("compact failed", res.error)
+    } catch (e) {
+      log("compact threw", e)
+    }
+  }
+
+  private async runInit(backend: Backend) {
+    const sel = this.deps.prefs.get()
+    if (!sel.modelProviderID || !sel.modelID) {
+      void vscode.window.showWarningMessage("Select a model before running /init.")
+      return
+    }
+    let sessionID = this.deps.getSessionID()
+    if (!sessionID) {
+      const created = await backend.client.session.create({ body: {} })
+      if (created.error || !created.data) {
+        log("session.create failed", created.error)
+        return
+      }
+      sessionID = created.data.id
+      this.deps.setSessionID(sessionID)
+      this.deps.manager.updateActive((conversation) => ({ ...conversation, sessionID }))
+      await this.deps.manager.flushPersist()
+      await this.deps.attachSubscription(backend, sessionID)
+    } else if (!this.deps.hasSubscription()) {
+      await this.deps.attachSubscription(backend, sessionID)
+    }
+    await this.deps.beginBuiltinTurn("/init")
+    try {
+      const res = await backend.client.session.init({
+        path: { id: sessionID },
+        query: { directory: backend.directory },
+        body: { providerID: sel.modelProviderID, modelID: sel.modelID, messageID: generateMessageID() },
+      })
+      if (res.error) log("init failed", res.error)
+    } catch (e) {
+      log("init threw", e)
+    }
+  }
+
+  private async runShare(backend: Backend) {
+    const sessionID = this.deps.getSessionID()
+    if (!sessionID) {
+      void vscode.window.showInformationMessage("Start a conversation before sharing.")
+      return
+    }
+    try {
+      const res = await backend.client.session.share({
+        path: { id: sessionID },
+        query: { directory: backend.directory },
+      })
+      if (res.error || !res.data) {
+        log("share failed", res.error)
+        void vscode.window.showErrorMessage("Failed to share session.")
+        return
+      }
+      const url = res.data.share?.url
+      if (!url) {
+        void vscode.window.showInformationMessage("Session shared.")
+        return
+      }
+      const pick = await vscode.window.showInformationMessage(`Session shared: ${url}`, "Copy Link")
+      if (pick === "Copy Link") await vscode.env.clipboard.writeText(url)
+    } catch (e) {
+      log("share threw", e)
+    }
+  }
+
+  private async runUnshare(backend: Backend) {
+    const sessionID = this.deps.getSessionID()
+    if (!sessionID) return
+    try {
+      const res = await backend.client.session.unshare({
+        path: { id: sessionID },
+        query: { directory: backend.directory },
+      })
+      if (res.error) {
+        log("unshare failed", res.error)
+        void vscode.window.showErrorMessage("Failed to disable sharing.")
+        return
+      }
+      void vscode.window.showInformationMessage("Session sharing disabled.")
+    } catch (e) {
+      log("unshare threw", e)
+    }
+  }
+
+  /**
+   * `/undo` — revert the last settled turn. Mirrors handleEdit's
+   * revert + truncate + sendConversationState, minus the resend: the removed
+   * tail is stashed for `/redo` and the undone prompt is restored to the composer.
+   */
+  private async runUndo(backend: Backend) {
+    const sessionID = this.deps.getSessionID()
+    if (!sessionID) {
+      void vscode.window.showInformationMessage("Nothing to undo yet.")
+      return
+    }
+    const messages = this.deps.getMessages()
+    const idx = lastUserTurnIndex(messages)
+    if (idx < 0) {
+      void vscode.window.showInformationMessage("Nothing to undo.")
+      return
+    }
+    const target = messages[idx]!
+    try {
+      const res = await backend.client.session.revert({
+        path: { id: sessionID },
+        query: { directory: backend.directory },
+        body: { messageID: target.backendID! },
+      })
+      if (res.error) {
+        log("undo: session.revert failed", res.error)
+        void vscode.window.showErrorMessage("Failed to undo the last turn.")
+        return
+      }
+    } catch (e) {
+      log("undo: session.revert threw", e)
+      return
+    }
+    this.deps.getRedoStack().push(messages.slice(idx))
+    this.deps.setMessages(messages.slice(0, idx))
+    this.deps.clearReviewHunks()
+    this.deps.saveActive()
+    this.deps.sendConversationState()
+    this.deps.queueReviewDecorationsSync()
+    // Restore the undone prompt so the user can edit and resend. Plain text only:
+    // mentions/attachments are not re-hydrated.
+    this.deps.post({ type: "setComposerText", text: userMessageText(target) })
+  }
+
+  /** `/redo` — re-apply the most recently undone turn from the in-memory buffer. */
+  private async runRedo(backend: Backend) {
+    const sessionID = this.deps.getSessionID()
+    if (!sessionID) return
+    const redoStack = this.deps.getRedoStack()
+    const tail = redoStack.pop()
+    if (!tail || tail.length === 0) {
+      void vscode.window.showInformationMessage("Nothing to redo.")
+      return
+    }
+    // Move the server revert pointer forward to the next still-reverted tail, or
+    // clear it entirely when this restores the latest turn.
+    const action = redoAction(redoStack[redoStack.length - 1])
+    try {
+      const res =
+        action.kind === "revert"
+          ? await backend.client.session.revert({
+              path: { id: sessionID },
+              query: { directory: backend.directory },
+              body: { messageID: action.messageID },
+            })
+          : await backend.client.session.unrevert({
+              path: { id: sessionID },
+              query: { directory: backend.directory },
+            })
+      if (res.error) {
+        log("redo failed", res.error)
+        void vscode.window.showErrorMessage("Failed to redo.")
+        redoStack.push(tail)
+        return
+      }
+    } catch (e) {
+      log("redo threw", e)
+      redoStack.push(tail)
+      return
+    }
+    this.deps.setMessages([...this.deps.getMessages(), ...tail])
+    this.deps.saveActive()
+    this.deps.sendConversationState()
+    this.deps.queueReviewDecorationsSync()
+    this.deps.post({ type: "setComposerText", text: "" })
+  }
+
+  /**
+   * `/fork` — duplicate the current session into a new conversation. The fork
+   * copies the current session, so its history equals our in-memory messages; we
+   * adopt the forked session id onto a fresh conversation and copy the messages
+   * over (re-stamping their backendIDs from the forked session so revert/edit
+   * keep working). No server->ChatMessage converter exists, hence the copy.
+   */
+  private async runFork(backend: Backend) {
+    const sessionID = this.deps.getSessionID()
+    if (!sessionID) {
+      void vscode.window.showInformationMessage("Nothing to fork yet.")
+      return
+    }
+    try {
+      const res = await backend.client.session.fork({
+        path: { id: sessionID },
+        query: { directory: backend.directory },
+        body: {},
+      })
+      if (res.error || !res.data) {
+        log("fork failed", res.error)
+        void vscode.window.showErrorMessage("Failed to fork the conversation.")
+        return
+      }
+      const forked = res.data
+      const copied = this.deps.getMessages().map((m) => ({ ...m, pending: false }))
+      await restampForkedIDs(backend, forked.id, copied)
+      const copiedHunks = { ...this.deps.getReviewHunks() }
+
+      this.deps.resetSessionState()
+      const conversation = this.deps.manager.add(forked.title || "Forked chat")
+      this.deps.manager.setActiveID(conversation.id)
+      this.deps.manager.updateActive((c) => ({ ...c, sessionID: forked.id, messages: copied, reviewHunks: copiedHunks }))
+      this.deps.applyActiveSnapshot()
+      await this.deps.manager.flushPersist()
+      this.deps.sendConversationState()
+      this.deps.post({ type: "contextUsage", usage: undefined })
+      await this.deps.attachSubscription(backend, forked.id)
+      void this.deps.refreshContextUsage(backend)
+    } catch (e) {
+      log("fork threw", e)
+      void vscode.window.showErrorMessage("Failed to fork the conversation.")
+    }
+  }
+}
+
+/**
+ * Align copied messages' backendIDs with the forked session's real message ids
+ * by position. Fork duplicates the whole session, so order + count match (every
+ * settled bubble has a server message, and `/fork` only runs when idle); if the
+ * counts diverge we keep the copied ids and log — edit/undo on a pre-fork message
+ * may then need a fresh turn first.
+ */
+async function restampForkedIDs(backend: Backend, sessionID: string, messages: ChatMessage[]) {
+  try {
+    const res = await backend.client.session.messages({
+      path: { id: sessionID },
+      query: { directory: backend.directory },
+    })
+    const server = (res.data ?? []) as Array<{ info?: { id?: string } }>
+    if (res.error || server.length !== messages.length) {
+      log("fork: skipping backendID re-stamp", { error: res.error, server: server.length, local: messages.length })
+      return
+    }
+    messages.forEach((m, i) => {
+      const id = server[i]?.info?.id
+      if (id) m.backendID = id
+    })
+  } catch (e) {
+    log("fork: restamp threw", e)
+  }
+}

--- a/src/chat/context-usage.ts
+++ b/src/chat/context-usage.ts
@@ -1,0 +1,108 @@
+import type { Backend } from "../server"
+import type { ContextUsage } from "../protocol"
+
+type ContextUsageMessageInfo = {
+  role?: string
+  providerID?: string
+  modelID?: string
+  cost?: number
+  tokens?: {
+    input?: number
+    output?: number
+    reasoning?: number
+    cache?: { read?: number; write?: number }
+  }
+}
+
+type ContextUsageMessage = { info?: ContextUsageMessageInfo }
+type ContextUsageProvider = {
+  id?: string
+  models?: Record<string, { limit?: { context?: number } } | undefined>
+}
+
+// Provider metadata (model context limits) changes only when the user edits
+// their opencode config, but readContextUsage runs after every turn. Cache it
+// per backend with a short TTL so the indicator stops re-fetching it each turn.
+type CachedProviders = { providers: ContextUsageProvider[]; at: number }
+const providersCache = new Map<string, CachedProviders>()
+const PROVIDERS_CACHE_MS = 5 * 60 * 1000
+
+async function fetchProviders(backend: Backend): Promise<ContextUsageProvider[]> {
+  const now = Date.now()
+  const cached = providersCache.get(backend.url)
+  if (cached && now - cached.at < PROVIDERS_CACHE_MS) return cached.providers
+  const res = await backend.client.config.providers()
+  if (res.error) {
+    if (cached) return cached.providers
+    throw new Error(`config.providers failed: ${JSON.stringify(res.error)}`)
+  }
+  const providers = (res.data as { providers?: ContextUsageProvider[] } | undefined)?.providers ?? []
+  providersCache.set(backend.url, { providers, at: now })
+  return providers
+}
+
+export async function readContextUsage(backend: Backend, sessionID: string): Promise<ContextUsage | undefined> {
+  const [messagesRes, providers] = await Promise.all([
+    backend.client.session.messages({
+      path: { id: sessionID },
+      query: { directory: backend.directory, limit: 100 },
+    }),
+    fetchProviders(backend),
+  ])
+  if (messagesRes.error) throw new Error(`session.messages failed: ${JSON.stringify(messagesRes.error)}`)
+
+  const messages = (messagesRes.data ?? []) as ContextUsageMessage[]
+  return contextUsageFromMessages(messages, providers)
+}
+
+export function contextUsageFromMessages(
+  messages: ContextUsageMessage[],
+  providers: ContextUsageProvider[],
+): ContextUsage | undefined {
+  const last = messages.findLast((item) =>
+    item.info?.role === "assistant" && numberOrZero(item.info.tokens?.output) > 0
+  )
+  if (!last?.info?.tokens) return undefined
+
+  const tokens = contextTokenCount(last.info.tokens)
+  if (tokens <= 0) return undefined
+
+  const providerID = last.info.providerID
+  const modelID = last.info.modelID
+  const limit = findContextLimit(providers, providerID, modelID)
+  const cost = messages.reduce((sum, item) => {
+    const info = item.info
+    return info?.role === "assistant" && typeof info.cost === "number" ? sum + info.cost : sum
+  }, 0)
+  return {
+    tokens,
+    limit,
+    percent: limit ? Math.round((tokens / limit) * 100) : undefined,
+    model: providerID && modelID ? `${providerID}/${modelID}` : undefined,
+    cost: cost > 0 ? cost : undefined,
+  }
+}
+
+function contextTokenCount(tokens: NonNullable<ContextUsageMessageInfo["tokens"]>): number {
+  return (
+    numberOrZero(tokens.input) +
+    numberOrZero(tokens.output) +
+    numberOrZero(tokens.reasoning) +
+    numberOrZero(tokens.cache?.read) +
+    numberOrZero(tokens.cache?.write)
+  )
+}
+
+function findContextLimit(
+  providers: ContextUsageProvider[],
+  providerID: string | undefined,
+  modelID: string | undefined,
+): number | undefined {
+  if (!providerID || !modelID) return undefined
+  const value = providers.find((provider) => provider.id === providerID)?.models?.[modelID]?.limit?.context
+  return typeof value === "number" && value > 0 ? value : undefined
+}
+
+function numberOrZero(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0
+}

--- a/src/chat/continuation-state.ts
+++ b/src/chat/continuation-state.ts
@@ -1,5 +1,28 @@
 import type { Outbound } from "../protocol"
+import type { Toast } from "./stream"
 import { log } from "../output"
+
+/**
+ * Recognize a toast that signals an imminent continuation. Exported so the
+ * regex is testable in isolation. Patterns matched:
+ *   - `Todo Continuation` / `Resuming in Ns...` — omo TodoContinuationEnforcer
+ *     (`src/hooks/todo-continuation-enforcer/countdown.ts:20-30`).
+ *   - `Background task complete|failed — ... Resuming the main thread.` —
+ *     opencode's `task` tool auto-resume after a background subagent finishes
+ *     (`packages/opencode/src/tool/task.ts:217-225`).
+ *   - `New Background Task` — omo's task-toast-manager when a backgrounded
+ *     subagent spawns (`src/features/task-toast-manager/manager.ts:193`).
+ *   - Any phrasing containing `resuming` as a defensive catch-all.
+ *
+ * Notably we do NOT match `Task Completed` on its own — that toast can fire
+ * for both midway and final task completions, so by itself it isn't a reliable
+ * "expect another turn" signal. The structural check on running `task` tool
+ * parts handles that case more precisely.
+ */
+export function isContinuationToast(toast: Toast): boolean {
+  const haystack = `${toast.title ?? ""} ${toast.message}`.toLowerCase()
+  return /continuation|resuming|new background task|background task (complete|failed)/.test(haystack)
+}
 
 /**
  * Tracks the deferred-idle state for "this turn isn't really done, a
@@ -12,7 +35,7 @@ import { log } from "../output"
  *    structural gate keeps `continuationPending: true` until the
  *    children settle.
  *  - **Signal**: a toast-style hint (e.g. omo's TodoContinuationEnforcer
- *    countdown). Recognized by `isContinuationToast` in view.ts; routed
+ *    countdown). Recognized by `isContinuationToast` in this module; routed
  *    here via `markSignal`. Caps at `DEFER_MS` so a missing follow-up
  *    can't pin the UI indefinitely.
  *

--- a/src/chat/subagent-dispatch.ts
+++ b/src/chat/subagent-dispatch.ts
@@ -5,8 +5,7 @@ import type { ToolUpdate } from "./stream"
 
 /**
  * Reduce a user prompt to a short title for the Agents popover. Lives
- * here because `recordMainTaskStart` is the only host-side caller; the
- * test suite imports it through the view.ts re-export.
+ * here because `recordMainTaskStart` is the only host-side caller.
  */
 export function summarizePrompt(text: string): string {
   return text.replace(/\s+/g, " ").trim().slice(0, 64) || "Main agent"

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -21,7 +21,6 @@ import type {
   ChatBlock,
   ChatMessage,
   CommandInfo,
-  ContextUsage,
   Inbound,
   Outbound,
   ToolUpdate as WireToolUpdate,
@@ -30,14 +29,14 @@ import type {
   ReviewChangeActor,
   ReviewHunkState,
 } from "../protocol"
-import { BUILTIN_COMMAND_NAMES, withBuiltinCommands, generateMessageID } from "./builtin-commands"
-import { lastUserTurnIndex, redoAction, userMessageText } from "./undo"
+import { BUILTIN_COMMAND_NAMES, withBuiltinCommands } from "./builtin-commands"
+import { BuiltinRunners } from "./builtin-runners"
+import { readContextUsage } from "./context-usage"
 import { migrateConversationsToWorkspace } from "./conversation-store"
 import { ConversationManager } from "./conversation-manager"
-import { ContinuationState } from "./continuation-state"
+import { ContinuationState, isContinuationToast } from "./continuation-state"
 import { sweepAbortTree, drainAbortTree } from "./abort-tree"
 import { SubagentDispatch } from "./subagent-dispatch"
-export { summarizePrompt } from "./subagent-dispatch"
 import { relativeToCwd, samePath } from "./paths"
 import { isTextReviewPath, reviewKey, splitReviewDiff } from "./diff"
 import { extractChanges, reviewChanges } from "./review-changes"
@@ -48,16 +47,9 @@ import { collectAutoContext } from "../workspace-context/collector"
 import { RecentEditsTracker } from "../workspace-context/recent-edits"
 import { readContextSettings } from "../workspace-context/budget"
 import type { IndexManager } from "../indexing/index-manager"
-import {
-  AgentTaskStore,
-  ATTENTION_STATUSES,
-  classifyTerminal,
-  isAttentionStatus,
-  type AgentTask,
-  type AttentionStatus,
-} from "../agents/task-store"
+import { AgentTaskStore, classifyTerminal, type AgentTask } from "../agents/task-store"
+import { summarizeAgentTasks } from "../agents/summary"
 import { SubagentTracker } from "../agents/subagent-tracker"
-import type { AgentsStatusInfo, AgentsTaskInfo } from "../protocol"
 import { toWire } from "./wire-format"
 import {
   applyCode,
@@ -65,28 +57,6 @@ import {
   openFileDocument,
   reviewPathExists,
 } from "./fs-ops"
-
-/**
- * Recognize a toast that signals an imminent continuation. Exported so the
- * regex is testable in isolation. Patterns matched:
- *   - `Todo Continuation` / `Resuming in Ns...` — omo TodoContinuationEnforcer
- *     (`src/hooks/todo-continuation-enforcer/countdown.ts:20-30`).
- *   - `Background task complete|failed — ... Resuming the main thread.` —
- *     opencode's `task` tool auto-resume after a background subagent finishes
- *     (`packages/opencode/src/tool/task.ts:217-225`).
- *   - `New Background Task` — omo's task-toast-manager when a backgrounded
- *     subagent spawns (`src/features/task-toast-manager/manager.ts:193`).
- *   - Any phrasing containing `resuming` as a defensive catch-all.
- *
- * Notably we do NOT match `Task Completed` on its own — that toast can fire
- * for both midway and final task completions, so by itself it isn't a reliable
- * "expect another turn" signal. The structural check on running `task` tool
- * parts handles that case more precisely.
- */
-export function isContinuationToast(toast: Toast): boolean {
-  const haystack = `${toast.title ?? ""} ${toast.message}`.toLowerCase()
-  return /continuation|resuming|new background task|background task (complete|failed)/.test(haystack)
-}
 
 export class ChatView implements vscode.WebviewViewProvider {
   static viewType = "opencui.chat"
@@ -147,6 +117,12 @@ export class ChatView implements vscode.WebviewViewProvider {
    */
   private subagentDispatch: SubagentDispatch
   /**
+   * Implementations of the backend-bound built-in slash commands
+   * (`/compact`, `/init`, `/share`, `/unshare`, `/undo`, `/redo`,
+   * `/fork`). See {@link BuiltinRunners}.
+   */
+  private builtinRunners: BuiltinRunners
+  /**
    * Single per-conversation subagent state machine. Reset on
    * `createConversation` / `selectConversation` / `dispose`. Constructed
    * lazily inside `attachSubscription` because the SSE subscription's
@@ -179,6 +155,33 @@ export class ChatView implements vscode.WebviewViewProvider {
       post: (msg) => this.post(msg),
       activeSubagentCount: () => this.subagentDispatch.activeSubagentCount(),
       emitIdle: () => this.settleSessionIdle(),
+    })
+    this.builtinRunners = new BuiltinRunners({
+      prefs: this.prefs,
+      manager: this.manager,
+      getSessionID: () => this.sessionID,
+      setSessionID: (id) => {
+        this.sessionID = id
+      },
+      hasSubscription: () => this.subscription !== undefined,
+      attachSubscription: (backend, sessionID) => this.attachSubscription(backend, sessionID),
+      beginBuiltinTurn: (display) => this.beginBuiltinTurn(display),
+      post: (msg) => this.post(msg),
+      getMessages: () => this.messages,
+      setMessages: (messages) => {
+        this.messages = messages
+      },
+      getRedoStack: () => this.redoStack,
+      getReviewHunks: () => this.reviewHunks,
+      clearReviewHunks: () => {
+        this.reviewHunks = {}
+      },
+      saveActive: () => this.saveActive(),
+      sendConversationState: () => this.sendConversationState(),
+      queueReviewDecorationsSync: () => this.queueReviewDecorationsSync(),
+      resetSessionState: () => this.resetSessionState(),
+      applyActiveSnapshot: () => this.applyActiveSnapshot(),
+      refreshContextUsage: (backend) => this.refreshContextUsage(backend),
     })
     this.applyActiveSnapshot()
     void this.manager.persist()
@@ -1334,22 +1337,7 @@ export class ChatView implements vscode.WebviewViewProvider {
       this.post({ type: "connected", connected: false, error: (e as Error).message })
       return
     }
-    switch (command) {
-      case "compact":
-        return this.runCompact(backend)
-      case "init":
-        return this.runInit(backend)
-      case "share":
-        return this.runShare(backend)
-      case "unshare":
-        return this.runUnshare(backend)
-      case "undo":
-        return this.runUndo(backend)
-      case "redo":
-        return this.runRedo(backend)
-      case "fork":
-        return this.runFork(backend)
-    }
+    await this.builtinRunners.run(command, backend)
   }
 
   /** Post the typed-invocation bubble and key the Agents popover for a built-in turn. */
@@ -1366,258 +1354,6 @@ export class ChatView implements vscode.WebviewViewProvider {
     })
     this.updateTitleFromPrompt(display)
     await this.subagentDispatch.recordMainTaskStart(display)
-  }
-
-  private async runCompact(backend: Backend) {
-    if (!this.sessionID) {
-      void vscode.window.showInformationMessage("Nothing to compact yet.")
-      return
-    }
-    if (!this.subscription) await this.attachSubscription(backend, this.sessionID)
-    await this.beginBuiltinTurn("/compact")
-    const sel = this.prefs.get()
-    const body = sel.modelProviderID && sel.modelID ? { providerID: sel.modelProviderID, modelID: sel.modelID } : undefined
-    try {
-      const res = await backend.client.session.summarize({
-        path: { id: this.sessionID },
-        query: { directory: backend.directory },
-        body,
-      })
-      if (res.error) log("compact failed", res.error)
-    } catch (e) {
-      log("compact threw", e)
-    }
-  }
-
-  private async runInit(backend: Backend) {
-    const sel = this.prefs.get()
-    if (!sel.modelProviderID || !sel.modelID) {
-      void vscode.window.showWarningMessage("Select a model before running /init.")
-      return
-    }
-    if (!this.sessionID) {
-      const created = await backend.client.session.create({ body: {} })
-      if (created.error || !created.data) {
-        log("session.create failed", created.error)
-        return
-      }
-      this.sessionID = created.data.id
-      this.manager.updateActive((conversation) => ({ ...conversation, sessionID: this.sessionID }))
-      await this.manager.flushPersist()
-      await this.attachSubscription(backend, this.sessionID)
-    } else if (!this.subscription) {
-      await this.attachSubscription(backend, this.sessionID)
-    }
-    await this.beginBuiltinTurn("/init")
-    try {
-      const res = await backend.client.session.init({
-        path: { id: this.sessionID },
-        query: { directory: backend.directory },
-        body: { providerID: sel.modelProviderID, modelID: sel.modelID, messageID: generateMessageID() },
-      })
-      if (res.error) log("init failed", res.error)
-    } catch (e) {
-      log("init threw", e)
-    }
-  }
-
-  private async runShare(backend: Backend) {
-    if (!this.sessionID) {
-      void vscode.window.showInformationMessage("Start a conversation before sharing.")
-      return
-    }
-    try {
-      const res = await backend.client.session.share({
-        path: { id: this.sessionID },
-        query: { directory: backend.directory },
-      })
-      if (res.error || !res.data) {
-        log("share failed", res.error)
-        void vscode.window.showErrorMessage("Failed to share session.")
-        return
-      }
-      const url = res.data.share?.url
-      if (!url) {
-        void vscode.window.showInformationMessage("Session shared.")
-        return
-      }
-      const pick = await vscode.window.showInformationMessage(`Session shared: ${url}`, "Copy Link")
-      if (pick === "Copy Link") await vscode.env.clipboard.writeText(url)
-    } catch (e) {
-      log("share threw", e)
-    }
-  }
-
-  private async runUnshare(backend: Backend) {
-    if (!this.sessionID) return
-    try {
-      const res = await backend.client.session.unshare({
-        path: { id: this.sessionID },
-        query: { directory: backend.directory },
-      })
-      if (res.error) {
-        log("unshare failed", res.error)
-        void vscode.window.showErrorMessage("Failed to disable sharing.")
-        return
-      }
-      void vscode.window.showInformationMessage("Session sharing disabled.")
-    } catch (e) {
-      log("unshare threw", e)
-    }
-  }
-
-  /**
-   * `/undo` — revert the last settled turn. Mirrors handleEdit's
-   * revert + truncate + sendConversationState, minus the resend: the removed
-   * tail is stashed for `/redo` and the undone prompt is restored to the composer.
-   */
-  private async runUndo(backend: Backend) {
-    if (!this.sessionID) {
-      void vscode.window.showInformationMessage("Nothing to undo yet.")
-      return
-    }
-    const idx = lastUserTurnIndex(this.messages)
-    if (idx < 0) {
-      void vscode.window.showInformationMessage("Nothing to undo.")
-      return
-    }
-    const target = this.messages[idx]!
-    try {
-      const res = await backend.client.session.revert({
-        path: { id: this.sessionID },
-        query: { directory: backend.directory },
-        body: { messageID: target.backendID! },
-      })
-      if (res.error) {
-        log("undo: session.revert failed", res.error)
-        void vscode.window.showErrorMessage("Failed to undo the last turn.")
-        return
-      }
-    } catch (e) {
-      log("undo: session.revert threw", e)
-      return
-    }
-    this.redoStack.push(this.messages.slice(idx))
-    this.messages = this.messages.slice(0, idx)
-    this.reviewHunks = {}
-    this.saveActive()
-    this.sendConversationState()
-    this.queueReviewDecorationsSync()
-    // Restore the undone prompt so the user can edit and resend. Plain text only:
-    // mentions/attachments are not re-hydrated.
-    this.post({ type: "setComposerText", text: userMessageText(target) })
-  }
-
-  /** `/redo` — re-apply the most recently undone turn from the in-memory buffer. */
-  private async runRedo(backend: Backend) {
-    if (!this.sessionID) return
-    const tail = this.redoStack.pop()
-    if (!tail || tail.length === 0) {
-      void vscode.window.showInformationMessage("Nothing to redo.")
-      return
-    }
-    // Move the server revert pointer forward to the next still-reverted tail, or
-    // clear it entirely when this restores the latest turn.
-    const action = redoAction(this.redoStack[this.redoStack.length - 1])
-    try {
-      const res =
-        action.kind === "revert"
-          ? await backend.client.session.revert({
-              path: { id: this.sessionID },
-              query: { directory: backend.directory },
-              body: { messageID: action.messageID },
-            })
-          : await backend.client.session.unrevert({
-              path: { id: this.sessionID },
-              query: { directory: backend.directory },
-            })
-      if (res.error) {
-        log("redo failed", res.error)
-        void vscode.window.showErrorMessage("Failed to redo.")
-        this.redoStack.push(tail)
-        return
-      }
-    } catch (e) {
-      log("redo threw", e)
-      this.redoStack.push(tail)
-      return
-    }
-    this.messages = [...this.messages, ...tail]
-    this.saveActive()
-    this.sendConversationState()
-    this.queueReviewDecorationsSync()
-    this.post({ type: "setComposerText", text: "" })
-  }
-
-  /**
-   * `/fork` — duplicate the current session into a new conversation. The fork
-   * copies the current session, so its history equals our in-memory messages; we
-   * adopt the forked session id onto a fresh conversation and copy the messages
-   * over (re-stamping their backendIDs from the forked session so revert/edit
-   * keep working). No server->ChatMessage converter exists, hence the copy.
-   */
-  private async runFork(backend: Backend) {
-    if (!this.sessionID) {
-      void vscode.window.showInformationMessage("Nothing to fork yet.")
-      return
-    }
-    try {
-      const res = await backend.client.session.fork({
-        path: { id: this.sessionID },
-        query: { directory: backend.directory },
-        body: {},
-      })
-      if (res.error || !res.data) {
-        log("fork failed", res.error)
-        void vscode.window.showErrorMessage("Failed to fork the conversation.")
-        return
-      }
-      const forked = res.data
-      const copied = this.messages.map((m) => ({ ...m, pending: false }))
-      await this.restampForkedIDs(backend, forked.id, copied)
-      const copiedHunks = { ...this.reviewHunks }
-
-      this.resetSessionState()
-      const conversation = this.manager.add(forked.title || "Forked chat")
-      this.manager.setActiveID(conversation.id)
-      this.manager.updateActive((c) => ({ ...c, sessionID: forked.id, messages: copied, reviewHunks: copiedHunks }))
-      this.applyActiveSnapshot()
-      await this.manager.flushPersist()
-      this.sendConversationState()
-      this.post({ type: "contextUsage", usage: undefined })
-      await this.attachSubscription(backend, forked.id)
-      void this.refreshContextUsage(backend)
-    } catch (e) {
-      log("fork threw", e)
-      void vscode.window.showErrorMessage("Failed to fork the conversation.")
-    }
-  }
-
-  /**
-   * Align copied messages' backendIDs with the forked session's real message ids
-   * by position. Fork duplicates the whole session, so order + count match (every
-   * settled bubble has a server message, and `/fork` only runs when idle); if the
-   * counts diverge we keep the copied ids and log — edit/undo on a pre-fork message
-   * may then need a fresh turn first.
-   */
-  private async restampForkedIDs(backend: Backend, sessionID: string, messages: ChatMessage[]) {
-    try {
-      const res = await backend.client.session.messages({
-        path: { id: sessionID },
-        query: { directory: backend.directory },
-      })
-      const server = (res.data ?? []) as Array<{ info?: { id?: string } }>
-      if (res.error || server.length !== messages.length) {
-        log("fork: skipping backendID re-stamp", { error: res.error, server: server.length, local: messages.length })
-        return
-      }
-      messages.forEach((m, i) => {
-        const id = server[i]?.info?.id
-        if (id) m.backendID = id
-      })
-    } catch (e) {
-      log("fork: restamp threw", e)
-    }
   }
 
   private async handleEdit(webviewID: string, text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) {
@@ -2121,199 +1857,6 @@ export class ChatView implements vscode.WebviewViewProvider {
     html = html.replace("<head>", `<head><meta http-equiv="Content-Security-Policy" content="${csp}">`)
     return html
   }
-}
-
-/**
- * Tool names that represent dispatching a subagent. Mirrors
- * `TASK_TOOLS` + `TARGET_TOOLS2` from oh-my-opencode's source plus the
- * omo background-task and delegate-task families:
- *   - `task` / `Task` / `task_tool` — opencode's built-in task tool (and
- *     omo's `delegateTask` which is registered under the name `task`).
- *   - `delegate_task` — defensive: if a future omo version re-registers
- *     this with its lowercase name we still catch it.
- *   - `call_omo_agent` — omo's parallel subagent dispatcher used by the
- *     deep-agent stack (Hephaestus / Sisyphus / Prometheus).
- *   - `background_task` — omo's pure background dispatcher, used by
- *     Hephaestus prompts for fire-and-forget worker tasks.
- * Kept in sync with the internal set in `src/agents/subagent-tracker.ts`.
- */
-export const SUBAGENT_TOOLS: ReadonlySet<string> = new Set([
-  "task",
-  "Task",
-  "task_tool",
-  "delegate_task",
-  "call_omo_agent",
-  "background_task",
-])
-
-export function isSubagentTool(toolName: string): boolean {
-  return SUBAGENT_TOOLS.has(toolName)
-}
-
-export function summarizeAgentTasks(
-  tasks: AgentTask[],
-  conversationID?: string,
-): AgentsStatusInfo {
-  const scoped = conversationID
-    ? tasks.filter((task) => task.conversationID === conversationID)
-    : tasks
-
-  // The popover shows ONLY currently-active work — main tasks and any
-  // subagents whose status is in ATTENTION_STATUSES. `completed` and
-  // `cancelled` rows are dropped so the popover reflects "what's happening
-  // right now," not a per-chat history. A second user prompt gets its own
-  // main row (see mainTaskID's per-turn keying); the prior turn's row is
-  // settled and filtered out.
-  const counts: Record<AttentionStatus, number> = Object.fromEntries(
-    ATTENTION_STATUSES.map((status) => [status, 0]),
-  ) as Record<AttentionStatus, number>
-  const items: AgentsTaskInfo[] = []
-  for (const task of scoped) {
-    if (!isAttentionStatus(task.status)) continue
-    counts[task.status] += 1
-    items.push({
-      id: task.id,
-      kind: task.kind,
-      title: task.title,
-      status: task.status,
-      error: task.error,
-      startedAt: task.startedAt,
-      updatedAt: task.updatedAt,
-      subagent: task.kind === "subagent" ? task.subagent : undefined,
-      category: task.kind === "subagent" ? task.category : undefined,
-      model: task.kind === "subagent" ? task.model : undefined,
-    })
-  }
-  // Stable order: main tasks first (the user's prompt anchor), then
-  // subagents by startedAt asc. Within each kind, chronological order
-  // is what makes "scrolling back through the turn" make sense.
-  items.sort((a, b) => {
-    if (a.kind !== b.kind) return a.kind === "main" ? -1 : 1
-    return a.startedAt - b.startedAt
-  })
-  return {
-    running: counts.running,
-    waiting: counts.waiting,
-    error: counts.error,
-    total: counts.running + counts.waiting + counts.error,
-    tasks: items,
-  }
-}
-
-export function taskTitleFromUpdate(update: ToolUpdate): string {
-  const input = update.input
-  if (input && typeof input === "object") {
-    const description = (input as Record<string, unknown>).description
-    if (typeof description === "string" && description.trim()) return description.trim()
-  }
-  if (update.title && update.title.trim()) return update.title.trim()
-  return "Background agent"
-}
-
-type ContextUsageMessageInfo = {
-  role?: string
-  providerID?: string
-  modelID?: string
-  cost?: number
-  tokens?: {
-    input?: number
-    output?: number
-    reasoning?: number
-    cache?: { read?: number; write?: number }
-  }
-}
-
-type ContextUsageMessage = { info?: ContextUsageMessageInfo }
-type ContextUsageProvider = {
-  id?: string
-  models?: Record<string, { limit?: { context?: number } } | undefined>
-}
-
-// Provider metadata (model context limits) changes only when the user edits
-// their opencode config, but readContextUsage runs after every turn. Cache it
-// per backend with a short TTL so the indicator stops re-fetching it each turn.
-type CachedProviders = { providers: ContextUsageProvider[]; at: number }
-const providersCache = new Map<string, CachedProviders>()
-const PROVIDERS_CACHE_MS = 5 * 60 * 1000
-
-async function fetchProviders(backend: Backend): Promise<ContextUsageProvider[]> {
-  const now = Date.now()
-  const cached = providersCache.get(backend.url)
-  if (cached && now - cached.at < PROVIDERS_CACHE_MS) return cached.providers
-  const res = await backend.client.config.providers()
-  if (res.error) {
-    if (cached) return cached.providers
-    throw new Error(`config.providers failed: ${JSON.stringify(res.error)}`)
-  }
-  const providers = (res.data as { providers?: ContextUsageProvider[] } | undefined)?.providers ?? []
-  providersCache.set(backend.url, { providers, at: now })
-  return providers
-}
-
-async function readContextUsage(backend: Backend, sessionID: string): Promise<ContextUsage | undefined> {
-  const [messagesRes, providers] = await Promise.all([
-    backend.client.session.messages({
-      path: { id: sessionID },
-      query: { directory: backend.directory, limit: 100 },
-    }),
-    fetchProviders(backend),
-  ])
-  if (messagesRes.error) throw new Error(`session.messages failed: ${JSON.stringify(messagesRes.error)}`)
-
-  const messages = (messagesRes.data ?? []) as ContextUsageMessage[]
-  return contextUsageFromMessages(messages, providers)
-}
-
-export function contextUsageFromMessages(
-  messages: ContextUsageMessage[],
-  providers: ContextUsageProvider[],
-): ContextUsage | undefined {
-  const last = messages.findLast((item) =>
-    item.info?.role === "assistant" && numberOrZero(item.info.tokens?.output) > 0
-  )
-  if (!last?.info?.tokens) return undefined
-
-  const tokens = contextTokenCount(last.info.tokens)
-  if (tokens <= 0) return undefined
-
-  const providerID = last.info.providerID
-  const modelID = last.info.modelID
-  const limit = findContextLimit(providers, providerID, modelID)
-  const cost = messages.reduce((sum, item) => {
-    const info = item.info
-    return info?.role === "assistant" && typeof info.cost === "number" ? sum + info.cost : sum
-  }, 0)
-  return {
-    tokens,
-    limit,
-    percent: limit ? Math.round((tokens / limit) * 100) : undefined,
-    model: providerID && modelID ? `${providerID}/${modelID}` : undefined,
-    cost: cost > 0 ? cost : undefined,
-  }
-}
-
-function contextTokenCount(tokens: NonNullable<ContextUsageMessageInfo["tokens"]>): number {
-  return (
-    numberOrZero(tokens.input) +
-    numberOrZero(tokens.output) +
-    numberOrZero(tokens.reasoning) +
-    numberOrZero(tokens.cache?.read) +
-    numberOrZero(tokens.cache?.write)
-  )
-}
-
-function findContextLimit(
-  providers: ContextUsageProvider[],
-  providerID: string | undefined,
-  modelID: string | undefined,
-): number | undefined {
-  if (!providerID || !modelID) return undefined
-  const value = providers.find((provider) => provider.id === providerID)?.models?.[modelID]?.limit?.context
-  return typeof value === "number" && value > 0 ? value : undefined
-}
-
-function numberOrZero(value: unknown): number {
-  return typeof value === "number" && Number.isFinite(value) ? value : 0
 }
 
 function collectSymbolFocus(activeRel: string | undefined, mentions: string[] | undefined): string[] {

--- a/test/host/agent-task-wiring.test.ts
+++ b/test/host/agent-task-wiring.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from "vitest"
 import {
   taskTitleFromUpdate,
-  summarizePrompt,
   summarizeAgentTasks,
   isSubagentTool,
-} from "../../src/chat/view"
+} from "../../src/agents/summary"
+import { summarizePrompt } from "../../src/chat/subagent-dispatch"
 import type { ToolUpdate } from "../../src/chat/stream"
 import type { AgentTask } from "../../src/agents/task-store"
 

--- a/test/host/context-usage.test.ts
+++ b/test/host/context-usage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { contextUsageFromMessages } from "../../src/chat/view"
+import { contextUsageFromMessages } from "../../src/chat/context-usage"
 
 describe("contextUsageFromMessages", () => {
   it("matches opencode's context calculation from the latest assistant token usage", () => {

--- a/test/host/continuation-toast.test.ts
+++ b/test/host/continuation-toast.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { isContinuationToast } from "../../src/chat/view"
+import { isContinuationToast } from "../../src/chat/continuation-state"
 
 describe("isContinuationToast", () => {
   it("matches omo TodoContinuationEnforcer toast", () => {


### PR DESCRIPTION
## Summary

`view.ts` goes from 2,374 to 1,917 lines with no behavior change:

- **`chat/context-usage.ts`** (new) — the context-usage cluster (`readContextUsage`, `contextUsageFromMessages`, provider cache, helpers) moved verbatim out of the view.ts tail.
- **`agents/summary.ts`** (new) — `SUBAGENT_TOOLS`, `isSubagentTool`, `summarizeAgentTasks`, `taskTitleFromUpdate` moved verbatim. `subagent-tracker.ts`'s duplicate `SUBAGENT_DISPATCH_TOOLS` set is deleted and now imports `SUBAGENT_TOOLS` — its only stated reason for existing was avoiding a circular import with view.ts, which no longer applies.
- **`chat/continuation-state.ts`** — `isContinuationToast` moved next to the state machine that consumes its signal.
- **`chat/builtin-runners.ts`** (new) — `BuiltinRunners` class owning `/compact`, `/init`, `/share`, `/unshare`, `/undo`, `/redo`, `/fork` and `restampForkedIDs`, built on the same deps-closure pattern as `SubagentDispatch` so ChatView's fields stay private. ChatView keeps the `/mcp` / `/provider` / `/new` special cases plus `beginBuiltinTurn` (it touches `pendingUserBackendID` and the subagent dispatch keying) and delegates the rest.
- Dropped the `summarizePrompt` re-export from view.ts; the test now imports from `subagent-dispatch` directly. Three test files (`context-usage`, `continuation-toast`, `agent-task-wiring`) now import pure helpers from their new modules instead of pulling in the whole ChatView module graph.
- Comment path references updated in `task-store.ts` / `subagent-dispatch.ts`.

Note: `taskTitleFromUpdate`, `SUBAGENT_TOOLS`, and `isSubagentTool` have no production callers (the tracker has its own entry points) — they are the documented public spelling exercised by tests. Moved as-is; deleting them would be a separate decision.

## Test plan

- [x] `bun run test` — 66 files, 1000 tests pass.
- [x] `bun run check-types` — clean.
- [x] `bun run compile` — builds.
- [x] Grep confirms no remaining imports from `chat/view` for the moved symbols and no references to the deleted duplicate set.
- [ ] Manual smoke of `/undo`, `/redo`, `/fork` against a live opencode session (logic moved verbatim; state access now via closures).

Closes #375