### PR TITLE
fix(chat): carry conversation mention label-id pairs end to end

### DIFF
--- a/src/chat/conversation-manager.ts
+++ b/src/chat/conversation-manager.ts
@@ -3,6 +3,7 @@ import type { ChatMessage, ConversationSummary, ReviewHunkState } from "../proto
 import {
   ACTIVE_CONVERSATION_KEY,
   CONVERSATIONS_KEY,
+  normalizeConversationMentions,
   type SavedConversation,
 } from "./conversation-store"
 
@@ -105,7 +106,7 @@ export class ConversationManager {
   getMessages(id: string): ChatMessage[] | undefined {
     const conv = this.conversations.find((c) => c.id === id)
     if (!conv) return undefined
-    return conv.messages.map((m) => ({ ...m, pending: false }))
+    return conv.messages.map((m) => normalizeConversationMentions({ ...m, pending: false }))
   }
 
   getTitle(id: string): string | undefined {
@@ -141,7 +142,7 @@ export class ConversationManager {
     const c = this.active()
     return {
       sessionID: c.sessionID,
-      messages: c.messages.map((m) => ({ ...m, pending: false })),
+      messages: c.messages.map((m) => normalizeConversationMentions({ ...m, pending: false })),
       reviewHunks: c.reviewHunks ?? {},
     }
   }

--- a/src/chat/conversation-store.ts
+++ b/src/chat/conversation-store.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode"
-import type { ChatMessage, ConversationSummary, ReviewHunkState } from "../protocol"
+import type { ChatMessage, ConversationMention, ConversationSummary, ReviewHunkState } from "../protocol"
 
 export const CONVERSATIONS_KEY = "opencui.conversations"
 export const ACTIVE_CONVERSATION_KEY = "opencui.activeConversation"
@@ -10,6 +10,41 @@ export type SavedConversation = ConversationSummary & {
   sessionID?: string
   messages: ChatMessage[]
   reviewHunks?: Record<string, ReviewHunkState>
+}
+
+/**
+ * Messages persisted before conversation mentions carried their chip label
+ * stored a bare conversation-id array; the label was re-derived from the text
+ * by position at edit time — the exact inference the pair shape removes.
+ * Normalize a legacy array by zipping ids with the `@chat:` tokens in text
+ * order (the same pairing the old edit flow computed), so old data behaves as
+ * it always did while everything written from now on carries exact pairs.
+ * Ids beyond the labels found in the text are dropped: with no label they
+ * could never match a chip, so they contributed nothing before either.
+ */
+export function normalizeConversationMentions(message: ChatMessage): ChatMessage {
+  const raw = message.conversationMentions as unknown
+  if (!Array.isArray(raw) || raw.length === 0) return message
+  if (raw.every(isConversationMention)) return message
+  const ids = raw.filter((item): item is string => typeof item === "string")
+  const textBlock = message.blocks.find((b) => b.type === "text")
+  const text = textBlock && textBlock.type === "text" ? textBlock.text : ""
+  const labels = Array.from(text.matchAll(/@chat:\S+/g), (match) => match[0].slice(1))
+  const pairs: ConversationMention[] = []
+  for (const [index, id] of ids.entries()) {
+    const label = labels[index]
+    if (label) pairs.push({ label, id })
+  }
+  return { ...message, conversationMentions: pairs.length ? pairs : undefined }
+}
+
+function isConversationMention(value: unknown): value is ConversationMention {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { label?: unknown }).label === "string" &&
+    typeof (value as { id?: unknown }).id === "string"
+  )
 }
 
 /**

--- a/src/chat/prompt-builder.ts
+++ b/src/chat/prompt-builder.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode"
 import * as path from "path"
 import type { getEditorContext } from "../context"
-import type { ChatMessage } from "../protocol"
+import type { ChatMessage, ConversationMention } from "../protocol"
 import type { WorkspaceRoot } from "../workspace-root"
 import type { PromptContextBlock } from "../workspace-context/types"
 import { log } from "../output"
@@ -159,6 +159,22 @@ async function readFirstCandidate(
     }
   }
   throw lastError ?? new Error(`no candidate for ${rel}`)
+}
+
+/**
+ * Conversation IDs to actually attach to a prompt, from the chips as written:
+ * each PAST conversation once. A self-mention (the active conversation) adds
+ * nothing the session doesn't already have, and duplicate chips for the same
+ * chat must not attach its transcript twice. The persisted message keeps
+ * every pair — filtering is a prompt-time concern only, so the edit flow
+ * always sees exactly what the user wrote.
+ */
+export function attachableConversationIDs(
+  mentions: ConversationMention[] | undefined,
+  activeConversationID: string,
+): string[] {
+  const ids = (mentions ?? []).map((m) => m.id)
+  return ids.filter((id, index) => !!id && id !== activeConversationID && ids.indexOf(id) === index)
 }
 
 export type ConversationMentionResult = {

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -21,6 +21,7 @@ import type {
   ChatBlock,
   ChatMessage,
   CommandInfo,
+  ConversationMention,
   Inbound,
   Outbound,
   ToolUpdate as WireToolUpdate,
@@ -41,7 +42,7 @@ import { relativeToCwd, samePath } from "./paths"
 import { isTextReviewPath, reviewKey, splitReviewDiff } from "./diff"
 import { extractChanges, reviewChanges } from "./review-changes"
 import { reviewAllForPath } from "./review-actions"
-import { buildPrompt, readMentions, readConversationMentions } from "./prompt-builder"
+import { attachableConversationIDs, buildPrompt, readMentions, readConversationMentions } from "./prompt-builder"
 import { buildManifest } from "../workspace-context/manifest"
 import { collectAutoContext } from "../workspace-context/collector"
 import { RecentEditsTracker } from "../workspace-context/recent-edits"
@@ -991,7 +992,7 @@ export class ChatView implements vscode.WebviewViewProvider {
    */
   private abortGen = 0
 
-  private async handleSend(text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) {
+  private async handleSend(text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: ConversationMention[]) {
     // A new turn supersedes any in-flight abort drain from a prior Stop so it
     // can't abort the session tree the new turn is about to (re)use.
     this.abortGen++
@@ -999,11 +1000,13 @@ export class ChatView implements vscode.WebviewViewProvider {
     const ctx = getEditorContext()
     const label = formatContextHeader(ctx)
     const userMessageID = "u_" + Date.now()
-    const activeConversationID = this.manager.getActiveID()
-    const pastConversationMentions = conversationMentions?.filter(
-      (id, index, ids) => id !== activeConversationID && ids.indexOf(id) === index,
+    // The message persists every chip pair as written — the edit flow rebuilds
+    // label→id bindings from them. Self-mentions and duplicate chips are
+    // filtered out of what the PROMPT attaches, never out of the message.
+    const attachedConversationIDs = attachableConversationIDs(
+      conversationMentions,
+      this.manager.getActiveID(),
     )
-    const attachedConversationMentions = pastConversationMentions?.length ? pastConversationMentions : undefined
     this.pendingUserBackendID = userMessageID
     this.post({
       type: "userMessage",
@@ -1012,7 +1015,7 @@ export class ChatView implements vscode.WebviewViewProvider {
       ref: { path: ctx.filePath, label },
       attachments,
       mentions,
-      conversationMentions: attachedConversationMentions,
+      conversationMentions: conversationMentions?.length ? conversationMentions : undefined,
     })
     this.updateTitleFromPrompt(text)
 
@@ -1105,7 +1108,7 @@ export class ChatView implements vscode.WebviewViewProvider {
       manifest.totals.skippedItems += 1
     }
     const convResult = readConversationMentions(
-      attachedConversationMentions,
+      attachedConversationIDs,
       (id) => this.manager.getMessages(id),
       (id) => this.manager.getTitle(id),
     )
@@ -1370,7 +1373,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     await this.subagentDispatch.recordMainTaskStart(display)
   }
 
-  private async handleEdit(webviewID: string, text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) {
+  private async handleEdit(webviewID: string, text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: ConversationMention[]) {
     const target = this.messages.find((m) => m.id === webviewID && m.role === "user")
     if (!target) {
       log("editMessage: user message not found", webviewID)

--- a/test/host/build-prompt.test.ts
+++ b/test/host/build-prompt.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import * as vscode from "vscode"
 import {
+  attachableConversationIDs,
   buildPrompt,
   readMentions,
   formatConversationContext,
@@ -320,6 +321,27 @@ describe("formatConversationContext", () => {
     const out = formatConversationContext("Empty", messages, 100_000)!
     expect(out.text).toBe('Past conversation "Empty":')
     expect(out.truncated).toBe(false)
+  })
+})
+
+describe("attachableConversationIDs", () => {
+  it("keeps each past conversation once, in chip order", () => {
+    expect(
+      attachableConversationIDs(
+        [
+          { label: "chat:A", id: "a" },
+          { label: "chat:Self", id: "current" },
+          { label: "chat:A_2", id: "a" },
+          { label: "chat:B", id: "b" },
+        ],
+        "current",
+      ),
+    ).toEqual(["a", "b"])
+  })
+
+  it("returns empty for undefined and for self-only mentions", () => {
+    expect(attachableConversationIDs(undefined, "current")).toEqual([])
+    expect(attachableConversationIDs([{ label: "chat:Me", id: "current" }], "current")).toEqual([])
   })
 })
 

--- a/test/host/normalize-conversation-mentions.test.ts
+++ b/test/host/normalize-conversation-mentions.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest"
+import {
+  ACTIVE_CONVERSATION_KEY,
+  CONVERSATIONS_KEY,
+  normalizeConversationMentions,
+  type SavedConversation,
+} from "../../src/chat/conversation-store"
+import { ConversationManager } from "../../src/chat/conversation-manager"
+import type { ChatMessage, ConversationMention } from "../../src/protocol"
+
+function userMessage(text: string, conversationMentions?: unknown): ChatMessage {
+  return {
+    id: "u1",
+    role: "user",
+    blocks: [{ type: "text", text }],
+    conversationMentions: conversationMentions as ConversationMention[] | undefined,
+  }
+}
+
+describe("normalizeConversationMentions", () => {
+  it("zips legacy id arrays with @chat: labels in text order", () => {
+    const out = normalizeConversationMentions(
+      userMessage("@chat:A @chat:B compare these", ["a", "b"]),
+    )
+    expect(out.conversationMentions).toEqual([
+      { label: "chat:A", id: "a" },
+      { label: "chat:B", id: "b" },
+    ])
+  })
+
+  it("returns pair-shaped mentions and mention-less messages unchanged", () => {
+    const pairs = [{ label: "chat:A", id: "a" }]
+    const withPairs = userMessage("@chat:A hi", pairs)
+    expect(normalizeConversationMentions(withPairs)).toBe(withPairs)
+    const withoutMentions = userMessage("plain")
+    expect(normalizeConversationMentions(withoutMentions)).toBe(withoutMentions)
+  })
+
+  it("drops legacy ids beyond the labels found in the text", () => {
+    const out = normalizeConversationMentions(userMessage("@chat:A only", ["a", "b"]))
+    expect(out.conversationMentions).toEqual([{ label: "chat:A", id: "a" }])
+  })
+
+  it("clears legacy mentions when the text has no chat tokens", () => {
+    const out = normalizeConversationMentions(userMessage("no chips here", ["a"]))
+    expect(out.conversationMentions).toBeUndefined()
+  })
+})
+
+describe("ConversationManager legacy mention normalization", () => {
+  function managerWith(messages: ChatMessage[]): ConversationManager {
+    const now = Date.now()
+    const conversations: SavedConversation[] = [
+      { id: "c1", title: "Chat", createdAt: now, updatedAt: now, messages, reviewHunks: {} },
+    ]
+    const store = new Map<string, unknown>([
+      [CONVERSATIONS_KEY, conversations],
+      [ACTIVE_CONVERSATION_KEY, "c1"],
+    ])
+    const workspaceState = {
+      get: <T,>(key: string, def?: T): T => (store.has(key) ? (store.get(key) as T) : (def as T)),
+      update: (key: string, value: unknown) => {
+        store.set(key, value)
+        return Promise.resolve()
+      },
+      keys: () => [...store.keys()],
+    }
+    return new ConversationManager({ workspaceState } as never)
+  }
+
+  it("normalizes persisted legacy arrays on both read paths", () => {
+    const manager = managerWith([userMessage("@chat:Old revisit", ["old-id"])])
+    const expected = [{ label: "chat:Old", id: "old-id" }]
+    expect(manager.loadActiveSnapshot().messages[0]!.conversationMentions).toEqual(expected)
+    expect(manager.getMessages("c1")![0]!.conversationMentions).toEqual(expected)
+  })
+})

--- a/test/webview/message-view.test.tsx
+++ b/test/webview/message-view.test.tsx
@@ -82,7 +82,7 @@ describe("MessageView (user role)", () => {
   it("restores past-chat mention chips when editing a sent message", async () => {
     const user = userEvent.setup()
     const message = userMessage("@chat:Old_chat revisit", { backendID: "b1" })
-    message.conversationMentions = ["old"]
+    message.conversationMentions = [{ label: "chat:Old_chat", id: "old" }]
     const { container } = render(
       <MessageView
         message={message}

--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -721,6 +721,37 @@ describe("PromptBox Past Chats grouping", () => {
     expect(screen.getByText("2h ago")).toBeInTheDocument()
   })
 
+  it("binds each restored conversation chip to its own id regardless of order", async () => {
+    const user = userEvent.setup()
+    const onSend = vi.fn()
+    render(
+      <PromptBox
+        busy={false}
+        onSend={onSend}
+        onAbort={vi.fn()}
+        searchFiles={vi.fn().mockResolvedValue([])}
+        initial={{
+          // Chip B was inserted first, chip A ahead of it in the text, and
+          // chip B was then removed during the edit — so the pair order
+          // (insertion) never matched the text order. Index pairing against
+          // the text used to bind chat:A to conv-b here.
+          text: "@chat:A keep this",
+          conversationMentions: [
+            { label: "chat:B", id: "conv-b" },
+            { label: "chat:A", id: "conv-a" },
+          ],
+        }}
+      />,
+    )
+    await user.click(screen.getByRole("button", { name: "Send" }))
+    expect(onSend).toHaveBeenCalledWith(
+      "@chat:A keep this",
+      undefined,
+      undefined,
+      [{ label: "chat:A", id: "conv-a" }],
+    )
+  })
+
   it("keeps Enter from submitting while the empty Past Chats list is open", async () => {
     const user = userEvent.setup()
     const onSend = vi.fn()

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -1,6 +1,6 @@
 import { memo, useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react"
 import type { Block, Message } from "../hooks/useChatState"
-import type { AgentsStatusInfo, Attachment, ConversationSummary, DirEntry, FileSearchHit } from "../protocol"
+import type { AgentsStatusInfo, Attachment, ConversationMention, ConversationSummary, DirEntry, FileSearchHit } from "../protocol"
 import { findMentionRanges, makeAttachmentLabel } from "../mention-tokens"
 import {
   answerStartIndex,
@@ -42,7 +42,7 @@ type MessageViewProps = {
   processOnly: boolean
   busy?: boolean
   onReviewFile?: (path: string) => void
-  onEditMessage?: (id: string, text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) => void
+  onEditMessage?: (id: string, text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: ConversationMention[]) => void
   onBeginEdit?: (id: string) => void
   onEndEdit?: (id: string) => void
   onRetry?: (assistantID: string) => void
@@ -186,7 +186,7 @@ function UserMessageView({
 }: {
   message: Message
   busy?: boolean
-  onEditMessage?: (id: string, text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) => void
+  onEditMessage?: (id: string, text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: ConversationMention[]) => void
   onBeginEdit?: (id: string) => void
   onEndEdit?: (id: string) => void
   searchFiles?: (query: string) => Promise<FileSearchHit[]>
@@ -258,7 +258,7 @@ function UserMessageView({
         ? "Saving your message — try again in a moment"
         : "Edit and regenerate"
 
-  const handleSubmit = (text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) => {
+  const handleSubmit = (text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: ConversationMention[]) => {
     const trimmed = text.trim()
     if (!trimmed && !attachments?.length) return
     const sameText = trimmed === originalText.trim()

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react"
-import type { Attachment, CommandInfo, ContextUsage, ConversationSummary, DirEntry, FileSearchHit } from "../protocol"
+import type { Attachment, CommandInfo, ContextUsage, ConversationMention, ConversationSummary, DirEntry, FileSearchHit } from "../protocol"
 import {
   extractMentions,
   findChipAtCaret,
@@ -47,14 +47,14 @@ type Props = {
    * one.
    */
   aborting?: boolean
-  onSend: (text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) => void
+  onSend: (text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: ConversationMention[]) => void
   /**
    * Queue the message for auto-send when the running turn finishes. When
    * provided (the primary send composers), Enter while busy/aborting queues
    * instead of being a no-op. Absent (edit composers), submit stays blocked
    * while busy — the old behavior.
    */
-  onQueue?: (text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) => void
+  onQueue?: (text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: ConversationMention[]) => void
   onAbort: () => void
   searchFiles?: (query: string) => Promise<FileSearchHit[]>
   listDir?: (path: string) => Promise<DirEntry[]>
@@ -65,7 +65,7 @@ type Props = {
    * left off — same picker, same chips, same paperclip — instead of a
    * stripped-down textarea.
    */
-  initial?: { text?: string; mentions?: string[]; attachments?: Attachment[]; conversationMentions?: string[] }
+  initial?: { text?: string; mentions?: string[]; attachments?: Attachment[]; conversationMentions?: ConversationMention[] }
   /**
    * "send" (default) renders the standard Send/Stop bottom row. "edit"
    * renders Cancel + Save & regenerate, plus a warning that subsequent
@@ -110,32 +110,19 @@ function buildInitialAttachments(initial: Props["initial"]): Map<string, Attachm
   return map
 }
 
-function buildInitialConversations(
-  initial: Props["initial"],
-  conversations: ConversationSummary[] | undefined,
-): Map<string, string> {
+function buildInitialConversations(initial: Props["initial"]): Map<string, string> {
   const map = new Map<string, string>()
   if (!initial?.conversationMentions) return map
-  const existing = new Set<string>(initial.mentions ?? [])
-  const labelsInText = extractConversationLabels(initial.text)
-  for (const [index, id] of initial.conversationMentions.entries()) {
-    const conv = conversations?.find((c) => c.id === id)
-    const preservedLabel = labelsInText[index]
-    const label = preservedLabel && !existing.has(preservedLabel)
-      ? preservedLabel
-      : conv
-        ? makeConversationLabel(conversationDisplayTitle(conv), existing)
-        : preservedLabel
-    if (!label) continue
-    existing.add(label)
+  // A label already claimed by a file mention (or an earlier pair) keeps its
+  // first binding — same first-come rule the composer's collision suffixes
+  // enforce at insert time.
+  const taken = new Set<string>(initial.mentions ?? [])
+  for (const { label, id } of initial.conversationMentions) {
+    if (!label || !id || taken.has(label)) continue
+    taken.add(label)
     map.set(label, id)
   }
   return map
-}
-
-function extractConversationLabels(text: string | undefined): string[] {
-  if (!text) return []
-  return Array.from(text.matchAll(/@chat:\S+/g), (match) => match[0].slice(1))
 }
 
 export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, searchFiles, listDir, attachFile, initial, variant = "send", position = "bottom", conversations, activeConversationID, onOpenConversation, contextUsage, commands = [], onRunCommand, inject }: Props) {
@@ -184,7 +171,7 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
   if (!knownMentions.current) {
     knownMentions.current = new Set<string>(initial?.mentions ?? [])
     knownAttachments.current = buildInitialAttachments(initial)
-    knownConversations.current = buildInitialConversations(initial, conversations)
+    knownConversations.current = buildInitialConversations(initial)
     for (const label of knownConversations.current.keys()) knownMentions.current.add(label)
   }
   const { mention, hits, activeIndex, setActiveIndex, detectAtCaret, closeMention, insertMention } =
@@ -372,14 +359,15 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
     if (!deliver) return
     const allMentions = extractMentions(text, knownMentions.current)
     const fileMentions = allMentions.filter((m) => !knownConversations.current.has(m))
-    const convIDs = allMentions
-      .map((m) => knownConversations.current.get(m))
-      .filter((id): id is string => !!id)
+    const convMentions = allMentions.flatMap((label) => {
+      const id = knownConversations.current.get(label)
+      return id ? [{ label, id }] : []
+    })
     deliver(
       trimmed,
       fileMentions.length ? fileMentions : undefined,
       activeAttachments.length ? activeAttachments : undefined,
-      convIDs.length ? convIDs : undefined,
+      convMentions.length ? convMentions : undefined,
     )
     clearComposer()
   }

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -8,6 +8,7 @@ import type {
   ChatMessage,
   CommandInfo,
   ContextUsage,
+  ConversationMention,
   ConversationSummary,
   DirEntry,
   EditorContextRef,
@@ -36,7 +37,7 @@ export type QueuedMessage = {
   text: string
   mentions?: string[]
   attachments?: Attachment[]
-  conversationMentions?: string[]
+  conversationMentions?: ConversationMention[]
 }
 
 export type ChatState = {
@@ -476,10 +477,10 @@ export function useChatState() {
 
   return {
     state,
-    send(text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) {
+    send(text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: ConversationMention[]) {
       vscode.post({ type: "send", text, mentions, attachments, conversationMentions })
     },
-    queueMessage(text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) {
+    queueMessage(text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: ConversationMention[]) {
       dispatch({
         type: "queueMessage",
         message: { id: `q_${Date.now()}_${nextQueueID.current++}`, text, mentions, attachments, conversationMentions },
@@ -491,7 +492,7 @@ export function useChatState() {
     runCommand(command: string, args: string) {
       vscode.post({ type: "runCommand", command, arguments: args })
     },
-    editMessage(id: string, text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: string[]) {
+    editMessage(id: string, text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: ConversationMention[]) {
       vscode.post({ type: "editMessage", id, text, mentions, attachments, conversationMentions })
     },
     searchFiles(query: string): Promise<FileSearchHit[]> {

--- a/webview/src/protocol.ts
+++ b/webview/src/protocol.ts
@@ -107,10 +107,12 @@ export type ChatMessage = {
    */
   mentions?: string[]
   /**
-   * Past-conversation IDs the user attached via the @ picker. Persisted so
-   * the edit flow can restore them.
+   * Past-conversation chips the user attached via the @ picker, each with
+   * the label it renders as in `text`. Persisted so the edit flow can
+   * restore them. Messages persisted before the pair shape carried bare id
+   * arrays; the ConversationManager normalizes those to pairs at read time.
    */
-  conversationMentions?: string[]
+  conversationMentions?: ConversationMention[]
   /**
    * Manifest of context the host attached when this turn was sent. Persisted
    * so historical messages can show what was included. Always set for new
@@ -123,6 +125,18 @@ export type ConversationSummary = {
   id: string
   title: string
   updatedAt: number
+}
+
+/**
+ * A past-conversation @-mention: the chip label exactly as it appears in the
+ * message text, bound to the conversation it references. Carried as a pair
+ * end to end so the edit flow restores label→id bindings by lookup —
+ * reconstructing them from the text desyncs from insertion order (a chip can
+ * be inserted ahead of an existing one) and from any filtered id list.
+ */
+export type ConversationMention = {
+  label: string
+  id: string
 }
 
 export type Todo = {
@@ -383,7 +397,7 @@ export type Outbound =
   | { type: "restore"; conversationID: string; messages: ChatMessage[]; reviewHunks?: Record<string, ReviewHunkState> }
   | { type: "context"; ref: EditorContextRef }
   | { type: "workspace"; workspace?: WorkspaceInfo }
-  | { type: "userMessage"; id: string; text: string; ref?: EditorContextRef; backendID?: string; attachments?: Attachment[]; mentions?: string[]; conversationMentions?: string[]; context?: PromptContextManifest }
+  | { type: "userMessage"; id: string; text: string; ref?: EditorContextRef; backendID?: string; attachments?: Attachment[]; mentions?: string[]; conversationMentions?: ConversationMention[]; context?: PromptContextManifest }
   | { type: "userMessageBackendID"; id: string; backendID: string }
   /**
    * Followup to `userMessage` after the host finishes reading mentions and
@@ -429,9 +443,9 @@ export type Outbound =
 /** Messages sent from the webview to the extension host. */
 export type Inbound =
   | { type: "mounted" }
-  | { type: "send"; text: string; mentions?: string[]; attachments?: Attachment[]; conversationMentions?: string[] }
+  | { type: "send"; text: string; mentions?: string[]; attachments?: Attachment[]; conversationMentions?: ConversationMention[] }
   | { type: "runCommand"; command: string; arguments: string }
-  | { type: "editMessage"; id: string; text: string; mentions?: string[]; attachments?: Attachment[]; conversationMentions?: string[] }
+  | { type: "editMessage"; id: string; text: string; mentions?: string[]; attachments?: Attachment[]; conversationMentions?: ConversationMention[] }
   | { type: "abort" }
   | { type: "newSession" }
   | { type: "createConversation" }


### PR DESCRIPTION
## Summary

- Conversation @-mentions were persisted as a bare id array in chip-insertion order, and the edit flow reconstructed each chip's label→id binding by pairing that array against the `@chat:` tokens in the message text by index. The two orders diverge (a chip can be inserted ahead of an existing one), and `handleSend` also filtered self-mentions and duplicate ids out of the persisted array — N labels facing N-1 ids shifts every pairing after the gap. Result: editing a message could bind a chip to the wrong conversation, so deleting one chip kept the wrong chat's transcript.
- The binding being reconstructed already exists when the chip is inserted, so it is now carried instead of inferred: `conversationMentions` is `Array<{ label, id }>` (`ConversationMention`) through `send` / `editMessage` / `userMessage` / `ChatMessage`. `buildInitialConversations` collapses to a lookup loop; `extractConversationLabels` and the index pairing are gone.
- The persisted message now records every chip as written; filtering self-mentions and duplicates moved to prompt-build time (`attachableConversationIDs` in prompt-builder.ts, unit-tested), so each past conversation is attached once and the message stays faithful for the edit flow.
- Messages persisted before the pair shape are normalized at read time (`normalizeConversationMentions` in conversation-store.ts, applied on both `ConversationManager` read paths) by zipping ids with text-order labels — the same pairing the old edit flow computed, so legacy data behaves no worse than before and the shape converges as new messages are written.

## Test plan

- [x] New regression test: pairs restored out of text order bind each chip to its own id; removing one chip keeps the right conversation (this scenario is exactly the swap the old index pairing produced — the old shape cannot compile against the new test, so the proof is the scenario, not a stash run)
- [x] `attachableConversationIDs`: dedup + self-mention drop + order, empty cases
- [x] `normalizeConversationMentions`: legacy zip, pair passthrough (same reference), excess-id drop, no-token clear, plus both `ConversationManager` read paths
- [x] Existing chip-restore test updated to the pair shape (also now proves rename-immunity: the label comes from the pair, not the current title)
- [x] `bun run test` — 1131 passed (75 files)
- [x] `bun run check-types` + webview `tsc --noEmit` — clean
- [x] `bun run package` — builds
- [ ] Visual check in VS Code: mention two past chats with the second inserted before the first, edit the message, delete one chip, confirm the surviving chip's conversation is the one attached

Closes #421