### PR TITLE
perf(webview): throttle streaming markdown and lazy-mount collapsed process bodies

### DIFF
--- a/test/webview/compaction-marker.test.tsx
+++ b/test/webview/compaction-marker.test.tsx
@@ -44,7 +44,10 @@ describe("MessageView: compaction marker", () => {
     expect(marker!.classList.contains("process")).toBe(true)
     expect(marker!.classList.contains("is-open")).toBe(false)
     expect(marker!.querySelector(".process-head")).not.toBeNull()
-    // The summary content stays available behind the disclosure.
+    // The body mounts lazily: nothing renders until the disclosure is
+    // first expanded, then the summary content is available.
+    expect(screen.queryByText("anchored summary body")).toBeNull()
+    fireEvent.click(marker!.querySelector<HTMLButtonElement>(".process-head")!)
     expect(screen.getByText("anchored summary body")).toBeInTheDocument()
     expect(container.querySelector(".msg.role-assistant")).toBeNull()
   })

--- a/test/webview/message-view.test.tsx
+++ b/test/webview/message-view.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest"
-import { render, screen, cleanup, waitFor } from "@testing-library/react"
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { MessageView } from "../../webview/src/components/MessageView"
 import type { Message } from "../../webview/src/hooks/useChatState"
@@ -338,7 +338,9 @@ describe("MessageView (assistant role)", () => {
     const { container } = render(<MessageView message={msg} processOpen={false} processOnly={false} />)
     const panel = container.querySelector(".process")
     expect(panel).not.toBeNull()
-    // The narration is folded into the panel (as its title/body), not promoted.
+    // The narration is folded into the panel (lazy body — expand to see it),
+    // not promoted to an answer.
+    fireEvent.click(panel!.querySelector<HTMLButtonElement>(".process-head")!)
     expect(panel?.textContent).toContain("Let me check the file")
     // No answer markdown is rendered as a sibling outside the panel.
     expect(container.querySelector(".msg.role-assistant > .md")).toBeNull()

--- a/test/webview/streaming-renders.test.tsx
+++ b/test/webview/streaming-renders.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, afterEach, vi } from "vitest"
+import { render, renderHook, screen, cleanup, fireEvent, act } from "@testing-library/react"
+import { MessageView } from "../../webview/src/components/MessageView"
+import { Markdown } from "../../webview/src/components/Markdown"
+import { useThrottledValue } from "../../webview/src/hooks/useThrottledValue"
+import type { Message } from "../../webview/src/hooks/useChatState"
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+describe("useThrottledValue", () => {
+  it("emits the leading value, skips intermediates, and lands the trailing value", () => {
+    vi.useFakeTimers()
+    const { result, rerender } = renderHook(({ v }) => useThrottledValue(v, 50), {
+      initialProps: { v: "a" },
+    })
+    expect(result.current).toBe("a")
+    rerender({ v: "ab" })
+    rerender({ v: "abc" })
+    expect(result.current).toBe("a")
+    act(() => {
+      vi.advanceTimersByTime(60)
+    })
+    expect(result.current).toBe("abc")
+  })
+
+  it("passes through instantly when ms is 0", () => {
+    const { result, rerender } = renderHook(({ v }) => useThrottledValue(v, 0), {
+      initialProps: { v: "x" },
+    })
+    rerender({ v: "y" })
+    expect(result.current).toBe("y")
+  })
+})
+
+describe("Markdown streaming throttle", () => {
+  it("samples streaming text at the throttle window and always lands the final text", () => {
+    vi.useFakeTimers()
+    const { container, rerender } = render(<Markdown text="hello" streaming />)
+    expect(container.textContent).toContain("hello")
+    rerender(<Markdown text="hello world" streaming />)
+    // Mid-window: the parse still shows the sampled text.
+    expect(container.textContent).not.toContain("world")
+    act(() => {
+      vi.advanceTimersByTime(60)
+    })
+    expect(container.textContent).toContain("world")
+  })
+
+  it("renders settled (non-streaming) text updates immediately", () => {
+    const { container, rerender } = render(<Markdown text="one" />)
+    rerender(<Markdown text="two" />)
+    expect(container.textContent).toContain("two")
+  })
+})
+
+describe("ProcessPanel lazy body", () => {
+  function toolMessage(): Message {
+    return {
+      id: "a1",
+      role: "assistant",
+      blocks: [
+        { type: "tool", update: { callID: "c1", tool: "read", status: "completed", input: { filePath: "src/foo.ts" } } },
+        { type: "text", text: "final answer text" },
+      ],
+    } as Message
+  }
+
+  it("mounts the collapsed body only after the first expand, then keeps it mounted", () => {
+    const { container } = render(<MessageView message={toolMessage()} processOpen={false} processOnly={false} />)
+    // The answer renders; the collapsed work panel's body is an empty shell.
+    expect(screen.getByText("final answer text")).toBeInTheDocument()
+    const body = container.querySelector(".process-body")!
+    expect(body.childNodes.length).toBe(0)
+
+    const head = container.querySelector<HTMLButtonElement>(".process-head")!
+    fireEvent.click(head)
+    expect(body.childNodes.length).toBeGreaterThan(0)
+
+    // Collapsing keeps the content mounted so the fold animation has
+    // something to clip.
+    fireEvent.click(head)
+    expect(container.querySelector(".process")!.classList.contains("is-open")).toBe(false)
+    expect(body.childNodes.length).toBeGreaterThan(0)
+  })
+})

--- a/webview/src/components/Markdown.tsx
+++ b/webview/src/components/Markdown.tsx
@@ -6,8 +6,16 @@ import remarkMath from "remark-math"
 import rehypeKatex from "rehype-katex"
 import "katex/dist/katex.min.css"
 import { CodeBlock } from "./CodeBlock"
+import { useThrottledValue } from "../hooks/useThrottledValue"
 
-type Props = { text: string }
+/**
+ * `streaming` marks text that is still growing (a pending message). The
+ * remark/rehype parse then samples the text at ~20 fps instead of re-running
+ * on every coalesced frame; settled messages stay pass-through.
+ */
+type Props = { text: string; streaming?: boolean }
+
+const STREAM_PARSE_MS = 50
 
 // Private Use Area code points — won't appear in normal text or LaTeX
 // source, so we use them as sentinels for the three-step rewrite below.
@@ -187,12 +195,13 @@ const katexOptions = { strict: "ignore", throwOnError: false } as const
 // the pipeline then escapes it correctly, exactly as before.
 const MATH_HINT = /\$|\\\(|\\\[/
 
-function MarkdownImpl({ text }: Props) {
+function MarkdownImpl({ text, streaming = false }: Props) {
+  const sampled = useThrottledValue(text, streaming ? STREAM_PARSE_MS : 0)
   const { source, hasMath } = useMemo(() => {
-    const enveloped = normalizeAgentEnvelopes(text)
+    const enveloped = normalizeAgentEnvelopes(sampled)
     const math = MATH_HINT.test(enveloped)
     return { source: math ? normalizeMath(enveloped) : enveloped, hasMath: math }
-  }, [text])
+  }, [sampled])
   return (
     <div className="md">
       <ReactMarkdown

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -448,15 +448,15 @@ function renderMessageBlocks(message: Message, processOpen: boolean, processOnly
 
   if (!answerHasText) {
     // Ends on activity/reasoning (or is empty) — no distinct answer to surface.
-    if (!hasProcessBlocks(message.blocks)) return renderBlocks(message.blocks, false, onReviewFile)
+    if (!hasProcessBlocks(message.blocks)) return renderBlocks(message.blocks, false, onReviewFile, pending)
     return <ProcessPanel blocks={message.blocks} pending={pending} openKey={`process-${message.id}-${message.blocks.length}`} defaultOpen={processOpen} onReviewFile={onReviewFile} />
   }
 
-  if (!hasProcessBlocks(process)) return renderBlocks(answer, false, onReviewFile)
+  if (!hasProcessBlocks(process)) return renderBlocks(answer, false, onReviewFile, pending)
   return (
     <>
       <ProcessPanel blocks={process} pending={false} openKey={`final-${message.id}-${start}`} defaultOpen={false} onReviewFile={onReviewFile} />
-      {renderBlocks(answer, false, onReviewFile)}
+      {renderBlocks(answer, false, onReviewFile, pending)}
     </>
   )
 }
@@ -475,23 +475,34 @@ function ProcessPanel({
   onReviewFile?: (path: string) => void
 }) {
   const [open, setOpen] = useState(defaultOpen)
+  // Lazy mount: nothing renders inside a never-opened body — a long
+  // transcript's collapsed tool traces and process text would otherwise all
+  // render invisibly. Once opened it stays mounted so the 0fr fold
+  // animation has content during collapse.
+  const [everOpened, setEverOpened] = useState(defaultOpen)
 
   useEffect(() => {
     setOpen(defaultOpen)
+    if (defaultOpen) setEverOpened(true)
   }, [defaultOpen, openKey])
+
+  const toggle = () => {
+    if (!open) setEverOpened(true)
+    setOpen(!open)
+  }
 
   const title = pending ? processTitle(blocks) : processSummary(blocks) ?? processTitle(blocks)
 
   return (
     <div className={`process ${open ? "is-open" : ""}`}>
-      <button className="process-head" onClick={() => setOpen(!open)} aria-expanded={open}>
+      <button className="process-head" onClick={toggle} aria-expanded={open}>
         <span className="process-title">{title}</span>
         <span className={`process-caret ${open ? "is-open" : ""}`}>›</span>
       </button>
-      {/* Body stays mounted; the grid wrapper clips it to 0fr when collapsed so
-          expand/collapse animates height instead of snapping. */}
+      {/* The clip wrapper stays mounted; the grid clips it to 0fr when
+          collapsed so expand/collapse animates height instead of snapping. */}
       <div className="process-body-clip">
-        <div className="process-body">{renderBlocks(blocks, true, onReviewFile)}</div>
+        <div className="process-body">{everOpened ? renderBlocks(blocks, true, onReviewFile, pending) : null}</div>
       </div>
     </div>
   )
@@ -506,21 +517,30 @@ function ProcessPanel({
  */
 function CompactionMarker({ message, onReviewFile }: { message: Message; onReviewFile?: (path: string) => void }) {
   const [open, setOpen] = useState(false)
+  // Same lazy-mount latch as ProcessPanel: the summary body only renders
+  // once the user first expands the marker.
+  const [everOpened, setEverOpened] = useState(false)
+  const toggle = () => {
+    if (!open) setEverOpened(true)
+    setOpen(!open)
+  }
   const label = message.pending ? "Compacting conversation…" : "Conversation compacted"
   return (
     <div className={`process compaction-marker ${open ? "is-open" : ""}`}>
-      <button className="process-head" onClick={() => setOpen(!open)} aria-expanded={open}>
+      <button className="process-head" onClick={toggle} aria-expanded={open}>
         <span className="process-title">{label}</span>
         <span className={`process-caret ${open ? "is-open" : ""}`}>›</span>
       </button>
       <div className="process-body-clip">
-        <div className="process-body">{renderBlocks(message.blocks, true, onReviewFile)}</div>
+        <div className="process-body">
+          {everOpened ? renderBlocks(message.blocks, true, onReviewFile, Boolean(message.pending)) : null}
+        </div>
       </div>
     </div>
   )
 }
 
-function renderBlocks(blocks: Block[], processMode = false, onReviewFile?: (path: string) => void) {
+function renderBlocks(blocks: Block[], processMode = false, onReviewFile?: (path: string) => void, streaming = false) {
   const nodes: ReactNode[] = []
   let tools: Extract<Block, { type: "tool" }>[] = []
   let patches: Extract<Block, { type: "patch" }>[] = []
@@ -569,7 +589,7 @@ function renderBlocks(blocks: Block[], processMode = false, onReviewFile?: (path
       // rendering, surface them as collapsible callouts.
       if (processMode) {
         const cleaned = stripInternalMarkers(b.text)
-        if (cleaned.trim()) nodes.push(<ProcessText key={i} text={cleaned} />)
+        if (cleaned.trim()) nodes.push(<ProcessText key={i} text={cleaned} streaming={streaming} />)
       } else {
         const segments = splitWithReminders(b.text)
         segments.forEach((seg, j) => {
@@ -577,7 +597,7 @@ function renderBlocks(blocks: Block[], processMode = false, onReviewFile?: (path
           if (seg.type === "reminder") {
             nodes.push(<SystemReminderCallout key={key} text={seg.content} />)
           } else {
-            nodes.push(<Markdown key={key} text={seg.content} />)
+            nodes.push(<Markdown key={key} text={seg.content} streaming={streaming} />)
           }
         })
       }
@@ -585,22 +605,22 @@ function renderBlocks(blocks: Block[], processMode = false, onReviewFile?: (path
     if (b.type === "reasoning") {
       const cleaned = stripInternalMarkers(b.text)
       if (!cleaned.trim()) return
-      nodes.push(<ProcessText key={i} text={cleaned} />)
+      nodes.push(<ProcessText key={i} text={cleaned} streaming={streaming} />)
     }
   })
   flushTrace()
   return nodes
 }
 
-function ProcessText({ text }: { text: string }) {
+function ProcessText({ text, streaming = false }: { text: string; streaming?: boolean }) {
   if (!text.trim()) return null
   const title = textTitle(text)
-  if (!title) return <div className="process-text"><Markdown text={text} /></div>
+  if (!title) return <div className="process-text"><Markdown text={text} streaming={streaming} /></div>
   const body = stripDuplicateTitle(text, title)
   return (
     <div className="process-text">
       <div className="process-text-title">{title}</div>
-      {body && <Markdown text={body} />}
+      {body && <Markdown text={body} streaming={streaming} />}
     </div>
   )
 }

--- a/webview/src/hooks/useThrottledValue.ts
+++ b/webview/src/hooks/useThrottledValue.ts
@@ -1,0 +1,45 @@
+import { useEffect, useRef, useState } from "react"
+
+/**
+ * Re-emit `value` at most once per `ms` (leading + trailing edge). `ms <= 0`
+ * is a plain pass-through. Used to sample a streaming message's text before
+ * the Markdown pipeline: parsing the whole growing text on every coalesced
+ * frame is the expensive part, and ~20 fps is indistinguishable in a chat
+ * bubble. The trailing emit guarantees the final text always lands even if
+ * the last delta arrives mid-window.
+ */
+export function useThrottledValue<T>(value: T, ms: number): T {
+  const [throttled, setThrottled] = useState(value)
+  const lastEmit = useRef(0)
+  const trailing = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  const latest = useRef(value)
+  latest.current = value
+
+  useEffect(() => {
+    if (ms <= 0) {
+      // Keep state in sync so a later switch to throttling starts current.
+      setThrottled(value)
+      return
+    }
+    const since = Date.now() - lastEmit.current
+    if (since >= ms) {
+      lastEmit.current = Date.now()
+      setThrottled(value)
+      return
+    }
+    trailing.current ??= setTimeout(() => {
+      trailing.current = undefined
+      lastEmit.current = Date.now()
+      setThrottled(latest.current)
+    }, ms - since)
+  }, [value, ms])
+
+  useEffect(
+    () => () => {
+      if (trailing.current) clearTimeout(trailing.current)
+    },
+    [],
+  )
+
+  return ms <= 0 ? value : throttled
+}


### PR DESCRIPTION
## Summary

- New `useThrottledValue` hook (leading + trailing, pass-through at `ms <= 0`). `Markdown` gains a `streaming` prop: a pending message's text is sampled at ~20 fps before the remark/rehype parse instead of re-parsing the full growing text every coalesced frame; the trailing emit guarantees the final text always renders. Settled messages keep instant pass-through.
- `streaming` is threaded through `renderBlocks`/`ProcessText` from the one place that knows it (`renderMessageBlocks`'s `message.pending`), so answer text, process text, and reasoning all get the sampled parse during streaming only.
- `ProcessPanel` and `CompactionMarker` bodies mount lazily: a never-expanded panel renders an empty shell (previously every collapsed tool trace and process text in the transcript rendered invisibly behind the 0fr clip). Once opened, the body stays mounted so the fold animation keeps its content. Same classes, same toggles, no interaction change.

## Test plan

- [x] New tests: throttle hook (leading/skip/trailing + ms=0 pass-through), Markdown streaming sampling (mid-window text withheld, final text lands), lazy body (empty until first expand, stays mounted after collapse).
- [x] Two existing tests updated for lazy bodies (compaction marker content, tool-panel narration) — both now expand before asserting content, same semantics.
- [x] Stash-run: old source fails the new expectations; everything else passes.
- [x] Full suite: 81 files / 1179 tests pass; both tsc trees clean; production build succeeds.

Closes #447