### PR TITLE
fix(chat): budget-driven whole-message truncation for conversation mentions

### DIFF
--- a/src/chat/prompt-builder.ts
+++ b/src/chat/prompt-builder.ts
@@ -10,7 +10,12 @@ import { stripWorkspaceFolderPrefix } from "./paths"
 export const DEFAULT_MENTION_MAX_BYTES = 200_000
 export const DEFAULT_CONVERSATION_MAX_BYTES = 100_000
 const MENTION_MAX_FILES = 20
-const CONVERSATION_MAX_MESSAGES = 29
+/**
+ * One message may consume at most this fraction of a conversation mention's
+ * byte budget, so a single pasted log cannot evict every other turn.
+ */
+const CONVERSATION_MESSAGE_MAX_FRACTION = 0.25
+const MESSAGE_TRUNCATED_MARKER = "\n[message truncated]"
 
 export function buildPrompt(
   userText: string,
@@ -158,45 +163,153 @@ async function readFirstCandidate(
 
 export type ConversationMentionResult = {
   block?: string
-  bytes: Record<string, { included: number; original: number }>
+  bytes: Record<string, { included: number; original: number; truncated: boolean }>
   capped: string[]
   failed: string[]
 }
 
-export function formatConversationContext(title: string, messages: ChatMessage[]): string {
-  const total = messages.length
-  let selected: ChatMessage[]
-  let truncationNote = ""
-  if (total <= CONVERSATION_MAX_MESSAGES + 1) {
-    selected = messages
-  } else {
-    const first = messages[0]!
-    const tail = messages.slice(-(CONVERSATION_MAX_MESSAGES))
-    const tailStart = total - CONVERSATION_MAX_MESSAGES
-    selected = tailStart > 0 ? [first, ...tail] : messages
-    truncationNote = ` (first message + last ${CONVERSATION_MAX_MESSAGES} of ${total} total)`
-  }
-  const lines: string[] = [`Past conversation "${title}"${truncationNote}:`]
-  for (const msg of selected) {
-    const role = msg.role === "user" ? "User" : "Assistant"
-    const parts: string[] = []
-    for (const block of msg.blocks) {
-      if (block.type === "text" && block.text.trim()) {
-        parts.push(block.text.trim())
-      } else if (block.type === "tool") {
-        const name = block.update.tool
-        const label = block.update.title ?? block.update.input?.path ?? ""
-        parts.push(`[${name}${label ? `: ${label}` : ""}]`)
-      } else if (block.type === "patch") {
-        const files = block.files.join(", ")
-        parts.push(`[patched ${files}]`)
-      }
-    }
-    if (parts.length > 0) {
-      lines.push(`${role}: ${parts.join("\n")}`)
+export type ConversationContextResult = {
+  text: string
+  /** Byte size of the full, untruncated transcript block. */
+  originalBytes: number
+  /**
+   * True when any message was omitted or cut. The manifest must use this
+   * rather than comparing byte counts: the omission marker and header note
+   * can outweigh a tiny omitted message, making `included > original`.
+   */
+  truncated: boolean
+}
+
+function formatConversationMessage(msg: ChatMessage): string | undefined {
+  const role = msg.role === "user" ? "User" : "Assistant"
+  const parts: string[] = []
+  for (const block of msg.blocks) {
+    if (block.type === "text" && block.text.trim()) {
+      parts.push(block.text.trim())
+    } else if (block.type === "tool") {
+      const name = block.update.tool
+      const label = block.update.title ?? block.update.input?.path ?? ""
+      parts.push(`[${name}${label ? `: ${label}` : ""}]`)
+    } else if (block.type === "patch") {
+      const files = block.files.join(", ")
+      parts.push(`[patched ${files}]`)
     }
   }
-  return lines.join("\n")
+  if (parts.length === 0) return undefined
+  return `${role}: ${parts.join("\n")}`
+}
+
+/**
+ * Cut `text` to at most `maxBytes` UTF-8 bytes without splitting a character
+ * (a Buffer cut mid-character decodes to trailing U+FFFD, which we strip).
+ * Prefers ending at the last newline, then the last space, when one exists in
+ * the second half of the cut, so truncation lands on a natural boundary.
+ */
+function truncateUtf8(text: string, maxBytes: number): string {
+  if (maxBytes <= 0) return ""
+  if (Buffer.byteLength(text, "utf8") <= maxBytes) return text
+  const hard = Buffer.from(text, "utf8").subarray(0, maxBytes).toString("utf8").replace(/�+$/, "")
+  const newline = hard.lastIndexOf("\n")
+  if (newline > hard.length / 2) return hard.slice(0, newline)
+  const space = hard.lastIndexOf(" ")
+  if (space > hard.length / 2) return hard.slice(0, space)
+  return hard
+}
+
+function capMessage(text: string, maxBytes: number): string {
+  if (Buffer.byteLength(text, "utf8") <= maxBytes) return text
+  const markerBytes = Buffer.byteLength(MESSAGE_TRUNCATED_MARKER, "utf8")
+  if (maxBytes <= markerBytes) return truncateUtf8(text, maxBytes)
+  return truncateUtf8(text, maxBytes - markerBytes) + MESSAGE_TRUNCATED_MARKER
+}
+
+/** A fence longer than any backtick run in `content`, so transcript code blocks cannot close it. */
+function fenceFor(content: string): string {
+  let longest = 0
+  for (const run of content.match(/`+/g) ?? []) longest = Math.max(longest, run.length)
+  return "`".repeat(Math.max(3, longest + 1))
+}
+
+/**
+ * Format a past conversation for the prompt within a hard byte budget.
+ * Selection and truncation are one mechanism: the first message is always
+ * kept (it anchors the conversation's intent), then whole messages are added
+ * walking backward from the end until the budget is spent, with an omission
+ * marker at the gap. Messages are never split mid-character or mid-turn, so
+ * the budget holds by construction regardless of content encoding. The
+ * transcript is fenced so its `User:` / `Assistant:` lines read as quoted
+ * reference material, not live turns.
+ *
+ * Returns undefined when not even the header plus the (capped) first message
+ * fits — the caller records the mention as capped.
+ */
+export function formatConversationContext(
+  title: string,
+  messages: ChatMessage[],
+  maxBytes: number,
+): ConversationContextResult | undefined {
+  if (maxBytes <= 0) return undefined
+  const header = (note: string) => `Past conversation "${title}"${note}:`
+  const formatted: string[] = []
+  for (const msg of messages) {
+    const text = formatConversationMessage(msg)
+    if (text !== undefined) formatted.push(text)
+  }
+  if (formatted.length === 0) {
+    const text = header("")
+    const bytes = Buffer.byteLength(text, "utf8")
+    return bytes <= maxBytes ? { text, originalBytes: bytes, truncated: false } : undefined
+  }
+
+  // Fence sized against the full transcript: capping only removes content
+  // (the appended markers contain no backticks), so a fence that clears the
+  // full text clears every capped variant too.
+  const fence = fenceFor(formatted.join("\n"))
+  const originalBytes = Buffer.byteLength([header(""), fence, ...formatted, fence].join("\n"), "utf8")
+
+  const perMessageMax = Math.max(1, Math.floor(maxBytes * CONVERSATION_MESSAGE_MAX_FRACTION))
+  const capped = formatted.map((m) => capMessage(m, perMessageMax))
+  const sizes = capped.map((m) => Buffer.byteLength(m, "utf8"))
+  const n = capped.length
+  // Neutral wording: the gap usually holds earlier turns, but when only the
+  // anchor fits the omitted messages are the later ones.
+  const omittedMarker = (k: number) => `[... ${k} messages omitted]`
+
+  // Reserve worst-case fixed overhead (header with note, both fence lines,
+  // omission marker, join newlines) up front. Actual overhead is never
+  // larger, so packing whole messages against the remainder cannot overshoot
+  // the budget — at worst it leaves a few dozen bytes unused.
+  const fixed =
+    Buffer.byteLength(header(` (first message + last ${n} of ${n} total)`), "utf8") +
+    fence.length * 2 +
+    Buffer.byteLength(omittedMarker(n), "utf8") +
+    4
+  const msgBudget = maxBytes - fixed
+  if (msgBudget < sizes[0]! + 1) return undefined
+
+  let used = sizes[0]! + 1
+  let tailStart = n
+  for (let i = n - 1; i >= 1; i--) {
+    const cost = sizes[i]! + 1
+    if (used + cost > msgBudget) break
+    used += cost
+    tailStart = i
+  }
+  const tail = capped.slice(Math.max(tailStart, 1))
+  const omitted = Math.max(tailStart, 1) - 1
+
+  const segments = [capped[0]!]
+  if (omitted > 0) segments.push(omittedMarker(omitted))
+  segments.push(...tail)
+  const note =
+    omitted === 0
+      ? ""
+      : tail.length > 0
+        ? ` (first message + last ${tail.length} of ${n} total)`
+        : ` (first message of ${n} total)`
+  const text = [header(note), fence, ...segments, fence].join("\n")
+  const anyMessageCapped = capped.some((m, i) => m !== formatted[i])
+  return { text, originalBytes, truncated: omitted > 0 || anyMessageCapped }
 }
 
 export function readConversationMentions(
@@ -210,7 +323,7 @@ export function readConversationMentions(
   }
   const seen = new Set<string>()
   const blocks: string[] = []
-  const bytes: Record<string, { included: number; original: number }> = {}
+  const bytes: Record<string, { included: number; original: number; truncated: boolean }> = {}
   const capped: string[] = []
   const failed: string[] = []
   let totalBytes = 0
@@ -223,19 +336,15 @@ export function readConversationMentions(
       failed.push(id)
       continue
     }
-    const formatted = formatConversationContext(title, messages)
-    const formattedBytes = Buffer.byteLength(formatted, "utf8")
-    const remaining = maxBytes - totalBytes
-    if (remaining <= 0) {
+    const result = formatConversationContext(title, messages, maxBytes - totalBytes)
+    if (!result) {
       capped.push(id)
       continue
     }
-    const truncated = formattedBytes > remaining
-    const content = truncated ? formatted.slice(0, remaining) : formatted
-    const includedBytes = Buffer.byteLength(content, "utf8")
-    blocks.push(content)
-    bytes[id] = { included: includedBytes, original: formattedBytes }
-    totalBytes += includedBytes
+    const included = Buffer.byteLength(result.text, "utf8")
+    blocks.push(result.text)
+    bytes[id] = { included, original: result.originalBytes, truncated: result.truncated }
+    totalBytes += included
   }
   const block = blocks.length > 0 ? blocks.join("\n\n") : undefined
   return { block, bytes, capped, failed }

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -1117,12 +1117,12 @@ export class ChatView implements vscode.WebviewViewProvider {
         kind: "conversation",
         label: title,
         reason: "Past conversation attached via @-mention",
-        status: info.included < info.original ? "truncated" : "included",
+        status: info.truncated ? "truncated" : "included",
         bytes: info.included,
       })
       manifest.totals.includedItems += 1
       manifest.totals.includedBytes += info.included
-      if (info.included < info.original) manifest.totals.truncatedItems += 1
+      if (info.truncated) manifest.totals.truncatedItems += 1
     }
     for (const id of convResult.capped) {
       manifest.items.push({

--- a/test/host/build-prompt.test.ts
+++ b/test/host/build-prompt.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import * as vscode from "vscode"
-import { buildPrompt, readMentions } from "../../src/chat/prompt-builder"
+import {
+  buildPrompt,
+  readMentions,
+  formatConversationContext,
+  readConversationMentions,
+} from "../../src/chat/prompt-builder"
 import type { WorkspaceRoot } from "../../src/workspace-root"
+import type { ChatMessage, ToolUpdate } from "../../src/protocol"
 
 const FAKE_ROOT: WorkspaceRoot = {
   uri: { fsPath: "/repo", scheme: "file" } as unknown as vscode.Uri,
@@ -191,5 +197,193 @@ describe("readMentions: multi-root workspaces", () => {
     const out = await readMentions(["folderB/missing.ts"])
     expect(out.failed).toEqual(["folderB/missing.ts"])
     expect(out.block).toBeUndefined()
+  })
+})
+
+function msg(role: "user" | "assistant", text: string, id = "m"): ChatMessage {
+  return { id, role, blocks: [{ type: "text", text }] }
+}
+
+const bytesOf = (s: string) => Buffer.byteLength(s, "utf8")
+
+describe("formatConversationContext", () => {
+  it("includes every message fenced under the header when the budget allows", () => {
+    const out = formatConversationContext(
+      "Fix the picker",
+      [msg("user", "hello"), msg("assistant", "hi there"), msg("user", "thanks")],
+      100_000,
+    )!
+    expect(out.truncated).toBe(false)
+    const lines = out.text.split("\n")
+    expect(lines[0]).toBe('Past conversation "Fix the picker":')
+    expect(lines[1]).toBe("```")
+    expect(lines.at(-1)).toBe("```")
+    expect(out.text).toContain("User: hello")
+    expect(out.text).toContain("Assistant: hi there")
+    expect(out.text).toContain("User: thanks")
+    expect(out.text).not.toContain("omitted")
+    expect(bytesOf(out.text)).toBe(out.originalBytes)
+  })
+
+  it("keeps the first message plus a contiguous tail and marks the gap", () => {
+    const messages = [
+      msg("user", "the original intent message"),
+      ...Array.from({ length: 40 }, (_, i) => msg("assistant", `middle turn ${i} ${"x".repeat(200)}`)),
+      msg("assistant", "the final conclusion"),
+    ]
+    const budget = 2_000
+    const out = formatConversationContext("T", messages, budget)!
+    expect(out.truncated).toBe(true)
+    expect(bytesOf(out.text)).toBeLessThanOrEqual(budget)
+    expect(out.text).toContain("User: the original intent message")
+    expect(out.text).toContain("Assistant: the final conclusion")
+    const marker = out.text.match(/\[\.\.\. (\d+) messages omitted\]/)
+    expect(marker).not.toBeNull()
+    const omitted = Number(marker![1])
+    const note = out.text.match(/\(first message \+ last (\d+) of (\d+) total\)/)
+    expect(note).not.toBeNull()
+    expect(Number(note![2])).toBe(42)
+    // Anchor + omitted + tail accounts for every message exactly once.
+    expect(1 + omitted + Number(note![1])).toBe(42)
+    // The tail is the most recent turns — the gap sits in the middle.
+    expect(out.text).not.toContain("middle turn 0 ")
+  })
+
+  it("never exceeds the budget or splits characters on CJK content", () => {
+    const messages = Array.from({ length: 30 }, (_, i) =>
+      msg(i % 2 === 0 ? "user" : "assistant", `第${i}轮：${"这是一段很长的中文内容。".repeat(20)}`),
+    )
+    const budget = 3_000
+    const out = formatConversationContext("中文对话", messages, budget)!
+    expect(bytesOf(out.text)).toBeLessThanOrEqual(budget)
+    expect(out.text).not.toContain("�")
+    expect(out.truncated).toBe(true)
+  })
+
+  it("caps a single oversized message instead of letting it evict the rest", () => {
+    const messages = [
+      msg("user", "short question"),
+      msg("assistant", "line\n".repeat(12_000)),
+      msg("user", "follow-up"),
+      msg("assistant", "final answer"),
+    ]
+    const budget = 100_000
+    const out = formatConversationContext("T", messages, budget)!
+    expect(out.text).toContain("[message truncated]")
+    expect(out.text).toContain("User: short question")
+    expect(out.text).toContain("User: follow-up")
+    expect(out.text).toContain("Assistant: final answer")
+    expect(out.truncated).toBe(true)
+    // The giant message was held to ~25% of the budget.
+    expect(bytesOf(out.text)).toBeLessThan(30_000)
+  })
+
+  it("uses a fence longer than any backtick run in the transcript", () => {
+    const out = formatConversationContext(
+      "T",
+      [msg("assistant", "use this:\n```ts\nconst x = 1\n```")],
+      100_000,
+    )!
+    const lines = out.text.split("\n")
+    expect(lines[1]).toBe("````")
+    expect(lines.at(-1)).toBe("````")
+    expect(out.text).toContain("```ts")
+  })
+
+  it("flattens tool and patch blocks to one-line summaries", () => {
+    const update: ToolUpdate = { callID: "c1", tool: "bash", status: "completed", title: "npm test" }
+    const messages: ChatMessage[] = [
+      msg("user", "run the tests"),
+      {
+        id: "a1",
+        role: "assistant",
+        blocks: [
+          { type: "tool", update },
+          { type: "patch", files: ["src/a.ts", "src/b.ts"] },
+          { type: "text", text: "done" },
+        ],
+      },
+    ]
+    const out = formatConversationContext("T", messages, 100_000)!
+    expect(out.text).toContain("[bash: npm test]")
+    expect(out.text).toContain("[patched src/a.ts, src/b.ts]")
+    expect(out.text).toContain("done")
+  })
+
+  it("returns undefined when not even the first message fits", () => {
+    const out = formatConversationContext("T", [msg("user", "hello world")], 40)
+    expect(out).toBeUndefined()
+  })
+
+  it("returns a header-only block for a conversation with no renderable parts", () => {
+    const messages: ChatMessage[] = [{ id: "m1", role: "assistant", blocks: [] }]
+    const out = formatConversationContext("Empty", messages, 100_000)!
+    expect(out.text).toBe('Past conversation "Empty":')
+    expect(out.truncated).toBe(false)
+  })
+})
+
+describe("readConversationMentions", () => {
+  const conversations: Record<string, ChatMessage[]> = {
+    a: [msg("user", "first question"), msg("assistant", "first answer")],
+    b: [msg("user", "second question"), msg("assistant", "second answer")],
+  }
+  const getMessages = (id: string) => conversations[id]
+  const getTitle = (id: string) => (id === "a" ? "Chat A" : id === "b" ? "Chat B" : undefined)
+
+  it("returns empty state for no ids", () => {
+    const out = readConversationMentions(undefined, getMessages, getTitle)
+    expect(out.block).toBeUndefined()
+    expect(out.bytes).toEqual({})
+  })
+
+  it("joins conversations with a blank line and records exact byte accounting", () => {
+    const out = readConversationMentions(["a", "b"], getMessages, getTitle)
+    expect(out.block).toContain('Past conversation "Chat A"')
+    expect(out.block).toContain('Past conversation "Chat B"')
+    expect(out.block!.split("\n\n")).toHaveLength(2)
+    expect(out.bytes.a).toMatchObject({ truncated: false })
+    expect(out.bytes.a!.included).toBe(out.bytes.a!.original)
+    expect(out.capped).toEqual([])
+    expect(out.failed).toEqual([])
+  })
+
+  it("dedups ids and records unknown conversations as failed", () => {
+    const out = readConversationMentions(["a", "a", "missing"], getMessages, getTitle)
+    expect(out.block!.match(/Chat A/g)).toHaveLength(1)
+    expect(out.failed).toEqual(["missing"])
+  })
+
+  it("records a conversation as capped when the budget cannot fit its first message", () => {
+    const out = readConversationMentions(["a"], getMessages, getTitle, 30)
+    expect(out.capped).toEqual(["a"])
+    expect(out.bytes.a).toBeUndefined()
+    expect(out.block).toBeUndefined()
+  })
+
+  it("gives earlier mentions budget priority and never exceeds the total", () => {
+    const big: Record<string, ChatMessage[]> = {
+      one: Array.from({ length: 12 }, (_, i) => msg("user", `one turn ${i} ${"alpha ".repeat(20)}`)),
+      two: Array.from({ length: 12 }, (_, i) => msg("user", `two turn ${i} ${"beta ".repeat(20)}`)),
+    }
+    const budget = 900
+    const out = readConversationMentions(["one", "two"], (id) => big[id], (id) => id, budget)
+    expect(out.bytes.one).toBeDefined()
+    const included = Object.values(out.bytes).reduce((sum, b) => sum + b.included, 0)
+    expect(included).toBeLessThanOrEqual(budget)
+    // Every id lands in exactly one bucket.
+    expect(Object.keys(out.bytes).length + out.capped.length + out.failed.length).toBe(2)
+  })
+
+  it("stays within the total budget when the first conversation is truncated", () => {
+    const big: Record<string, ChatMessage[]> = {
+      long: Array.from({ length: 50 }, (_, i) => msg("user", `turn ${i} ${"content ".repeat(50)}`)),
+    }
+    const budget = 2_500
+    const out = readConversationMentions(["long"], (id) => big[id], () => "Long chat", budget)
+    expect(out.bytes.long).toBeDefined()
+    expect(out.bytes.long!.truncated).toBe(true)
+    expect(out.bytes.long!.included).toBeLessThanOrEqual(budget)
+    expect(out.bytes.long!.original).toBeGreaterThan(budget)
   })
 })


### PR DESCRIPTION
## Summary

- `readConversationMentions` enforced its 100KB budget with `formatted.slice(0, remaining)` — UTF-16 code units, not bytes — so CJK transcripts could inline roughly 3x the budget and the cut could split a character or land mid-sentence.
- Selection (fixed "first message + last 29") and truncation were two independent mechanisms that both lost information. They are now one: format each message individually, always keep the first message as the intent anchor, then pack whole messages walking backward from the newest until the byte budget is spent, with a `[... N messages omitted]` marker at the gap. Worst-case header/fence/marker overhead is reserved up front, so the emitted block can never exceed the remaining budget; message count now adapts to content instead of a magic 29.
- A single message is capped to 25% of the budget (newline/space-boundary cut + `[message truncated]` marker), so one pasted log cannot evict every other turn.
- The transcript is wrapped in a code fence — escalated past any backtick run in the content — under the existing `Past conversation "title"` header, so its `User:` / `Assistant:` lines read as quoted reference material rather than live turns.
- Manifest status now derives from an explicit `truncated` flag returned by the formatter instead of comparing `included < original` bytes, which the added marker/note could invert when a tiny message is omitted. A conversation whose first message cannot fit at all is recorded as capped instead of emitting a useless stub.

## Test plan

- [x] 15 new unit tests in `test/host/build-prompt.test.ts`: full inclusion under budget, backward-walk omission with marker/note accounting, CJK byte safety (no budget overshoot, no U+FFFD), per-message cap, fence escalation, tool/patch flattening, anchor-does-not-fit → capped, header-only empty conversation, dedup/failed ids, greedy budget priority, exact byte accounting on truncation.
- [x] Full suite: 74 files, 1120 tests pass.
- [x] `bun run check-types` and webview `tsc --noEmit` both clean.
- [x] `bun run compile` builds.
- [ ] Visual: manifest chip shows truncated status for a long @-mentioned chat (needs a live opencode session).

Closes #413