### PR TITLE
chore(build): watch the webview alongside the host in bun run watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
   },
   "scripts": {
     "compile": "bun run build:webview && node esbuild.js",
-    "watch": "bun run build:webview && node esbuild.js --watch",
+    "watch": "node scripts/watch.mjs",
     "package": "bun run build:webview && node esbuild.js --production",
     "build:webview": "cd webview && bun install --frozen-lockfile --silent && bun run build",
     "check-types": "tsc --noEmit",

--- a/scripts/watch.mjs
+++ b/scripts/watch.mjs
@@ -1,0 +1,41 @@
+/**
+ * Dev watcher for `bun run watch`: runs the vite webview build and the
+ * esbuild host bundle in watch mode side by side and tears both down
+ * together. The script used to build the webview once and then only watch
+ * the host, so webview edits silently never reached dist/ until the next
+ * full compile.
+ */
+import { spawn, spawnSync } from "node:child_process"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+const webviewDir = path.join(root, "webview")
+
+const install = spawnSync("bun", ["install", "--frozen-lockfile", "--silent"], {
+  cwd: webviewDir,
+  stdio: "inherit",
+})
+if (install.status !== 0) process.exit(install.status ?? 1)
+
+const children = [
+  spawn("bun", ["run", "watch"], { cwd: webviewDir, stdio: "inherit" }),
+  spawn(process.execPath, [path.join(root, "esbuild.js"), "--watch"], { cwd: root, stdio: "inherit" }),
+]
+
+let exiting = false
+function shutdown(code) {
+  if (exiting) return
+  exiting = true
+  process.exitCode = code
+  for (const child of children) child.kill("SIGTERM")
+}
+
+// Either watcher dying takes the other down with it — a half-alive watch
+// (host rebuilding, webview frozen) looks exactly like the bug this script
+// replaces.
+for (const child of children) {
+  child.on("exit", (code) => shutdown(code ?? 0))
+}
+process.on("SIGINT", () => shutdown(0))
+process.on("SIGTERM", () => shutdown(0))

--- a/webview/package.json
+++ b/webview/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
+    "watch": "vite build --watch",
     "dev": "vite"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- `bun run watch` previously ran `build:webview` once and then only `esbuild.js --watch`, so webview edits never reached `dist/webview/index.html` until the next manual compile.
- New `scripts/watch.mjs` installs webview deps, then runs `vite build --watch` (via a new `watch` script in `webview/package.json`) and `node esbuild.js --watch` side by side with inherited stdio.
- Teardown is symmetric: SIGINT/SIGTERM kills both watchers, and either watcher exiting takes the other down — a half-alive watch would reproduce the original bug.

## Test plan

Scripted end-to-end run of `bun run watch` (log-marker + mtime assertions):

- [x] Phase 1 — both initial builds complete (vite `built in` + esbuild `[watch] build finished`).
- [x] Phase 2 — touching `webview/src/App.tsx` triggers a vite rebuild (build count 1 -> 2, `dist/webview/index.html` mtime advances).
- [x] Phase 3 — touching `src/extension.ts` triggers an esbuild rebuild (`[watch] build started (change: "src/extension.ts")` -> `build finished`).
- [x] Phase 4 — SIGINT tears down cleanly; zero leftover vite/esbuild processes.
- [x] `bun run test` passes; host and webview tsc clean.

Closes #439