### PR TITLE
feat(chat): render compaction turns as a collapsed marker

### DIFF
--- a/src/chat/stream.ts
+++ b/src/chat/stream.ts
@@ -63,6 +63,8 @@ export type StreamHandlers = {
   onUserMessage?: (messageID: string) => void
   /** Fired when a new assistant message appears for this session. */
   onAssistantStart?: (messageID: string) => void
+  /** Fired once when an assistant message is flagged as opencode's compaction summary. */
+  onAssistantSummary?: (messageID: string) => void
   /** Fired once when an assistant message is marked finished or errored. */
   onAssistantEnd?: (messageID: string, payload: { usage?: MessageUsage; finish?: string; error?: string }) => void
   /** Text-field deltas for a specific assistant message. */
@@ -220,6 +222,7 @@ export function subscribeSession(
 
   const seenLen = new Map<string, number>()
   const seenAssistantMessages = new Set<string>()
+  const summaryFlagged = new Set<string>()
   const seenUserMessages = new Set<string>()
   const assistantFinished = new Set<string>()
   const toolStatus = new Map<string, string>()
@@ -568,6 +571,13 @@ export function subscribeSession(
     if (!seenAssistantMessages.has(mid)) {
       seenAssistantMessages.add(mid)
       handlers.onAssistantStart?.(mid)
+    }
+    // Checked on every update (not just the first): opencode sets the flag
+    // when it creates the summarization message, but nothing guarantees the
+    // first event we observe carries it.
+    if (info.summary === true && !summaryFlagged.has(mid)) {
+      summaryFlagged.add(mid)
+      handlers.onAssistantSummary?.(mid)
     }
     if (info.error && !assistantFinished.has(mid)) {
       assistantFinished.add(mid)

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -506,6 +506,10 @@ export class ChatView implements vscode.WebviewViewProvider {
         this.messages = [...this.messages, { id: msg.id, role: "assistant", blocks: [], pending: true }]
         this.saveActive()
         return
+      case "assistantSummary":
+        this.messages = this.messages.map((m) => (m.id === msg.id ? { ...m, summary: true } : m))
+        this.saveActive()
+        return
       case "textDelta":
         this.messages = appendText(this.messages, msg.id, "text", msg.delta)
         this.saveActive()
@@ -1498,6 +1502,13 @@ export class ChatView implements vscode.WebviewViewProvider {
         const webviewID = "a_" + mid
         this.messageMap.set(mid, webviewID)
         this.post({ type: "assistantStart", id: webviewID })
+      },
+      onAssistantSummary: (mid) => {
+        // Presentation-only flag; same ignore-while-aborting gate as the
+        // other non-terminal events.
+        if (this.aborting) return
+        const webviewID = this.messageMap.get(mid) ?? this.ensureWebviewID(mid)
+        this.post({ type: "assistantSummary", id: webviewID })
       },
       onAssistantEnd: (mid, payload) => {
         const webviewID = this.messageMap.get(mid)

--- a/test/host/chatview-harness.test.ts
+++ b/test/host/chatview-harness.test.ts
@@ -434,3 +434,29 @@ describe("ChatView harness: builtin command failures", () => {
     expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining("Command failed"))
   })
 })
+
+describe("ChatView harness: compaction summary turns", () => {
+  it("forwards opencode's summary flag to the webview and persists it", async () => {
+    await harness.send({ type: "mounted" })
+    await harness.send({ type: "send", text: "please compact" })
+
+    server.push({ type: "message.updated", info: { id: "usr_1", role: "user", sessionID: SESSION_ID } })
+    server.push({ type: "message.updated", info: { id: "msg_s", role: "assistant", sessionID: SESSION_ID, summary: true } })
+    server.push({
+      type: "message.part.updated",
+      part: { id: "part_1", messageID: "msg_s", sessionID: SESSION_ID, type: "text", text: "anchored summary" },
+    })
+    server.push({ type: "message.updated", info: { id: "msg_s", role: "assistant", sessionID: SESSION_ID, summary: true, finish: "stop" } })
+    server.push({ type: "session.idle", sessionID: SESSION_ID })
+    await until(() => harness.posted.some((m) => m.type === "sessionIdle"))
+
+    expect(harness.posted.some((m) => m.type === "assistantSummary" && m.id === "a_msg_s")).toBe(true)
+
+    await harness.chatView.flushPersist()
+    const [active] = savedConversations()
+    const assistant = active!.messages[1]!
+    expect(assistant.role).toBe("assistant")
+    expect(assistant.summary).toBe(true)
+    expect(assistant.pending).toBe(false)
+  })
+})

--- a/test/host/stream-summary.test.ts
+++ b/test/host/stream-summary.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { createOpencodeClient } from "@opencode-ai/sdk"
+import { startMockOpencode, type MockOpencodeServer } from "./mock-opencode-server"
+import { subscribeSession } from "../../src/chat/stream"
+
+let server: MockOpencodeServer
+
+beforeEach(async () => {
+  server = await startMockOpencode()
+})
+
+afterEach(async () => {
+  await server.close()
+})
+
+function makeBackend() {
+  const client = createOpencodeClient({ baseUrl: server.url })
+  return { url: server.url, client, directory: "/tmp" }
+}
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+describe("subscribeSession compaction summary flag", () => {
+  it("fires onAssistantSummary once per flagged message, after onAssistantStart", async () => {
+    const calls: string[] = []
+    const subscription = subscribeSession(
+      makeBackend(),
+      "ses_test",
+      {
+        onAssistantStart: (mid) => calls.push("start:" + mid),
+        onAssistantSummary: (mid) => calls.push("summary:" + mid),
+        onTextDelta: () => {},
+      },
+      { watchdogMs: 10_000 },
+    )
+    await subscription.ready
+    await server.awaitClient()
+
+    // A normal assistant message never fires the summary handler; the
+    // compaction message fires it exactly once across repeated updates.
+    server.push({ type: "message.updated", info: { id: "msg_a", role: "assistant", sessionID: "ses_test" } })
+    server.push({ type: "message.updated", info: { id: "msg_s", role: "assistant", sessionID: "ses_test", summary: true } })
+    server.push({ type: "message.updated", info: { id: "msg_s", role: "assistant", sessionID: "ses_test", summary: true } })
+    await wait(30)
+
+    expect(calls).toEqual(["start:msg_a", "start:msg_s", "summary:msg_s"])
+
+    // The flag is honored even when it only appears on a later update of an
+    // already-started message.
+    server.push({ type: "message.updated", info: { id: "msg_a", role: "assistant", sessionID: "ses_test", summary: true } })
+    await wait(30)
+
+    subscription.abort()
+    expect(calls).toEqual(["start:msg_a", "start:msg_s", "summary:msg_s", "summary:msg_a"])
+  })
+})

--- a/test/webview/compaction-marker.test.tsx
+++ b/test/webview/compaction-marker.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+import { MessageView } from "../../webview/src/components/MessageView"
+import { reducer, initialChatState, type Message } from "../../webview/src/hooks/useChatState"
+
+afterEach(cleanup)
+
+function summaryMessage(text: string, opts: { pending?: boolean; stopped?: boolean; error?: string } = {}): Message {
+  return {
+    id: "a1",
+    role: "assistant",
+    blocks: text ? [{ type: "text", text }] : [],
+    summary: true,
+    ...opts,
+  } as Message
+}
+
+describe("reducer: assistantSummary", () => {
+  it("flags the target assistant message", () => {
+    const started = reducer(initialChatState, { type: "assistantStart", id: "a1" })
+    const flagged = reducer(started, { type: "assistantSummary", id: "a1" })
+    expect(flagged.messages[0]).toMatchObject({ id: "a1", summary: true })
+  })
+
+  it("is dropped while aborting, like the other non-terminal stream events", () => {
+    let state = reducer(initialChatState, { type: "assistantStart", id: "a1" })
+    state = reducer(state, { type: "aborted" })
+    const after = reducer(state, { type: "assistantSummary", id: "a1" })
+    expect(after).toBe(state)
+    expect(after.messages[0]!.summary).toBeUndefined()
+  })
+})
+
+describe("MessageView: compaction marker", () => {
+  it("renders a settled summary turn as a collapsed marker instead of a bubble", () => {
+    const { container } = render(
+      <MessageView message={summaryMessage("anchored summary body")} processOpen={false} processOnly={false} />,
+    )
+    expect(screen.getByText("Conversation compacted")).toBeInTheDocument()
+    const marker = container.querySelector("details.compaction-marker")
+    expect(marker).not.toBeNull()
+    expect(marker!.hasAttribute("open")).toBe(false)
+    // The summary content stays available behind the disclosure.
+    expect(screen.getByText("anchored summary body")).toBeInTheDocument()
+    expect(container.querySelector(".msg.role-assistant")).toBeNull()
+  })
+
+  it("labels a still-streaming summary turn as compacting", () => {
+    render(<MessageView message={summaryMessage("", { pending: true })} processOpen={false} processOnly={false} />)
+    expect(screen.getByText("Compacting conversation…")).toBeInTheDocument()
+  })
+
+  it("falls back to the Stopped badge when the compaction was interrupted", () => {
+    const { container } = render(
+      <MessageView message={summaryMessage("partial", { stopped: true })} processOpen={false} processOnly={false} />,
+    )
+    expect(container.querySelector(".compaction-marker")).toBeNull()
+    expect(screen.getByText("Stopped")).toBeInTheDocument()
+  })
+
+  it("falls back to the error block when the compaction failed", () => {
+    const { container } = render(
+      <MessageView message={summaryMessage("", { error: "rate limit exceeded" })} processOpen={false} processOnly={false} />,
+    )
+    expect(container.querySelector(".compaction-marker")).toBeNull()
+    expect(screen.getByText("rate limit exceeded")).toBeInTheDocument()
+  })
+
+  it("leaves normal assistant messages untouched", () => {
+    const normal = {
+      id: "a2",
+      role: "assistant",
+      blocks: [{ type: "text", text: "plain reply" }],
+    } as Message
+    const { container } = render(<MessageView message={normal} processOpen={false} processOnly={false} />)
+    expect(container.querySelector(".compaction-marker")).toBeNull()
+    expect(screen.getByText("plain reply")).toBeInTheDocument()
+  })
+})

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -110,6 +110,25 @@ function MessageViewComponent({
       />
     )
   }
+  // opencode's compaction turn (AssistantMessage.summary): the raw summary
+  // text is internal bookkeeping, so it collapses to a marker instead of
+  // rendering as a normal reply. Stopped/errored compactions fall through to
+  // the regular bubble — an interrupted compaction is not a completed one.
+  if (message.summary && !message.error && !message.stopped) {
+    return (
+      <details className="compaction-marker">
+        <summary className="compaction-marker-summary">
+          <span className="compaction-chevron" aria-hidden>▸</span>
+          <span className="compaction-label">
+            {message.pending ? "Compacting conversation…" : "Conversation compacted"}
+          </span>
+        </summary>
+        <div className="compaction-body">
+          {renderMessageBlocks(message, processOpen, processOnly, onReviewFile)}
+        </div>
+      </details>
+    )
+  }
   return (
     <div className={`msg role-${message.role}`}>
       {message.ref?.label && <div className="msg-ref">{message.ref.label}</div>}

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -279,6 +279,11 @@ export function reducer(state: ChatState, action: Action): ChatState {
         busy: true,
         messages: [...state.messages, { id: action.id, role: "assistant", blocks: [], pending: true }],
       }
+    case "assistantSummary":
+      // Presentation-only flag on an existing bubble; same ignore-while-
+      // aborting gate as the other non-terminal stream events.
+      if (state.aborting) return state
+      return { ...state, messages: upsertMessage(state.messages, action.id, { summary: true }) }
     case "textDelta":
       // Drop deltas that race in after Stop — the message is already marked
       // `stopped: true` and opencode is still draining its in-flight response.

--- a/webview/src/protocol.ts
+++ b/webview/src/protocol.ts
@@ -100,6 +100,12 @@ export type ChatMessage = {
    */
   stopped?: boolean
   /**
+   * True when this assistant message is opencode's compaction summary turn
+   * (`AssistantMessage.summary` in the SDK). Rendered as a collapsed
+   * "Conversation compacted" marker instead of a normal reply bubble.
+   */
+  summary?: boolean
+  /**
    * @-mention paths the user originally selected when this message was sent.
    * Persisted on the message so the edit flow can preserve them — when the
    * user clicks an old user message to revise it, we know which `@path`
@@ -407,6 +413,7 @@ export type Outbound =
    */
   | { type: "userMessageContext"; id: string; context: PromptContextManifest }
   | { type: "assistantStart"; id: string }
+  | { type: "assistantSummary"; id: string }
   | { type: "textDelta"; id: string; delta: string }
   | { type: "reasoningDelta"; id: string; delta: string }
   | { type: "tool"; id: string; update: ToolUpdate; actor?: ReviewChangeActor }

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -2497,6 +2497,52 @@ button:focus-visible {
 .system-reminder-body p:first-child { margin-top: 0; }
 .system-reminder-body p:last-child { margin-bottom: 0; }
 
+/* ===== Compaction marker (opencode summary turns) ===== */
+.compaction-marker {
+  margin: 8px 0;
+  padding: 0;
+  border: 1px solid var(--vscode-panel-border);
+  border-radius: var(--radius-sm);
+  background: var(--vscode-editorWidget-background);
+  font-size: 12px;
+  overflow: hidden;
+}
+.compaction-marker-summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 6px 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  color: var(--vscode-descriptionForeground);
+  user-select: none;
+}
+.compaction-marker-summary::-webkit-details-marker { display: none; }
+.compaction-marker-summary::marker { display: none; content: ""; }
+.compaction-chevron {
+  flex: 0 0 10px;
+  font-size: 10px;
+  line-height: 1;
+  /* 0.16s matches .process-caret / .review-caret — every disclosure chevron
+     rotates at the same speed. */
+  transition: transform 0.16s ease;
+  transform-origin: 50% 55%;
+}
+.compaction-marker[open] > .compaction-marker-summary .compaction-chevron {
+  transform: rotate(90deg);
+}
+.compaction-label {
+  font-weight: 600;
+  flex: 0 0 auto;
+}
+.compaction-body {
+  padding: 4px 12px 10px;
+  border-top: 1px solid var(--vscode-panel-border);
+  color: var(--vscode-foreground);
+  opacity: 0.9;
+}
+
 /* ===== Attachments (read-only thumbnails in user-message bubbles) ===== */
 .attachment-tile {
   display: inline-flex;


### PR DESCRIPTION
## Summary

- `subscribeSession` gains an `onAssistantSummary` handler, fired once per assistant message when `message.updated` carries opencode's `summary: true` flag. The check runs on every update (not just first-seen), since nothing guarantees the first observed event carries the flag.
- `ChatView` forwards it as a new `assistantSummary` protocol message (same ignore-while-aborting gate as the other non-terminal events) and mirrors `summary: true` onto the persisted message in `applyLocal`, so restored conversations keep the treatment.
- The webview reducer applies the flag via `upsertMessage`; `MessageView` renders flagged messages as a collapsed `<details class="compaction-marker">` — "Conversation compacted", or "Compacting conversation…" while streaming — with the full summary content behind the disclosure, styled after the existing system-reminder callout (shared chevron timing). Stopped or errored compaction turns fall through to the existing Stopped badge / error block, since an interrupted compaction is not a completed one.
- Detection is SSE-driven rather than keyed off the `/compact` command, so opencode's automatic compaction gets the same rendering.

## Test plan

- [x] 8 new tests across all four layers: stream (flag fired once per message, after `onAssistantStart`, honored on late updates), reducer (flag applied; dropped while aborting), component (collapsed marker for settled turns, streaming label, Stopped/error/normal fallbacks), harness E2E (posted `assistantSummary` + persisted `summary: true`).
- [x] Stash-run proof: with the six source files stashed, exactly the 5 behavior tests fail (the 3 fallback/guard tests correctly pass on both sides); with the feature, 1154/1154 pass.
- [x] `bun run check-types` and webview `tsc --noEmit` both fully clean; `bun run compile` production build succeeds.
- [ ] Visual check: run `/compact` in the panel — expect a slim collapsed "Conversation compacted" row instead of the raw summary wall, expandable to the summary text.

Closes #431