### PR TITLE
fix(package): exclude local AI and build artifacts from the VSIX

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -23,6 +23,7 @@ bun.lock
 tsconfig*.json
 webview/vite.config.ts
 webview/tsconfig*.json
+out/**
 
 # Editor / VCS / OS / AI-assistant metadata
 .vscode/**
@@ -35,6 +36,12 @@ webview/tsconfig*.json
 .DS_Store
 .npmrc
 .claude/**
+# Untracked local AI session artifacts — never in git, but present on dev
+# machines, so a locally built .vsix would ship them without these lines.
+.omo/**
+.sisyphus/**
+.codegraph
+.codegraph/**
 
 # Repo-meta docs (Marketplace renders README; CLAUDE.md is internal guidance)
 CLAUDE.md


### PR DESCRIPTION
## Summary

- Add `out/**`, `.omo/**`, `.sisyphus/**`, and `.codegraph` (plus `.codegraph/**`) to `.vscodeignore`.
- Before: `bunx vsce ls` on a dev machine packaged `out/tsconfig.tsbuildinfo`, one `.sisyphus/run-continuation/ses_*.json`, three `.omo/run-continuation/ses_*.json`, and the `.codegraph` symlink — the session JSONs are personal AI artifacts, and the symlink breaks vsce's secret scan during `vsce package`.
- After: the packaged list is exactly the 17 intended files (manifest, README, LICENSE, CHANGELOG, `dist/extension.js`, `dist/webview/index.html`, media, docs, screenshots).
- CI-built releases were never affected (all four paths are untracked); this closes the local-packaging hole.

## Test plan

- [x] `bunx vsce ls` before/after diff: only the six leaked entries disappear; no legitimate file drops out.
- [x] `grep` for `out/ | .omo/ | .sisyphus/ | .codegraph` over the new listing returns nothing.
- [x] `bun run test` — 77 files / 1155 tests pass.
- [x] `bun run check-types` — clean.

Closes #435