### PR TITLE
feat(history): edit chat titles in place without swapping the row

### DIFF
--- a/test/webview/statusbar.test.tsx
+++ b/test/webview/statusbar.test.tsx
@@ -277,6 +277,61 @@ describe("StatusBar: history popover", () => {
     await user.type(input, "renamed{Enter}")
     expect(onRename).toHaveBeenCalledWith("c1", "renamed")
   })
+
+  it("rename mode renders only the input, no Save/Cancel buttons", async () => {
+    const user = userEvent.setup()
+    render(<StatusBar {...baseProps} conversations={conversations} />)
+    await user.click(screen.getByRole("button", { name: /chat history/i }))
+    await user.click(screen.getAllByRole("button", { name: /^Rename$/ })[0]!)
+    expect(screen.getByDisplayValue("First chat")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /^Save$/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /^Cancel$/ })).not.toBeInTheDocument()
+  })
+
+  it("commits the rename when the input loses focus", async () => {
+    const user = userEvent.setup()
+    const onRename = vi.fn()
+    render(<StatusBar {...baseProps} conversations={conversations} onRenameConversation={onRename} />)
+    await user.click(screen.getByRole("button", { name: /chat history/i }))
+    await user.click(screen.getAllByRole("button", { name: /^Rename$/ })[0]!)
+    const input = screen.getByDisplayValue("First chat")
+    await user.clear(input)
+    await user.type(input, "renamed by blur")
+    fireEvent.blur(input)
+    expect(onRename).toHaveBeenCalledWith("c1", "renamed by blur")
+    expect(screen.queryByDisplayValue("renamed by blur")).not.toBeInTheDocument()
+  })
+
+  it("cancels the rename on Escape without committing", async () => {
+    const user = userEvent.setup()
+    const onRename = vi.fn()
+    render(<StatusBar {...baseProps} conversations={conversations} onRenameConversation={onRename} />)
+    await user.click(screen.getByRole("button", { name: /chat history/i }))
+    await user.click(screen.getAllByRole("button", { name: /^Rename$/ })[0]!)
+    const input = screen.getByDisplayValue("First chat")
+    await user.type(input, " edited")
+    await user.keyboard("{Escape}")
+    expect(onRename).not.toHaveBeenCalled()
+    expect(screen.queryByDisplayValue(/First chat/)).not.toBeInTheDocument()
+    // Reopen: the row is out of edit mode with the original title intact.
+    await user.click(screen.getByRole("button", { name: /chat history/i }))
+    expect(screen.getByText("First chat")).toBeInTheDocument()
+  })
+
+  it("reverts to the previous title when the committed title is empty", async () => {
+    const user = userEvent.setup()
+    const onRename = vi.fn()
+    render(<StatusBar {...baseProps} conversations={conversations} onRenameConversation={onRename} />)
+    await user.click(screen.getByRole("button", { name: /chat history/i }))
+    await user.click(screen.getAllByRole("button", { name: /^Rename$/ })[0]!)
+    const input = screen.getByDisplayValue("First chat")
+    await user.clear(input)
+    fireEvent.blur(input)
+    expect(onRename).not.toHaveBeenCalled()
+    // Edit mode is closed and the old title still renders (blur does not
+    // dismiss the popover, so the row itself must be visible again).
+    expect(screen.getByText("First chat")).toBeInTheDocument()
+  })
 })
 
 describe("AgentActivity", () => {

--- a/webview/src/components/StatusBar.tsx
+++ b/webview/src/components/StatusBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type Dispatch, type SetStateAction } from "react"
+import { useEffect, useRef, useState, type Dispatch, type SetStateAction } from "react"
 import type { ConversationSummary, Selection } from "../protocol"
 import { useDismissableMenu } from "../hooks/useDismissableMenu"
 import { StatusIndicator, type StatusIndicatorKind } from "./StatusIndicator"
@@ -140,6 +140,7 @@ function ChatHistoryMenu({
   const { toggle, close, ref } = useDismissableMenu({ open, onOpenChange })
   const [renamingID, setRenamingID] = useState<string>()
   const [renamingTitle, setRenamingTitle] = useState("")
+  const renameCancelledRef = useRef(false)
   const [confirmDeleteID, setConfirmDeleteID] = useState<string>()
   const [query, setQuery] = useState("")
 
@@ -157,6 +158,7 @@ function ChatHistoryMenu({
   }, [confirmDeleteID])
 
   const startRename = (conversation: ConversationSummary) => {
+    renameCancelledRef.current = false
     setRenamingID(conversation.id)
     setRenamingTitle(conversation.title)
     setConfirmDeleteID(undefined)
@@ -165,8 +167,17 @@ function ChatHistoryMenu({
   const commitRename = () => {
     if (!renamingID) return
     const title = renamingTitle.replace(/\s+/g, " ").trim()
-    if (!title) return
-    onRename(renamingID, title.slice(0, 80))
+    // Empty title reverts to the previous one rather than staying in edit
+    // mode — with commit-on-blur there is no way to "stay" once focus left.
+    if (title) onRename(renamingID, title.slice(0, 80))
+    setRenamingID(undefined)
+    setRenamingTitle("")
+  }
+
+  const cancelRename = () => {
+    // Set before clearing state: unmounting the input fires a trailing blur
+    // that must not re-commit the edit Escape just discarded.
+    renameCancelledRef.current = true
     setRenamingID(undefined)
     setRenamingTitle("")
   }
@@ -175,10 +186,6 @@ function ChatHistoryMenu({
     if (confirmDeleteID === id) {
       onDelete(id)
       setConfirmDeleteID(undefined)
-      if (renamingID === id) {
-        setRenamingID(undefined)
-        setRenamingTitle("")
-      }
       return
     }
     setConfirmDeleteID(id)
@@ -234,35 +241,34 @@ function ChatHistoryMenu({
               const isEditing = conversation.id === renamingID
               return (
                 <div
-                  className={`history-item ${conversation.id === activeID ? "is-active" : ""} ${isEditing ? "is-editing" : ""} ${isConfirming ? "is-confirming" : ""}`}
+                  className={`history-item ${conversation.id === activeID ? "is-active" : ""} ${isConfirming ? "is-confirming" : ""}`}
                   key={conversation.id}
                 >
                   {isEditing ? (
-                    <>
-                      <input
-                        className="history-rename-input"
-                        value={renamingTitle}
-                        autoFocus
-                        onChange={(event) => setRenamingTitle(event.target.value)}
-                        onKeyDown={(event) => {
-                          // While IME composition is active, Enter commits
-                          // the IME candidate — don't intercept it as Save.
-                          if (event.nativeEvent.isComposing || event.keyCode === 229) return
-                          if (event.key === "Enter") commitRename()
-                          if (event.key === "Escape") {
-                            // Consume so Esc-to-stop doesn't also abort the turn.
-                            event.preventDefault()
-                            setRenamingID(undefined)
-                          }
-                        }}
-                      />
-                      <button className="history-action" onClick={commitRename}>
-                        Save
-                      </button>
-                      <button className="history-action" onClick={() => setRenamingID(undefined)}>
-                        Cancel
-                      </button>
-                    </>
+                    <input
+                      className="history-rename-input"
+                      value={renamingTitle}
+                      autoFocus
+                      onChange={(event) => setRenamingTitle(event.target.value)}
+                      onBlur={() => {
+                        if (renameCancelledRef.current) {
+                          renameCancelledRef.current = false
+                          return
+                        }
+                        commitRename()
+                      }}
+                      onKeyDown={(event) => {
+                        // While IME composition is active, Enter commits
+                        // the IME candidate — don't intercept it as Save.
+                        if (event.nativeEvent.isComposing || event.keyCode === 229) return
+                        if (event.key === "Enter") commitRename()
+                        if (event.key === "Escape") {
+                          // Consume so Esc-to-stop doesn't also abort the turn.
+                          event.preventDefault()
+                          cancelRename()
+                        }
+                      }}
+                    />
                   ) : (
                     <>
                       <button

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -714,7 +714,6 @@ button:focus-visible {
 }
 .history-item:hover .history-action,
 .history-item:focus-within .history-action,
-.history-item.is-editing .history-action,
 .history-item.is-confirming .history-action {
   opacity: 1;
 }
@@ -745,15 +744,23 @@ button:focus-visible {
   }
 }
 .history-rename-input {
+  /* Impersonate .history-open/.history-title so entering edit mode doesn't
+     reflow the row: same font metrics and vertical padding, no fixed height,
+     spanning the full row where title + date + actions were. The only visual
+     cue is the thin focus outline (drawn inward so it adds no size). */
+  grid-column: 1 / -1;
   min-width: 0;
   width: 100%;
-  height: 24px;
-  padding: 3px 6px;
-  border: 1px solid var(--vscode-input-border, var(--vscode-focusBorder));
+  padding: 3px 0;
+  border: 0;
   border-radius: var(--radius-sm);
-  background: var(--vscode-input-background);
-  color: var(--vscode-input-foreground);
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+  background: transparent;
+  color: inherit;
+  font-family: inherit;
   font-size: 12px;
+  line-height: 1.2;
 }
 
 /* ===== Todo panel ===== */


### PR DESCRIPTION
## Summary

Clicking Rename on a chat history row used to transform the entire row at once: the plain title became a boxed input with its own border, background, and a taller fixed 24px height; the date disappeared; and the Rename/Delete buttons were relabeled Save/Cancel, shifting the grid columns. This PR switches to VS Code's own rename idiom (what F2 does in the Explorer):

- The input impersonates the title: same 12px font, line-height, and vertical padding, transparent background, spanning the full row. The only visual cue is a thin `--vscode-focusBorder` outline drawn inward so it adds no size. No row-height change, no text shift.
- The Save/Cancel buttons are removed. Enter commits, Escape cancels, and blur (clicking anywhere else) commits.
- A ref flag guards the trailing blur after Escape so it cannot re-commit through the input's stale closure (`renamingID` is captured by the unmounting input's `onBlur`).
- Committing an empty/whitespace title reverts to the previous title instead of staying in edit mode — with commit-on-blur there is no way to "stay" once focus has left. This also unifies the previous Enter-on-empty no-op.
- Dead code removed: the `is-editing` row class and its CSS rule (it only targeted the removed buttons), and the rename cleanup in `handleDelete` (the editing row no longer renders a Delete button, and blur ends edit mode before any other click lands).

Preserved: IME composition guard on Enter, Escape `preventDefault()` so Esc-to-stop does not also abort the turn (existing `esc-to-stop` test still covers this), 80-char cap, whitespace normalization, two-click delete confirmation.

## Test plan

- [x] 4 new tests: rename mode renders only the input (no Save/Cancel), blur commits, Escape cancels without committing (and the row reverts on reopen), empty title reverts without calling `onRename`
- [x] Existing Enter-commit rename test and esc-to-stop rename test pass unchanged
- [x] Full suite: 69 files, 1047 tests passing
- [x] `bun run check-types` clean; webview `tsc --noEmit` shows only the 3 known pre-existing errors
- [x] `bun run compile` production build OK
- [ ] Visual check in the dev host (row geometry stable when entering/leaving edit mode across themes)

Closes #393