### PR TITLE
fix(chat): restyle the compaction marker as a process row

### DIFF
--- a/test/webview/compaction-marker.test.tsx
+++ b/test/webview/compaction-marker.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest"
-import { render, screen, cleanup } from "@testing-library/react"
+import { render, screen, cleanup, fireEvent } from "@testing-library/react"
 import { MessageView } from "../../webview/src/components/MessageView"
 import { reducer, initialChatState, type Message } from "../../webview/src/hooks/useChatState"
 
@@ -32,17 +32,33 @@ describe("reducer: assistantSummary", () => {
 })
 
 describe("MessageView: compaction marker", () => {
-  it("renders a settled summary turn as a collapsed marker instead of a bubble", () => {
+  it("renders a settled summary turn as a collapsed process-style row instead of a bubble", () => {
     const { container } = render(
       <MessageView message={summaryMessage("anchored summary body")} processOpen={false} processOnly={false} />,
     )
     expect(screen.getByText("Conversation compacted")).toBeInTheDocument()
-    const marker = container.querySelector("details.compaction-marker")
+    // Same visual idiom as tool traces / the process panel: the shared
+    // process-* classes, collapsed by default.
+    const marker = container.querySelector(".compaction-marker")
     expect(marker).not.toBeNull()
-    expect(marker!.hasAttribute("open")).toBe(false)
+    expect(marker!.classList.contains("process")).toBe(true)
+    expect(marker!.classList.contains("is-open")).toBe(false)
+    expect(marker!.querySelector(".process-head")).not.toBeNull()
     // The summary content stays available behind the disclosure.
     expect(screen.getByText("anchored summary body")).toBeInTheDocument()
     expect(container.querySelector(".msg.role-assistant")).toBeNull()
+  })
+
+  it("toggles open on click like the other process rows", () => {
+    const { container } = render(
+      <MessageView message={summaryMessage("anchored summary body")} processOpen={false} processOnly={false} />,
+    )
+    const head = container.querySelector<HTMLButtonElement>(".compaction-marker .process-head")!
+    fireEvent.click(head)
+    expect(container.querySelector(".compaction-marker")!.classList.contains("is-open")).toBe(true)
+    expect(head.getAttribute("aria-expanded")).toBe("true")
+    fireEvent.click(head)
+    expect(container.querySelector(".compaction-marker")!.classList.contains("is-open")).toBe(false)
   })
 
   it("labels a still-streaming summary turn as compacting", () => {

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -115,19 +115,7 @@ function MessageViewComponent({
   // rendering as a normal reply. Stopped/errored compactions fall through to
   // the regular bubble — an interrupted compaction is not a completed one.
   if (message.summary && !message.error && !message.stopped) {
-    return (
-      <details className="compaction-marker">
-        <summary className="compaction-marker-summary">
-          <span className="compaction-chevron" aria-hidden>▸</span>
-          <span className="compaction-label">
-            {message.pending ? "Compacting conversation…" : "Conversation compacted"}
-          </span>
-        </summary>
-        <div className="compaction-body">
-          {renderMessageBlocks(message, processOpen, processOnly, onReviewFile)}
-        </div>
-      </details>
-    )
+    return <CompactionMarker message={message} onReviewFile={onReviewFile} />
   }
   return (
     <div className={`msg role-${message.role}`}>
@@ -503,6 +491,29 @@ function ProcessPanel({
           expand/collapse animates height instead of snapping. */}
       <div className="process-body-clip">
         <div className="process-body">{renderBlocks(blocks, true, onReviewFile)}</div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * The compaction summary rendered in the same visual idiom as tool traces
+ * and the process panel (shared `process-*` classes), so it reads as one of
+ * the turn's collapsible work rows rather than a callout box. Unlike
+ * ProcessPanel there is no openKey/defaultOpen churn: it starts collapsed
+ * and stays wherever the user toggled it.
+ */
+function CompactionMarker({ message, onReviewFile }: { message: Message; onReviewFile?: (path: string) => void }) {
+  const [open, setOpen] = useState(false)
+  const label = message.pending ? "Compacting conversation…" : "Conversation compacted"
+  return (
+    <div className={`process compaction-marker ${open ? "is-open" : ""}`}>
+      <button className="process-head" onClick={() => setOpen(!open)} aria-expanded={open}>
+        <span className="process-title">{label}</span>
+        <span className={`process-caret ${open ? "is-open" : ""}`}>›</span>
+      </button>
+      <div className="process-body-clip">
+        <div className="process-body">{renderBlocks(message.blocks, true, onReviewFile)}</div>
       </div>
     </div>
   )

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -2497,52 +2497,6 @@ button:focus-visible {
 .system-reminder-body p:first-child { margin-top: 0; }
 .system-reminder-body p:last-child { margin-bottom: 0; }
 
-/* ===== Compaction marker (opencode summary turns) ===== */
-.compaction-marker {
-  margin: 8px 0;
-  padding: 0;
-  border: 1px solid var(--vscode-panel-border);
-  border-radius: var(--radius-sm);
-  background: var(--vscode-editorWidget-background);
-  font-size: 12px;
-  overflow: hidden;
-}
-.compaction-marker-summary {
-  list-style: none;
-  cursor: pointer;
-  padding: 6px 10px;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  min-width: 0;
-  color: var(--vscode-descriptionForeground);
-  user-select: none;
-}
-.compaction-marker-summary::-webkit-details-marker { display: none; }
-.compaction-marker-summary::marker { display: none; content: ""; }
-.compaction-chevron {
-  flex: 0 0 10px;
-  font-size: 10px;
-  line-height: 1;
-  /* 0.16s matches .process-caret / .review-caret — every disclosure chevron
-     rotates at the same speed. */
-  transition: transform 0.16s ease;
-  transform-origin: 50% 55%;
-}
-.compaction-marker[open] > .compaction-marker-summary .compaction-chevron {
-  transform: rotate(90deg);
-}
-.compaction-label {
-  font-weight: 600;
-  flex: 0 0 auto;
-}
-.compaction-body {
-  padding: 4px 12px 10px;
-  border-top: 1px solid var(--vscode-panel-border);
-  color: var(--vscode-foreground);
-  opacity: 0.9;
-}
-
 /* ===== Attachments (read-only thumbnails in user-message bubbles) ===== */
 .attachment-tile {
   display: inline-flex;


### PR DESCRIPTION
## Summary

- The compaction marker from #432 rendered as a bordered `<details>` callout (system-reminder styling), visually apart from the other collapsible rows inside a turn. It now reuses the shared `process` / `process-head` / `process-title` / `process-caret` / `process-body-clip` / `process-body` classes, so "Conversation compacted" renders identically to tool traces (Read/Edit) and the process panel — unboxed muted head, trailing `›` caret, animated body fold — and inherits any future restyle of those rows automatically.
- Unlike `ProcessPanel` there is no `openKey`/`defaultOpen` churn: the marker starts collapsed and stays wherever the user toggled it.
- The bespoke `.compaction-marker` CSS block is deleted (the class remains on the root element as a semantic hook only). Interaction semantics unchanged: collapsed by default, click toggles, Stopped/error fallbacks untouched.

## Test plan

- [x] Component tests updated to the new structure (shared `process` classes, collapsed by default, no assistant bubble) plus a new click-toggle test asserting `is-open` and `aria-expanded`; 1155/1155 pass.
- [x] `bun run check-types` and webview `tsc --noEmit` clean; `bun run compile` production build succeeds; no `compaction` rules left in `styles.css`.
- [ ] Visual check: run `/compact` — the marker should look exactly like a tool-trace row (same typography, caret, fold animation), not a boxed callout.

Closes #433