### PR TITLE
chore(release): 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-07-04
+
+### Added
+- Pressing Esc now stops the running turn, exactly when the Stop button is clickable. Esc keeps its dismiss-first meaning: an open slash-command picker, @ mention picker, header popover, image preview, rename input, or highlighted mention chip consumes the first Esc and the turn keeps running; the next Esc stops it. Esc during IME composition cancels the composition, not the turn, and the Stop button tooltip now advertises the shortcut as "Stop (Esc)" (#383, #384).
+
 ## [1.6.0] - 2026-07-02
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Bumps the extension version to 1.7.0 and adds the changelog entry for the Esc-to-stop feature (#383, #384): pressing Esc stops the running turn exactly when the Stop button is clickable, with dismiss-first layering — an open picker, popover, image preview, rename input, or highlighted mention chip consumes the first Esc; the next Esc stops the turn. IME-safe, and the Stop button tooltip now reads "Stop (Esc)".

## Test plan

- [x] `bun run test` — 69 files, 1039 tests passed
- [x] `bun run check-types` — clean
- [x] `cd webview && bunx tsc --noEmit` — clean
- [x] `bun run package` — production build succeeds (webview bundle 7,477 kB inlined)
- [ ] After merge: tag v1.7.0, publish GitHub Release, verify the publish workflow succeeds on Marketplace + Open VSX

Closes #385