### PR TITLE
fix(chat): ignore part events for user messages rewritten by plugins

### DIFF
--- a/src/chat/stream.ts
+++ b/src/chat/stream.ts
@@ -617,6 +617,13 @@ export function subscribeSession(
     if (!part || part.sessionID !== sessionID) return
     const messageID = part.messageID as string | undefined
     if (!messageID) return
+    // Server-side plugins (e.g. oh-my-opencode) rewrite the USER message's
+    // text part after prompt submission, re-emitting message.part.updated for
+    // a user-role message. Without this guard the unseen id below would mint
+    // a phantom assistant bubble echoing the entire built prompt. opencode
+    // saves the message info before its parts, so seenUserMessages is
+    // populated before any part event for that message arrives.
+    if (seenUserMessages.has(messageID)) return
     if (!seenAssistantMessages.has(messageID)) {
       seenAssistantMessages.add(messageID)
       handlers.onAssistantStart?.(messageID)
@@ -686,6 +693,9 @@ export function subscribeSession(
     const messageID = p.messageID as string | undefined
     const partID = p.partID as string | undefined
     if (!messageID || !partID) return
+    // Same user-role guard as onPartUpdated: plugin rewrites of the user
+    // prompt must not stream into a phantom assistant bubble.
+    if (seenUserMessages.has(messageID)) return
     if (!seenAssistantMessages.has(messageID)) {
       seenAssistantMessages.add(messageID)
       handlers.onAssistantStart?.(messageID)

--- a/test/host/e2e-mock-opencode.test.ts
+++ b/test/host/e2e-mock-opencode.test.ts
@@ -443,6 +443,78 @@ describe("E2E (mock opencode): subscribeSession streaming", () => {
     expect(deltas.join("")).toBe("Hello, world")
   })
 
+  it("ignores part updates for user messages so plugin prompt rewrites are not echoed", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const starts: string[] = []
+    const deltas: string[] = []
+    const subscription = subscribeSession({ url: server.url, client, directory: "/tmp" }, "ses_test", {
+      onUserMessage: () => {},
+      onAssistantStart: (mid) => starts.push(mid),
+      onTextDelta: (_mid, delta) => deltas.push(delta),
+    })
+    await subscription.ready
+    await server.awaitClient()
+    // opencode saves the user message info before its parts
+    server.push({
+      type: "message.updated",
+      info: { id: "usr_1", role: "user", sessionID: "ses_test" },
+    })
+    // A server-side plugin (e.g. oh-my-opencode) rewrites the user prompt,
+    // which re-emits the user message's text part
+    server.push({
+      type: "message.part.updated",
+      part: {
+        id: "part_u",
+        messageID: "usr_1",
+        sessionID: "ses_test",
+        type: "text",
+        text: "[search-mode]\nMAXIMIZE SEARCH EFFORT\n\nWorkspace:\n- Name: opencui\n\nHello",
+      },
+    })
+    // The real assistant reply still streams normally
+    server.push({
+      type: "message.updated",
+      info: { id: "msg_a", role: "assistant", sessionID: "ses_test" },
+    })
+    server.push({
+      type: "message.part.updated",
+      part: { id: "part_1", messageID: "msg_a", sessionID: "ses_test", type: "text", text: "Hi" },
+    })
+    await new Promise((r) => setTimeout(r, 50))
+    subscription.abort()
+    expect(starts).toEqual(["msg_a"])
+    expect(deltas).toEqual(["Hi"])
+  })
+
+  it("ignores part deltas for user messages", async () => {
+    const client = createOpencodeClient({ baseUrl: server.url })
+    const starts: string[] = []
+    const deltas: string[] = []
+    const subscription = subscribeSession({ url: server.url, client, directory: "/tmp" }, "ses_test", {
+      onUserMessage: () => {},
+      onAssistantStart: (mid) => starts.push(mid),
+      onTextDelta: (_mid, delta) => deltas.push(delta),
+    })
+    await subscription.ready
+    await server.awaitClient()
+    server.push({
+      type: "message.updated",
+      info: { id: "usr_1", role: "user", sessionID: "ses_test" },
+    })
+    server.push({
+      type: "message.part.delta",
+      sessionID: "ses_test",
+      messageID: "usr_1",
+      partID: "part_u",
+      field: "text",
+      delta: "[analyze-mode]\nANALYSIS MODE",
+    })
+    await new Promise((r) => setTimeout(r, 50))
+    subscription.abort()
+    expect(starts).toEqual([])
+    expect(deltas).toEqual([])
+  })
+
   it("forwards tool updates with status running/completed", async () => {
     const client = createOpencodeClient({ baseUrl: server.url })
     const toolUpdates: { tool: string; status: string }[] = []

--- a/test/host/mock-opencode-server.ts
+++ b/test/host/mock-opencode-server.ts
@@ -12,6 +12,14 @@ export type ScriptedEvent =
   | { type: "session.idle"; sessionID: string }
   | { type: "message.updated"; info: Record<string, unknown> }
   | { type: "message.part.updated"; part: Record<string, unknown> }
+  | {
+      type: "message.part.delta"
+      sessionID: string
+      messageID: string
+      partID: string
+      field: string
+      delta: string
+    }
   | { type: "session.error"; error: { name?: string; data?: { message?: string } } }
   | { type: "session.status"; sessionID: string; status: { type: string } }
   | { type: "session.created"; info: Record<string, unknown> }


### PR DESCRIPTION
## Summary

opencode plugins (e.g. oh-my-opencode) rewrite the user message's text part server-side after prompt submission, which re-emits `message.part.updated` for a **user**-role message. `onPartUpdated` and `onPartDelta` in `src/chat/stream.ts` treated any unseen message ID as a new assistant message, so the rewrite minted a phantom assistant bubble that echoed the entire built prompt (workspace context block, README/CLAUDE.md auto-context, plugin mode directives like `[search-mode]` / `[analyze-mode]`, and the user's own text) at the start of the turn — and persisted it into conversation history.

Both paths now bail out when the message ID is in the `seenUserMessages` set that `onMessageUpdated` already maintains. opencode saves message info before its parts, so the set is populated before any part event for that message arrives. Assistant streaming is unchanged; user messages never carry tool/patch parts, so no terminal-closure handling is affected.

Also adds a `message.part.delta` variant to the mock server's `ScriptedEvent` union so the delta path is testable.

## Test plan

- [x] `bun run test` — 69 files, 1043 tests pass (2 new: user part update is not echoed while assistant parts still stream; user part deltas are ignored)
- [x] `bun run check-types` — clean
- [x] `cd webview && bunx tsc --noEmit` — only the 3 known pre-existing errors
- [ ] Visual check in the dev host with a prompt-rewriting plugin installed: no phantom prompt-echo bubble at the start of a turn

Closes #389