### PR TITLE
fix(chat): reuse existing empty New conversation from any active chat

### DIFF
--- a/src/chat/conversation-manager.ts
+++ b/src/chat/conversation-manager.ts
@@ -80,18 +80,22 @@ export class ConversationManager {
   }
 
   /**
-   * Backing for the New-chat action ("+" / "+ New chat"). If the active
-   * conversation is already an untouched "New conversation", reuse it — bump
-   * its created/updated time and move it to the front (`reused: true`) —
-   * instead of stacking a second identical empty chat. This is what keeps
-   * repeated New-chat clicks from piling up duplicate empty conversations.
-   * Otherwise add a fresh one (`reused: false`).
+   * Backing for the New-chat action ("+" / "+ New chat"). If an untouched
+   * "New conversation" already exists anywhere in the list — not just as the
+   * active chat — reuse it: bump its created/updated time and move it to the
+   * front (`reused: true`) instead of stacking a second identical empty
+   * chat. The active conversation is preferred when several qualify (legacy
+   * duplicates). Otherwise add a fresh one (`reused: false`).
    */
   addOrReuseEmpty(title: string): { conversation: SavedConversation; reused: boolean } {
     const active = this.conversations.find((c) => c.id === this.activeID)
-    if (active && this.isUntouchedNew(active)) {
+    const candidate =
+      active && this.isUntouchedNew(active)
+        ? active
+        : this.conversations.find((c) => this.isUntouchedNew(c))
+    if (candidate) {
       const now = Date.now()
-      const refreshed: SavedConversation = { ...active, createdAt: now, updatedAt: now }
+      const refreshed: SavedConversation = { ...candidate, createdAt: now, updatedAt: now }
       this.conversations = [refreshed, ...this.conversations.filter((c) => c.id !== refreshed.id)]
       return { conversation: refreshed, reused: true }
     }

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -264,9 +264,9 @@ export class ChatView implements vscode.WebviewViewProvider {
 
   async createConversation() {
     this.resetSessionState()
-    // Reuse the active chat if it is already an untouched "New conversation"
-    // so repeated New-chat clicks refresh that empty chat instead of piling
-    // up duplicates.
+    // Reuse an existing untouched "New conversation" (active or anywhere in
+    // the list) so New-chat clicks switch to that empty chat instead of
+    // piling up duplicates.
     const { conversation } = this.manager.addOrReuseEmpty("New conversation")
     this.manager.setActiveID(conversation.id)
     this.messages = []

--- a/test/host/conversation-manager-reuse.test.ts
+++ b/test/host/conversation-manager-reuse.test.ts
@@ -55,6 +55,33 @@ describe("ConversationManager.addOrReuseEmpty", () => {
     expect(manager.summaries()[0]!.updatedAt).toBeGreaterThan(before)
   })
 
+  it("reuses an untouched New conversation even when another chat is active", () => {
+    const { context } = fakeContext()
+    const manager = new ConversationManager(context)
+    const untouchedID = manager.getActiveID()
+    const touched = manager.add("Touched chat")
+    manager.setActiveID(touched.id)
+    manager.saveActiveSnapshot(withMessage())
+
+    const { conversation, reused } = manager.addOrReuseEmpty("New conversation")
+
+    expect(reused).toBe(true)
+    expect(conversation.id).toBe(untouchedID)
+    expect(manager.summaries()).toHaveLength(2) // no duplicate empty chat
+  })
+
+  it("prefers the active conversation when several untouched New conversations exist", () => {
+    const { context } = fakeContext()
+    const manager = new ConversationManager(context)
+    const second = manager.add("New conversation")
+    manager.setActiveID(second.id)
+
+    const { conversation, reused } = manager.addOrReuseEmpty("New conversation")
+
+    expect(reused).toBe(true)
+    expect(conversation.id).toBe(second.id)
+  })
+
   it("adds a fresh conversation when the active one already has messages", () => {
     const { context } = fakeContext()
     const manager = new ConversationManager(context)


### PR DESCRIPTION
## Summary

`ConversationManager.addOrReuseEmpty` only reused an untouched "New conversation" when it was the **active** chat, so clicking + New chat while viewing any other conversation created a duplicate empty chat even though one already existed in the history (the exact pile-up #368 was meant to prevent, reachable from a different starting chat).

The reuse candidate search now covers the whole conversation list: the active conversation is preferred when it qualifies, otherwise the first untouched "New conversation" in the list is reused (timestamp refreshed and moved to the front, same as the active-reuse path). `ChatView.createConversation` already calls `setActiveID` and resets live session state after the reuse, so switching to a non-active reused conversation needs no caller changes. A genuinely fresh conversation is still created when no untouched one exists anywhere.

## Test plan

- [x] `bun run test` — 69 files, 1041 tests passed (two new tests: reuse from another active chat; prefer-active tiebreak when several untouched New conversations exist)
- [x] `bun run check-types` — clean
- [x] `cd webview && bunx tsc --noEmit` — clean
- [ ] Visual check: from an older chat, + New chat switches to the existing empty "New conversation" instead of adding a duplicate

Closes #387