### PR TITLE
feat(chat): queue messages typed while a turn is running

### DIFF
--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -1452,3 +1452,109 @@ describe("PromptBox / command picker", () => {
     expect(onRunCommand).not.toHaveBeenCalled()
   })
 })
+
+describe("PromptBox / queueing while busy", () => {
+  it("Enter while busy queues the message and clears the composer when onQueue is wired", async () => {
+    const user = userEvent.setup()
+    const onSend = vi.fn()
+    const onQueue = vi.fn()
+    render(<PromptBox busy={true} onSend={onSend} onQueue={onQueue} onAbort={vi.fn()} />)
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    await user.type(textarea, "follow-up prompt")
+    await user.keyboard("{Enter}")
+    expect(onSend).not.toHaveBeenCalled()
+    expect(onQueue).toHaveBeenCalledWith("follow-up prompt", undefined, undefined, undefined)
+    expect(textarea.value).toBe("")
+  })
+
+  it("Enter while aborting queues too — a follow-up typed after Stop is deliberate", async () => {
+    const user = userEvent.setup()
+    const onSend = vi.fn()
+    const onQueue = vi.fn()
+    render(<PromptBox busy={false} aborting={true} onSend={onSend} onQueue={onQueue} onAbort={vi.fn()} />)
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    await user.type(textarea, "after the stop")
+    await user.keyboard("{Enter}")
+    expect(onSend).not.toHaveBeenCalled()
+    expect(onQueue).toHaveBeenCalledWith("after the stop", undefined, undefined, undefined)
+    expect(textarea.value).toBe("")
+  })
+
+  it("Enter while busy WITHOUT onQueue keeps the old block: nothing fires, text retained", async () => {
+    const user = userEvent.setup()
+    const onSend = vi.fn()
+    render(<PromptBox busy={true} onSend={onSend} onAbort={vi.fn()} />)
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    await user.type(textarea, "not queued")
+    await user.keyboard("{Enter}")
+    expect(onSend).not.toHaveBeenCalled()
+    expect(textarea.value).toBe("not queued")
+  })
+
+  it("the edit composer never queues, even with onQueue passed", async () => {
+    const user = userEvent.setup()
+    const onSend = vi.fn()
+    const onQueue = vi.fn()
+    render(
+      <PromptBox
+        busy={true}
+        variant="edit"
+        initial={{ text: "edited text" }}
+        onSend={onSend}
+        onQueue={onQueue}
+        onAbort={vi.fn()}
+      />,
+    )
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    textarea.focus()
+    await user.keyboard("{Enter}")
+    expect(onSend).not.toHaveBeenCalled()
+    expect(onQueue).not.toHaveBeenCalled()
+    expect(textarea.value).toBe("edited text")
+  })
+
+  it("a typed known command while busy neither runs nor queues (would send '/compact' as prose)", async () => {
+    const user = userEvent.setup()
+    const onRunCommand = vi.fn()
+    const onQueue = vi.fn()
+    const commands = [{ name: "compact", description: "Compact the session", takesArguments: false }]
+    render(
+      <PromptBox
+        busy={true}
+        onSend={vi.fn()}
+        onQueue={onQueue}
+        onAbort={vi.fn()}
+        commands={commands}
+        onRunCommand={onRunCommand}
+      />,
+    )
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    await user.type(textarea, "/compact")
+    await screen.findByRole("listbox", { name: /Commands/i })
+    // Close the picker so Enter reaches submit() instead of the picker.
+    await user.keyboard("{Escape}")
+    await user.keyboard("{Enter}")
+    expect(onRunCommand).not.toHaveBeenCalled()
+    expect(onQueue).not.toHaveBeenCalled()
+    expect(textarea.value).toBe("/compact")
+  })
+
+  it("swaps the placeholder to the queue hint while busy with onQueue wired", () => {
+    const { rerender } = render(<PromptBox busy={true} onSend={vi.fn()} onQueue={vi.fn()} onAbort={vi.fn()} />)
+    expect(screen.getByPlaceholderText(/Enter to queue/i)).toBeInTheDocument()
+    rerender(<PromptBox busy={false} onSend={vi.fn()} onQueue={vi.fn()} onAbort={vi.fn()} />)
+    expect(screen.getByPlaceholderText(/Enter to send/i)).toBeInTheDocument()
+  })
+
+  it("keeps the attach button enabled while busy when queueing is available", () => {
+    const { rerender } = render(
+      <PromptBox busy={true} onSend={vi.fn()} onQueue={vi.fn()} onAbort={vi.fn()} attachFile={async () => ({ attachments: [] })} />,
+    )
+    const attach = () => screen.getByRole("button", { name: /Attach image/i }) as HTMLButtonElement
+    expect(attach().disabled).toBe(false)
+    rerender(
+      <PromptBox busy={true} onSend={vi.fn()} onAbort={vi.fn()} attachFile={async () => ({ attachments: [] })} />,
+    )
+    expect(attach().disabled).toBe(true)
+  })
+})

--- a/test/webview/queue-flow.test.tsx
+++ b/test/webview/queue-flow.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { render, screen, cleanup, renderHook } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import {
+  reducer,
+  initialChatState,
+  type ChatState,
+  type QueuedMessage,
+} from "../../webview/src/hooks/useChatState"
+import { useQueueFlush } from "../../webview/src/hooks/useQueueFlush"
+import { QueuedMessages } from "../../webview/src/components/QueuedMessages"
+
+afterEach(cleanup)
+
+function q(id: string, text = `text of ${id}`): QueuedMessage {
+  return { id, text }
+}
+
+describe("reducer queue transitions", () => {
+  it("queueMessage appends in order; unqueueMessage removes by id", () => {
+    let state = reducer(initialChatState, { type: "queueMessage", message: q("q1") })
+    state = reducer(state, { type: "queueMessage", message: q("q2") })
+    expect(state.queued.map((m) => m.id)).toEqual(["q1", "q2"])
+    state = reducer(state, { type: "unqueueMessage", id: "q1" })
+    expect(state.queued.map((m) => m.id)).toEqual(["q2"])
+  })
+
+  it("sessionIdle bumps idleNonce — the only flush trigger", () => {
+    const idle = reducer(initialChatState, { type: "sessionIdle" })
+    expect(idle.idleNonce).toBe(1)
+    expect(reducer(idle, { type: "sessionIdle" }).idleNonce).toBe(2)
+  })
+
+  it("assistantDone does NOT bump idleNonce (busy flickers false mid-turn; flushing there would inject the prompt between assistant messages)", () => {
+    const state = reducer(initialChatState, { type: "queueMessage", message: q("q1") })
+    const done = reducer(state, { type: "assistantDone", id: "a1" })
+    expect(done.idleNonce).toBe(state.idleNonce)
+    expect(done.queued).toEqual(state.queued)
+  })
+
+  it("aborted clears the queue — Stop must not auto-restart work via a queued follow-up", () => {
+    const state = reducer(initialChatState, { type: "queueMessage", message: q("q1") })
+    expect(reducer(state, { type: "aborted" }).queued).toEqual([])
+  })
+
+  it("messages queued AFTER Stop (during the drain) survive to the idle flush", () => {
+    let state = reducer(initialChatState, { type: "aborted" })
+    state = reducer(state, { type: "queueMessage", message: q("q_post_stop") })
+    const idle = reducer(state, { type: "sessionIdle" })
+    expect(idle.queued.map((m) => m.id)).toEqual(["q_post_stop"])
+    expect(idle.aborting).toBe(false)
+  })
+
+  it("restore (conversation switch) drops the queue", () => {
+    const state = reducer(initialChatState, { type: "queueMessage", message: q("q1") })
+    const restored = reducer(state, {
+      type: "restore",
+      conversationID: "conv2",
+      messages: [],
+    })
+    expect(restored.queued).toEqual([])
+  })
+
+  it("clear and reset preserve idleNonce so the flush hook's last-seen ref never desyncs", () => {
+    let state: ChatState = initialChatState
+    for (let i = 0; i < 3; i++) state = reducer(state, { type: "sessionIdle" })
+    expect(reducer(state, { type: "clear" }).idleNonce).toBe(3)
+    expect(reducer(state, { type: "reset" }).idleNonce).toBe(3)
+  })
+})
+
+type FlushState = Pick<ChatState, "idleNonce" | "queued" | "aborting" | "continuationPending">
+
+const flushBase: FlushState = {
+  idleNonce: 0,
+  queued: [],
+  aborting: false,
+  continuationPending: false,
+}
+
+function renderFlush(initial: FlushState) {
+  const deliver = vi.fn()
+  const view = renderHook(({ s }: { s: FlushState }) => useQueueFlush(s, deliver), {
+    initialProps: { s: initial },
+  })
+  return { deliver, rerender: (s: FlushState) => view.rerender({ s }) }
+}
+
+describe("useQueueFlush", () => {
+  it("delivers the oldest queued message when idleNonce bumps", () => {
+    const start = { ...flushBase, queued: [q("q1"), q("q2")] }
+    const { deliver, rerender } = renderFlush(start)
+    expect(deliver).not.toHaveBeenCalled()
+    rerender({ ...start, idleNonce: 1 })
+    expect(deliver).toHaveBeenCalledTimes(1)
+    expect(deliver).toHaveBeenCalledWith(q("q1"))
+  })
+
+  it("queue changes at the same nonce do not deliver again (no double-fire from the unqueue re-render)", () => {
+    const start = { ...flushBase, queued: [q("q1"), q("q2")] }
+    const { deliver, rerender } = renderFlush(start)
+    rerender({ ...start, idleNonce: 1 })
+    rerender({ ...flushBase, idleNonce: 1, queued: [q("q2")] })
+    expect(deliver).toHaveBeenCalledTimes(1)
+  })
+
+  it("delivers one message per idle: the next idle flushes the next message", () => {
+    const start = { ...flushBase, queued: [q("q1"), q("q2")] }
+    const { deliver, rerender } = renderFlush(start)
+    rerender({ ...start, idleNonce: 1 })
+    rerender({ ...flushBase, idleNonce: 1, queued: [q("q2")] })
+    rerender({ ...flushBase, idleNonce: 2, queued: [q("q2")] })
+    expect(deliver).toHaveBeenCalledTimes(2)
+    expect(deliver).toHaveBeenLastCalledWith(q("q2"))
+  })
+
+  it("does not deliver on mount even with a non-zero nonce (remounted webview must not flush an idle it never observed)", () => {
+    const { deliver } = renderFlush({ ...flushBase, idleNonce: 5, queued: [q("q1")] })
+    expect(deliver).not.toHaveBeenCalled()
+  })
+
+  it("skips (and consumes) an idle that arrives while aborting or continuation-pending", () => {
+    const start = { ...flushBase, queued: [q("q1")] }
+    const { deliver, rerender } = renderFlush(start)
+    rerender({ ...start, idleNonce: 1, aborting: true })
+    expect(deliver).not.toHaveBeenCalled()
+    rerender({ ...start, idleNonce: 1 })
+    expect(deliver).not.toHaveBeenCalled()
+    rerender({ ...start, idleNonce: 2 })
+    expect(deliver).toHaveBeenCalledTimes(1)
+  })
+
+  it("an idle with an empty queue is a no-op", () => {
+    const { deliver, rerender } = renderFlush(flushBase)
+    rerender({ ...flushBase, idleNonce: 1 })
+    expect(deliver).not.toHaveBeenCalled()
+  })
+})
+
+describe("QueuedMessages", () => {
+  it("renders nothing when the queue is empty", () => {
+    const { container } = render(<QueuedMessages queued={[]} onRemove={vi.fn()} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("lists queued texts in order with a remove button per row", async () => {
+    const user = userEvent.setup()
+    const onRemove = vi.fn()
+    render(
+      <QueuedMessages queued={[q("q1", "run the tests"), q("q2", "then lint")]} onRemove={onRemove} />,
+    )
+    const rows = screen.getAllByRole("listitem")
+    expect(rows).toHaveLength(2)
+    expect(rows[0]).toHaveTextContent("run the tests")
+    expect(rows[1]).toHaveTextContent("then lint")
+    await user.click(screen.getAllByRole("button", { name: "Remove queued message" })[0])
+    expect(onRemove).toHaveBeenCalledWith("q1")
+  })
+
+  it("summarizes attachments in the row label", () => {
+    const attachment = { id: "att1", mime: "image/png", filename: "shot.png", dataUrl: "data:", bytes: 10 }
+    render(
+      <QueuedMessages
+        queued={[
+          { id: "q1", text: "look at this", attachments: [attachment, { ...attachment, id: "att2" }] },
+          { id: "q2", text: "", attachments: [attachment] },
+        ]}
+        onRemove={vi.fn()}
+      />,
+    )
+    const rows = screen.getAllByRole("listitem")
+    expect(rows[0]).toHaveTextContent("look at this · 2 attachments")
+    expect(rows[1]).toHaveTextContent("1 attachment")
+  })
+})

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties } from "react"
 import { useChatState } from "./hooks/useChatState"
 import type { Message } from "./hooks/useChatState"
+import { useQueueFlush } from "./hooks/useQueueFlush"
 import type { Attachment } from "./protocol"
 import { MessageView } from "./components/MessageView"
 import { PromptBox } from "./components/PromptBox"
+import { QueuedMessages } from "./components/QueuedMessages"
 import { StatusBar, type HeaderPopoverID } from "./components/StatusBar"
 import { PermissionDialog } from "./components/PermissionDialog"
 import { QuestionDialog } from "./components/QuestionDialog"
@@ -14,6 +16,8 @@ export default function App() {
   const {
     state,
     send,
+    queueMessage,
+    unqueueMessage,
     runCommand,
     abort,
     newSession,
@@ -88,6 +92,13 @@ export default function App() {
     stickToBottom.current = true
     runCommand(...args)
   }
+  // Auto-send the oldest queued message when the session goes idle. Plain
+  // `send` (not sendAndPinTop): the user may be reading scrollback when the
+  // flush fires, and an auto-send must not yank their scroll position.
+  useQueueFlush(state, (q) => {
+    unqueueMessage(q.id)
+    send(q.text, q.mentions, q.attachments, q.conversationMentions)
+  })
   const [reviewRequest, setReviewRequest] = useState<{ path: string; key: number }>()
   const openReviewFile = (path: string) => {
     setReviewRequest((current) => ({ path, key: (current?.key ?? 0) + 1 }))
@@ -248,6 +259,7 @@ export default function App() {
           busy={busy}
           aborting={state.aborting}
           onSend={sendAndPinTop}
+          onQueue={queueMessage}
           onAbort={abort}
           searchFiles={searchFiles}
           listDir={listDir}
@@ -360,12 +372,14 @@ export default function App() {
           onOpenReviewChange={openReviewChangeDebounced}
           onReviewAllInChange={reviewAllInChange}
         />
+        <QueuedMessages queued={state.queued} onRemove={unqueueMessage} />
         {state.messages.length > 0 && (
           <div className="bottom-composer">
             <PromptBox
               busy={busy}
               aborting={state.aborting}
               onSend={sendAndPinTop}
+              onQueue={queueMessage}
               onAbort={abort}
               searchFiles={searchFiles}
               listDir={listDir}

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -48,6 +48,13 @@ type Props = {
    */
   aborting?: boolean
   onSend: (text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) => void
+  /**
+   * Queue the message for auto-send when the running turn finishes. When
+   * provided (the primary send composers), Enter while busy/aborting queues
+   * instead of being a no-op. Absent (edit composers), submit stays blocked
+   * while busy — the old behavior.
+   */
+  onQueue?: (text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) => void
   onAbort: () => void
   searchFiles?: (query: string) => Promise<FileSearchHit[]>
   listDir?: (path: string) => Promise<DirEntry[]>
@@ -131,12 +138,14 @@ function extractConversationLabels(text: string | undefined): string[] {
   return Array.from(text.matchAll(/@chat:\S+/g), (match) => match[0].slice(1))
 }
 
-export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles, listDir, attachFile, initial, variant = "send", position = "bottom", conversations, activeConversationID, onOpenConversation, contextUsage, commands = [], onRunCommand, inject }: Props) {
+export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, searchFiles, listDir, attachFile, initial, variant = "send", position = "bottom", conversations, activeConversationID, onOpenConversation, contextUsage, commands = [], onRunCommand, inject }: Props) {
   const { text, setText, ref, backdropRef, pendingCursor } = usePromptText(initial?.text ?? "")
   // The Send button renders a disabled "Stopping…" while aborting, but Enter
   // routes through submit() — both must honor the same block, or a prompt
-  // races the in-flight abort and gets its early events dropped.
+  // races the in-flight abort and gets its early events dropped. With onQueue
+  // wired, a blocked submit queues instead of dropping.
   const sendBlocked = busy || aborting
+  const canQueue = sendBlocked && variant === "send" && Boolean(onQueue)
   const [selectedChipStart, setSelectedChipStart] = useState<number | undefined>(undefined)
   const [attachError, setAttachError] = useState<string | undefined>(undefined)
   const [attaching, setAttaching] = useState(false)
@@ -303,10 +312,13 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
     // Route a typed `/name args` to the command path when the name matches a
     // known command. Unknown slashes (and prose like `/etc/hosts`) fall through
     // to a normal prompt send. Edit composers never route (no onRunCommand).
-    if (variant === "send" && !sendBlocked && onRunCommand) {
+    // While a turn runs, a known command neither runs NOR queues — commands
+    // are immediate session operations, not prompts; queueing one as prose
+    // would send the literal "/compact" text to the model.
+    if (variant === "send" && onRunCommand) {
       const parsed = parseCommandInput(trimmed)
       if (parsed && commands.some((c) => c.name === parsed.name)) {
-        runCommandAndClear(parsed.name, parsed.args)
+        if (!sendBlocked) runCommandAndClear(parsed.name, parsed.args)
         return
       }
     }
@@ -322,13 +334,15 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
     // so display order in the bubble matches input order: chip-cited
     // files first, pasted images second.
     for (const a of imageAttachments) activeAttachments.push(a)
-    if ((!trimmed && activeAttachments.length === 0) || sendBlocked) return
+    if (!trimmed && activeAttachments.length === 0) return
+    const deliver = sendBlocked ? (canQueue ? onQueue : undefined) : onSend
+    if (!deliver) return
     const allMentions = extractMentions(text, knownMentions.current)
     const fileMentions = allMentions.filter((m) => !knownConversations.current.has(m))
     const convIDs = allMentions
       .map((m) => knownConversations.current.get(m))
       .filter((id): id is string => !!id)
-    onSend(
+    deliver(
       trimmed,
       fileMentions.length ? fileMentions : undefined,
       activeAttachments.length ? activeAttachments : undefined,
@@ -669,7 +683,7 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
           ref={ref}
           value={text}
           rows={variant === "edit" ? 1 : position === "top" ? 3 : 2}
-          placeholder="/ for commands, @ for files, Enter to send"
+          placeholder={canQueue ? "@ for files, Enter to queue" : "/ for commands, @ for files, Enter to send"}
           onChange={(e) => updateText(e.target.value, e.target.selectionStart ?? e.target.value.length)}
           onKeyDown={onKeyDown}
           onPaste={onPaste}
@@ -842,7 +856,7 @@ export function PromptBox({ busy, aborting = false, onSend, onAbort, searchFiles
               className="icon-btn attach-btn"
               aria-label="Attach image, PDF, or code/text file"
               title="Attach image, PDF, or code/text file"
-              disabled={attaching || busy}
+              disabled={attaching || (busy && !canQueue)}
               onClick={handleAttachClick}
             >
               <svg width={ICON_SIZE.lg} height={ICON_SIZE.lg} viewBox="5.5 1.5 8 14" aria-hidden="true" style={{ display: "block" }}>

--- a/webview/src/components/QueuedMessages.tsx
+++ b/webview/src/components/QueuedMessages.tsx
@@ -1,0 +1,41 @@
+import type { QueuedMessage } from "../hooks/useChatState"
+
+type Props = {
+  queued: QueuedMessage[]
+  onRemove: (id: string) => void
+}
+
+/**
+ * Messages typed while a turn was running, waiting to auto-send on the next
+ * session idle. Rendered inside the bottom dock just above the composer so
+ * the dock's ResizeObserver reserves scroll padding for it automatically.
+ */
+export function QueuedMessages({ queued, onRemove }: Props) {
+  if (queued.length === 0) return null
+  return (
+    <div className="queued-messages" role="list" aria-label="Queued messages">
+      {queued.map((q) => (
+        <div className="queued-row" role="listitem" key={q.id} title={q.text}>
+          <span className="queued-badge">Queued</span>
+          <span className="queued-text">{queuedLabel(q)}</span>
+          <button
+            type="button"
+            className="queued-remove"
+            aria-label="Remove queued message"
+            title="Remove queued message"
+            onClick={() => onRemove(q.id)}
+          >
+            <span className="codicon codicon-close" aria-hidden="true" />
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function queuedLabel(q: QueuedMessage): string {
+  const count = q.attachments?.length ?? 0
+  const suffix = count === 0 ? "" : count === 1 ? " · 1 attachment" : ` · ${count} attachments`
+  if (!q.text) return suffix ? suffix.slice(3) : ""
+  return q.text + suffix
+}

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -26,6 +26,19 @@ import type {
 export type Block = ChatBlock
 export type Message = ChatMessage
 
+/**
+ * A prompt the user submitted while a turn was still running. Held
+ * webview-side (never crosses the wire) and flushed through the normal
+ * `send` path when the session goes idle.
+ */
+export type QueuedMessage = {
+  id: string
+  text: string
+  mentions?: string[]
+  attachments?: Attachment[]
+  conversationMentions?: string[]
+}
+
 export type ChatState = {
   connected: boolean
   busy: boolean
@@ -63,6 +76,16 @@ export type ChatState = {
    * `PromptBox` consumes it via an effect.
    */
   injectedText?: { text: string; nonce: number }
+  /** Prompts submitted while busy, waiting for the session to go idle. */
+  queued: QueuedMessage[]
+  /**
+   * Counts `sessionIdle` events. The queue flush keys off this rather than
+   * `busy`, because `busy` flickers false between assistant messages inside
+   * one turn (`assistantDone` → next `assistantStart`) — flushing there would
+   * inject the queued prompt mid-turn. `sessionIdle` is the only end-of-turn
+   * signal, and the host already defers it during pending continuations.
+   */
+  idleNonce: number
 }
 
 export type Action =
@@ -70,6 +93,8 @@ export type Action =
   | { type: "reset" }
   | { type: "clearPermission" }
   | { type: "clearQuestion"; id: string }
+  | { type: "queueMessage"; message: QueuedMessage }
+  | { type: "unqueueMessage"; id: string }
 
 const initial: ChatState = {
   connected: false,
@@ -81,6 +106,8 @@ const initial: ChatState = {
   commands: [],
   messages: [],
   reviewHunks: {},
+  queued: [],
+  idleNonce: 0,
 }
 
 function upsertMessage(messages: Message[], id: string, patch: Partial<Message>): Message[] {
@@ -148,7 +175,9 @@ export { initial as initialChatState }
 export function reducer(state: ChatState, action: Action): ChatState {
   switch (action.type) {
     case "reset":
-      return { ...initial, selection: state.selection, context: state.context, connected: state.connected, commands: state.commands }
+      // idleNonce is monotonic for the webview's lifetime — resetting it to 0
+      // would desync the flush hook's last-seen ref.
+      return { ...initial, selection: state.selection, context: state.context, connected: state.connected, commands: state.commands, idleNonce: state.idleNonce }
     case "ready":
       return { ...state, connected: action.connected, selection: action.selection }
     case "connected":
@@ -186,6 +215,9 @@ export function reducer(state: ChatState, action: Action): ChatState {
         // render forever in the new conversation's dock.
         pendingQuestion: undefined,
         injectedText: undefined,
+        // The queue is per-conversation: a switch (or /undo rewind) must not
+        // fire the old conversation's follow-ups into the restored one.
+        queued: [],
       }
     case "context":
       return { ...state, context: action.ref }
@@ -319,6 +351,10 @@ export function reducer(state: ChatState, action: Action): ChatState {
         aborting: true,
         pendingPermission: undefined,
         pendingQuestion: undefined,
+        // Stop means stop: a queued follow-up auto-firing right after the
+        // abort would restart the very work the user just killed. Messages
+        // queued AFTER this (during the drain) are deliberate and survive.
+        queued: [],
         messages: state.messages.map((m, i) => {
           if (m.role !== "assistant" || !m.pending) return m
           if (i === lastPendingIdx) return { ...m, pending: false, stopped: true }
@@ -337,6 +373,7 @@ export function reducer(state: ChatState, action: Action): ChatState {
         busy: false,
         aborting: false,
         continuationPending: false,
+        idleNonce: state.idleNonce + 1,
         messages: state.messages.map((m) =>
           m.role === "assistant" && m.pending ? { ...m, pending: false } : m,
         ),
@@ -380,8 +417,12 @@ export function reducer(state: ChatState, action: Action): ChatState {
       const anyPending = next.some((m) => m.pending)
       return { ...state, messages: next, busy: state.busy && anyPending }
     }
+    case "queueMessage":
+      return { ...state, queued: [...state.queued, action.message] }
+    case "unqueueMessage":
+      return { ...state, queued: state.queued.filter((q) => q.id !== action.id) }
     case "clear":
-      return { ...initial, selection: state.selection, context: state.context, connected: state.connected, commands: state.commands }
+      return { ...initial, selection: state.selection, context: state.context, connected: state.connected, commands: state.commands, idleNonce: state.idleNonce }
     default:
       return state
   }
@@ -395,6 +436,7 @@ export function useChatState() {
     new Map<number, (result: { attachments: Attachment[]; error?: string }) => void>(),
   )
   const nextRequestID = useRef(1)
+  const nextQueueID = useRef(1)
 
   useEffect(() => {
     // Streaming deltas are coalesced to one render per frame; request/response
@@ -436,6 +478,15 @@ export function useChatState() {
     state,
     send(text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) {
       vscode.post({ type: "send", text, mentions, attachments, conversationMentions })
+    },
+    queueMessage(text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) {
+      dispatch({
+        type: "queueMessage",
+        message: { id: `q_${Date.now()}_${nextQueueID.current++}`, text, mentions, attachments, conversationMentions },
+      })
+    },
+    unqueueMessage(id: string) {
+      dispatch({ type: "unqueueMessage", id })
     },
     runCommand(command: string, args: string) {
       vscode.post({ type: "runCommand", command, arguments: args })

--- a/webview/src/hooks/useQueueFlush.ts
+++ b/webview/src/hooks/useQueueFlush.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from "react"
+import type { ChatState, QueuedMessage } from "./useChatState"
+
+type FlushState = Pick<ChatState, "idleNonce" | "queued" | "aborting" | "continuationPending">
+
+/**
+ * Auto-send queued messages when the session goes idle. Keyed on `idleNonce`
+ * (one flush per `sessionIdle` event) instead of watching `busy`, which
+ * flickers false between assistant messages inside a single turn — a
+ * busy-based flush would inject the queued prompt mid-turn. One message per
+ * idle: the flushed prompt starts a new turn, and the NEXT idle flushes the
+ * next queued message.
+ *
+ * `deliver` both unqueues and sends; it runs at most once per nonce, so the
+ * unqueue dispatch re-rendering with a shorter queue cannot double-fire.
+ */
+export function useQueueFlush(state: FlushState, deliver: (message: QueuedMessage) => void) {
+  // Initialized to the mount-time nonce so a freshly (re)mounted webview
+  // never flushes on an idle it did not observe.
+  const lastFlushedNonce = useRef(state.idleNonce)
+  useEffect(() => {
+    if (state.idleNonce === lastFlushedNonce.current) return
+    lastFlushedNonce.current = state.idleNonce
+    // Defensive: sessionIdle clears both flags in the same reducer action,
+    // but a host that ever posts them in another order must not leak a
+    // queued prompt into an abort drain or a pending continuation.
+    if (state.aborting || state.continuationPending) return
+    const next = state.queued[0]
+    if (!next) return
+    deliver(next)
+    // Deps are the nonce alone: queue mutations at the same nonce (enqueue,
+    // manual remove) must not start a turn.
+  }, [state.idleNonce])
+}

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -2385,6 +2385,66 @@ button:focus-visible {
   pointer-events: auto;
 }
 
+/* ===== Queued messages (typed while a turn was running) ===== */
+.queued-messages {
+  pointer-events: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0 12px;
+}
+.queued-messages + .bottom-composer {
+  padding-top: var(--space-1);
+}
+.queued-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  padding: 3px 4px 3px 8px;
+  border: 1px dashed var(--vscode-panel-border);
+  border-radius: var(--radius-sm);
+  background: var(--vscode-editorWidget-background);
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+}
+.queued-badge {
+  flex: none;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.8;
+}
+.queued-text {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--vscode-foreground);
+}
+.queued-remove {
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--vscode-descriptionForeground);
+  cursor: pointer;
+}
+.queued-remove:hover {
+  background: var(--vscode-toolbar-hoverBackground);
+  color: var(--vscode-foreground);
+}
+.queued-remove .codicon {
+  font-size: 12px;
+}
+
 /* ===== System reminder callout ===== */
 .system-reminder {
   margin: 8px 0;


### PR DESCRIPTION
## Summary

- Enter while a turn is running (busy or aborting) now queues the message instead of doing nothing. Queued messages keep their `@file` mentions, attachments, and `@chat` conversation mentions, render above the composer with a remove control, and auto-send when the session goes idle.
- The flush is keyed off a new `idleNonce` counter that only `sessionIdle` bumps — never `busy`, which flickers false between assistant messages inside one turn (`assistantDone` → next `assistantStart`). One message flushes per idle, so multiple queued follow-ups run as separate sequential turns. Since the host already defers `sessionIdle` during pending continuations, the queue naturally waits out omo continuation windows.
- Stop discards the queue: a queued follow-up auto-firing right after an abort would restart the work the user just killed. Messages queued after Stop (during the drain) are deliberate and survive to the idle flush.
- A typed slash command matching a known command neither runs nor queues while busy (queueing would send the literal `/compact` text as prose); the picker path is unchanged. Composers without `onQueue` wired — the edit-in-place flow — keep the old blocking behavior, so existing semantics and tests hold.
- The composer placeholder switches to "@ for files, Enter to queue" while queueing is available, and the paperclip stays enabled so a queued message can carry attachments.
- The queue is webview-local state (no protocol change): flushing reuses the existing `send` path, and the strip renders inside the bottom dock so the existing ResizeObserver reserves scroll padding automatically.

## Test plan

- [x] `bun run test` — 1029 tests pass (68 files), including 16 new: reducer queue transitions (append/remove, idleNonce only bumped by `sessionIdle`, `aborted` clears queue, post-Stop queueing survives, `restore` drops queue, `clear`/`reset` preserve idleNonce), `useQueueFlush` (delivers oldest on nonce bump, no double-fire on unqueue re-render, one per idle, no flush on mount, abort/continuation guard), `QueuedMessages` rendering, and PromptBox queue paths (queue on busy and aborting, no-onQueue block retained, edit variant never queues, known command neither runs nor queues, placeholder swap, attach button enablement).
- [x] `bun run check-types` and `cd webview && bunx tsc --noEmit` — both clean.
- [x] `bun run compile` — production build succeeds.
- [ ] Visual verification in the Extension Development Host (queue strip styling, flush after a real opencode turn, Stop clearing the strip).

Closes #379