### PR TITLE
fix(agents): clear errored Main rows when the next turn starts

### DIFF
--- a/src/agents/task-store.ts
+++ b/src/agents/task-store.ts
@@ -300,6 +300,23 @@ export class AgentTaskStore {
   }
 
   /**
+   * Drop a conversation's errored rows. The popover keeps a failed task
+   * visible (see ATTENTION_STATUSES) only "until the user starts the next
+   * turn" — this is that clearing half, called from recordMainTaskStart.
+   * Removal rather than a status transition: `error` is terminal, so the
+   * terminal-state guard (correctly) refuses to rewrite it, and without
+   * removal the red row haunts the conversation forever.
+   */
+  async clearErrored(conversationID: string): Promise<void> {
+    const next = this.tasks.filter(
+      (task) => !(task.conversationID === conversationID && task.status === "error"),
+    )
+    if (next.length === this.tasks.length) return
+    this.tasks = next
+    await this.persistAndEmit()
+  }
+
+  /**
    * Mark every still-running/waiting *main* task for a session as completed.
    * Subagent tasks are NOT touched: their lifecycle is owned by the child
    * session's own SSE events (via SubagentTracker) — completing them here

--- a/src/chat/subagent-dispatch.ts
+++ b/src/chat/subagent-dispatch.ts
@@ -93,6 +93,9 @@ export class SubagentDispatch {
       return
     }
     const conversationID = this.deps.getActiveConversationID()
+    // A failed prior turn stays visible in the popover only until the next
+    // turn starts — clear it now, or the terminal error row lingers forever.
+    await this.deps.taskStore.clearErrored(conversationID)
     const turnID = crypto.randomUUID()
     const id = mainTaskID(conversationID, sessionID, turnID)
     const now = Date.now()

--- a/test/host/agent-task-store.test.ts
+++ b/test/host/agent-task-store.test.ts
@@ -413,3 +413,34 @@ describe("classifyTerminal", () => {
     expect(classifyTerminal(undefined)).toEqual({ status: "error", error: undefined })
   })
 })
+
+describe("AgentTaskStore.clearErrored", () => {
+  let memento: FakeMemento
+  beforeEach(() => {
+    memento = new FakeMemento()
+  })
+
+  it("removes only the conversation's errored rows, any kind", async () => {
+    const store = new AgentTaskStore(memento)
+    await store.upsert(fixedTask({ id: "m1", status: "error", error: "boom" }))
+    await store.upsert(fixedTask({ id: "s1", kind: "subagent", status: "error", error: "boom" }))
+    await store.upsert(fixedTask({ id: "m2", status: "running" }))
+    await store.upsert(fixedTask({ id: "m3", status: "completed" }))
+    await store.upsert(fixedTask({ id: "other", conversationID: "conv2", status: "error", error: "x" }))
+
+    await store.clearErrored("conv")
+
+    const ids = store.list().map((t) => t.id).sort()
+    expect(ids).toEqual(["m2", "m3", "other"])
+  })
+
+  it("is a no-op (no persist, no emit) when nothing is errored", async () => {
+    const store = new AgentTaskStore(memento)
+    await store.upsert(fixedTask({ id: "m2", status: "running" }))
+    let fires = 0
+    store.onDidChange(() => (fires += 1))
+    await store.clearErrored("conv")
+    expect(fires).toBe(0)
+    expect(store.list()).toHaveLength(1)
+  })
+})

--- a/test/host/chatview-harness.test.ts
+++ b/test/host/chatview-harness.test.ts
@@ -670,3 +670,23 @@ describe("ChatView harness: host-side delta coalescing", () => {
     expect(lines.some((l) => l.includes("[sse] session.idle"))).toBe(true)
   })
 })
+
+describe("ChatView harness: errored Main task clears on next turn", () => {
+  it("keeps the error row visible until the next send, then drops it", async () => {
+    await harness.send({ type: "mounted" })
+    await harness.send({ type: "send", text: "first try" })
+    // A parent session.error (e.g. unsupported model) settles the Main row
+    // to error; the trailing idle's sweep must not resurrect or clear it.
+    server.push({ type: "session.error", sessionID: SESSION_ID, error: { data: { message: "rate limit exceeded" } } })
+    server.push({ type: "session.idle", sessionID: SESSION_ID })
+    await until(() => harness.taskStore.list().some((t) => t.status === "error"))
+    await until(() => harness.posted.some((m) => m.type === "sessionIdle"))
+
+    await harness.send({ type: "send", text: "second try" })
+    await until(() => harness.taskStore.list().every((t) => t.status !== "error"))
+    const mains = harness.taskStore.list().filter((t) => t.kind === "main")
+    expect(mains).toHaveLength(1)
+    expect(mains[0]!.status).toBe("running")
+    expect(mains[0]!.title).toContain("second try")
+  })
+})

--- a/test/host/stop-flow.test.ts
+++ b/test/host/stop-flow.test.ts
@@ -48,6 +48,7 @@ function fakeTaskStore() {
     upsert: vi.fn(async () => {}),
     update: vi.fn(async () => {}),
     cancelSessionTasks: vi.fn(async () => {}),
+    clearErrored: vi.fn(async () => {}),
     activeSubagentsForSession: () => [],
     onDidChange: () => ({ dispose() {} }),
   }


### PR DESCRIPTION
## Summary

- `AgentTaskStore.clearErrored(conversationID)`: removes the conversation's `error` rows (any kind). Removal, not a status transition — `error` is terminal and the terminal-state guard correctly refuses to rewrite it.
- `SubagentDispatch.recordMainTaskStart` calls it before minting the new turn's Main row, implementing the documented "failed task stays visible until the user starts the next turn" contract (covers regular sends and builtin turns, which share this path).
- Observed live: an errored row from a rejected-model dispatch survived two later successful turns and their idles — the Agents pill showed a permanent red error for that conversation.

## Test plan

- [x] Store unit tests: clears only the conversation's errored rows (main and subagent kinds), leaves running/completed and other conversations' errors; no-op emits nothing.
- [x] Harness end-to-end: send → `session.error` → idle keeps the error row visible; the next send drops it and leaves exactly one running Main titled by the new prompt.
- [x] Stash-run: exactly the 3 new tests fail on the old source.
- [x] Full suite: 81 files / 1183 tests pass (one pre-existing test stub extended with the new store method); host tsc clean; build succeeds.

Closes #451