### PR TITLE
chore(release): 1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.7.2] - 2026-07-06
+
+### Changed
+- Renaming a chat in the history popover now edits the title in place. The input keeps the title's exact font and no longer draws a bordered box, so the row doesn't jump or reflow when entering edit mode — the only visible change is the caret and the Save/Cancel buttons replacing Rename/Delete. Save and Cancel behave as before: Save (or Enter) commits, Cancel (or Escape) discards, and clicking elsewhere never commits by accident (#393–#398).
+
 ## [1.7.1] - 2026-07-05
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Version bump to 1.7.2 with a dated CHANGELOG section covering the net change since v1.7.1: the in-place chat rename polish (#393/#394, #395/#396, #397/#398) — the rename input keeps the title's font with no bordered box, Save/Cancel are retained, and commit semantics are unchanged.

## Test plan

- [x] Full suite: 69 files, 1048 tests passing
- [x] `bun run check-types` clean
- [x] `bun run package` production build OK (webview bundle 7,477.67 kB)
- [ ] Publish workflow verified after the GitHub Release is created (Marketplace + Open VSX)

Closes #399