### PR TITLE
perf(chat): store attachment bytes on disk instead of workspaceState

### DIFF
--- a/src/chat/attachment-store.ts
+++ b/src/chat/attachment-store.ts
@@ -1,0 +1,84 @@
+import * as vscode from "vscode"
+import { log } from "../output"
+
+/**
+ * Decode a `data:<mime>;base64,...` URL into raw bytes. Returns undefined for
+ * non-base64 or malformed data URLs so callers can fall back to persisting the
+ * string as-is rather than corrupting the payload.
+ */
+export function dataUrlToBytes(dataUrl: string): Uint8Array | undefined {
+  const comma = dataUrl.indexOf(",")
+  if (comma === -1 || !dataUrl.slice(0, comma).includes(";base64")) return undefined
+  try {
+    return new Uint8Array(Buffer.from(dataUrl.slice(comma + 1), "base64"))
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Disk home for attachment payloads (`<storage>/attachments/<storageID>`).
+ * Conversation state keeps only the storageID; the bytes live here exactly
+ * once, so the 300 ms persist loop never re-serializes megabytes of base64
+ * into workspaceState.
+ *
+ * All methods are best-effort: a missing storage root (no workspace) or a
+ * failed write returns undefined and the caller keeps the legacy inline
+ * dataUrl behavior instead of losing the attachment.
+ */
+export class AttachmentStore {
+  private readonly dir?: vscode.Uri
+  private ensuredDir = false
+
+  constructor(base: vscode.Uri | undefined) {
+    this.dir = base ? vscode.Uri.joinPath(base, "attachments") : undefined
+  }
+
+  /**
+   * Resolve a storageID to its file Uri. IDs are validated against the
+   * generated shape so a corrupted/hostile persisted value can never path-
+   * traverse out of the attachments directory.
+   */
+  uriFor(storageID: string): vscode.Uri | undefined {
+    if (!this.dir || !/^[A-Za-z0-9_-]+$/.test(storageID)) return undefined
+    return vscode.Uri.joinPath(this.dir, storageID)
+  }
+
+  async save(bytes: Uint8Array): Promise<string | undefined> {
+    if (!this.dir) return undefined
+    const storageID = `att_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`
+    const uri = this.uriFor(storageID)
+    if (!uri) return undefined
+    try {
+      if (!this.ensuredDir) {
+        await vscode.workspace.fs.createDirectory(this.dir)
+        this.ensuredDir = true
+      }
+      await vscode.workspace.fs.writeFile(uri, bytes)
+      return storageID
+    } catch (e) {
+      log("attachment store: write failed", e)
+      return undefined
+    }
+  }
+
+  async read(storageID: string): Promise<Uint8Array | undefined> {
+    const uri = this.uriFor(storageID)
+    if (!uri) return undefined
+    try {
+      return await vscode.workspace.fs.readFile(uri)
+    } catch {
+      return undefined
+    }
+  }
+
+  async delete(storageID: string): Promise<void> {
+    const uri = this.uriFor(storageID)
+    if (!uri) return
+    try {
+      await vscode.workspace.fs.delete(uri)
+    } catch {
+      // Already gone (or storage unavailable) — GC is best-effort.
+    }
+  }
+}

--- a/src/chat/conversation-manager.ts
+++ b/src/chat/conversation-manager.ts
@@ -3,9 +3,12 @@ import type { ChatMessage, ConversationSummary, ReviewHunkState } from "../proto
 import {
   ACTIVE_CONVERSATION_KEY,
   CONVERSATIONS_KEY,
+  attachmentStorageIDs,
   normalizeConversationMentions,
+  stripAttachmentDataForPersist,
   type SavedConversation,
 } from "./conversation-store"
+import { dataUrlToBytes } from "./attachment-store"
 
 /**
  * The slice of ChatView state that gets stamped onto the active
@@ -200,8 +203,65 @@ export class ConversationManager {
   }
 
   async persist(): Promise<void> {
-    await this.context.workspaceState.update(CONVERSATIONS_KEY, this.conversations)
+    // Store-backed attachments persist as a storageID reference only; the
+    // inline base64 stays in memory for previews but never reaches
+    // workspaceState (it's what made streaming persists cost ~100 ms+).
+    await this.context.workspaceState.update(
+      CONVERSATIONS_KEY,
+      stripAttachmentDataForPersist(this.conversations),
+    )
     await this.context.workspaceState.update(ACTIVE_CONVERSATION_KEY, this.activeID)
+  }
+
+  /**
+   * One-shot legacy migration: move inline base64 attachments (persisted
+   * before the attachment store existed) onto disk via `save`, stamping the
+   * resulting storageID onto each block. The dataUrl is kept in memory —
+   * `persist()` strips it now that a storageID exists. Blocks whose save
+   * fails are left untouched and keep working the legacy way.
+   */
+  async migrateAttachments(save: (bytes: Uint8Array) => Promise<string | undefined>): Promise<boolean> {
+    let changed = false
+    const next: SavedConversation[] = []
+    for (const conversation of this.conversations) {
+      let conversationChanged = false
+      const messages: SavedConversation["messages"] = []
+      for (const message of conversation.messages) {
+        let messageChanged = false
+        const blocks = [...message.blocks]
+        for (let i = 0; i < blocks.length; i++) {
+          const block = blocks[i]!
+          if (block.type !== "attachment" || block.storageID || !block.dataUrl) continue
+          const bytes = dataUrlToBytes(block.dataUrl)
+          if (!bytes) continue
+          const storageID = await save(bytes)
+          if (!storageID) continue
+          blocks[i] = { ...block, storageID }
+          messageChanged = true
+        }
+        messages.push(messageChanged ? { ...message, blocks } : message)
+        if (messageChanged) conversationChanged = true
+      }
+      next.push(conversationChanged ? { ...conversation, messages } : conversation)
+      if (conversationChanged) changed = true
+    }
+    if (changed) this.conversations = next
+    return changed
+  }
+
+  /** Attachment-store references held by one conversation (delete-time GC). */
+  storageIDs(id: string): string[] {
+    const conversation = this.conversations.find((c) => c.id === id)
+    return conversation ? attachmentStorageIDs(conversation.messages) : []
+  }
+
+  /** Attachment-store references held by every remaining conversation. */
+  allStorageIDs(): Set<string> {
+    const ids = new Set<string>()
+    for (const conversation of this.conversations) {
+      for (const id of attachmentStorageIDs(conversation.messages)) ids.add(id)
+    }
+    return ids
   }
 
   /**

--- a/src/chat/conversation-store.ts
+++ b/src/chat/conversation-store.ts
@@ -48,6 +48,67 @@ function isConversationMention(value: unknown): value is ConversationMention {
 }
 
 /**
+ * Persistence-boundary strip: attachment blocks whose bytes live in the
+ * attachment store (they carry a `storageID`) lose their inline base64
+ * `dataUrl` copy before hitting workspaceState. In-memory and wire
+ * representations keep the dataUrl for previews; this only shapes what the
+ * 300 ms persist loop serializes. Legacy blocks without a storageID are left
+ * untouched — stripping them would lose the only copy of the bytes.
+ */
+export function stripAttachmentDataForPersist(conversations: SavedConversation[]): SavedConversation[] {
+  const stripBlock = (b: ChatMessage["blocks"][number]) =>
+    b.type === "attachment" && b.storageID && b.dataUrl ? { ...b, dataUrl: undefined } : b
+  const needsStrip = (m: ChatMessage) =>
+    m.blocks.some((b) => b.type === "attachment" && b.storageID && b.dataUrl)
+  return conversations.map((c) => {
+    if (!c.messages.some(needsStrip)) return c
+    return {
+      ...c,
+      messages: c.messages.map((m) => (needsStrip(m) ? { ...m, blocks: m.blocks.map(stripBlock) } : m)),
+    }
+  })
+}
+
+/** All attachment-store references inside a message list (GC bookkeeping). */
+export function attachmentStorageIDs(messages: ChatMessage[]): string[] {
+  const ids: string[] = []
+  for (const m of messages) {
+    for (const b of m.blocks) {
+      if (b.type === "attachment" && b.storageID) ids.push(b.storageID)
+    }
+  }
+  return ids
+}
+
+/**
+ * Copy freshly-minted storageIDs from a migrated copy of the active
+ * conversation onto the live message array, matching by message id + block
+ * position. Keeps ChatView's in-memory state in step with the manager after
+ * a legacy-attachment migration WITHOUT re-hydrating (which would clobber
+ * in-flight message state) and without writing the bytes a second time.
+ */
+export function adoptStorageIDs(live: ChatMessage[], migrated: ChatMessage[]): ChatMessage[] {
+  const byID = new Map(migrated.map((m) => [m.id, m]))
+  return live.map((m) => {
+    const source = byID.get(m.id)
+    if (!source) return m
+    let changed = false
+    const blocks = m.blocks.map((b, i) => {
+      const s = source.blocks[i]
+      if (
+        b.type === "attachment" && !b.storageID &&
+        s?.type === "attachment" && s.storageID
+      ) {
+        changed = true
+        return { ...b, storageID: s.storageID }
+      }
+      return b
+    })
+    return changed ? { ...m, blocks } : m
+  })
+}
+
+/**
  * One-shot copy of conversation data from the legacy global storage into the
  * current workspace's state. Runs once per workspace; subsequent activations
  * see the migrated data already in workspaceState and skip the copy.

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -12,7 +12,8 @@ import {
 } from "./stream"
 import { getEditorContext, formatContextHeader } from "../context"
 import { searchWorkspaceFiles, listWorkspaceDir } from "../file-search"
-import { pickAttachments } from "../attachments"
+import { pickAttachments, bytesToDataUrl } from "../attachments"
+import { AttachmentStore, dataUrlToBytes } from "./attachment-store"
 import { log } from "../output"
 import { getWorkspaceRoots, primaryWorkspaceRoot } from "../workspace-root"
 import type { WorkspaceInfo } from "../protocol"
@@ -33,7 +34,7 @@ import type {
 import { BUILTIN_COMMAND_NAMES, withBuiltinCommands } from "./builtin-commands"
 import { BuiltinRunners } from "./builtin-runners"
 import { readContextUsage } from "./context-usage"
-import { migrateConversationsToWorkspace } from "./conversation-store"
+import { adoptStorageIDs, migrateConversationsToWorkspace } from "./conversation-store"
 import { ConversationManager } from "./conversation-manager"
 import { ContinuationState, isContinuationToast } from "./continuation-state"
 import { sweepAbortTree, drainAbortTree } from "./abort-tree"
@@ -131,6 +132,8 @@ export class ChatView implements vscode.WebviewViewProvider {
    * on — both don't exist until we have a session to subscribe to.
    */
   private subagentTracker?: SubagentTracker
+  /** Disk home for attachment bytes; conversation state keeps references only. */
+  private attachmentStore: AttachmentStore
 
   constructor(
     private context: vscode.ExtensionContext,
@@ -146,6 +149,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     // logged (and the migration-done flag stays unset, retrying next launch).
     void migrateConversationsToWorkspace(context).catch((e) => log("migrateConversations failed", e))
     this.manager = new ConversationManager(context)
+    this.attachmentStore = new AttachmentStore(context.storageUri ?? context.globalStorageUri)
     this.subagentDispatch = new SubagentDispatch({
       taskStore: this.taskStore,
       getSessionID: () => this.sessionID,
@@ -398,6 +402,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.resetSessionState()
     this.manager.setActiveID(id)
     this.applyActiveSnapshot()
+    await this.inflateActiveAttachments()
     await this.manager.flushPersist()
     this.sendConversationState()
     this.post({ type: "contextUsage", usage: undefined })
@@ -413,6 +418,7 @@ export class ChatView implements vscode.WebviewViewProvider {
 
   private async deleteConversation(id: string) {
     const wasActive = this.manager.getActiveID() === id
+    const removedStorageIDs = this.manager.storageIDs(id)
     this.manager.remove(id)
     // Drop the deleted conversation's task history so the popover
     // doesn't carry forward rows the user can no longer trace back to
@@ -420,10 +426,19 @@ export class ChatView implements vscode.WebviewViewProvider {
     if (this.taskStore) {
       void this.taskStore.clearForConversation(id)
     }
+    // GC attachment bytes nothing references anymore. Best-effort: a file
+    // that survives a failed delete is orphaned disk, not broken state.
+    if (removedStorageIDs.length) {
+      const remaining = this.manager.allStorageIDs()
+      for (const storageID of removedStorageIDs) {
+        if (!remaining.has(storageID)) void this.attachmentStore.delete(storageID)
+      }
+    }
     if (wasActive) {
       this.resetSessionState()
       this.manager.setActiveID(this.manager.summaries()[0]!.id)
       this.applyActiveSnapshot()
+      await this.inflateActiveAttachments()
       await this.manager.flushPersist()
       this.sendConversationState()
       this.post({ type: "contextUsage", usage: undefined })
@@ -441,6 +456,110 @@ export class ChatView implements vscode.WebviewViewProvider {
       reviewHunks: this.reviewHunks,
     })
     this.manager.schedulePersist()
+  }
+
+  /**
+   * One-shot per mount: move legacy inline-base64 attachments into the
+   * attachment store (so `persist()` can strip them) and re-inflate image
+   * previews for storage-backed blocks. Runs before the restore post so the
+   * webview's first paint has its thumbnails. Idempotent — after the first
+   * migration there are no legacy blocks left, and inflation skips blocks
+   * that already carry a dataUrl.
+   */
+  private async prepareStoredAttachments() {
+    try {
+      const migrated = await this.manager.migrateAttachments((bytes) => this.attachmentStore.save(bytes))
+      if (migrated) {
+        const active = this.manager.getMessages(this.manager.getActiveID()) ?? []
+        this.messages = adoptStorageIDs(this.messages, active)
+        this.saveActive()
+      }
+      await this.inflateActiveAttachments()
+    } catch (e) {
+      log("attachment migration/inflation failed", e)
+    }
+  }
+
+  /**
+   * Storage-backed image blocks persist without their base64 copy; the
+   * webview's `<img>` previews need it back after a restore. Non-images
+   * render as filename chips and never need bytes, so only image/* blocks
+   * are read. Missing/empty files leave the block as-is (the thumbnail
+   * falls back to a file icon).
+   */
+  private async inflateActiveAttachments() {
+    const needsInflate = (b: ChatBlock) =>
+      b.type === "attachment" && Boolean(b.storageID) && !b.dataUrl && b.mime.startsWith("image/")
+    let changed = false
+    const messages = await Promise.all(
+      this.messages.map(async (m) => {
+        if (!m.blocks.some(needsInflate)) return m
+        const blocks = await Promise.all(
+          m.blocks.map(async (b) => {
+            if (!needsInflate(b) || b.type !== "attachment") return b
+            const bytes = await this.attachmentStore.read(b.storageID!)
+            if (!bytes || bytes.byteLength === 0) return b
+            changed = true
+            return { ...b, dataUrl: bytesToDataUrl(b.mime, bytes) }
+          }),
+        )
+        return { ...m, blocks }
+      }),
+    )
+    if (changed) this.messages = messages
+  }
+
+  /**
+   * Write new attachment bytes into the attachment store and patch the
+   * just-posted user message's blocks with the resulting storageIDs so the
+   * persist layer can strip the inline base64. Attachments already carrying
+   * a storageID (edit/retry resends) are reused without rewriting; a failed
+   * save falls back to legacy inline persistence for that attachment.
+   */
+  private async stashAttachments(
+    messageID: string,
+    attachments?: Attachment[],
+  ): Promise<Attachment[] | undefined> {
+    if (!attachments?.length) return attachments
+    const stored = await Promise.all(
+      attachments.map(async (a) => {
+        if (a.storageID || !a.dataUrl) return a
+        const bytes = dataUrlToBytes(a.dataUrl)
+        if (!bytes) return a
+        const storageID = await this.attachmentStore.save(bytes)
+        return storageID ? { ...a, storageID } : a
+      }),
+    )
+    if (stored.some((a, i) => a !== attachments[i])) {
+      this.messages = this.messages.map((m) => {
+        if (m.id !== messageID) return m
+        // applyLocal built the attachment blocks in `attachments` order
+        // (before the text block), so a running index maps block -> source.
+        let idx = 0
+        return {
+          ...m,
+          blocks: m.blocks.map((b) =>
+            b.type === "attachment" ? { ...b, storageID: stored[idx++]?.storageID ?? b.storageID } : b,
+          ),
+        }
+      })
+      this.saveActive()
+    }
+    return stored
+  }
+
+  /**
+   * Resolve the URL opencode receives for an attachment file part:
+   * the original on-disk file when we still know it, else our stored copy,
+   * else the inline data URL (legacy conversations only).
+   */
+  private attachmentPartUrl(a: Attachment): string | undefined {
+    if (a.sourcePath) return vscode.Uri.file(a.sourcePath).toString()
+    if (a.storageID) {
+      const uri = this.attachmentStore.uriFor(a.storageID)
+      if (uri) return uri.toString()
+    }
+    return a.dataUrl
   }
 
   private updateTitleFromPrompt(text: string) {
@@ -471,6 +590,7 @@ export class ChatView implements vscode.WebviewViewProvider {
               filename: a.filename,
               dataUrl: a.dataUrl,
               bytes: a.bytes,
+              storageID: a.storageID,
             })
           }
         }
@@ -671,6 +791,7 @@ export class ChatView implements vscode.WebviewViewProvider {
           connected: false,
           selection: this.buildSelection(),
         })
+        await this.prepareStoredAttachments()
         this.sendConversationState()
         this.pushContext()
         this.pushWorkspace()
@@ -1023,6 +1144,10 @@ export class ChatView implements vscode.WebviewViewProvider {
       conversationMentions: conversationMentions?.length ? conversationMentions : undefined,
     })
     this.updateTitleFromPrompt(text)
+    // After the optimistic bubble post (attachment writes must not delay the
+    // user's message appearing) but before the prompt parts are built, which
+    // prefer the stored copy over inline base64.
+    const storedAttachments = await this.stashAttachments(userMessageID, attachments)
 
     let backend: Backend
     try {
@@ -1157,13 +1282,13 @@ export class ChatView implements vscode.WebviewViewProvider {
       this.post({ type: "userMessageContext", id: userMessageID, context: manifest })
     }
     const parts: Array<Record<string, unknown>> = []
-    if (attachments) {
-      for (const a of attachments) {
-        // Prefer the file:// URL of the actual file on disk so opencode can
-        // read it directly (works regardless of whether the file lives in the
-        // workspace). Falls back to the inline data URL for restored
-        // attachments where the source path is no longer available.
-        const url = a.sourcePath ? vscode.Uri.file(a.sourcePath).toString() : a.dataUrl
+    if (storedAttachments) {
+      for (const a of storedAttachments) {
+        const url = this.attachmentPartUrl(a)
+        if (!url) {
+          log("attachment has no resolvable source, skipping part", a.filename)
+          continue
+        }
         parts.push({
           type: "file",
           mime: a.mime,

--- a/test/host/attachment-store.test.ts
+++ b/test/host/attachment-store.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest"
+import * as vscode from "vscode"
+import { AttachmentStore, dataUrlToBytes } from "../../src/chat/attachment-store"
+import {
+  adoptStorageIDs,
+  attachmentStorageIDs,
+  stripAttachmentDataForPersist,
+  type SavedConversation,
+} from "../../src/chat/conversation-store"
+import type { ChatMessage } from "../../src/protocol"
+
+const fsFiles = (vscode as unknown as { __fsFiles: Map<string, Uint8Array> }).__fsFiles
+
+describe("dataUrlToBytes", () => {
+  it("round-trips base64 payloads", () => {
+    const bytes = new Uint8Array([1, 2, 250, 0, 7])
+    const dataUrl = `data:image/png;base64,${Buffer.from(bytes).toString("base64")}`
+    expect(dataUrlToBytes(dataUrl)).toEqual(bytes)
+  })
+
+  it("rejects non-base64 and malformed data URLs", () => {
+    expect(dataUrlToBytes("data:text/plain,hello")).toBeUndefined()
+    expect(dataUrlToBytes("not a data url")).toBeUndefined()
+  })
+})
+
+describe("AttachmentStore", () => {
+  it("saves bytes under the attachments dir and reads them back", async () => {
+    const store = new AttachmentStore(vscode.Uri.file("/store-base"))
+    const bytes = new Uint8Array([9, 8, 7])
+    const storageID = await store.save(bytes)
+    expect(storageID).toMatch(/^att_/)
+    expect(fsFiles.get(`file:///store-base/attachments/${storageID}`)).toEqual(bytes)
+    expect(await store.read(storageID!)).toEqual(bytes)
+    await store.delete(storageID!)
+    expect(fsFiles.has(`file:///store-base/attachments/${storageID}`)).toBe(false)
+  })
+
+  it("is a no-op without a storage root", async () => {
+    const store = new AttachmentStore(undefined)
+    expect(await store.save(new Uint8Array([1]))).toBeUndefined()
+    expect(store.uriFor("att_x")).toBeUndefined()
+  })
+
+  it("refuses storageIDs that could escape the attachments dir", () => {
+    const store = new AttachmentStore(vscode.Uri.file("/store-base"))
+    expect(store.uriFor("../evil")).toBeUndefined()
+    expect(store.uriFor("a/b")).toBeUndefined()
+    expect(store.uriFor("att_ok-1_x")).toBeDefined()
+  })
+})
+
+function conv(messages: ChatMessage[]): SavedConversation {
+  return { id: "c1", title: "t", createdAt: 1, updatedAt: 1, messages }
+}
+
+function attachmentMessage(block: Record<string, unknown>): ChatMessage {
+  return {
+    id: "u1",
+    role: "user",
+    blocks: [
+      { type: "attachment", mime: "image/png", filename: "a.png", bytes: 3, ...block },
+      { type: "text", text: "hi" },
+    ],
+  } as ChatMessage
+}
+
+describe("stripAttachmentDataForPersist", () => {
+  it("drops dataUrl only when a storageID references the bytes", () => {
+    const stored = attachmentMessage({ dataUrl: "data:image/png;base64,AAAA", storageID: "att_1" })
+    const legacy = { ...attachmentMessage({ dataUrl: "data:image/png;base64,BBBB" }), id: "u2" }
+    const [stripped] = stripAttachmentDataForPersist([conv([stored, legacy])])
+    const [strippedStored, strippedLegacy] = stripped!.messages
+    expect(strippedStored!.blocks[0]).toMatchObject({ storageID: "att_1", dataUrl: undefined })
+    expect(strippedLegacy!.blocks[0]).toMatchObject({ dataUrl: "data:image/png;base64,BBBB" })
+  })
+
+  it("returns the same conversation object when nothing needs stripping", () => {
+    const c = conv([attachmentMessage({ storageID: "att_1" })])
+    const [out] = stripAttachmentDataForPersist([c])
+    expect(out).toBe(c)
+  })
+})
+
+describe("attachmentStorageIDs / adoptStorageIDs", () => {
+  it("collects every storage reference in a message list", () => {
+    const messages = [
+      attachmentMessage({ storageID: "att_a" }),
+      { ...attachmentMessage({}), id: "u2" },
+      { ...attachmentMessage({ storageID: "att_b" }), id: "u3" },
+    ]
+    expect(attachmentStorageIDs(messages)).toEqual(["att_a", "att_b"])
+  })
+
+  it("copies freshly-minted storageIDs onto the live copy by id + position", () => {
+    const live = [attachmentMessage({ dataUrl: "data:image/png;base64,AAAA" })]
+    const migrated = [attachmentMessage({ dataUrl: "data:image/png;base64,AAAA", storageID: "att_new" })]
+    const adopted = adoptStorageIDs(live, migrated)
+    expect(adopted[0]!.blocks[0]).toMatchObject({ storageID: "att_new", dataUrl: "data:image/png;base64,AAAA" })
+    // Messages the migration never touched keep their identity.
+    const untouched = adoptStorageIDs(live, [{ ...attachmentMessage({}), id: "other" }])
+    expect(untouched[0]).toBe(live[0])
+  })
+})

--- a/test/host/chatview-harness.test.ts
+++ b/test/host/chatview-harness.test.ts
@@ -3,7 +3,11 @@ import * as vscode from "vscode"
 import { createOpencodeClient } from "@opencode-ai/sdk"
 import { startMockOpencode, type MockOpencodeServer } from "./mock-opencode-server"
 import { ChatView } from "../../src/chat/view"
-import { CONVERSATIONS_KEY, type SavedConversation } from "../../src/chat/conversation-store"
+import {
+  ACTIVE_CONVERSATION_KEY,
+  CONVERSATIONS_KEY,
+  type SavedConversation,
+} from "../../src/chat/conversation-store"
 import { AgentTaskStore } from "../../src/agents/task-store"
 import type { Backend, ServerManager } from "../../src/server"
 import type { Preferences } from "../../src/preferences"
@@ -114,6 +118,7 @@ beforeEach(async () => {
     workspaceState,
     globalState: makeMemento(),
     extensionUri: vscode.Uri.file("/ext"),
+    storageUri: vscode.Uri.file("/storage"),
     subscriptions: [],
   } as unknown as vscode.ExtensionContext
 
@@ -458,5 +463,163 @@ describe("ChatView harness: compaction summary turns", () => {
     expect(assistant.role).toBe("assistant")
     expect(assistant.summary).toBe(true)
     expect(assistant.pending).toBe(false)
+  })
+})
+
+describe("ChatView harness: attachment storage", () => {
+  const fsFiles = (vscode as unknown as { __fsFiles: Map<string, Uint8Array> }).__fsFiles
+  const PNG_BYTES = new Uint8Array([137, 80, 78, 71])
+  const PNG_B64 = Buffer.from(PNG_BYTES).toString("base64")
+
+  /**
+   * A ChatView over a pre-seeded workspaceState — the beforeEach harness
+   * constructs before a test can seed, so restore/migration flows need
+   * their own instance. Uses a per-test storage root to keep the shared
+   * fs map from cross-contaminating tests.
+   */
+  async function freshChatView(seed: SavedConversation[], storageBase: string) {
+    const workspaceState = makeMemento()
+    await workspaceState.update(CONVERSATIONS_KEY, seed)
+    await workspaceState.update(ACTIVE_CONVERSATION_KEY, seed[0]!.id)
+    const context = {
+      workspaceState,
+      globalState: makeMemento(),
+      extensionUri: vscode.Uri.file("/ext"),
+      storageUri: vscode.Uri.file(storageBase),
+      subscriptions: [],
+    } as unknown as vscode.ExtensionContext
+    const prefs = { get: () => ({}), onChange: vi.fn(() => ({ dispose: vi.fn() })) } as unknown as Preferences
+    const indexManager = {
+      onStatusChange: vi.fn(() => ({ dispose: vi.fn() })),
+      currentStatus: vi.fn(() => ({ state: "disabled" })),
+      start: vi.fn(),
+      stop: vi.fn(),
+    } as unknown as IndexManager
+    const chatView = new ChatView(
+      context,
+      harness.servers,
+      prefs,
+      {} as RecentEditsTracker,
+      indexManager,
+      new AgentTaskStore(makeMemento() as unknown as vscode.Memento),
+    )
+    const fake = makeFakeWebviewView()
+    await chatView.resolveWebviewView(fake.view)
+    return { chatView, posted: fake.posted, send: fake.send, disposeView: fake.disposeView, workspaceState }
+  }
+
+  function seededConversation(blocks: SavedConversation["messages"][number]["blocks"]): SavedConversation {
+    return {
+      id: "conv_seed",
+      title: "seeded",
+      createdAt: 1,
+      updatedAt: 1,
+      messages: [{ id: "u_seed", role: "user", blocks }],
+    }
+  }
+
+  it("stores sent attachment bytes on disk, strips them from workspaceState, and points the prompt at the file", async () => {
+    // fsFiles is shared across the file's tests; diff keys instead of
+    // grabbing the first match so leftovers from other tests can't leak in.
+    const preexisting = new Set(fsFiles.keys())
+    await harness.send({ type: "mounted" })
+    await harness.send({
+      type: "send",
+      text: "look at this screenshot",
+      attachments: [
+        // No sourcePath — the pasted-image case that used to ride as base64.
+        { id: "att_1", mime: "image/png", filename: "shot.png", dataUrl: `data:image/png;base64,${PNG_B64}`, bytes: PNG_BYTES.byteLength },
+      ],
+    })
+    await until(() => server.prompts.length === 1)
+
+    // The prompt part references the stored file, not an inline data URL.
+    const body = server.prompts[0]!.body as { parts: Array<{ type: string; url?: string }> }
+    const filePart = body.parts.find((p) => p.type === "file")!
+    expect(filePart.url).toMatch(/^file:\/\/\/storage\/attachments\/att_/)
+
+    // The bytes landed in the store exactly once.
+    const storedKey = [...fsFiles.keys()].find(
+      (k) => !preexisting.has(k) && k.startsWith("file:///storage/attachments/"),
+    )!
+    expect(fsFiles.get(storedKey)).toEqual(PNG_BYTES)
+
+    // The webview still received the preview data URL on the wire.
+    const posted = harness.posted.find((m) => m.type === "userMessage")!
+    expect("attachments" in posted && posted.attachments?.[0]?.dataUrl).toContain("base64")
+
+    // Persistence carries the reference, never the base64.
+    await harness.chatView.flushPersist()
+    const active = savedConversations().find((c) => c.messages.length > 0)!
+    const block = active.messages[0]!.blocks[0]!
+    expect(block).toMatchObject({ type: "attachment", storageID: expect.stringMatching(/^att_/) })
+    expect((block as { dataUrl?: string }).dataUrl).toBeUndefined()
+  })
+
+  it("re-inflates image previews from the store when restoring a conversation", async () => {
+    fsFiles.set("file:///storeB/attachments/attseed1", PNG_BYTES)
+    const fresh = await freshChatView(
+      [seededConversation([
+        { type: "attachment", mime: "image/png", filename: "pic.png", bytes: PNG_BYTES.byteLength, storageID: "attseed1" },
+        { type: "text", text: "restored" },
+      ])],
+      "/storeB",
+    )
+    await fresh.send({ type: "mounted" })
+    const restore = fresh.posted.find((m) => m.type === "restore")!
+    const block = ("messages" in restore ? restore.messages : [])[0]!.blocks[0]!
+    expect(block).toMatchObject({ type: "attachment", dataUrl: `data:image/png;base64,${PNG_B64}` })
+    fresh.disposeView()
+  })
+
+  it("migrates legacy inline attachments to the store on mount", async () => {
+    const fresh = await freshChatView(
+      [seededConversation([
+        { type: "attachment", mime: "application/pdf", filename: "doc.pdf", bytes: PNG_BYTES.byteLength, dataUrl: `data:application/pdf;base64,${PNG_B64}` },
+        { type: "text", text: "legacy" },
+      ])],
+      "/storeC",
+    )
+    await fresh.send({ type: "mounted" })
+
+    // In-memory (and the restore post) keeps the dataUrl for this session,
+    // but gains the storage reference.
+    const restore = fresh.posted.find((m) => m.type === "restore")!
+    const restored = ("messages" in restore ? restore.messages : [])[0]!.blocks[0]! as {
+      storageID?: string
+      dataUrl?: string
+    }
+    expect(restored.storageID).toMatch(/^att_/)
+    expect(restored.dataUrl).toContain("base64")
+
+    // Persisted state is stripped, and the bytes are on disk.
+    await fresh.chatView.flushPersist()
+    const persisted = (fresh.workspaceState.get(CONVERSATIONS_KEY) as SavedConversation[])[0]!
+    const block = persisted.messages[0]!.blocks[0]! as { storageID?: string; dataUrl?: string }
+    expect(block.storageID).toBe(restored.storageID)
+    expect(block.dataUrl).toBeUndefined()
+    expect(fsFiles.get(`file:///storeC/attachments/${restored.storageID}`)).toEqual(PNG_BYTES)
+    fresh.disposeView()
+  })
+
+  it("deletes now-unreferenced stored bytes when a conversation is deleted", async () => {
+    const preexisting = new Set(fsFiles.keys())
+    await harness.send({ type: "mounted" })
+    await harness.send({
+      type: "send",
+      text: "attach then delete",
+      attachments: [
+        { id: "att_1", mime: "image/png", filename: "shot.png", dataUrl: `data:image/png;base64,${PNG_B64}`, bytes: PNG_BYTES.byteLength },
+      ],
+    })
+    await until(() => server.prompts.length === 1)
+    const storedKey = [...fsFiles.keys()].find(
+      (k) => !preexisting.has(k) && k.startsWith("file:///storage/attachments/"),
+    )
+    expect(storedKey).toBeDefined()
+
+    const activeID = harness.workspaceState.get(ACTIVE_CONVERSATION_KEY) as string
+    await harness.send({ type: "deleteConversation", id: activeID })
+    await until(() => !fsFiles.has(storedKey!))
   })
 })

--- a/test/host/setup.ts
+++ b/test/host/setup.ts
@@ -5,6 +5,9 @@ import { vi } from "vitest"
 // helpers we test never call into the API surface — class field initializers
 // in ChatView do, but those only run on construction (not on import).
 vi.mock("vscode", () => {
+  // In-memory backing for workspace.fs so write/read/delete round-trip.
+  // Exposed on the stub as __fsFiles for test assertions/seeding.
+  const fsFiles = new Map<string, Uint8Array>()
   class Position {
     constructor(public line: number, public character: number) {}
   }
@@ -104,7 +107,17 @@ vi.mock("vscode", () => {
       }),
       fs: {
         stat: vi.fn().mockResolvedValue({}),
-        readFile: vi.fn().mockResolvedValue(new Uint8Array()),
+        // Map-backed so writeFile/readFile round-trip (attachment-store
+        // tests). Unknown paths keep the legacy empty-buffer default;
+        // per-test mockResolvedValueOnce overrides still win.
+        readFile: vi.fn(async (uri: Uri) => fsFiles.get(uri.toString()) ?? new Uint8Array()),
+        writeFile: vi.fn(async (uri: Uri, content: Uint8Array) => {
+          fsFiles.set(uri.toString(), content)
+        }),
+        createDirectory: vi.fn(async () => {}),
+        delete: vi.fn(async (uri: Uri) => {
+          fsFiles.delete(uri.toString())
+        }),
       },
       onDidChangeTextDocument: vi.fn(() => ({ dispose: vi.fn() })),
       onDidSaveTextDocument: vi.fn(() => ({ dispose: vi.fn() })),
@@ -176,6 +189,7 @@ vi.mock("vscode", () => {
       registerCodeLensProvider: vi.fn(() => ({ dispose: vi.fn() })),
       getDiagnostics: vi.fn(() => [] as Array<[Uri, unknown[]]>),
     },
+    __fsFiles: fsFiles,
     DiagnosticSeverity: { Error: 0, Warning: 1, Information: 2, Hint: 3 },
     SymbolKind: {
       File: 0, Module: 1, Namespace: 2, Package: 3, Class: 4, Method: 5,

--- a/test/webview/attachment-storage.test.tsx
+++ b/test/webview/attachment-storage.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, afterEach } from "vitest"
+import { render, screen, cleanup } from "@testing-library/react"
+import { reducer, initialChatState } from "../../webview/src/hooks/useChatState"
+import { ImageThumbnail } from "../../webview/src/components/ImageThumbnail"
+
+afterEach(cleanup)
+
+describe("reducer: storage-backed attachments", () => {
+  it("carries storageID onto the attachment block and tolerates a missing dataUrl", () => {
+    const state = reducer(initialChatState, {
+      type: "userMessage",
+      id: "u1",
+      text: "resend",
+      attachments: [
+        { id: "a1", mime: "application/pdf", filename: "doc.pdf", bytes: 10, storageID: "att_ref" },
+      ],
+    })
+    expect(state.messages[0]!.blocks[0]).toMatchObject({
+      type: "attachment",
+      filename: "doc.pdf",
+      storageID: "att_ref",
+      dataUrl: undefined,
+    })
+  })
+})
+
+describe("ImageThumbnail without a dataUrl", () => {
+  it("renders a file icon instead of a broken img", () => {
+    const { container } = render(
+      <ImageThumbnail
+        attachment={{ mime: "image/png", filename: "gone.png", bytes: 4 }}
+        onPreview={() => {}}
+      />,
+    )
+    expect(container.querySelector("img")).toBeNull()
+    expect(container.querySelector(".codicon-file-media")).not.toBeNull()
+    // The tile itself still renders with its filename tooltip.
+    expect(screen.getByLabelText("Preview gone.png")).toBeInTheDocument()
+  })
+
+  it("renders the img when a dataUrl is present", () => {
+    const { container } = render(
+      <ImageThumbnail
+        attachment={{ mime: "image/png", filename: "ok.png", bytes: 4, dataUrl: "data:image/png;base64,AAAA" }}
+        onPreview={() => {}}
+      />,
+    )
+    expect(container.querySelector("img")?.getAttribute("src")).toBe("data:image/png;base64,AAAA")
+  })
+})

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -141,6 +141,7 @@ export default function App() {
             filename: b.filename,
             dataUrl: b.dataUrl,
             bytes: b.bytes,
+            storageID: b.storageID,
           })
         }
       }

--- a/webview/src/components/ImageThumbnail.tsx
+++ b/webview/src/components/ImageThumbnail.tsx
@@ -39,7 +39,14 @@ export function ImageThumbnail({ attachment, onPreview, onRemove }: Props) {
           onPreview(attachment)
         }}
       >
-        <img src={attachment.dataUrl} alt="" />
+        {/* No dataUrl = storage-backed block whose bytes could not be
+            re-inflated (file missing). Show a generic media icon instead
+            of a broken <img>. */}
+        {attachment.dataUrl ? (
+          <img src={attachment.dataUrl} alt="" />
+        ) : (
+          <span className="codicon codicon-file-media" aria-hidden="true" />
+        )}
       </button>
       {onRemove && attachment.id && (
         <button

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -238,13 +238,14 @@ function UserMessageView({
   // Re-derive attachment labels (same algorithm PromptBox originally used) and
   // wrap each attachment block into the Attachment shape, including a synthetic
   // id and an undefined sourcePath (the original file path is lost after the
-  // first send — host falls back to the dataUrl for restored attachments).
+  // first send — host resolves restored attachments via storageID / dataUrl).
   const initialAttachments: Attachment[] = attachmentBlocks.map((block, i) => ({
     id: `att_${message.id}_${i}`,
     mime: block.mime,
     filename: block.filename,
     dataUrl: block.dataUrl,
     bytes: block.bytes,
+    storageID: block.storageID,
   }))
   const knownLabels: Set<string> = (() => {
     const existing = new Set<string>(message.mentions ?? [])
@@ -373,7 +374,7 @@ function UserMessageView({
         </>
       )}
       <ImagePreviewModal
-        src={previewImage ? { dataUrl: previewImage.dataUrl, filename: previewImage.filename } : null}
+        src={previewImage?.dataUrl ? { dataUrl: previewImage.dataUrl, filename: previewImage.filename } : null}
         onClose={() => setPreviewImage(null)}
       />
     </div>

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -700,7 +700,7 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
         </ul>
       )}
       <ImagePreviewModal
-        src={previewImage ? { dataUrl: previewImage.dataUrl, filename: previewImage.filename } : null}
+        src={previewImage?.dataUrl ? { dataUrl: previewImage.dataUrl, filename: previewImage.filename } : null}
         onClose={() => setPreviewImage(null)}
       />
       <div className="promptbox-input">

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -231,6 +231,7 @@ export function reducer(state: ChatState, action: Action): ChatState {
             filename: a.filename,
             dataUrl: a.dataUrl,
             bytes: a.bytes,
+            storageID: a.storageID,
           })
         }
       }

--- a/webview/src/protocol.ts
+++ b/webview/src/protocol.ts
@@ -82,7 +82,13 @@ export type ChatBlock =
    */
   | { type: "tool"; update: ToolUpdate; actor?: ReviewChangeActor }
   | { type: "patch"; files: string[]; diff?: string; actor?: ReviewChangeActor }
-  | { type: "attachment"; mime: string; filename: string; dataUrl: string; bytes: number }
+  /**
+   * `dataUrl` is transient display data (image `<img>` previews): present on
+   * the wire and in memory, stripped from persistence whenever `storageID`
+   * points at the bytes in the host-side attachment store. Blocks persisted
+   * before the store existed carry `dataUrl` and no `storageID`.
+   */
+  | { type: "attachment"; mime: string; filename: string; dataUrl?: string; bytes: number; storageID?: string }
 
 export type ChatMessage = {
   id: string
@@ -379,8 +385,12 @@ export type Attachment = {
   id: string
   mime: string
   filename: string
-  /** `data:<mime>;base64,...` — used for `<img src>` previews in the bubble. */
-  dataUrl: string
+  /**
+   * `data:<mime>;base64,...` — used for `<img src>` previews. Optional: an
+   * attachment rebuilt from a restored non-image block carries only its
+   * `storageID`; the host resolves the bytes from the attachment store.
+   */
+  dataUrl?: string
   /** Bytes of the underlying file (for size display + cap enforcement). */
   bytes: number
   /**
@@ -390,6 +400,8 @@ export type Attachment = {
    * conversations may not have it.
    */
   sourcePath?: string
+  /** Reference into the host-side attachment store (see the block doc above). */
+  storageID?: string
 }
 
 /** Messages sent from the extension host to the webview. */


### PR DESCRIPTION
## Summary

- New `AttachmentStore` (`src/chat/attachment-store.ts`): attachment bytes are written once to `<storage>/attachments/<storageID>` at send time; storageIDs are validated against the generated shape so persisted values can never path-traverse.
- `ConversationManager.persist()` strips the inline base64 `dataUrl` from any block that carries a `storageID` — workspaceState now holds references, not payloads. In-memory and wire copies keep the dataUrl so previews are unaffected.
- Restoring a conversation re-inflates `dataUrl` for image blocks from the store (non-images render as chips and never need bytes); a missing file falls back to a file icon instead of a broken `<img>`.
- Legacy conversations (inline base64, pre-store) migrate to the store once on mount; the live message array adopts the new storageIDs by id + block position so in-flight state is never re-hydrated.
- Prompt parts resolve `sourcePath` → stored file → legacy dataUrl, so pasted images (no source path) now reach opencode as a `file://` URL instead of inline base64. Edit/retry resends reuse the stored copy without rewriting.
- Deleting a conversation best-effort deletes its no-longer-referenced storage files.
- Every storage operation is fail-open: no storage root or a failed write keeps the legacy inline behavior for that attachment.

## Test plan

- [x] 16 new tests: `dataUrlToBytes` round-trip/rejects, store save/read/delete + traversal guard + no-root no-op, strip-only-when-referenced, storageID collection, adopt-by-position, and four ChatView harness flows (send → stored bytes + stripped persistence + `file://` prompt part; restore inflation; legacy migration; delete GC), plus webview reducer/thumbnail coverage.
- [x] Stash-run regression proof: with the new tests against the old source, only the new coverage fails — 1157/1157 pre-existing tests still pass.
- [x] Full suite: 79 files / 1171 tests pass.
- [x] Host and webview tsc clean; production build succeeds.

Closes #441