### PR TITLE
fix(history): scope rename to the visual change; no commit-on-blur

### DIFF
--- a/test/webview/statusbar.test.tsx
+++ b/test/webview/statusbar.test.tsx
@@ -288,7 +288,7 @@ describe("StatusBar: history popover", () => {
     expect(screen.queryByRole("button", { name: /^Cancel$/ })).not.toBeInTheDocument()
   })
 
-  it("commits the rename when the input loses focus", async () => {
+  it("does not commit or exit edit mode on blur; Enter is the commit", async () => {
     const user = userEvent.setup()
     const onRename = vi.fn()
     render(<StatusBar {...baseProps} conversations={conversations} onRenameConversation={onRename} />)
@@ -296,10 +296,10 @@ describe("StatusBar: history popover", () => {
     await user.click(screen.getAllByRole("button", { name: /^Rename$/ })[0]!)
     const input = screen.getByDisplayValue("First chat")
     await user.clear(input)
-    await user.type(input, "renamed by blur")
+    await user.type(input, "not committed yet")
     fireEvent.blur(input)
-    expect(onRename).toHaveBeenCalledWith("c1", "renamed by blur")
-    expect(screen.queryByDisplayValue("renamed by blur")).not.toBeInTheDocument()
+    expect(onRename).not.toHaveBeenCalled()
+    expect(screen.getByDisplayValue("not committed yet")).toBeInTheDocument()
   })
 
   it("cancels the rename on Escape without committing", async () => {
@@ -318,7 +318,7 @@ describe("StatusBar: history popover", () => {
     expect(screen.getByText("First chat")).toBeInTheDocument()
   })
 
-  it("reverts to the previous title when the committed title is empty", async () => {
+  it("stays in edit mode when Enter is pressed with an empty title", async () => {
     const user = userEvent.setup()
     const onRename = vi.fn()
     render(<StatusBar {...baseProps} conversations={conversations} onRenameConversation={onRename} />)
@@ -326,11 +326,9 @@ describe("StatusBar: history popover", () => {
     await user.click(screen.getAllByRole("button", { name: /^Rename$/ })[0]!)
     const input = screen.getByDisplayValue("First chat")
     await user.clear(input)
-    fireEvent.blur(input)
+    await user.keyboard("{Enter}")
     expect(onRename).not.toHaveBeenCalled()
-    // Edit mode is closed and the old title still renders (blur does not
-    // dismiss the popover, so the row itself must be visible again).
-    expect(screen.getByText("First chat")).toBeInTheDocument()
+    expect(input).toBeInTheDocument()
   })
 })
 

--- a/webview/src/components/StatusBar.tsx
+++ b/webview/src/components/StatusBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type Dispatch, type SetStateAction } from "react"
+import { useEffect, useState, type Dispatch, type SetStateAction } from "react"
 import type { ConversationSummary, Selection } from "../protocol"
 import { useDismissableMenu } from "../hooks/useDismissableMenu"
 import { StatusIndicator, type StatusIndicatorKind } from "./StatusIndicator"
@@ -140,7 +140,6 @@ function ChatHistoryMenu({
   const { toggle, close, ref } = useDismissableMenu({ open, onOpenChange })
   const [renamingID, setRenamingID] = useState<string>()
   const [renamingTitle, setRenamingTitle] = useState("")
-  const renameCancelledRef = useRef(false)
   const [confirmDeleteID, setConfirmDeleteID] = useState<string>()
   const [query, setQuery] = useState("")
 
@@ -158,7 +157,6 @@ function ChatHistoryMenu({
   }, [confirmDeleteID])
 
   const startRename = (conversation: ConversationSummary) => {
-    renameCancelledRef.current = false
     setRenamingID(conversation.id)
     setRenamingTitle(conversation.title)
     setConfirmDeleteID(undefined)
@@ -167,17 +165,8 @@ function ChatHistoryMenu({
   const commitRename = () => {
     if (!renamingID) return
     const title = renamingTitle.replace(/\s+/g, " ").trim()
-    // Empty title reverts to the previous one rather than staying in edit
-    // mode — with commit-on-blur there is no way to "stay" once focus left.
-    if (title) onRename(renamingID, title.slice(0, 80))
-    setRenamingID(undefined)
-    setRenamingTitle("")
-  }
-
-  const cancelRename = () => {
-    // Set before clearing state: unmounting the input fires a trailing blur
-    // that must not re-commit the edit Escape just discarded.
-    renameCancelledRef.current = true
+    if (!title) return
+    onRename(renamingID, title.slice(0, 80))
     setRenamingID(undefined)
     setRenamingTitle("")
   }
@@ -250,13 +239,6 @@ function ChatHistoryMenu({
                       value={renamingTitle}
                       autoFocus
                       onChange={(event) => setRenamingTitle(event.target.value)}
-                      onBlur={() => {
-                        if (renameCancelledRef.current) {
-                          renameCancelledRef.current = false
-                          return
-                        }
-                        commitRename()
-                      }}
                       onKeyDown={(event) => {
                         // While IME composition is active, Enter commits
                         // the IME candidate — don't intercept it as Save.
@@ -265,7 +247,7 @@ function ChatHistoryMenu({
                         if (event.key === "Escape") {
                           // Consume so Esc-to-stop doesn't also abort the turn.
                           event.preventDefault()
-                          cancelRename()
+                          setRenamingID(undefined)
                         }
                       }}
                     />


### PR DESCRIPTION
## Summary

Rolls back the behavioral extras that #394 added alongside the requested visual change, restoring the pre-#394 rename semantics:

- Blur no longer commits — losing focus does nothing; the input stays in edit mode.
- Enter with an empty/whitespace-only title is a no-op again (stays editing) instead of silently reverting.
- The `renameCancelledRef` guard and `cancelRename` helper are removed (they existed only to protect the now-removed blur-commit path); Escape goes back to plain `setRenamingID(undefined)` with the same `preventDefault()` so Esc-to-stop still doesn't fire.

What stays from #394 (the requested part): the input impersonates the title — same font metrics and padding, transparent background, thin `--vscode-focusBorder` outline, full-row span with no Save/Cancel buttons, no row-height change.

## Test plan

- [x] Replaced the blur-commit test with one pinning the opposite contract: blur neither commits nor exits edit mode
- [x] Replaced the empty-title-revert test with the pre-#394 behavior: Enter on an empty title stays in edit mode without calling `onRename`
- [x] Kept: Enter-commit test, no-Save/Cancel test, Escape-cancel tests (statusbar + esc-to-stop) — all pass unchanged
- [x] Full suite: 69 files, 1047 tests passing
- [x] `bun run check-types` clean; `bun run compile` production build OK

Closes #395