### PR TITLE
fix(webview): cancel PromptBox blur-dismiss timer on unmount

### DIFF
--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest"
-import { render, screen, cleanup, waitFor, within } from "@testing-library/react"
+import { render, screen, cleanup, fireEvent, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { PromptBox, detectMention, extractMentions, findMentionRanges, findChipAtCaret, makeAttachmentLabel } from "../../webview/src/components/PromptBox"
 
@@ -11,6 +11,27 @@ async function enterFilesCategory(user: ReturnType<typeof userEvent.setup>, targ
   await waitFor(() => expect(screen.getByText("Files")).toBeInTheDocument())
   await user.keyboard("{Enter}")
 }
+
+describe("PromptBox blur-dismiss timer", () => {
+  // The 120ms deferred picker dismissal must die with the component —
+  // a timer surviving unmount setStates into a torn-down tree (the flaky
+  // "window is not defined" CI failure once jsdom's realm is gone, #415).
+  it("cancels the deferred dismissal on unmount and never stacks timers", () => {
+    vi.useFakeTimers()
+    try {
+      const { unmount } = render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} />)
+      const textarea = screen.getByRole("textbox")
+      const before = vi.getTimerCount()
+      fireEvent.blur(textarea)
+      fireEvent.blur(textarea)
+      expect(vi.getTimerCount()).toBe(before + 1)
+      unmount()
+      expect(vi.getTimerCount()).toBe(before)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
 
 describe("PromptBox", () => {
   it("renders a textarea with placeholder", () => {

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -149,6 +149,11 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
   const [selectedChipStart, setSelectedChipStart] = useState<number | undefined>(undefined)
   const [attachError, setAttachError] = useState<string | undefined>(undefined)
   const [attaching, setAttaching] = useState(false)
+  const blurTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  // Cancel the deferred blur-dismiss on unmount: a timer surviving unmount
+  // setStates into a torn-down tree — the flaky "window is not defined" CI
+  // failure when the timer outlives jsdom's realm (#415).
+  useEffect(() => () => clearTimeout(blurTimer.current), [])
   const {
     imageAttachments,
     addImages,
@@ -699,7 +704,8 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
           }}
           onBlur={() => {
             // Defer so onMouseDown on a hit can fire first.
-            setTimeout(() => {
+            clearTimeout(blurTimer.current)
+            blurTimer.current = setTimeout(() => {
               closeMention()
               closeCommand()
             }, 120)


### PR DESCRIPTION
## Summary

- PromptBox's textarea `onBlur` defers picker dismissal by 120 ms so a `mousedown` on a picker hit can land first, but the `setTimeout` was never cancelled. When the component unmounted inside that window (edit-in-place teardown, conversation switch, test cleanup), the callback still ran and `closeMention()` setStated into a torn-down tree. In CI the timer could outlive jsdom's realm entirely, crashing the run with `ReferenceError: window is not defined` from react-dom internals while all tests passed (observed on main run 28979361057, originating in `message-view.test.tsx`).
- Fix: hold the timer ID in a ref, clear any pending timer before scheduling on repeated blurs, and clear it in a `useEffect` unmount cleanup. The 120 ms mousedown-before-blur behavior in the live webview is unchanged.

## Test plan

- [x] New regression test asserts via fake-timer counts that two blurs schedule exactly one pending dismissal and unmount removes it — fails against the previous code on both assertions.
- [x] Full suite: 74 files, 1121 tests pass (132 existing PromptBox tests cover picker behavior unchanged).
- [x] `bun run check-types` and webview `tsc --noEmit` clean; `bun run compile` builds.

Closes #415