### PR TITLE
test(webview): cover PermissionDialog and QuestionDialog

### DIFF
--- a/test/webview/permission-dialog.test.tsx
+++ b/test/webview/permission-dialog.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, afterEach, vi } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { PermissionDialog } from "../../webview/src/components/PermissionDialog"
+
+afterEach(cleanup)
+
+describe("PermissionDialog", () => {
+  it("renders the title and the pattern", () => {
+    render(<PermissionDialog id="p1" title="Run a shell command" pattern="rm -rf dist" onReply={() => {}} />)
+    expect(screen.getByText(/Permission requested/)).toBeInTheDocument()
+    expect(screen.getByText("Run a shell command")).toBeInTheDocument()
+    expect(screen.getByText("rm -rf dist")).toBeInTheDocument()
+  })
+
+  it("joins array patterns with a comma", () => {
+    render(<PermissionDialog id="p1" title="Edit files" pattern={["src/**", "test/**"]} onReply={() => {}} />)
+    expect(screen.getByText("src/**, test/**")).toBeInTheDocument()
+  })
+
+  it("omits the pattern element when none is given", () => {
+    const { container } = render(<PermissionDialog id="p1" title="Do a thing" onReply={() => {}} />)
+    expect(container.querySelector(".permission-pattern")).toBeNull()
+  })
+
+  it.each([
+    ["Reject", "reject"],
+    ["Allow once", "once"],
+    ["Allow always", "always"],
+  ] as const)("replies %s as %s", async (label, response) => {
+    const onReply = vi.fn()
+    render(<PermissionDialog id="p1" title="Run a command" onReply={onReply} />)
+    await userEvent.click(screen.getByRole("button", { name: label }))
+    expect(onReply).toHaveBeenCalledTimes(1)
+    expect(onReply).toHaveBeenCalledWith("p1", response)
+  })
+})

--- a/test/webview/question-dialog.test.tsx
+++ b/test/webview/question-dialog.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, afterEach, vi } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { QuestionDialog } from "../../webview/src/components/QuestionDialog"
+import type { QuestionInfo } from "../../webview/src/protocol"
+
+afterEach(cleanup)
+
+function q(overrides: Partial<QuestionInfo> = {}): QuestionInfo {
+  return {
+    question: "Which library?",
+    header: "Library",
+    options: [
+      { label: "React", description: "the incumbent" },
+      { label: "Solid", description: "" },
+    ],
+    ...overrides,
+  }
+}
+
+describe("QuestionDialog", () => {
+  it("renders header, question, options and descriptions", () => {
+    render(<QuestionDialog id="q1" questions={[q()]} onReply={() => {}} onReject={() => {}} />)
+    expect(screen.getByText(/Question from the assistant/)).toBeInTheDocument()
+    expect(screen.getByText("Library")).toBeInTheDocument()
+    expect(screen.getByText("Which library?")).toBeInTheDocument()
+    expect(screen.getByText("React")).toBeInTheDocument()
+    expect(screen.getByText("the incumbent")).toBeInTheDocument()
+  })
+
+  it("pluralizes the title for multiple questions", () => {
+    render(
+      <QuestionDialog
+        id="q1"
+        questions={[q(), q({ question: "Which style?", header: "Style" })]}
+        onReply={() => {}}
+        onReject={() => {}}
+      />,
+    )
+    expect(screen.getByText(/Questions from the assistant/)).toBeInTheDocument()
+  })
+
+  it("disables Send until every question has an answer", async () => {
+    const onReply = vi.fn()
+    render(
+      <QuestionDialog
+        id="q1"
+        questions={[q(), q({ question: "Which style?", header: "Style" })]}
+        onReply={onReply}
+        onReject={() => {}}
+      />,
+    )
+    const send = screen.getByRole("button", { name: "Send" })
+    expect(send).toBeDisabled()
+    await userEvent.click(screen.getAllByRole("radio", { name: /React/ })[0]!)
+    expect(send).toBeDisabled()
+    await userEvent.click(screen.getAllByRole("radio", { name: /Solid/ })[1]!)
+    expect(send).toBeEnabled()
+    await userEvent.click(send)
+    expect(onReply).toHaveBeenCalledWith("q1", [["React"], ["Solid"]])
+  })
+
+  it("single-select replaces the previous choice", async () => {
+    const onReply = vi.fn()
+    render(<QuestionDialog id="q1" questions={[q()]} onReply={onReply} onReject={() => {}} />)
+    await userEvent.click(screen.getByRole("radio", { name: /React/ }))
+    await userEvent.click(screen.getByRole("radio", { name: /Solid/ }))
+    expect(screen.getByRole("radio", { name: /React/ })).toHaveAttribute("aria-checked", "false")
+    expect(screen.getByRole("radio", { name: /Solid/ })).toHaveAttribute("aria-checked", "true")
+    await userEvent.click(screen.getByRole("button", { name: "Send" }))
+    expect(onReply).toHaveBeenCalledWith("q1", [["Solid"]])
+  })
+
+  it("multi-select toggles options independently", async () => {
+    const onReply = vi.fn()
+    render(<QuestionDialog id="q1" questions={[q({ multiple: true })]} onReply={onReply} onReject={() => {}} />)
+    const react = screen.getByRole("checkbox", { name: /React/ })
+    const solid = screen.getByRole("checkbox", { name: /Solid/ })
+    await userEvent.click(react)
+    await userEvent.click(solid)
+    expect(react).toHaveAttribute("aria-checked", "true")
+    expect(solid).toHaveAttribute("aria-checked", "true")
+    await userEvent.click(react)
+    expect(react).toHaveAttribute("aria-checked", "false")
+    await userEvent.click(screen.getByRole("button", { name: "Send" }))
+    expect(onReply).toHaveBeenCalledWith("q1", [["Solid"]])
+  })
+
+  it("appends a trimmed custom answer to the selected labels", async () => {
+    const onReply = vi.fn()
+    render(<QuestionDialog id="q1" questions={[q()]} onReply={onReply} onReject={() => {}} />)
+    await userEvent.click(screen.getByRole("radio", { name: /React/ }))
+    await userEvent.type(screen.getByPlaceholderText("Or type a custom answer…"), "  with hooks  ")
+    await userEvent.click(screen.getByRole("button", { name: "Send" }))
+    expect(onReply).toHaveBeenCalledWith("q1", [["React", "with hooks"]])
+  })
+
+  it("a custom answer alone enables Send", async () => {
+    const onReply = vi.fn()
+    render(<QuestionDialog id="q1" questions={[q()]} onReply={onReply} onReject={() => {}} />)
+    const send = screen.getByRole("button", { name: "Send" })
+    await userEvent.type(screen.getByPlaceholderText("Or type a custom answer…"), "neither")
+    expect(send).toBeEnabled()
+    await userEvent.click(send)
+    expect(onReply).toHaveBeenCalledWith("q1", [["neither"]])
+  })
+
+  it("whitespace-only custom text does not enable Send", async () => {
+    render(<QuestionDialog id="q1" questions={[q()]} onReply={() => {}} onReject={() => {}} />)
+    await userEvent.type(screen.getByPlaceholderText("Or type a custom answer…"), "   ")
+    expect(screen.getByRole("button", { name: "Send" })).toBeDisabled()
+  })
+
+  it("hides the custom textarea when custom is disabled", () => {
+    render(<QuestionDialog id="q1" questions={[q({ custom: false })]} onReply={() => {}} onReject={() => {}} />)
+    expect(document.querySelector(".question-custom")).toBeNull()
+  })
+
+  it("uses the answer-only placeholder when there are no options", () => {
+    render(<QuestionDialog id="q1" questions={[q({ options: [] })]} onReply={() => {}} onReject={() => {}} />)
+    expect(screen.getByPlaceholderText("Type your answer…")).toBeInTheDocument()
+  })
+
+  it("Skip rejects the request without answers", async () => {
+    const onReject = vi.fn()
+    render(<QuestionDialog id="q1" questions={[q()]} onReply={() => {}} onReject={onReject} />)
+    await userEvent.click(screen.getByRole("button", { name: "Skip" }))
+    expect(onReject).toHaveBeenCalledWith("q1")
+  })
+
+  it("resets selections when a different request is swapped in", async () => {
+    const { rerender } = render(
+      <QuestionDialog id="q1" questions={[q()]} onReply={() => {}} onReject={() => {}} />,
+    )
+    await userEvent.click(screen.getByRole("radio", { name: /React/ }))
+    expect(screen.getByRole("button", { name: "Send" })).toBeEnabled()
+    rerender(<QuestionDialog id="q2" questions={[q()]} onReply={() => {}} onReject={() => {}} />)
+    expect(screen.getByRole("radio", { name: /React/ })).toHaveAttribute("aria-checked", "false")
+    expect(screen.getByRole("button", { name: "Send" })).toBeDisabled()
+  })
+})


### PR DESCRIPTION
## Summary

Adds RTL component tests for the two previously untested dock dialogs (18 tests):

- `test/webview/permission-dialog.test.tsx` — title and pattern rendering (plain string, array joined with commas, omitted element when absent); Reject / Allow once / Allow always each posting the right response with the request id.
- `test/webview/question-dialog.test.tsx` — option/header/description rendering and title pluralization; Send stays disabled until *every* question has an answer and posts `string[][]` payloads; single-select replaces the previous choice while multi-select toggles independently (asserted via `aria-checked`); custom answers are trimmed and appended to selected labels, enable Send on their own, and whitespace-only text does not; `custom: false` hides the textarea and option-less questions get the answer-only placeholder; Skip calls `onReject`; swapping in a new request id resets all selections.

Raises both components from 0% to full line coverage. No production code changes.

## Test plan

- [x] `bun run test` — 73 files, 1103 tests (18 new), all passing
- [x] `bun run check-types` — clean
- [x] `cd webview && bunx tsc --noEmit` — clean
- [x] No src changes, so no build impact

Closes #407