### PR TITLE
perf(webview): fine-grained shiki and woff2-only KaTeX fonts

### DIFF
--- a/test/webview/codeblock.test.tsx
+++ b/test/webview/codeblock.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest"
-import { render, screen, cleanup } from "@testing-library/react"
+import { render, screen, cleanup, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { CodeBlock } from "../../webview/src/components/CodeBlock"
 import { vscode } from "../../webview/src/vscode"
@@ -19,6 +19,16 @@ beforeEach(() => {
 afterEach(cleanup)
 
 describe("CodeBlock", () => {
+  it("highlights alias languages through the fine-grained grammar set", async () => {
+    // "bash" resolves via the shellscript grammar's aliases — if that grammar
+    // ever drops out of the curated list, codeToHtml throws and this renders
+    // the plain fallback <pre> without the .shiki wrapper.
+    const { container } = render(<CodeBlock code="ls -la" language="bash" />)
+    await waitFor(() => expect(container.querySelector(".codeblock-body .shiki")).not.toBeNull(), {
+      timeout: 5000,
+    })
+  })
+
   it("shows 'Apply' button label for non-shell languages", async () => {
     render(<CodeBlock code="const x = 1" language="typescript" />)
     expect(await screen.findByRole("button", { name: /^Apply$/ })).toBeInTheDocument()

--- a/webview/src/components/CodeBlock.tsx
+++ b/webview/src/components/CodeBlock.tsx
@@ -1,5 +1,6 @@
 import { memo, useEffect, useMemo, useState } from "react"
-import { codeToHtml, type BundledLanguage } from "shiki/bundle/web"
+import { createHighlighterCore, type HighlighterCore } from "shiki/core"
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript"
 import { vscode } from "../vscode"
 
 type Props = { code: string; language?: string }
@@ -10,6 +11,57 @@ const SUPPORTED = new Set<string>([
   "sql", "c", "cpp", "csharp", "ruby", "php", "swift", "kotlin", "toml",
   "xml", "docker", "dockerfile", "ini", "diff",
 ])
+
+/**
+ * Fine-grained shiki: only the SUPPORTED grammars and the two GitHub themes
+ * get bundled — `shiki/bundle/web` shipped every web language, every theme,
+ * and the oniguruma wasm (~5.3 MB of bundle input). The JavaScript regex
+ * engine replaces the wasm; `forgiving` skips grammar patterns it cannot
+ * compile instead of failing the whole highlight. Constructed lazily on the
+ * first fenced code block; aliases (bash/shell/md/docker/…) ride along on
+ * their canonical grammar registrations, and `text` is shiki's built-in
+ * plaintext passthrough.
+ */
+let highlighterPromise: Promise<HighlighterCore> | undefined
+function getHighlighter(): Promise<HighlighterCore> {
+  highlighterPromise ??= createHighlighterCore({
+    themes: [
+      import("@shikijs/themes/github-dark-default"),
+      import("@shikijs/themes/github-light-default"),
+    ],
+    langs: [
+      import("@shikijs/langs/typescript"),
+      import("@shikijs/langs/tsx"),
+      import("@shikijs/langs/javascript"),
+      import("@shikijs/langs/jsx"),
+      import("@shikijs/langs/python"),
+      import("@shikijs/langs/shellscript"),
+      import("@shikijs/langs/json"),
+      import("@shikijs/langs/html"),
+      import("@shikijs/langs/css"),
+      import("@shikijs/langs/yaml"),
+      import("@shikijs/langs/markdown"),
+      import("@shikijs/langs/go"),
+      import("@shikijs/langs/rust"),
+      import("@shikijs/langs/java"),
+      import("@shikijs/langs/sql"),
+      import("@shikijs/langs/c"),
+      import("@shikijs/langs/cpp"),
+      import("@shikijs/langs/csharp"),
+      import("@shikijs/langs/ruby"),
+      import("@shikijs/langs/php"),
+      import("@shikijs/langs/swift"),
+      import("@shikijs/langs/kotlin"),
+      import("@shikijs/langs/toml"),
+      import("@shikijs/langs/xml"),
+      import("@shikijs/langs/dockerfile"),
+      import("@shikijs/langs/ini"),
+      import("@shikijs/langs/diff"),
+    ],
+    engine: createJavaScriptRegexEngine({ forgiving: true }),
+  })
+  return highlighterPromise
+}
 
 // While a fenced block streams in, `code` grows on every delta. Debounce the
 // shiki tokenization so it runs once the content settles instead of
@@ -29,7 +81,8 @@ function CodeBlockImpl({ code, language }: Props) {
     let cancelled = false
     const lang = normaliseLang(language)
     const timer = setTimeout(() => {
-      codeToHtml(code, { lang: lang as BundledLanguage, theme })
+      getHighlighter()
+        .then((highlighter) => highlighter.codeToHtml(code, { lang, theme }))
         .then((h) => {
           if (!cancelled) setHtml(h)
         })

--- a/webview/vite.config.ts
+++ b/webview/vite.config.ts
@@ -1,10 +1,35 @@
-import { defineConfig } from "vite"
+import { defineConfig, type Plugin } from "vite"
 import react from "@vitejs/plugin-react"
 import { viteSingleFile } from "vite-plugin-singlefile"
 import path from "node:path"
 
+/**
+ * KaTeX declares every font in woff2 + woff + ttf; with everything inlined
+ * into the single-file bundle, that base64-encodes each font three times.
+ * Every VS Code webview supports woff2, so drop the woff/ttf fallback
+ * clauses from katex's CSS. Must be `enforce: "pre"`: vite:css compiles,
+ * inlines, and caches the CSS in its own styles map before normal-order
+ * transforms run, so a later transform never reaches the emitted output.
+ */
+function katexWoff2Only(): Plugin {
+  return {
+    name: "katex-woff2-only",
+    enforce: "pre",
+    transform(code, id) {
+      if (!id.includes("katex") || !id.split("?")[0]!.endsWith(".css")) return
+      return code.replace(/src:\s*([^;}]+)/g, (whole, srcs: string) => {
+        const woff2 = srcs
+          .split(",")
+          .map((s) => s.trim())
+          .filter((s) => s.includes("woff2"))
+        return woff2.length ? `src:${woff2.join(",")}` : whole
+      })
+    },
+  }
+}
+
 export default defineConfig({
-  plugins: [react(), viteSingleFile()],
+  plugins: [react(), katexWoff2Only(), viteSingleFile()],
   build: {
     outDir: path.resolve(__dirname, "../dist/webview"),
     emptyOutDir: true,


### PR DESCRIPTION
## Summary

- **Shiki**: `CodeBlock` now builds a lazy `HighlighterCore` (`shiki/core`) with exactly the 29 supported grammars, the two GitHub themes, and the JavaScript regex engine (`forgiving` mode) — replacing `shiki/bundle/web`, which shipped every web grammar, every theme, and the oniguruma wasm. The highlighter is constructed on the first fenced code block. Aliases (`bash`/`shell`/`md`/`docker`…) ride on their canonical grammar registrations; unknown languages still normalize to shiki's built-in plain `text`.
- **KaTeX fonts**: an `enforce: "pre"` vite plugin strips the woff/ttf fallback clauses from katex's CSS so each font inlines once as woff2 (every VS Code webview supports woff2). It must be pre-enforced — `vite:css` compiles, inlines, and caches CSS in its own styles map before normal-order transforms run, so a later transform never reaches the emitted output (found empirically). The codicon icon font (ttf-only, non-katex) is untouched.

## Measured result

| | before | after |
|---|---|---|
| raw | 7,478.9 kB | **3,685.6 kB** (−51%) |
| gzip | 2,069.0 kB | **873.7 kB** (−58%) |

Font payloads in the bundle: 20 woff2, 0 woff, 1 ttf (codicon).

## Test plan

- [x] New test: `bash` (alias) produces `.shiki` output — fails if the shellscript grammar drops out of the curated list (a highlight error falls back to a plain `<pre>`).
- [x] Alias + docker + plain-text rendering validated in node against the real packages before wiring.
- [x] Full suite: 81 files / 1180 tests pass (existing CodeBlock tests exercise the new highlighter in jsdom).
- [x] Both tsc trees clean; production build verified with per-format font counts.

Closes #449