### PR TITLE
chore(release): 1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.7.1] - 2026-07-05
+
+### Fixed
+- Clicking New chat ("+" or "+ New chat") from any conversation now switches to an existing empty "New conversation" instead of creating a duplicate. Previously the reuse only worked when the empty chat was already active; starting from an older chat stacked identical "New conversation" entries in the history list (#387, #388).
+- opencode plugins that rewrite the user prompt server-side (for example oh-my-opencode's `[search-mode]` / `[analyze-mode]` directives) no longer cause the entire built prompt — workspace context, injected docs, and your own text — to be echoed back into the chat as a phantom assistant bubble at the start of the turn. The echo was also being persisted into conversation history; new turns stay clean (#389, #390).
+
 ## [1.7.0] - 2026-07-04
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Version bump to 1.7.1 and CHANGELOG entry for the two bug fixes merged since v1.7.0:

- #388 — New chat now reuses an existing empty "New conversation" from any active chat instead of stacking duplicates.
- #390 — Part events for user messages rewritten by server-side plugins (oh-my-opencode mode directives) are ignored, eliminating the phantom assistant bubble that echoed the entire built prompt.

## Test plan

- [x] `bun run test` — 69 files, 1043 tests pass
- [x] `bun run check-types` — clean
- [x] `bun run package` — production build succeeds
- [ ] After merge: create GitHub Release v1.7.1 and verify the publish workflow succeeds for both registries

Closes #391