### PR TITLE
fix(chat): unbrick the composer when /compact or /init fails

### DIFF
--- a/src/chat/builtin-runners.ts
+++ b/src/chat/builtin-runners.ts
@@ -22,6 +22,12 @@ export type BuiltinRunnerDeps = {
   attachSubscription: (backend: Backend, sessionID: string) => Promise<void>
   /** Post the typed-invocation bubble and key the Agents popover for the turn. */
   beginBuiltinTurn: (display: string) => Promise<void>
+  /**
+   * Settle a turn that failed after {@link beginBuiltinTurn}: a call that
+   * never started a server turn produces no SSE events, so nothing else
+   * would clear the webview's busy state or settle the popover's Main task.
+   */
+  failTurn: (message: string) => void
   post: (msg: Outbound) => void
   getMessages: () => ChatMessage[]
   setMessages: (messages: ChatMessage[]) => void
@@ -85,9 +91,13 @@ export class BuiltinRunners {
         query: { directory: backend.directory },
         body,
       })
-      if (res.error) log("compact failed", res.error)
+      if (res.error) {
+        log("compact failed", res.error)
+        this.deps.failTurn("opencode could not compact the session; see the output log for details.")
+      }
     } catch (e) {
       log("compact threw", e)
+      this.deps.failTurn((e as Error).message || "Could not reach the opencode server.")
     }
   }
 
@@ -99,9 +109,15 @@ export class BuiltinRunners {
     }
     let sessionID = this.deps.getSessionID()
     if (!sessionID) {
-      const created = await backend.client.session.create({ body: {} })
-      if (created.error || !created.data) {
-        log("session.create failed", created.error)
+      // No turn has begun yet (no bubble, no busy state), so a create failure
+      // needs direct feedback rather than the failTurn unbrick path.
+      const created = await backend.client.session.create({ body: {} }).catch((e: unknown) => {
+        log("init: session.create threw", e)
+        return undefined
+      })
+      if (!created || created.error || !created.data) {
+        if (created) log("init: session.create failed", created.error)
+        void vscode.window.showErrorMessage("Failed to create a session for /init.")
         return
       }
       sessionID = created.data.id
@@ -119,9 +135,13 @@ export class BuiltinRunners {
         query: { directory: backend.directory },
         body: { providerID: sel.modelProviderID, modelID: sel.modelID, messageID: generateMessageID() },
       })
-      if (res.error) log("init failed", res.error)
+      if (res.error) {
+        log("init failed", res.error)
+        this.deps.failTurn("opencode could not initialize the project; see the output log for details.")
+      }
     } catch (e) {
       log("init threw", e)
+      this.deps.failTurn((e as Error).message || "Could not reach the opencode server.")
     }
   }
 

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -167,6 +167,7 @@ export class ChatView implements vscode.WebviewViewProvider {
       hasSubscription: () => this.subscription !== undefined,
       attachSubscription: (backend, sessionID) => this.attachSubscription(backend, sessionID),
       beginBuiltinTurn: (display) => this.beginBuiltinTurn(display),
+      failTurn: (message) => this.failBuiltinTurn(message),
       post: (msg) => this.post(msg),
       getMessages: () => this.messages,
       setMessages: (messages) => {
@@ -1225,6 +1226,22 @@ export class ChatView implements vscode.WebviewViewProvider {
   private failSend(message: string) {
     this.post({ type: "sessionIdle" })
     this.surfaceToast({ variant: "error", title: "Send failed", message })
+  }
+
+  /**
+   * failSend for builtin turns: by the time /compact or /init fails,
+   * beginBuiltinTurn has already recorded a popover Main task, so that row
+   * must settle too — before anything else, so the terminal-state guard
+   * protects the status from a later idle sweep. classifyTerminal keeps an
+   * "Aborted" outcome quiet (no toast), mirroring onSessionError.
+   */
+  private failBuiltinTurn(message: string) {
+    const classified = classifyTerminal(message)
+    void this.subagentDispatch.recordMainTaskFinish(classified.status, classified.error)
+    this.post({ type: "sessionIdle" })
+    if (classified.status === "error") {
+      this.surfaceToast({ variant: "error", title: "Command failed", message })
+    }
   }
 
   /**

--- a/test/host/builtin-runners.test.ts
+++ b/test/host/builtin-runners.test.ts
@@ -64,6 +64,7 @@ function makeHarness(opts: HarnessOpts = {}) {
     hasSubscription: vi.fn(() => opts.subscribed ?? true),
     attachSubscription: vi.fn().mockResolvedValue(undefined),
     beginBuiltinTurn: vi.fn().mockResolvedValue(undefined),
+    failTurn: vi.fn(),
     post: vi.fn((msg: Outbound) => {
       state.posted.push(msg)
     }),
@@ -136,6 +137,21 @@ describe("BuiltinRunners: /compact", () => {
     await runners.run("compact", makeBackend({ summarize }))
     expect(summarize).toHaveBeenCalledWith(expect.objectContaining({ body: undefined }))
   })
+
+  it("unbricks the turn when summarize reports an error", async () => {
+    const { runners, deps } = makeHarness()
+    const summarize = vi.fn().mockResolvedValue({ error: "boom" })
+    await runners.run("compact", makeBackend({ summarize }))
+    expect(deps.beginBuiltinTurn).toHaveBeenCalledWith("/compact")
+    expect(deps.failTurn).toHaveBeenCalledTimes(1)
+  })
+
+  it("unbricks the turn with the thrown message when summarize throws", async () => {
+    const { runners, deps } = makeHarness()
+    const summarize = vi.fn().mockRejectedValue(new Error("socket hang up"))
+    await runners.run("compact", makeBackend({ summarize }))
+    expect(deps.failTurn).toHaveBeenCalledWith("socket hang up")
+  })
 })
 
 describe("BuiltinRunners: /init", () => {
@@ -166,13 +182,41 @@ describe("BuiltinRunners: /init", () => {
     expect(typeof body.messageID).toBe("string")
   })
 
-  it("aborts without running init when session.create fails", async () => {
+  it("shows an error and aborts without running init when session.create fails", async () => {
     const { runners, deps } = makeHarness({ sessionID: undefined })
     const create = vi.fn().mockResolvedValue({ error: "boom" })
     const init = vi.fn()
     await runners.run("init", makeBackend({ create, init }))
     expect(init).not.toHaveBeenCalled()
     expect(deps.beginBuiltinTurn).not.toHaveBeenCalled()
+    expect(win.showErrorMessage).toHaveBeenCalledWith("Failed to create a session for /init.")
+    expect(deps.failTurn).not.toHaveBeenCalled()
+  })
+
+  it("shows an error and aborts without running init when session.create throws", async () => {
+    const { runners, deps } = makeHarness({ sessionID: undefined })
+    const create = vi.fn().mockRejectedValue(new Error("socket hang up"))
+    const init = vi.fn()
+    await runners.run("init", makeBackend({ create, init }))
+    expect(init).not.toHaveBeenCalled()
+    expect(deps.beginBuiltinTurn).not.toHaveBeenCalled()
+    expect(win.showErrorMessage).toHaveBeenCalledWith("Failed to create a session for /init.")
+    expect(deps.failTurn).not.toHaveBeenCalled()
+  })
+
+  it("unbricks the turn when init reports an error", async () => {
+    const { runners, deps } = makeHarness()
+    const init = vi.fn().mockResolvedValue({ error: "boom" })
+    await runners.run("init", makeBackend({ init }))
+    expect(deps.beginBuiltinTurn).toHaveBeenCalledWith("/init")
+    expect(deps.failTurn).toHaveBeenCalledTimes(1)
+  })
+
+  it("unbricks the turn with the thrown message when init throws", async () => {
+    const { runners, deps } = makeHarness()
+    const init = vi.fn().mockRejectedValue(new Error("connect ECONNREFUSED"))
+    await runners.run("init", makeBackend({ init }))
+    expect(deps.failTurn).toHaveBeenCalledWith("connect ECONNREFUSED")
   })
 
   it("reuses the existing session and re-attaches when unsubscribed", async () => {

--- a/test/host/chatview-harness.test.ts
+++ b/test/host/chatview-harness.test.ts
@@ -4,6 +4,7 @@ import { createOpencodeClient } from "@opencode-ai/sdk"
 import { startMockOpencode, type MockOpencodeServer } from "./mock-opencode-server"
 import { ChatView } from "../../src/chat/view"
 import { CONVERSATIONS_KEY, type SavedConversation } from "../../src/chat/conversation-store"
+import { AgentTaskStore } from "../../src/agents/task-store"
 import type { Backend, ServerManager } from "../../src/server"
 import type { Preferences } from "../../src/preferences"
 import type { RecentEditsTracker } from "../../src/workspace-context/recent-edits"
@@ -90,6 +91,7 @@ let harness: {
   disposeView: () => void
   workspaceState: Memento
   servers: ServerManager
+  taskStore: AgentTaskStore
 }
 
 beforeEach(async () => {
@@ -115,16 +117,18 @@ beforeEach(async () => {
     subscriptions: [],
   } as unknown as vscode.ExtensionContext
 
+  const taskStore = new AgentTaskStore(makeMemento() as unknown as vscode.Memento)
   const chatView = new ChatView(
     context,
     servers,
     prefs,
     {} as RecentEditsTracker, // only consulted when backend.workspace is set
     indexManager,
+    taskStore,
   )
   const fake = makeFakeWebviewView()
   await chatView.resolveWebviewView(fake.view)
-  harness = { chatView, posted: fake.posted, send: fake.send, disposeView: fake.disposeView, workspaceState, servers }
+  harness = { chatView, posted: fake.posted, send: fake.send, disposeView: fake.disposeView, workspaceState, servers, taskStore }
 })
 
 afterEach(async () => {
@@ -376,5 +380,57 @@ describe("ChatView harness: pre-dispatch send failures", () => {
     expect(server.commandCalls).toHaveLength(0)
     expect(harness.posted.some((m) => m.type === "sessionIdle")).toBe(true)
     expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining("Send failed"))
+  })
+})
+
+describe("ChatView harness: builtin command failures", () => {
+  // beginBuiltinTurn has already posted the bubble (webview busy) and recorded
+  // a Main task by the time /compact's summarize call fails; failBuiltinTurn's
+  // sessionIdle + settle is the only thing that recovers either, because a
+  // turn that never started produces no SSE events.
+
+  beforeEach(() => {
+    vi.mocked(vscode.window.showErrorMessage).mockClear()
+  })
+
+  // One settled turn so /compact has a session to run against.
+  async function completeTurn(): Promise<void> {
+    await harness.send({ type: "mounted" })
+    await harness.send({ type: "send", text: "original prompt" })
+    server.push({ type: "message.updated", info: { id: "usr_1", role: "user", sessionID: SESSION_ID } })
+    server.push({ type: "message.updated", info: { id: "msg_a", role: "assistant", sessionID: SESSION_ID } })
+    server.push({ type: "message.updated", info: { id: "msg_a", role: "assistant", sessionID: SESSION_ID, finish: "stop" } })
+    server.push({ type: "session.idle", sessionID: SESSION_ID })
+    await until(() => harness.posted.some((m) => m.type === "sessionIdle"))
+  }
+
+  function idleCount(): number {
+    return harness.posted.filter((m) => m.type === "sessionIdle").length
+  }
+
+  it("unbricks the composer and settles the Main task when /compact's summarize reports an error", async () => {
+    await completeTurn()
+    server.setSummarizeStatus(500)
+    const before = idleCount()
+
+    await harness.send({ type: "runCommand", command: "compact", arguments: "" })
+
+    expect(idleCount()).toBe(before + 1)
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining("Command failed"))
+    await until(() => {
+      const mains = harness.taskStore.list().filter((t) => t.kind === "main")
+      return mains.some((t) => t.status === "error") && mains.every((t) => t.status !== "running")
+    })
+  })
+
+  it("unbricks the composer when the summarize call throws (connection drop)", async () => {
+    await completeTurn()
+    server.setSummarizeStatus(0)
+    const before = idleCount()
+
+    await harness.send({ type: "runCommand", command: "compact", arguments: "" })
+
+    expect(idleCount()).toBe(before + 1)
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining("Command failed"))
   })
 })

--- a/test/host/mock-opencode-server.ts
+++ b/test/host/mock-opencode-server.ts
@@ -45,6 +45,11 @@ export type MockOpencodeServer = {
    * 0 destroys the socket without replying, so the client-side call throws.
    */
   setSessionCreateStatus: (status: number) => void
+  /**
+   * HTTP status POST /session/{id}/summarize replies with (default 200).
+   * 0 destroys the socket without replying, so the client-side call throws.
+   */
+  setSummarizeStatus: (status: number) => void
   /** Records of every unrevert (redo) call's sessionID. */
   unreverts: string[]
   /** Records of every fork call. */
@@ -85,6 +90,7 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
   const reverts: Array<{ sessionID: string; body: unknown }> = []
   let revertStatus = 200
   let sessionCreateStatus = 200
+  let summarizeStatus = 200
   const unreverts: string[] = []
   const forks: Array<{ sessionID: string; body: unknown }> = []
   const aborts: string[] = []
@@ -212,7 +218,12 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
     // /share → share (POST) / unshare (DELETE).
     if (path.match(/^\/session\/[^/]+\/summarize$/) && req.method === "POST") {
       await readBody(req)
-      reply(res, 200, true)
+      if (summarizeStatus === 0) {
+        req.socket.destroy()
+        return
+      }
+      if (summarizeStatus === 200) reply(res, 200, true)
+      else reply(res, summarizeStatus, { error: "scripted summarize failure" })
       return
     }
     if (path.match(/^\/session\/[^/]+\/init$/) && req.method === "POST") {
@@ -373,6 +384,9 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
     },
     setSessionCreateStatus(status) {
       sessionCreateStatus = status
+    },
+    setSummarizeStatus(status) {
+      summarizeStatus = status
     },
     unreverts,
     forks,


### PR DESCRIPTION
## Summary

- `BuiltinRunners.runCompact` / `runInit` now route a failed or thrown `session.summarize` / `session.init` through a new `failTurn` dep instead of only logging. By that point `beginBuiltinTurn` has already posted the user bubble (webview `busy: true`) and recorded an Agents-popover Main task, and a turn that never started produces no SSE events — so previously the composer stayed on "Working…" forever and the popover kept a phantom `running` row.
- `ChatView.failBuiltinTurn` (the `failTurn` implementation) settles the Main task first via `classifyTerminal` (so the terminal-state guard protects the status from any later idle sweep, and an "Aborted" outcome settles quietly), then posts `sessionIdle` and surfaces a "Command failed" error toast — the builtin-path mirror of `failSend` (#427/#428).
- `/init`'s private session-create path now shows "Failed to create a session for /init." on both failure shapes and aborts before beginning the turn; a *thrown* `session.create` previously escaped `runInit` entirely as an unhandled rejection.
- Mock server gains `setSummarizeStatus` (same contract as `setRevertStatus`/`setSessionCreateStatus`: non-200 = error reply, 0 = socket destroy so the call throws). The ChatView harness now wires a real `AgentTaskStore` so the popover settle is asserted end-to-end.

## Test plan

- [x] 7 new/extended regression tests: summarize error + throw, init error + throw, session.create error + throw (runner level with spied `failTurn`), plus 2 harness tests proving a failed `/compact` posts exactly one more `sessionIdle`, toasts "Command failed", and settles the Main task to `error` with nothing left `running`.
- [x] Stash-run proof: with `src/chat/view.ts` + `src/chat/builtin-runners.ts` stashed, exactly the 8 new/extended tests fail and all 1137 pre-existing tests pass; with the fix, 1145/1145 pass.
- [x] `bun run check-types` clean; webview `tsc --noEmit` shows only the two known pre-existing errors.
- [ ] Visual check: point the panel at a stopped/broken backend and run `/compact` — expect an error toast and a re-enabled composer instead of a permanent "Working…".

Closes #429