### PR TITLE
test(integration): replace placebo assertions with a webview round-trip

### DIFF
--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -258,6 +258,19 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.view?.show?.(true)
   }
 
+  private webviewMounted = false
+
+  /**
+   * Test-facing snapshot exposed through the extension's `activate()` exports.
+   * `resolved` — VS Code called resolveWebviewView; `mounted` — the bundled
+   * React app booted inside the webview and completed the `mounted` handshake.
+   * The integration suite polls this to prove the real webview loads end to
+   * end (CSP, bundle, protocol) — something no unit test can observe.
+   */
+  webviewState(): { resolved: boolean; mounted: boolean } {
+    return { resolved: this.view !== undefined, mounted: this.webviewMounted }
+  }
+
   async newSession() {
     await this.createConversation()
   }
@@ -646,6 +659,7 @@ export class ChatView implements vscode.WebviewViewProvider {
   private async onMessage(msg: Inbound) {
     switch (msg.type) {
       case "mounted": {
+        this.webviewMounted = true
         this.post({
           type: "ready",
           connected: false,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -77,6 +77,12 @@ export async function activate(context: vscode.ExtensionContext) {
       status.set("error", String(e))
       vscode.window.showErrorMessage(`OpenCode Panel: failed to start opencode backend: ${e.message}`)
     })
+
+  // Test-facing API (ext.exports). The integration suite polls this to verify
+  // the real webview bundle loads and completes the mounted handshake.
+  return {
+    chatWebviewState: () => chat.webviewState(),
+  }
 }
 
 export async function deactivate() {

--- a/test/integration/extension.test.ts
+++ b/test/integration/extension.test.ts
@@ -53,25 +53,34 @@ suite("Settings", () => {
   })
 })
 
-suite("Webview view registration", () => {
-  test("OpenCode Panel chat view is registered", async () => {
-    // The chat view is registered via registerWebviewViewProvider during
-    // activation. We verify by checking that the activity bar can show it.
+suite("Webview round-trip", () => {
+  async function until(cond: () => boolean, ms: number, label: string) {
+    const start = Date.now()
+    while (!cond()) {
+      if (Date.now() - start > ms) {
+        assert.fail(`timed out after ${ms}ms waiting for ${label}`)
+      }
+      await new Promise((r) => setTimeout(r, 100))
+    }
+  }
+
+  test("the chat webview loads its bundle and completes the mounted handshake", async function () {
+    this.timeout(45_000)
     const ext = vscode.extensions.getExtension(EXTENSION_ID)!
     if (!ext.isActive) await ext.activate()
-    // Show the OpenCode Panel sidebar — this will fail if the view container
-    // wasn't contributed properly in package.json.
-    await vscode.commands.executeCommand("workbench.view.extension.opencui")
-    // No throw means the view container exists and was opened.
-    assert.ok(true)
-  })
-})
+    const api = ext.exports as {
+      chatWebviewState: () => { resolved: boolean; mounted: boolean }
+    }
+    assert.ok(api?.chatWebviewState, "activate() should export chatWebviewState")
 
-suite("Configuration migration", () => {
-  test("workspace state is empty initially in test fixture", () => {
-    // The fixture workspace has no prior conversations; activation should
-    // create a default "New conversation" entry.
-    // This is validated indirectly via the chat view loading — covered above.
-    assert.ok(true)
+    // Opening the container makes VS Code resolve the webview view provider,
+    // which loads the real bundled React app inside a real webview.
+    await vscode.commands.executeCommand("workbench.view.extension.opencui")
+    await until(() => api.chatWebviewState().resolved, 15_000, "resolveWebviewView")
+
+    // The bundle booting and posting `mounted` proves the CSP, the single-file
+    // bundle, and the host<->webview protocol all work end to end — the one
+    // thing unit tests cannot observe.
+    await until(() => api.chatWebviewState().mounted, 30_000, "the webview mounted handshake")
   })
 })


### PR DESCRIPTION
## Summary

Makes the integration suite assert the one thing only it can verify — the real bundled webview loading end to end:

- **Removes the placebo** "Configuration migration" suite (`assert.ok(true)` with a comment admitting it tested nothing).
- **Replaces** the no-throw webview-registration test with a real round-trip: open the `opencui` view container, then poll until (1) VS Code calls `resolveWebviewView` and (2) the actual single-file React bundle boots inside the real webview and posts `mounted` — proving CSP, bundle loading, `acquireVsCodeApi`, and the host/webview protocol together. Timeouts fail with a labelled message instead of hanging.
- **Adds the minimal test surface this needs**: `ChatView.webviewState()` (a `resolved`/`mounted` snapshot; the flag is set in the existing `mounted` handler) exposed through `activate()`'s return value as `ext.exports.chatWebviewState()` — the standard extension-testing pattern. No behavior change for users.

The activation, command-registration, and settings smoke tests stay as they were.

## Test plan

- [x] `bun run test:integration` — 13 passing in a real VS Code (1.119.0); the round-trip test completes the mounted handshake in ~0.8s
- [x] `bun run test` — 74 files, 1106 tests, all passing
- [x] `bun run check-types` — clean
- [x] `bun run compile` — builds clean

Closes #411