### PR TITLE
fix(webview): scroll active popover row into view on keyboard nav

### DIFF
--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -382,6 +382,45 @@ describe("PromptBox @file autocomplete", () => {
     expect((textarea as HTMLTextAreaElement).value).toBe("@src/bar.ts ")
   })
 
+  it("scrolls the active row into view on arrow-key nav but not on hover", async () => {
+    const user = userEvent.setup()
+    const searchFiles = vi.fn().mockResolvedValue([
+      { path: "src/a.ts", name: "a.ts" },
+      { path: "src/b.ts", name: "b.ts" },
+      { path: "src/c.ts", name: "c.ts" },
+    ])
+    // jsdom has no scrollIntoView; install a recording stub so the effect's
+    // typeof guard passes and we can see which element it scrolled.
+    const proto = Element.prototype as { scrollIntoView?: (opts?: unknown) => void }
+    const original = proto.scrollIntoView
+    const scrolled: Array<{ el: Element; opts: unknown }> = []
+    proto.scrollIntoView = function (this: Element, opts?: unknown) {
+      scrolled.push({ el: this, opts })
+    }
+    try {
+      render(
+        <PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} searchFiles={searchFiles} />,
+      )
+      await user.type(screen.getByRole("textbox"), "@a")
+      await waitFor(() => expect(screen.getByText("b.ts")).toBeInTheDocument())
+      scrolled.length = 0
+      await user.keyboard("{ArrowDown}")
+      expect(scrolled).toHaveLength(1)
+      expect(scrolled[0]!.opts).toEqual({ block: "nearest" })
+      expect(scrolled[0]!.el.getAttribute("aria-selected")).toBe("true")
+      expect(scrolled[0]!.el.textContent).toContain("b.ts")
+
+      scrolled.length = 0
+      const lastRow = screen.getByText("c.ts").closest("li")!
+      fireEvent.mouseEnter(lastRow)
+      expect(lastRow.getAttribute("aria-selected")).toBe("true")
+      expect(scrolled).toHaveLength(0)
+    } finally {
+      if (original) proto.scrollIntoView = original
+      else delete proto.scrollIntoView
+    }
+  })
+
   it("Click on a hit inserts that path", async () => {
     const user = userEvent.setup()
     const searchFiles = vi.fn().mockResolvedValue([

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -154,6 +154,11 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
   // setStates into a torn-down tree — the flaky "window is not defined" CI
   // failure when the timer outlives jsdom's realm (#415).
   useEffect(() => () => clearTimeout(blurTimer.current), [])
+  const popoverHostRef = useRef<HTMLDivElement | null>(null)
+  // True only while an arrow key is moving a popover's active row. Hover also
+  // moves the index (onMouseEnter), but scrolling on hover would shift rows
+  // under the cursor — so the scroll-into-view effect only acts on key moves.
+  const keyboardNavRef = useRef(false)
   const {
     imageAttachments,
     addImages,
@@ -223,6 +228,20 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
     drillInto,
     goUp,
   } = useFileBrowser({ listDir, active: showBrowse })
+
+  // Keep the active row visible when arrow keys move it past the popover's
+  // max-height fold — the chat list and folder browser overflow routinely.
+  // Keyed on every popover's index; whichever popover is open owns the single
+  // [aria-selected="true"] row. The typeof guard is for jsdom, which doesn't
+  // implement scrollIntoView.
+  useEffect(() => {
+    const byKeyboard = keyboardNavRef.current
+    keyboardNavRef.current = false
+    if (!byKeyboard) return
+    const active = popoverHostRef.current?.querySelector('.mention-popover [aria-selected="true"]')
+    if (active && typeof active.scrollIntoView === "function") active.scrollIntoView({ block: "nearest" })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [commandIndex, menuIndex, activeIndex, browseIndex])
 
   const pastConversations = (conversations ?? []).filter((c) => c.id !== activeConversationID)
   const filteredConversations = showChatList
@@ -452,6 +471,9 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
     // the IME. keyCode 229 is the legacy fallback for older Chromium builds
     // that don't surface isComposing reliably.
     if (e.nativeEvent.isComposing || e.keyCode === 229) return
+    if (e.key.startsWith("Arrow") && (command || showCategoryMenu || showChatList || showFileHits || showBrowse)) {
+      keyboardNavRef.current = true
+    }
     if (command) {
       // When nothing matches we only handle Escape — Enter must fall through to
       // submit so `/unknown` sends as a normal prompt.
@@ -686,7 +708,7 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
         onClose={() => setPreviewImage(null)}
       />
       <div className="promptbox-input">
-        <div className="promptbox-textarea-wrap">
+        <div ref={popoverHostRef} className="promptbox-textarea-wrap">
         <div ref={backdropRef} className="promptbox-backdrop" aria-hidden="true">
           {renderHighlightedText(text, allKnownLabels(), selectedChipStart)}
         </div>


### PR DESCRIPTION
## Summary

- Arrow-key navigation in the prompt-box popovers (slash commands, @ category menu, folder browser, file hits, past-chats list) now keeps the active row visible: a single effect scrolls the `[aria-selected="true"]` row into view with `block: "nearest"` whenever a popover index changes by keyboard.
- A `keyboardNavRef` flag, set in `onKeyDown` only for arrow keys while a popover is open, distinguishes key moves from hover moves — `onMouseEnter` also moves the active index, and scrolling on hover would shift rows under the cursor.
- `typeof` guard on `scrollIntoView` keeps jsdom (which doesn't implement it) from crashing.

## Test plan

- [x] New regression test: arrow-down scrolls exactly the newly active row with `{ block: "nearest" }`; hovering another row moves the selection but performs no scroll. Verified it fails against the previous code (1 failed) and passes with the fix.
- [x] `bun run test` — 74 files, 1122 tests pass.
- [x] `bun run check-types` and `cd webview && bunx tsc --noEmit` — clean.
- [x] `bun run compile` — builds.
- [ ] Visual check in VS Code: arrow past the fold in a long past-chats list / folder browser and confirm the list follows.

Closes #417