### PR TITLE
fix(chat): unbrick the composer when a send fails before dispatch

### DIFF
--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -1024,16 +1024,14 @@ export class ChatView implements vscode.WebviewViewProvider {
       backend = await this.servers.ensure()
     } catch (e) {
       this.post({ type: "connected", connected: false, error: (e as Error).message })
+      this.failSend((e as Error).message || "Could not start the opencode server.")
       return
     }
 
     if (!this.sessionID) {
-      const created = await backend.client.session.create({ body: {} })
-      if (created.error || !created.data) {
-        log("session.create failed", created.error)
-        return
-      }
-      this.sessionID = created.data.id
+      const sessionID = await this.createSessionForSend(backend)
+      if (!sessionID) return
+      this.sessionID = sessionID
       this.manager.updateActive((conversation) => ({ ...conversation, sessionID: this.sessionID }))
       await this.manager.flushPersist()
       log("created session", this.sessionID)
@@ -1230,6 +1228,27 @@ export class ChatView implements vscode.WebviewViewProvider {
   }
 
   /**
+   * Create the opencode session for a first send. Returns undefined after
+   * routing the failure through failSend — a session that was never created
+   * produces no SSE events, so the caller must stop instead of dispatching.
+   */
+  private async createSessionForSend(backend: Backend): Promise<string | undefined> {
+    try {
+      const created = await backend.client.session.create({ body: {} })
+      if (created.error || !created.data) {
+        log("session.create failed", created.error)
+        this.failSend("opencode could not create a session; see the output log for details.")
+        return undefined
+      }
+      return created.data.id
+    } catch (e) {
+      log("session.create threw", e)
+      this.failSend((e as Error).message || "Could not reach the opencode server.")
+      return undefined
+    }
+  }
+
+  /**
    * Run an opencode custom command. Unlike handleSend this skips the entire
    * auto-context/manifest pipeline: `session.command` takes no `parts`, so the
    * server expands the command's own template (including its `!shell` / `@file`
@@ -1263,16 +1282,14 @@ export class ChatView implements vscode.WebviewViewProvider {
       backend = await this.servers.ensure()
     } catch (e) {
       this.post({ type: "connected", connected: false, error: (e as Error).message })
+      this.failSend((e as Error).message || "Could not start the opencode server.")
       return
     }
 
     if (!this.sessionID) {
-      const created = await backend.client.session.create({ body: {} })
-      if (created.error || !created.data) {
-        log("session.create failed", created.error)
-        return
-      }
-      this.sessionID = created.data.id
+      const sessionID = await this.createSessionForSend(backend)
+      if (!sessionID) return
+      this.sessionID = sessionID
       this.manager.updateActive((conversation) => ({ ...conversation, sessionID: this.sessionID }))
       await this.manager.flushPersist()
       log("created session", this.sessionID)

--- a/test/host/chatview-harness.test.ts
+++ b/test/host/chatview-harness.test.ts
@@ -89,6 +89,7 @@ let harness: {
   send: (msg: Inbound) => Promise<unknown>
   disposeView: () => void
   workspaceState: Memento
+  servers: ServerManager
 }
 
 beforeEach(async () => {
@@ -123,7 +124,7 @@ beforeEach(async () => {
   )
   const fake = makeFakeWebviewView()
   await chatView.resolveWebviewView(fake.view)
-  harness = { chatView, posted: fake.posted, send: fake.send, disposeView: fake.disposeView, workspaceState }
+  harness = { chatView, posted: fake.posted, send: fake.send, disposeView: fake.disposeView, workspaceState, servers }
 })
 
 afterEach(async () => {
@@ -324,5 +325,56 @@ describe("ChatView harness: edit-in-place revert", () => {
 
     const active = await persistedConversation()
     expect(active.messages).toHaveLength(2)
+  })
+})
+
+describe("ChatView harness: pre-dispatch send failures", () => {
+  // The user bubble is already posted and the webview is busy by the time
+  // these paths fail; failSend's sessionIdle is the only thing that re-enables
+  // the composer, because a send that never dispatched produces no SSE events.
+
+  it("posts sessionIdle and a toast when session.create reports an error", async () => {
+    await harness.send({ type: "mounted" })
+    server.setSessionCreateStatus(500)
+
+    await harness.send({ type: "send", text: "doomed prompt" })
+
+    expect(server.prompts).toHaveLength(0)
+    expect(harness.posted.some((m) => m.type === "sessionIdle")).toBe(true)
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining("Send failed"))
+  })
+
+  it("posts sessionIdle and a toast when session.create throws (connection drop)", async () => {
+    await harness.send({ type: "mounted" })
+    server.setSessionCreateStatus(0)
+
+    await harness.send({ type: "send", text: "doomed prompt" })
+
+    expect(server.prompts).toHaveLength(0)
+    expect(harness.posted.some((m) => m.type === "sessionIdle")).toBe(true)
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining("Send failed"))
+  })
+
+  it("posts sessionIdle alongside the disconnected banner when the backend cannot start", async () => {
+    await harness.send({ type: "mounted" })
+    vi.mocked(harness.servers.ensure).mockRejectedValue(new Error("spawn opencode ENOENT"))
+
+    await harness.send({ type: "send", text: "doomed prompt" })
+
+    expect(server.prompts).toHaveLength(0)
+    expect(harness.posted.some((m) => m.type === "connected" && m.connected === false)).toBe(true)
+    expect(harness.posted.some((m) => m.type === "sessionIdle")).toBe(true)
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining("Send failed"))
+  })
+
+  it("posts sessionIdle and a toast when a custom command's session.create fails", async () => {
+    await harness.send({ type: "mounted" })
+    server.setSessionCreateStatus(500)
+
+    await harness.send({ type: "runCommand", command: "definitely-custom", arguments: "" })
+
+    expect(server.commandCalls).toHaveLength(0)
+    expect(harness.posted.some((m) => m.type === "sessionIdle")).toBe(true)
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining("Send failed"))
   })
 })

--- a/test/host/mock-opencode-server.ts
+++ b/test/host/mock-opencode-server.ts
@@ -40,6 +40,11 @@ export type MockOpencodeServer = {
    * 0 destroys the socket without replying, so the client-side call throws.
    */
   setRevertStatus: (status: number) => void
+  /**
+   * HTTP status POST /session (create) replies with (default 200).
+   * 0 destroys the socket without replying, so the client-side call throws.
+   */
+  setSessionCreateStatus: (status: number) => void
   /** Records of every unrevert (redo) call's sessionID. */
   unreverts: string[]
   /** Records of every fork call. */
@@ -79,6 +84,7 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
   const prompts: Array<{ sessionID: string; body: unknown }> = []
   const reverts: Array<{ sessionID: string; body: unknown }> = []
   let revertStatus = 200
+  let sessionCreateStatus = 200
   const unreverts: string[] = []
   const forks: Array<{ sessionID: string; body: unknown }> = []
   const aborts: string[] = []
@@ -174,7 +180,12 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
 
     // Session create
     if (path === "/session" && req.method === "POST") {
-      reply(res, 200, { id: "ses_test", title: "Test Session" })
+      if (sessionCreateStatus === 0) {
+        req.socket.destroy()
+        return
+      }
+      if (sessionCreateStatus === 200) reply(res, 200, { id: "ses_test", title: "Test Session" })
+      else reply(res, sessionCreateStatus, { error: "scripted session.create failure" })
       return
     }
 
@@ -359,6 +370,9 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
     reverts,
     setRevertStatus(status) {
       revertStatus = status
+    },
+    setSessionCreateStatus(status) {
+      sessionCreateStatus = status
     },
     unreverts,
     forks,


### PR DESCRIPTION
## Summary

- The webview marks the composer busy as soon as the user sends, and only a `sessionIdle` re-enables it. The pre-dispatch failure paths in `handleSend` and `handleRunCommand` returned without posting one: `servers.ensure()` throwing posted only `connected: false` (which the reducer does not treat as busy-clearing), and a `session.create` error response just logged and returned. The optimistic user bubble stayed unanswered, Send stayed disabled, and queued messages never flushed (the queue keys off `idleNonce`, bumped only by `sessionIdle`) — a dead end until window reload, hit by anyone whose opencode binary is missing or whose backend crashed. A *thrown* `session.create` additionally escaped both handlers as an unhandled rejection.
- All pre-dispatch failures now route through the existing `failSend` (posts `sessionIdle` + the "Send failed" error toast), exactly like the late promptAsync/command failure paths already did. The `ensure()` path keeps posting `connected: false` for the disconnected banner. The duplicated session-create block in both handlers is now a shared `createSessionForSend` helper that owns the failure routing for both the error-response and thrown shapes.
- Test support: the mock opencode server gains `setSessionCreateStatus(status)` in the established knob style (non-200 replies an error; 0 destroys the socket so the client call throws), and the harness now exposes its `ServerManager` mock so the ensure-throw path can be driven.

## Test plan

- [x] Four new harness tests: `session.create` error response, `session.create` connection drop, `ensure()` rejection (asserting the disconnected banner still posts alongside `sessionIdle`), and a custom command's `session.create` failure — each asserting `sessionIdle` posted, the "Send failed" toast, and zero prompts/commands dispatched.
- [x] Stash-run regression proof: against the pre-fix `view.ts`, exactly the four new tests fail while all six existing harness tests pass on both sides.
- [x] Full suite: 75 files, 1138 tests pass.
- [x] `bun run check-types` and webview `tsc --noEmit` clean; `bun run compile` builds.
- [ ] Visual: with `opencui.binaryPath` pointed at a nonexistent binary, send a prompt and confirm the toast + re-enabled composer instead of a stuck "Working..." (needs a live VS Code).

Closes #427