### PR TITLE
perf(chat): coalesce token deltas host-side and stop per-token SSE logging

### DIFF
--- a/src/chat/stream.ts
+++ b/src/chat/stream.ts
@@ -280,7 +280,9 @@ export function subscribeSession(
   })()
 
   function route(type: string, props: any) {
-    log(`[sse] ${type}`)
+    // Token deltas arrive per-token; logging each one puts an appendLine on
+    // the hottest path in the extension. Every other event type stays logged.
+    if (type !== "message.part.delta") log(`[sse] ${type}`)
     // First, fan child-session events off to the subagent tracker (if
     // any registered). We do this BEFORE the parent-session switch so
     // events for sessions in both sets (unlikely, but possible) are

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -322,6 +322,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.subscription?.abort()
     this.subscription = undefined
     this.aborting = false
+    this.clearPendingDeltas()
     this.taskStoreUnsub?.dispose()
     this.taskStoreUnsub = undefined
     // Write any debounced tail before the view (and its context) goes away,
@@ -341,8 +342,54 @@ export class ChatView implements vscode.WebviewViewProvider {
   }
 
   private post(msg: Outbound) {
+    // Any non-delta message flushes buffered deltas first so nothing (tool
+    // closures, sessionIdle, aborted…) can overtake text that arrived
+    // before it. flushDeltas() itself posts delta-typed messages, so this
+    // guard is also the recursion stop.
+    if (msg.type !== "textDelta" && msg.type !== "reasoningDelta") this.flushDeltas()
     this.applyLocal(msg)
     this.view?.webview.postMessage(msg)
+  }
+
+  /**
+   * Host-side token coalescing: streamed text/reasoning deltas buffer here
+   * for up to DELTA_FLUSH_MS and go out as one post per (kind, message)
+   * pair. Every delta used to cost its own webview IPC message plus an
+   * applyLocal pass (message-array rebuild + conversation snapshot); at fast
+   * token rates that work now happens ~40×/s instead of per token. The
+   * webview's own per-frame coalescer sits downstream, unchanged.
+   */
+  private pendingDeltas = new Map<string, { type: "textDelta" | "reasoningDelta"; id: string; delta: string }>()
+  private deltaFlushTimer?: ReturnType<typeof setTimeout>
+  private static readonly DELTA_FLUSH_MS = 25
+
+  private queueDelta(type: "textDelta" | "reasoningDelta", id: string, delta: string) {
+    const key = `${type}:${id}`
+    const pending = this.pendingDeltas.get(key)
+    if (pending) pending.delta += delta
+    else this.pendingDeltas.set(key, { type, id, delta })
+    this.deltaFlushTimer ??= setTimeout(() => this.flushDeltas(), ChatView.DELTA_FLUSH_MS)
+  }
+
+  private flushDeltas() {
+    if (this.deltaFlushTimer) {
+      clearTimeout(this.deltaFlushTimer)
+      this.deltaFlushTimer = undefined
+    }
+    if (!this.pendingDeltas.size) return
+    const batch = [...this.pendingDeltas.values()]
+    this.pendingDeltas.clear()
+    for (const d of batch) this.post({ type: d.type, id: d.id, delta: d.delta })
+  }
+
+  /** Drop (not flush) buffered deltas — for teardown paths where posting
+   *  them would leak stream content into a switched/disposed view. */
+  private clearPendingDeltas() {
+    if (this.deltaFlushTimer) {
+      clearTimeout(this.deltaFlushTimer)
+      this.deltaFlushTimer = undefined
+    }
+    this.pendingDeltas.clear()
   }
 
   private sendConversationState() {
@@ -391,6 +438,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.subscription = undefined
     this.aborting = false
     this.sessionID = undefined
+    this.clearPendingDeltas()
     this.messageMap.clear()
     this.redoStack = []
     this.activePermissions.clear()
@@ -1657,12 +1705,12 @@ export class ChatView implements vscode.WebviewViewProvider {
       onTextDelta: (mid, delta) => {
         if (this.aborting) return
         const webviewID = this.messageMap.get(mid) ?? this.ensureWebviewID(mid)
-        this.post({ type: "textDelta", id: webviewID, delta })
+        this.queueDelta("textDelta", webviewID, delta)
       },
       onReasoningDelta: (mid, delta) => {
         if (this.aborting) return
         const webviewID = this.messageMap.get(mid) ?? this.ensureWebviewID(mid)
-        this.post({ type: "reasoningDelta", id: webviewID, delta })
+        this.queueDelta("reasoningDelta", webviewID, delta)
       },
       onTool: (mid, update) => {
         // While aborting, drop in-flight churn but let TERMINAL closures

--- a/test/host/chatview-harness.test.ts
+++ b/test/host/chatview-harness.test.ts
@@ -8,6 +8,7 @@ import {
   CONVERSATIONS_KEY,
   type SavedConversation,
 } from "../../src/chat/conversation-store"
+import { getOutputChannel } from "../../src/output"
 import { AgentTaskStore } from "../../src/agents/task-store"
 import type { Backend, ServerManager } from "../../src/server"
 import type { Preferences } from "../../src/preferences"
@@ -621,5 +622,51 @@ describe("ChatView harness: attachment storage", () => {
     const activeID = harness.workspaceState.get(ACTIVE_CONVERSATION_KEY) as string
     await harness.send({ type: "deleteConversation", id: activeID })
     await until(() => !fsFiles.has(storedKey!))
+  })
+})
+
+describe("ChatView harness: host-side delta coalescing", () => {
+  it("batches token deltas into fewer posts, flushes before sessionIdle, and persists the full text", async () => {
+    await harness.send({ type: "mounted" })
+    await harness.send({ type: "send", text: "stream fast" })
+    server.push({ type: "message.updated", info: { id: "usr_1", role: "user", sessionID: SESSION_ID } })
+    for (const ch of ["a", "b", "c", "d", "e"]) {
+      server.push({ type: "message.part.delta", sessionID: SESSION_ID, messageID: "msg_a", partID: "p1", field: "text", delta: ch })
+    }
+    server.push({ type: "message.part.delta", sessionID: SESSION_ID, messageID: "msg_a", partID: "p2", field: "reasoning", delta: "R" })
+    server.push({ type: "session.idle", sessionID: SESSION_ID })
+    await until(() => harness.posted.some((m) => m.type === "sessionIdle"))
+
+    const textDeltas = harness.posted.filter((m) => m.type === "textDelta")
+    expect(textDeltas.map((d) => ("delta" in d ? d.delta : "")).join("")).toBe("abcde")
+    // Five tokens arrive inside one 25 ms window; the invariant that matters
+    // is "fewer posts than tokens", not an exact batch count.
+    expect(textDeltas.length).toBeLessThan(5)
+    const reasoningDeltas = harness.posted.filter((m) => m.type === "reasoningDelta")
+    expect(reasoningDeltas.map((d) => ("delta" in d ? d.delta : "")).join("")).toBe("R")
+
+    // sessionIdle flushed the buffer before itself — buffered text can never
+    // be overtaken by a later event.
+    const types = harness.posted.map((m) => m.type)
+    expect(types.lastIndexOf("textDelta")).toBeLessThan(types.indexOf("sessionIdle"))
+
+    await harness.chatView.flushPersist()
+    const [active] = savedConversations()
+    const assistant = active!.messages[1]!
+    expect(assistant.blocks).toContainEqual({ type: "text", text: "abcde" })
+  })
+
+  it("no longer logs a line per token delta", async () => {
+    const appendLine = getOutputChannel().appendLine as unknown as ReturnType<typeof vi.fn>
+    await harness.send({ type: "mounted" })
+    await harness.send({ type: "send", text: "quiet stream" })
+    appendLine.mockClear()
+    server.push({ type: "message.part.delta", sessionID: SESSION_ID, messageID: "msg_a", partID: "p1", field: "text", delta: "x" })
+    server.push({ type: "session.idle", sessionID: SESSION_ID })
+    await until(() => harness.posted.some((m) => m.type === "sessionIdle"))
+
+    const lines = appendLine.mock.calls.map((c) => String(c[0]))
+    expect(lines.some((l) => l.includes("[sse] message.part.delta"))).toBe(false)
+    expect(lines.some((l) => l.includes("[sse] session.idle"))).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary

- `stream.ts` no longer logs `[sse] message.part.delta` per token — a timestamped `appendLine` on the hottest path. Every other SSE event type keeps its log line.
- ChatView buffers text/reasoning deltas per (kind, message) pair and flushes them as one batched post every 25 ms, instead of one IPC message + one `applyLocal` pass (message-array rebuild + conversation snapshot) per token. At fast token rates the host-side work drops by roughly an order of magnitude; the webview's per-frame coalescer sits downstream unchanged.
- Ordering invariant: `post()` flushes buffered deltas before any non-delta message, so tool closures, `sessionIdle`, `aborted`, and `assistantDone` can never overtake text that arrived before them (the same guard doubles as the recursion stop for the flush's own posts).
- Conversation switch (`resetSessionState`) and dispose drop pending deltas instead of leaking them into the next view.

## Test plan

- [x] New harness test: six token deltas + a reasoning delta arrive as fewer batched posts with identical concatenated content, the last `textDelta` precedes `sessionIdle`, and the persisted turn carries the full text.
- [x] New harness test: no `[sse] message.part.delta` log line; other event types still logged.
- [x] Stash-run proof: on the old source exactly these 2 tests fail, 17/17 other harness tests pass.
- [x] Full suite: 79 files / 1173 tests pass (existing delta assertions are count-agnostic `join("")` checks).
- [x] Host + webview tsc clean; production build succeeds.

Closes #443