### PR TITLE
chore(ci): type-check the webview and enable unused-code checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,11 @@ jobs:
       - name: Type-check (host)
         run: bun run check-types
 
+      # The webview tree has its own tsconfig + node_modules; the root
+      # check-types never sees it, so type-check it explicitly.
+      - name: Type-check (webview)
+        run: cd webview && bun install --frozen-lockfile --silent && bunx tsc --noEmit
+
       - name: Build (host esbuild + webview vite)
         run: bun run compile
 

--- a/src/chat/fs-ops.ts
+++ b/src/chat/fs-ops.ts
@@ -292,7 +292,6 @@ async function undoHunk(
 ): Promise<ReviewHunkOutcome> {
   if (!hunk.reversible) {
     return reportUnsupported(
-      change.path,
       `Cannot undo ${change.path}: the diff did not provide a parseable hunk header.`,
       silent,
     )
@@ -339,7 +338,6 @@ async function undoDelete(
 ): Promise<ReviewHunkOutcome> {
   if (!hunk.oldText && !hunk.newText) {
     return reportUnsupported(
-      change.path,
       `Cannot restore ${change.path}: original content is not available in the diff.`,
       silent,
     )
@@ -376,7 +374,6 @@ async function undoMove(
 ): Promise<ReviewHunkOutcome> {
   if (!change.oldPath) {
     return reportUnsupported(
-      change.path,
       `Cannot undo move of ${change.path}: original path not recorded.`,
       silent,
     )
@@ -477,7 +474,7 @@ function reportMissing(p: string, reason: string, silent: boolean, tried?: strin
   return { status: "missing", reason }
 }
 
-function reportUnsupported(p: string, reason: string, silent: boolean): ReviewHunkOutcome {
+function reportUnsupported(reason: string, silent: boolean): ReviewHunkOutcome {
   if (!silent) vscode.window.showWarningMessage(`OpenCode Panel: ${reason}`)
   return { status: "unsupported", reason }
 }

--- a/src/inline/edit.ts
+++ b/src/inline/edit.ts
@@ -89,8 +89,8 @@ async function previewAndApply(
   const leftUri = vscode.Uri.parse(`untitled:OpenCode Panel-original.${ext(language)}`)
   const rightUri = vscode.Uri.parse(`untitled:OpenCode Panel-proposed.${ext(language)}`)
 
-  const left = await vscode.workspace.openTextDocument(leftUri)
-  const right = await vscode.workspace.openTextDocument(rightUri)
+  await vscode.workspace.openTextDocument(leftUri)
+  await vscode.workspace.openTextDocument(rightUri)
   const leftEdit = new vscode.WorkspaceEdit()
   leftEdit.insert(leftUri, new vscode.Position(0, 0), original)
   await vscode.workspace.applyEdit(leftEdit)

--- a/src/status.ts
+++ b/src/status.ts
@@ -7,7 +7,7 @@ export class StatusBar {
   private health: vscode.StatusBarItem
   private agent: vscode.StatusBarItem
 
-  constructor(context: vscode.ExtensionContext, private prefs: Preferences) {
+  constructor(context: vscode.ExtensionContext, prefs: Preferences) {
     this.health = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100)
     this.health.command = "opencui.chat.focus"
     this.health.show()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
     "rootDir": ".",
     "outDir": "out",
     "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -271,7 +271,6 @@ export default function App() {
           position="top"
           conversations={state.conversations}
           activeConversationID={state.conversationID}
-          onOpenConversation={openConversation}
           contextUsage={state.contextUsage}
           commands={state.commands}
           onRunCommand={runCommandAndPinTop}
@@ -390,7 +389,6 @@ export default function App() {
               attachFile={attachFile}
               conversations={state.conversations}
               activeConversationID={state.conversationID}
-              onOpenConversation={openConversation}
               contextUsage={state.contextUsage}
               commands={state.commands}
               onRunCommand={runCommandAndPinTop}

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -75,7 +75,6 @@ type Props = {
   position?: "top" | "bottom"
   conversations?: ConversationSummary[]
   activeConversationID?: string
-  onOpenConversation?: (id: string) => void
   contextUsage?: ContextUsage
   /** Workspace opencode commands for the `/` picker. Empty disables it. */
   commands?: CommandInfo[]
@@ -125,7 +124,7 @@ function buildInitialConversations(initial: Props["initial"]): Map<string, strin
   return map
 }
 
-export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, searchFiles, listDir, attachFile, initial, variant = "send", position = "bottom", conversations, activeConversationID, onOpenConversation, contextUsage, commands = [], onRunCommand, inject }: Props) {
+export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, searchFiles, listDir, attachFile, initial, variant = "send", position = "bottom", conversations, activeConversationID, contextUsage, commands = [], onRunCommand, inject }: Props) {
   const { text, setText, ref, backdropRef, pendingCursor } = usePromptText(initial?.text ?? "")
   // The Send button renders a disabled "Stopping…" while aborting, but Enter
   // routes through submit() — both must honor the same block, or a prompt

--- a/webview/src/components/ReviewPanel.tsx
+++ b/webview/src/components/ReviewPanel.tsx
@@ -4,7 +4,6 @@ import type { ReviewChange, ReviewChangeActor, ReviewHunkState } from "../protoc
 import {
   basename,
   isTextReviewChange,
-  normalizePath,
   reviewKey,
   samePath,
   turnChanges,

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -21,7 +21,6 @@ import type {
   ReviewHunkState,
   Selection,
   ToolUpdate,
-  UsageDelta,
 } from "../protocol"
 
 export type Block = ChatBlock

--- a/webview/tsconfig.json
+++ b/webview/tsconfig.json
@@ -6,6 +6,8 @@
     "moduleResolution": "Bundler",
     "jsx": "react-jsx",
     "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "skipLibCheck": true,
     "noEmit": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary

- Add a `Type-check (webview)` step to CI (installs webview deps, runs `bunx tsc --noEmit`) — the webview tree was never type-checked in CI.
- Enable `noUnusedLocals` + `noUnusedParameters` in both `tsconfig.json` and `webview/tsconfig.json`.
- Fix the exactly-seven dead symbols the flags surface:
  - `fs-ops.ts`: drop `reportUnsupported`'s unused `p` parameter (three call sites updated; the reason string already embeds the path).
  - `inline/edit.ts`: drop the unused `left`/`right` bindings (the awaited `openTextDocument` calls stay — materializing the untitled docs is what matters).
  - `status.ts`: `prefs` becomes a plain constructor parameter instead of an unread class property.
  - `PromptBox.tsx` + `App.tsx`: remove the `onOpenConversation` prop — declared, destructured, and passed from both App composers, but never read inside PromptBox (StatusBar's own `onOpenConversation` is unrelated and untouched).
  - `ReviewPanel.tsx`: drop unused `normalizePath` import.
  - `useChatState.ts`: drop unused `UsageDelta` type import.

## Test plan

- [x] `bun run check-types` — clean with the new flags.
- [x] `cd webview && bunx tsc --noEmit` — clean with the new flags.
- [x] `bun run test` — 77 files / 1155 tests pass.
- [x] `bun run compile` — production build succeeds.
- [ ] CI on this PR runs the new webview type-check step (visible in the job log).

Closes #437