### PR TITLE
fix(chat): abort the edit when session.revert fails

### DIFF
--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -1383,15 +1383,27 @@ export class ChatView implements vscode.WebviewViewProvider {
     if (!trimmed) return
 
     if (target.backendID && this.sessionID) {
+      // A failed revert means the opencode session still holds the original
+      // turns; truncating and resending anyway would silently diverge the
+      // panel from the model's context, so the edit is abandoned instead.
+      let revertFailed = false
       try {
         const backend = await this.servers.ensure()
         const res = await backend.client.session.revert({
           path: { id: this.sessionID },
           body: { messageID: target.backendID },
         })
-        if (res.error) log("session.revert failed", res.error)
+        if (res.error) {
+          log("session.revert failed", res.error)
+          revertFailed = true
+        }
       } catch (e) {
         log("session.revert threw", e)
+        revertFailed = true
+      }
+      if (revertFailed) {
+        void vscode.window.showErrorMessage("Failed to edit the message. The conversation is unchanged.")
+        return
       }
     } else {
       log("editMessage: no backendID — truncating locally only", webviewID)

--- a/test/host/chatview-harness.test.ts
+++ b/test/host/chatview-harness.test.ts
@@ -252,3 +252,77 @@ describe("ChatView harness: Stop mid-stream", () => {
     expect(assistant!.blocks).toEqual([{ type: "text", text: "Working" }])
   })
 })
+
+describe("ChatView harness: edit-in-place revert", () => {
+  const EDIT_FAILED_TOAST = "Failed to edit the message. The conversation is unchanged."
+
+  // One completed turn (user usr_1 + finished assistant, session idle) so
+  // there is history the edit must either replace or leave intact.
+  async function runTurn(): Promise<string> {
+    await harness.send({ type: "mounted" })
+    await harness.send({ type: "send", text: "original prompt" })
+    server.push({ type: "message.updated", info: { id: "usr_1", role: "user", sessionID: SESSION_ID } })
+    server.push({ type: "message.updated", info: { id: "msg_a", role: "assistant", sessionID: SESSION_ID } })
+    server.push({
+      type: "message.part.updated",
+      part: { id: "part_1", messageID: "msg_a", sessionID: SESSION_ID, type: "text", text: "answer" },
+    })
+    server.push({ type: "message.updated", info: { id: "msg_a", role: "assistant", sessionID: SESSION_ID, finish: "stop" } })
+    server.push({ type: "session.idle", sessionID: SESSION_ID })
+    await until(() => harness.posted.some((m) => m.type === "sessionIdle"))
+    const userMsg = harness.posted.find((m) => m.type === "userMessage")
+    return userMsg && "id" in userMsg ? userMsg.id : ""
+  }
+
+  async function persistedConversation(): Promise<SavedConversation> {
+    await harness.chatView.flushPersist()
+    return savedConversations()[0]!
+  }
+
+  it("truncates the turn and resends when the revert succeeds", async () => {
+    const userID = await runTurn()
+
+    await harness.send({ type: "editMessage", id: userID, text: "edited prompt" })
+
+    expect(server.reverts).toHaveLength(1)
+    expect(JSON.stringify(server.reverts[0]!.body)).toContain("usr_1")
+    expect(server.prompts).toHaveLength(2)
+    expect(JSON.stringify(server.prompts[1]!.body)).toContain("edited prompt")
+
+    const active = await persistedConversation()
+    expect(active.messages).toHaveLength(1)
+    expect(active.messages[0]!.blocks).toContainEqual({ type: "text", text: "edited prompt" })
+  })
+
+  it("aborts the edit when the revert reports an error: no truncation, no resend, a visible toast", async () => {
+    const userID = await runTurn()
+    server.setRevertStatus(500)
+
+    await harness.send({ type: "editMessage", id: userID, text: "edited prompt" })
+
+    expect(server.reverts).toHaveLength(1)
+    expect(server.prompts).toHaveLength(1)
+    expect(
+      harness.posted.some((m) => m.type === "userMessage" && "text" in m && m.text === "edited prompt"),
+    ).toBe(false)
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(EDIT_FAILED_TOAST)
+
+    const active = await persistedConversation()
+    expect(active.messages).toHaveLength(2)
+    expect(active.messages[0]!.blocks).toContainEqual({ type: "text", text: "original prompt" })
+    expect(active.messages[1]!.blocks).toContainEqual({ type: "text", text: "answer" })
+  })
+
+  it("aborts the edit when the revert call throws (connection drop): same untouched state", async () => {
+    const userID = await runTurn()
+    server.setRevertStatus(0)
+
+    await harness.send({ type: "editMessage", id: userID, text: "edited prompt" })
+
+    expect(server.prompts).toHaveLength(1)
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(EDIT_FAILED_TOAST)
+
+    const active = await persistedConversation()
+    expect(active.messages).toHaveLength(2)
+  })
+})

--- a/test/host/mock-opencode-server.ts
+++ b/test/host/mock-opencode-server.ts
@@ -35,6 +35,11 @@ export type MockOpencodeServer = {
   prompts: Array<{ sessionID: string; body: unknown }>
   /** Records of every revert call. */
   reverts: Array<{ sessionID: string; body: unknown }>
+  /**
+   * HTTP status POST /session/{id}/revert replies with (default 200).
+   * 0 destroys the socket without replying, so the client-side call throws.
+   */
+  setRevertStatus: (status: number) => void
   /** Records of every unrevert (redo) call's sessionID. */
   unreverts: string[]
   /** Records of every fork call. */
@@ -73,6 +78,7 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
   const sseClients: ServerResponse[] = []
   const prompts: Array<{ sessionID: string; body: unknown }> = []
   const reverts: Array<{ sessionID: string; body: unknown }> = []
+  let revertStatus = 200
   const unreverts: string[] = []
   const forks: Array<{ sessionID: string; body: unknown }> = []
   const aborts: string[] = []
@@ -218,7 +224,12 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
     if (revertMatch && req.method === "POST") {
       const body = await readBody(req)
       reverts.push({ sessionID: revertMatch[1]!, body })
-      reply(res, 200, { id: revertMatch[1] })
+      if (revertStatus === 0) {
+        req.socket.destroy()
+        return
+      }
+      if (revertStatus === 200) reply(res, 200, { id: revertMatch[1] })
+      else reply(res, revertStatus, { error: "scripted revert failure" })
       return
     }
 
@@ -346,6 +357,9 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
     },
     prompts,
     reverts,
+    setRevertStatus(status) {
+      revertStatus = status
+    },
     unreverts,
     forks,
     aborts,


### PR DESCRIPTION
## Summary

- `ChatView.handleEdit` treated a failed `session.revert` exactly like a successful one: both the error-response and the thrown shape (including `servers.ensure()` failing) were logged and swallowed, then execution fell through to local truncation, the review-decision wipe, persistence, and `handleSend` — silently diverging the panel from the opencode session, which still holds the original turns. The edited prompt got answered in addition to the old turn rather than instead of it.
- A failed revert now abandons the edit: no truncation, no review wipe, no persistence change, no resend, and a visible toast ("Failed to edit the message. The conversation is unchanged.", matching the terse builtin-runner error style). The no-`backendID` local-truncate fallback keeps its current deliberate behavior.
- Test support: the mock opencode server gains `setRevertStatus(status)` in the existing `set*` knob style — a non-200 status makes the revert reply an error; 0 destroys the socket without replying so the client-side call throws.

## Test plan

- [x] Three new harness tests (`test/host/chatview-harness.test.ts`): the success path still truncates and resends; an error-response revert aborts with the conversation untouched, no resend, and the toast; a thrown (connection-drop) revert aborts identically — the same catch branch an `ensure()` failure takes.
- [x] Stash-run regression proof: against the pre-fix `view.ts`, exactly the two abort tests fail while the success-path test passes on both sides — the fix changes only the failure behavior.
- [x] Full suite: 75 files, 1134 tests. One initial run failed transiently (3x normal duration under load; the failure detail was truncated by an output filter and did not involve the harness file, which passes in isolation) — four consecutive full-suite re-runs pass clean, so I could not attribute or reproduce it.
- [x] `bun run check-types` and webview `tsc --noEmit` clean; `bun run compile` builds.
- [ ] Visual: edit a message while the opencode backend is stopped and confirm the toast appears with the conversation intact (needs a live session).

Closes #425