### PR TITLE
fix(history): restore Save/Cancel in rename mode, drop the input box

### DIFF
--- a/test/webview/statusbar.test.tsx
+++ b/test/webview/statusbar.test.tsx
@@ -278,14 +278,32 @@ describe("StatusBar: history popover", () => {
     expect(onRename).toHaveBeenCalledWith("c1", "renamed")
   })
 
-  it("rename mode renders only the input, no Save/Cancel buttons", async () => {
+  it("rename mode shows Save and Cancel; Save commits the rename", async () => {
     const user = userEvent.setup()
-    render(<StatusBar {...baseProps} conversations={conversations} />)
+    const onRename = vi.fn()
+    render(<StatusBar {...baseProps} conversations={conversations} onRenameConversation={onRename} />)
     await user.click(screen.getByRole("button", { name: /chat history/i }))
     await user.click(screen.getAllByRole("button", { name: /^Rename$/ })[0]!)
-    expect(screen.getByDisplayValue("First chat")).toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: /^Save$/ })).not.toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: /^Cancel$/ })).not.toBeInTheDocument()
+    const input = screen.getByDisplayValue("First chat")
+    await user.clear(input)
+    await user.type(input, "saved title")
+    await user.click(screen.getByRole("button", { name: /^Save$/ }))
+    expect(onRename).toHaveBeenCalledWith("c1", "saved title")
+    expect(screen.queryByDisplayValue("saved title")).not.toBeInTheDocument()
+  })
+
+  it("Cancel exits rename mode without committing", async () => {
+    const user = userEvent.setup()
+    const onRename = vi.fn()
+    render(<StatusBar {...baseProps} conversations={conversations} onRenameConversation={onRename} />)
+    await user.click(screen.getByRole("button", { name: /chat history/i }))
+    await user.click(screen.getAllByRole("button", { name: /^Rename$/ })[0]!)
+    const input = screen.getByDisplayValue("First chat")
+    await user.type(input, " edited")
+    await user.click(screen.getByRole("button", { name: /^Cancel$/ }))
+    expect(onRename).not.toHaveBeenCalled()
+    expect(screen.queryByDisplayValue(/First chat/)).not.toBeInTheDocument()
+    expect(screen.getByText("First chat")).toBeInTheDocument()
   })
 
   it("does not commit or exit edit mode on blur; Enter is the commit", async () => {

--- a/webview/src/components/StatusBar.tsx
+++ b/webview/src/components/StatusBar.tsx
@@ -230,27 +230,35 @@ function ChatHistoryMenu({
               const isEditing = conversation.id === renamingID
               return (
                 <div
-                  className={`history-item ${conversation.id === activeID ? "is-active" : ""} ${isConfirming ? "is-confirming" : ""}`}
+                  className={`history-item ${conversation.id === activeID ? "is-active" : ""} ${isEditing ? "is-editing" : ""} ${isConfirming ? "is-confirming" : ""}`}
                   key={conversation.id}
                 >
                   {isEditing ? (
-                    <input
-                      className="history-rename-input"
-                      value={renamingTitle}
-                      autoFocus
-                      onChange={(event) => setRenamingTitle(event.target.value)}
-                      onKeyDown={(event) => {
-                        // While IME composition is active, Enter commits
-                        // the IME candidate — don't intercept it as Save.
-                        if (event.nativeEvent.isComposing || event.keyCode === 229) return
-                        if (event.key === "Enter") commitRename()
-                        if (event.key === "Escape") {
-                          // Consume so Esc-to-stop doesn't also abort the turn.
-                          event.preventDefault()
-                          setRenamingID(undefined)
-                        }
-                      }}
-                    />
+                    <>
+                      <input
+                        className="history-rename-input"
+                        value={renamingTitle}
+                        autoFocus
+                        onChange={(event) => setRenamingTitle(event.target.value)}
+                        onKeyDown={(event) => {
+                          // While IME composition is active, Enter commits
+                          // the IME candidate — don't intercept it as Save.
+                          if (event.nativeEvent.isComposing || event.keyCode === 229) return
+                          if (event.key === "Enter") commitRename()
+                          if (event.key === "Escape") {
+                            // Consume so Esc-to-stop doesn't also abort the turn.
+                            event.preventDefault()
+                            setRenamingID(undefined)
+                          }
+                        }}
+                      />
+                      <button className="history-action" onClick={commitRename}>
+                        Save
+                      </button>
+                      <button className="history-action" onClick={() => setRenamingID(undefined)}>
+                        Cancel
+                      </button>
+                    </>
                   ) : (
                     <>
                       <button

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -714,6 +714,7 @@ button:focus-visible {
 }
 .history-item:hover .history-action,
 .history-item:focus-within .history-action,
+.history-item.is-editing .history-action,
 .history-item.is-confirming .history-action {
   opacity: 1;
 }
@@ -744,18 +745,13 @@ button:focus-visible {
   }
 }
 .history-rename-input {
-  /* Impersonate .history-open/.history-title so entering edit mode doesn't
-     reflow the row: same font metrics and vertical padding, no fixed height,
-     spanning the full row where title + date + actions were. The only visual
-     cue is the thin focus outline (drawn inward so it adds no size). */
-  grid-column: 1 / -1;
+  /* Editing must look like the title itself: same font metrics, no box,
+     no focus ring. The Save/Cancel buttons appearing is the edit cue. */
   min-width: 0;
   width: 100%;
   padding: 3px 0;
   border: 0;
-  border-radius: var(--radius-sm);
-  outline: 1px solid var(--vscode-focusBorder);
-  outline-offset: -1px;
+  outline: none;
   background: transparent;
   color: inherit;
   font-family: inherit;


### PR DESCRIPTION
## Summary

Final shape of the rename UX after iterating in #393/#395: the original layout with the requested minimal styling.

- Save and Cancel buttons are back in the action columns while editing (Save commits, Cancel exits without committing), and the `is-editing` row state returns so they stay visible even when the pointer leaves the row and the input is unfocused.
- The input draws no highlight box at all: no border, no background, and `outline: none` to suppress the browser focus ring. It keeps the title's exact font metrics (12px, inherited family, 1.2 line-height, 3px vertical padding), so entering edit mode changes nothing visually except the appearing Save/Cancel buttons and the text caret. No row-height change.
- Commit semantics unchanged from #396: Enter/Save commit, Escape/Cancel exit, blur does nothing, empty-title Enter stays in edit mode. IME guard and the Escape `preventDefault()` for Esc-to-stop are untouched.

## Test plan

- [x] New tests: Save commits the rename; Cancel exits without committing (both previously untested paths)
- [x] Kept: Enter-commit, Escape-cancel (statusbar + esc-to-stop), blur-does-nothing, empty-title-stays tests — all pass unchanged
- [x] Full suite: 69 files, 1048 tests passing
- [x] `bun run check-types` clean; `bun run compile` production build OK
- [ ] Visual check in the dev host (no box or font change on entering edit mode)

Closes #397