### PR TITLE
perf(webview): make useChatState's API identity-stable across renders

### DIFF
--- a/test/webview/stable-callbacks.test.ts
+++ b/test/webview/stable-callbacks.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import { useChatState } from "../../webview/src/hooks/useChatState"
+
+describe("useChatState callback stability", () => {
+  it("keeps every API method identity-stable across state updates", () => {
+    const { result } = renderHook(() => useChatState())
+    const before = { ...result.current }
+
+    // queueMessage dispatches, so the reducer produces new state and the
+    // component re-renders — the exact situation that used to mint fresh
+    // callbacks (and re-fire searchFiles/listDir effects downstream).
+    act(() => {
+      result.current.queueMessage("queued while busy")
+    })
+    expect(result.current.state.queued).toHaveLength(1)
+    expect(result.current.state).not.toBe(before.state)
+
+    for (const key of Object.keys(before) as Array<keyof typeof before>) {
+      if (key === "state") continue
+      expect(result.current[key], `${String(key)} changed identity across renders`).toBe(before[key])
+    }
+  })
+})

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -1,4 +1,4 @@
-import { useEffect, useReducer, useRef } from "react"
+import { useEffect, useMemo, useReducer, useRef } from "react"
 import { vscode } from "../vscode"
 import { createDeltaCoalescer } from "../delta-coalescer"
 import type {
@@ -480,8 +480,14 @@ export function useChatState() {
     return off
   }, [])
 
-  return {
-    state,
+  // Identity-stable API: everything captured below is render-stable (the
+  // vscode shim is a module singleton, dispatch never changes identity, the
+  // request/queue counters are refs). Without the memo, every state update —
+  // including every streaming frame — handed consumers fresh callbacks, and
+  // the ones sitting in effect deps (searchFiles in useMentionPicker, listDir
+  // in useFileBrowser) re-fired a host round-trip per render while open.
+  const api = useMemo(
+    () => ({
     send(text: string, mentions?: string[], attachments?: Attachment[], conversationMentions?: ConversationMention[]) {
       vscode.post({ type: "send", text, mentions, attachments, conversationMentions })
     },
@@ -585,5 +591,8 @@ export function useChatState() {
     stopIndex() {
       vscode.post({ type: "stopIndex" })
     },
-  }
+    }),
+    [],
+  )
+  return { state, ...api }
 }


### PR DESCRIPTION
## Summary

- Wrap `useChatState`'s returned method object in a single `useMemo(() => ({ ... }), [])`. Every capture is render-stable — the `vscode` shim is a module singleton, `dispatch` never changes identity, and the request/queue counters are refs — so the memo is safe and the methods keep exact previous behavior.
- Effect of the fix: `searchFiles`/`listDir` sit in the dependency arrays of `useMentionPicker`/`useFileBrowser`; with fresh identities every render, any state update (every coalesced streaming frame, queue changes, etc.) re-fired those effects while the @ picker or folder browser was open — one host round-trip per render, each result discarded as stale by the query guard. With stable identities the effects fire only when the query/folder actually changes.

## Test plan

- [x] New test renders the hook, forces a real state update (`queueMessage` → reducer → re-render), and asserts every returned method keeps its identity.
- [x] Stash-run proof: the test fails against the old source, passes with the memo.
- [x] Full suite: 80 files / 1172 tests pass; webview + host tsc clean; production build succeeds.

Closes #445