### PR TITLE
feat(chat): Esc stops the running turn, after dismissable layers

### DIFF
--- a/test/webview/esc-to-stop.test.tsx
+++ b/test/webview/esc-to-stop.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { render, screen, cleanup, renderHook, fireEvent, act } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { useEscapeToStop } from "../../webview/src/hooks/useEscapeToStop"
+import { useDismissableMenu } from "../../webview/src/hooks/useDismissableMenu"
+import { ImagePreviewModal } from "../../webview/src/components/ImagePreviewModal"
+import { StatusBar } from "../../webview/src/components/StatusBar"
+
+afterEach(cleanup)
+
+function pressEscape(init: KeyboardEventInit & { keyCode?: number } = {}) {
+  fireEvent.keyDown(document.body, { key: "Escape", ...init })
+}
+
+describe("useEscapeToStop", () => {
+  it("calls stop on Escape while active", () => {
+    const stop = vi.fn()
+    renderHook(() => useEscapeToStop(true, stop))
+    pressEscape()
+    expect(stop).toHaveBeenCalledTimes(1)
+  })
+
+  it("ignores keys other than Escape", () => {
+    const stop = vi.fn()
+    renderHook(() => useEscapeToStop(true, stop))
+    fireEvent.keyDown(document.body, { key: "Enter" })
+    fireEvent.keyDown(document.body, { key: "s" })
+    expect(stop).not.toHaveBeenCalled()
+  })
+
+  it("does nothing while inactive (idle or already aborting)", () => {
+    const stop = vi.fn()
+    renderHook(() => useEscapeToStop(false, stop))
+    pressEscape()
+    expect(stop).not.toHaveBeenCalled()
+  })
+
+  it("skips an Escape already consumed by an earlier layer (document fires before window)", () => {
+    const stop = vi.fn()
+    renderHook(() => useEscapeToStop(true, stop))
+    const consume = (e: KeyboardEvent) => {
+      if (e.key === "Escape") e.preventDefault()
+    }
+    document.addEventListener("keydown", consume)
+    try {
+      pressEscape()
+    } finally {
+      document.removeEventListener("keydown", consume)
+    }
+    expect(stop).not.toHaveBeenCalled()
+    pressEscape()
+    expect(stop).toHaveBeenCalledTimes(1)
+  })
+
+  it("ignores Escape during IME composition", () => {
+    const stop = vi.fn()
+    renderHook(() => useEscapeToStop(true, stop))
+    pressEscape({ isComposing: true })
+    pressEscape({ keyCode: 229 })
+    expect(stop).not.toHaveBeenCalled()
+  })
+
+  it("deactivating removes the listener; reactivating restores it", () => {
+    const stop = vi.fn()
+    const { rerender } = renderHook(({ active }) => useEscapeToStop(active, stop), {
+      initialProps: { active: true },
+    })
+    rerender({ active: false })
+    pressEscape()
+    expect(stop).not.toHaveBeenCalled()
+    rerender({ active: true })
+    pressEscape()
+    expect(stop).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("Escape layer precedence over stop", () => {
+  it("image preview: first Esc closes the preview, next Esc stops", () => {
+    const stop = vi.fn()
+    const onClose = vi.fn()
+    function Harness({ open }: { open: boolean }) {
+      useEscapeToStop(true, stop)
+      return (
+        <ImagePreviewModal
+          src={open ? { dataUrl: "data:image/png;base64,x", filename: "shot.png" } : null}
+          onClose={onClose}
+        />
+      )
+    }
+    const { rerender } = render(<Harness open={true} />)
+    pressEscape()
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(stop).not.toHaveBeenCalled()
+    rerender(<Harness open={false} />)
+    pressEscape()
+    expect(stop).toHaveBeenCalledTimes(1)
+  })
+
+  it("dismissable popover: first Esc closes the menu, next Esc stops", () => {
+    const stop = vi.fn()
+    const { result } = renderHook(() => {
+      useEscapeToStop(true, stop)
+      return useDismissableMenu()
+    })
+    act(() => result.current.setOpen(true))
+    pressEscape()
+    expect(result.current.open).toBe(false)
+    expect(stop).not.toHaveBeenCalled()
+    pressEscape()
+    expect(stop).toHaveBeenCalledTimes(1)
+  })
+
+  it("rename input: Esc cancels the rename without stopping the turn", async () => {
+    const user = userEvent.setup()
+    const stop = vi.fn()
+    const onRename = vi.fn()
+    function Harness() {
+      useEscapeToStop(true, stop)
+      return (
+        <StatusBar
+          connected={true}
+          selection={{}}
+          conversations={[{ id: "c1", title: "First chat", updatedAt: Date.now() }]}
+          activeConversationID="c1"
+          onSelectAgent={vi.fn()}
+          onSelectModel={vi.fn()}
+          onSelectVariant={vi.fn()}
+          onCreateConversation={vi.fn()}
+          onOpenConversation={vi.fn()}
+          onRenameConversation={onRename}
+          onDeleteConversation={vi.fn()}
+        />
+      )
+    }
+    render(<Harness />)
+    await user.click(screen.getByRole("button", { name: /chat history/i }))
+    await user.click(screen.getByRole("button", { name: /^Rename$/ }))
+    const input = screen.getByDisplayValue("First chat")
+    fireEvent.keyDown(input, { key: "Escape" })
+    expect(screen.queryByDisplayValue("First chat")).not.toBeInTheDocument()
+    expect(onRename).not.toHaveBeenCalled()
+    expect(stop).not.toHaveBeenCalled()
+  })
+})

--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -864,6 +864,24 @@ describe("PromptBox two-step Backspace on chip", () => {
     expect(textarea.value).toBe("@src/foo.ts a")
   })
 
+  it("Escape clears the selected chip and is consumed, not left for Esc-to-stop", async () => {
+    const { user, container } = await setupChip()
+    await user.keyboard("{Backspace}")
+    expect(container.querySelector(".mention-chip-selected")).not.toBeNull()
+    const seen: boolean[] = []
+    const record = (e: KeyboardEvent) => {
+      if (e.key === "Escape") seen.push(e.defaultPrevented)
+    }
+    window.addEventListener("keydown", record)
+    try {
+      await user.keyboard("{Escape}")
+    } finally {
+      window.removeEventListener("keydown", record)
+    }
+    expect(container.querySelector(".mention-chip-selected")).toBeNull()
+    expect(seen).toEqual([true])
+  })
+
   it("Backspace away from a chip deletes a single character normally", async () => {
     const { user, textarea } = await setupChip()
     await user.type(textarea, "abc")

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperti
 import { useChatState } from "./hooks/useChatState"
 import type { Message } from "./hooks/useChatState"
 import { useQueueFlush } from "./hooks/useQueueFlush"
+import { useEscapeToStop } from "./hooks/useEscapeToStop"
 import type { Attachment } from "./protocol"
 import { MessageView } from "./components/MessageView"
 import { PromptBox } from "./components/PromptBox"
@@ -159,6 +160,9 @@ export default function App() {
   // Rebuild the turn structure only when the message list actually changes,
   // not on every coalesced streaming frame.
   const turns = useMemo(() => groupTurns(state.messages), [state.messages])
+
+  // Active exactly when the Stop button is clickable.
+  useEscapeToStop(busy && !state.aborting, abort)
 
   useEffect(() => {
     if (editingMessageID) setActiveHeaderPopover(null)

--- a/webview/src/components/ImagePreviewModal.tsx
+++ b/webview/src/components/ImagePreviewModal.tsx
@@ -15,8 +15,12 @@ type Props = {
 export function ImagePreviewModal({ src, onClose }: Props) {
   useEffect(() => {
     if (!src) return
+    // preventDefault marks the Esc consumed so the window-level
+    // Esc-to-stop listener closes the preview instead of stopping the turn.
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose()
+      if (e.key !== "Escape") return
+      e.preventDefault()
+      onClose()
     }
     document.addEventListener("keydown", onKey)
     return () => document.removeEventListener("keydown", onKey)

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -618,6 +618,12 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
     }
     if (e.key !== "Backspace" && selectedChipStart !== undefined) {
       setSelectedChipStart(undefined)
+      // Esc that dismisses a highlighted chip is consumed like the pickers'
+      // Esc — it must not fall through to the Esc-to-stop window listener.
+      if (e.key === "Escape") {
+        e.preventDefault()
+        return
+      }
     }
     // In edit variant, Escape cancels (matches the original edit-textarea UX).
     if (variant === "edit" && e.key === "Escape") {
@@ -895,7 +901,7 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
               className="btn danger icon"
               onClick={onAbort}
               aria-label="Stop"
-              title="Stop"
+              title="Stop (Esc)"
             >
               <StopIcon />
             </button>

--- a/webview/src/components/StatusBar.tsx
+++ b/webview/src/components/StatusBar.tsx
@@ -249,7 +249,11 @@ function ChatHistoryMenu({
                           // the IME candidate — don't intercept it as Save.
                           if (event.nativeEvent.isComposing || event.keyCode === 229) return
                           if (event.key === "Enter") commitRename()
-                          if (event.key === "Escape") setRenamingID(undefined)
+                          if (event.key === "Escape") {
+                            // Consume so Esc-to-stop doesn't also abort the turn.
+                            event.preventDefault()
+                            setRenamingID(undefined)
+                          }
                         }}
                       />
                       <button className="history-action" onClick={commitRename}>

--- a/webview/src/hooks/useDismissableMenu.ts
+++ b/webview/src/hooks/useDismissableMenu.ts
@@ -46,14 +46,20 @@ export function useDismissableMenu(options: DismissableMenuOptions = {}): {
       if (ref.current?.contains(event.target as Node)) return
       setOpen(false)
     }
+    // Escape marks itself consumed and listens on `document` (which bubbles
+    // BEFORE `window`) so the Esc-to-stop window listener sees
+    // `defaultPrevented` and lets the popover close win over stopping the
+    // running turn.
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOpen(false)
+      if (event.key !== "Escape") return
+      event.preventDefault()
+      setOpen(false)
     }
     window.addEventListener("click", onClick)
-    window.addEventListener("keydown", onKeyDown)
+    document.addEventListener("keydown", onKeyDown)
     return () => {
       window.removeEventListener("click", onClick)
-      window.removeEventListener("keydown", onKeyDown)
+      document.removeEventListener("keydown", onKeyDown)
     }
   }, [open])
 

--- a/webview/src/hooks/useEscapeToStop.ts
+++ b/webview/src/hooks/useEscapeToStop.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from "react"
+
+/**
+ * Esc anywhere in the panel stops the running turn — but only as the last
+ * resort. Every dismissable layer (prompt pickers, header popovers, the
+ * image preview, the rename input, a highlighted mention chip) consumes its
+ * Escape with `preventDefault()` from a handler that fires before this
+ * window-level bubble listener (React handlers at the root container,
+ * document-level listeners), so an open layer closes and the turn keeps
+ * running; the NEXT Esc stops it.
+ *
+ * The listener only exists while `active` (a turn is running and not
+ * already aborting), so idle Esc presses cost nothing and "Stopping…"
+ * cannot double-post an abort.
+ */
+export function useEscapeToStop(active: boolean, stop: () => void) {
+  // `stop` comes from a per-render object literal in useChatState; track it
+  // in a ref so the listener isn't torn down and re-added every render.
+  const stopRef = useRef(stop)
+  stopRef.current = stop
+  useEffect(() => {
+    if (!active) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Escape" || e.defaultPrevented) return
+      // Esc during IME composition cancels the composition, not the turn.
+      // keyCode 229 is the legacy fallback for older Chromium builds.
+      if (e.isComposing || e.keyCode === 229) return
+      stopRef.current()
+    }
+    window.addEventListener("keydown", onKeyDown)
+    return () => window.removeEventListener("keydown", onKeyDown)
+  }, [active])
+}


### PR DESCRIPTION
## Summary

- New `useEscapeToStop` hook in `App.tsx`: a window-level (bubble phase) Escape listener that triggers the same `abort` as the Stop button. It is registered only while the Stop button is clickable (`busy && !aborting`), so idle Esc presses cost nothing and "Stopping…" cannot double-post an abort.
- Esc keeps dismiss-first semantics — an open transient layer closes and the turn keeps running; the next Esc stops it. Each layer consumes its Escape with `preventDefault()` from a handler that fires before the window listener:
  - Prompt pickers and the edit composer's cancel already consumed it (React handlers fire at the root container).
  - Added consumption to the chat-rename input, a highlighted mention chip pending Backspace-delete, the image preview modal, and `useDismissableMenu` popovers. The popover keydown listener moves from `window` to `document` (which bubbles before `window`) so its `preventDefault` is visible to the stop listener regardless of registration order.
- Esc during IME composition (`isComposing` / keyCode 229) is ignored — it cancels the composition, not the turn.
- The Stop button title now reads "Stop (Esc)" for discoverability.

## Test plan

- [x] `bun run test` — 1039 passed (10 new: 6 hook tests in `esc-to-stop.test.tsx` covering fire/ignore/inactive/consumed/IME/re-activation, 3 layer-precedence tests with real ImagePreviewModal / useDismissableMenu / StatusBar rename, 1 chip-highlight Escape consumption test in `promptbox.test.tsx`)
- [x] `bun run check-types` and `cd webview && bunx tsc --noEmit` — both clean
- [x] `bun run compile` — builds
- [ ] F5 visual check: Esc mid-stream stops the turn; Esc with the slash picker / history popover / image preview open closes that layer only

Closes #383