### PR TITLE
fix(webview): clear stale popover keyboard-nav flag on hover moves

### DIFF
--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -421,6 +421,41 @@ describe("PromptBox @file autocomplete", () => {
     }
   })
 
+  it("does not scroll on hover after an arrow press that changed no index", async () => {
+    const user = userEvent.setup()
+    const searchFiles = vi.fn().mockResolvedValue([
+      { path: "src/a.ts", name: "a.ts" },
+      { path: "src/b.ts", name: "b.ts" },
+      { path: "src/c.ts", name: "c.ts" },
+    ])
+    const proto = Element.prototype as { scrollIntoView?: (opts?: unknown) => void }
+    const original = proto.scrollIntoView
+    const scrolled: Array<{ el: Element; opts: unknown }> = []
+    proto.scrollIntoView = function (this: Element, opts?: unknown) {
+      scrolled.push({ el: this, opts })
+    }
+    try {
+      render(
+        <PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} searchFiles={searchFiles} />,
+      )
+      await user.type(screen.getByRole("textbox"), "@a")
+      await waitFor(() => expect(screen.getByText("b.ts")).toBeInTheDocument())
+      scrolled.length = 0
+      // The file-hits popover only handles Up/Down/Enter/Tab/Escape:
+      // ArrowRight sets the keyboard-nav flag but changes no index, so the
+      // scroll effect never runs to consume it.
+      await user.keyboard("{ArrowRight}")
+      expect(scrolled).toHaveLength(0)
+      const lastRow = screen.getByText("c.ts").closest("li")!
+      fireEvent.mouseEnter(lastRow)
+      expect(lastRow.getAttribute("aria-selected")).toBe("true")
+      expect(scrolled).toHaveLength(0)
+    } finally {
+      if (original) proto.scrollIntoView = original
+      else delete proto.scrollIntoView
+    }
+  })
+
   it("Click on a hit inserts that path", async () => {
     const user = userEvent.setup()
     const searchFiles = vi.fn().mockResolvedValue([

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -159,6 +159,15 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
   // moves the index (onMouseEnter), but scrolling on hover would shift rows
   // under the cursor — so the scroll-into-view effect only acts on key moves.
   const keyboardNavRef = useRef(false)
+  // Hover claims the index move by clearing the flag first. An arrow press
+  // that changed no index (ArrowRight on a file row, Left/Right where only
+  // Up/Down are handled, wrap on a single-row list, arrows over an empty
+  // popover) never reaches the effect that consumes the flag, and the next
+  // hover-driven index change would otherwise scroll the row under the cursor.
+  const hoverMove = (apply: () => void) => {
+    keyboardNavRef.current = false
+    apply()
+  }
   const {
     imageAttachments,
     addImages,
@@ -740,7 +749,7 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
               aria-selected={menuIndex === 0}
               className={"mention-hit mention-category" + (menuIndex === 0 ? " active" : "")}
               onMouseDown={(e) => { e.preventDefault(); setMentionCategory("files"); setMenuIndex(0) }}
-              onMouseEnter={() => setMenuIndex(0)}
+              onMouseEnter={() => hoverMove(() => setMenuIndex(0))}
             >
               <FolderIcon />
               <span className="mention-category-label">Files</span>
@@ -751,7 +760,7 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
               aria-selected={menuIndex === 1}
               className={"mention-hit mention-category" + (menuIndex === 1 ? " active" : "")}
               onMouseDown={(e) => { e.preventDefault(); setMentionCategory("chats"); setMenuIndex(0) }}
-              onMouseEnter={() => setMenuIndex(1)}
+              onMouseEnter={() => hoverMove(() => setMenuIndex(1))}
             >
               <ChatIcon />
               <span className="mention-category-label">Past Chats</span>
@@ -788,7 +797,7 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
                     if (entry.kind === "folder") drillInto(entry)
                     else insertMention(entry)
                   }}
-                  onMouseEnter={() => setBrowseIndex(i)}
+                  onMouseEnter={() => hoverMove(() => setBrowseIndex(i))}
                 >
                   {entry.kind === "folder"
                     ? <FolderIcon />
@@ -814,7 +823,7 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
                   e.preventDefault()
                   insertMention(hit)
                 }}
-                onMouseEnter={() => setActiveIndex(i)}
+                onMouseEnter={() => hoverMove(() => setActiveIndex(i))}
               >
                 <span className={`codicon codicon-${fileTypeCodicon(hit.name)}`} aria-hidden="true" />
                 <span className="mention-name">{hit.name}</span>
@@ -841,7 +850,7 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
                       e.preventDefault()
                       insertConversationMention(conv)
                     }}
-                    onMouseEnter={() => setMenuIndex(i)}
+                    onMouseEnter={() => hoverMove(() => setMenuIndex(i))}
                   >
                     <ChatIcon />
                     <span className="mention-name">{conversationDisplayTitle(conv)}</span>
@@ -868,7 +877,7 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
                   e.preventDefault()
                   chooseCommand(cmd)
                 }}
-                onMouseEnter={() => setCommandIndex(i)}
+                onMouseEnter={() => hoverMove(() => setCommandIndex(i))}
               >
                 <span className="mention-name">/{cmd.name}</span>
                 <span className="mention-path">{cmd.description ?? (cmd.agent ? `agent: ${cmd.agent}` : "")}</span>


### PR DESCRIPTION
## Summary

- `keyboardNavRef` (added in #418) is set on any Arrow key while a prompt-box popover is open, but only cleared when the index-keyed scroll effect runs. An arrow press that changes no index — ArrowRight on a file row, Left/Right in popovers that only handle Up/Down, modulo wrap on a single-row list, arrows over an empty-result popover — leaves the flag set, and the next hover-driven index change consumes it, scrolling the list under the cursor (the exact behavior the flag exists to prevent).
- Fix: hover claims the move. All six popover row `onMouseEnter` handlers route through a `hoverMove` helper that clears the flag before moving the index, so a stale flag can never be consumed by a mouse-driven change. Keyboard-driven scrolls are unaffected: the keydown that sets the flag and the effect that consumes it run before any hover can fire.
- Regression test: ArrowRight over the file-hits popover (flag set, no index change), then hover a different row — asserts zero `scrollIntoView` calls. Verified to fail against the pre-fix component (1 failed with only `PromptBox.tsx` stashed).

## Test plan

- [x] New regression test fails on pre-fix code, passes with fix
- [x] Existing #418 test (keyboard scrolls, hover does not) still passes
- [x] `bun run test` — 1123 passed
- [x] `bun run check-types` + webview `tsc --noEmit` — clean
- [x] `bun run package` — builds
- [ ] Visual check in VS Code: hover rows near the popover fold after a dead-end arrow press; list must not shift

Closes #419