### PR TITLE
fix(stream): stop post-idle bookkeeping from re-arming the watchdog

### DIFF
--- a/src/chat/stream.ts
+++ b/src/chat/stream.ts
@@ -306,7 +306,16 @@ export function subscribeSession(
     switch (type) {
       case "message.updated":
         onMessageUpdated(props?.info)
-        markActivity(props?.info?.sessionID)
+        // Only an in-flight assistant message implies live work. opencode
+        // sends trailing message.updated bookkeeping (finished assistant
+        // rows, user-row rewrites) AFTER session.idle; letting those re-arm
+        // the watchdog scheduled a spurious status poll + duplicate
+        // onSessionIdle 30s after every settled turn. Turn-start arming is
+        // covered by the busy session.status and part events that follow
+        // within moments of a dispatch.
+        if (props?.info?.role === "assistant" && !props?.info?.finish) {
+          markActivity(props?.info?.sessionID)
+        }
         return
       case "message.part.updated":
         onPartUpdated(props?.part)
@@ -331,8 +340,9 @@ export function subscribeSession(
         markActivity(props?.sessionID)
         return
       case "message.removed":
+        // Revert bookkeeping, not live work — the send that follows a
+        // revert arms the watchdog through its own busy/part events.
         onMessageRemoved(props)
-        markActivity(props?.sessionID)
         return
       case "tui.toast.show":
         return onToast(props)
@@ -508,8 +518,17 @@ export function subscribeSession(
     return props?.sessionID
   }
 
+  /**
+   * Monotonic count of busy-implying events. `runWatchdog` snapshots it
+   * before its status poll and discards the answer if it moved — a poll
+   * already in flight when a new turn starts must not deliver a stale
+   * "idle" into the running turn.
+   */
+  let activityGen = 0
+
   function markActivity(eventSessionID: string | undefined) {
     if (eventSessionID !== sessionID) return
+    activityGen++
     busyTracked = true
     armWatchdog()
   }
@@ -536,12 +555,21 @@ export function subscribeSession(
   async function runWatchdog() {
     watchdogTimer = null
     if (stopped || !busyTracked) return
+    const genAtPoll = activityGen
     log(`[watchdog] no SSE events for ${watchdogMs}ms, polling /session/status`)
     try {
       const result = await backend.client.session.status({
         query: { directory: backend.directory },
       })
-      if (stopped) return
+      // The poll's answer describes the moment it was asked. If the session
+      // showed life while it was in flight (a new turn's events, or a real
+      // session.idle already handled by markIdle), the stale answer must not
+      // emit a bogus idle into the running turn — trust the live stream.
+      if (stopped || !busyTracked) return
+      if (activityGen !== genAtPoll) {
+        armWatchdog()
+        return
+      }
       const statuses = (result?.data ?? {}) as Record<string, { type?: string } | undefined>
       const status = statuses[sessionID]
       if (!status || status.type === "idle") {

--- a/test/host/mock-opencode-server.ts
+++ b/test/host/mock-opencode-server.ts
@@ -67,6 +67,11 @@ export type MockOpencodeServer = {
    * the entry. Tests use this to drive the watchdog's recovery path.
    */
   setSessionStatus: (sessionID: string, status: { type: "idle" | "busy" | "retry" } | undefined) => void
+  /**
+   * Delay GET /session/status responses by `ms` (0 = immediate). Tests use
+   * this to race stream events against an in-flight watchdog poll.
+   */
+  setStatusDelay: (ms: number) => void
   /** Number of times GET /session/status has been called. */
   statusPollCount: () => number
   /** Records of every mcp.add body, and the server name for each lifecycle/auth call. */
@@ -98,6 +103,7 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
   const commandCalls: Array<{ sessionID: string; body: unknown }> = []
   let commands: Array<Record<string, unknown>> = []
   const sessionStatuses = new Map<string, { type: "idle" | "busy" | "retry" }>()
+  let statusDelayMs = 0
   let statusPolls = 0
   let mcpStatus: Record<string, { status: string; error?: string }> = {}
   const mcpAddCalls: Array<{ body: unknown }> = []
@@ -293,6 +299,10 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
       statusPolls++
       const body: Record<string, { type: string }> = {}
       for (const [sid, status] of sessionStatuses) body[sid] = status
+      if (statusDelayMs > 0) {
+        setTimeout(() => reply(res, 200, body), statusDelayMs)
+        return
+      }
       reply(res, 200, body)
       return
     }
@@ -401,6 +411,9 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
     setSessionStatus(sessionID, status) {
       if (status) sessionStatuses.set(sessionID, status)
       else sessionStatuses.delete(sessionID)
+    },
+    setStatusDelay(ms) {
+      statusDelayMs = ms
     },
     statusPollCount() {
       return statusPolls

--- a/test/host/stream-watchdog.test.ts
+++ b/test/host/stream-watchdog.test.ts
@@ -316,3 +316,143 @@ describe("subscribeSession terminal-finish gating", () => {
     expect(ends).toHaveLength(0)
   })
 })
+
+describe("subscribeSession watchdog: post-idle bookkeeping and stale polls", () => {
+  it("post-idle bookkeeping events do not re-arm the watchdog", async () => {
+    let idleCount = 0
+    const backend = makeBackend()
+    server.setSessionStatus("ses_test", { type: "idle" })
+
+    const subscription = subscribeSession(
+      backend,
+      "ses_test",
+      { onSessionIdle: () => idleCount++, onTextDelta: () => {} },
+      { watchdogMs: 50 },
+    )
+    await subscription.ready
+    await server.awaitClient()
+
+    server.push({
+      type: "message.part.updated",
+      part: { messageID: "msg_a", sessionID: "ses_test", id: "p1", type: "text", text: "hi" },
+    })
+    await wait(10)
+    server.push({ type: "session.idle", sessionID: "ses_test" })
+    await wait(20)
+    expect(idleCount).toBe(1)
+
+    // The trailing bookkeeping opencode sends AFTER idle (observed live):
+    // an update for the finished assistant message, a user-row rewrite,
+    // and a revert-style removal. None of these mean live work.
+    server.push({
+      type: "message.updated",
+      info: { id: "msg_a", role: "assistant", sessionID: "ses_test", finish: "stop" },
+    })
+    server.push({ type: "message.updated", info: { id: "usr_1", role: "user", sessionID: "ses_test" } })
+    server.push({ type: "message.removed", sessionID: "ses_test", messageID: "msg_gone" })
+
+    // Several watchdog windows of silence: no poll, no duplicate idle.
+    await wait(220)
+    subscription.abort()
+    expect(idleCount).toBe(1)
+    expect(server.statusPollCount()).toBe(0)
+  })
+
+  it("an in-flight assistant message.updated still arms the watchdog", async () => {
+    let idleCount = 0
+    const backend = makeBackend()
+    server.setSessionStatus("ses_test", { type: "idle" })
+
+    const subscription = subscribeSession(
+      backend,
+      "ses_test",
+      { onSessionIdle: () => idleCount++, onTextDelta: () => {} },
+      { watchdogMs: 50 },
+    )
+    await subscription.ready
+    await server.awaitClient()
+
+    // A stream that dies right after the assistant message appears (no
+    // parts yet, no finish) must still be recoverable.
+    server.push({
+      type: "message.updated",
+      info: { id: "msg_a", role: "assistant", sessionID: "ses_test" },
+    })
+    await wait(200)
+    subscription.abort()
+    expect(idleCount).toBe(1)
+    expect(server.statusPollCount()).toBeGreaterThanOrEqual(1)
+  })
+
+  it("a new turn's part events resume watchdog tracking after idle", async () => {
+    let idleCount = 0
+    const backend = makeBackend()
+    server.setSessionStatus("ses_test", { type: "idle" })
+
+    const subscription = subscribeSession(
+      backend,
+      "ses_test",
+      { onSessionIdle: () => idleCount++, onTextDelta: () => {} },
+      { watchdogMs: 50 },
+    )
+    await subscription.ready
+    await server.awaitClient()
+
+    server.push({
+      type: "message.part.updated",
+      part: { messageID: "msg_a", sessionID: "ses_test", id: "p1", type: "text", text: "hi" },
+    })
+    await wait(10)
+    server.push({ type: "session.idle", sessionID: "ses_test" })
+    await wait(20)
+    expect(idleCount).toBe(1)
+
+    // Next turn streams, then the connection goes quiet — recovery must
+    // still work after an idle latch.
+    server.push({
+      type: "message.part.updated",
+      part: { messageID: "msg_b", sessionID: "ses_test", id: "p2", type: "text", text: "again" },
+    })
+    await wait(200)
+    subscription.abort()
+    expect(idleCount).toBe(2)
+    expect(server.statusPollCount()).toBeGreaterThanOrEqual(1)
+  })
+
+  it("discards a stale status poll answered after new activity", async () => {
+    let idleCount = 0
+    const backend = makeBackend()
+    server.setSessionStatus("ses_test", { type: "idle" })
+    server.setStatusDelay(120)
+
+    const subscription = subscribeSession(
+      backend,
+      "ses_test",
+      { onSessionIdle: () => idleCount++, onTextDelta: () => {} },
+      { watchdogMs: 50 },
+    )
+    await subscription.ready
+    await server.awaitClient()
+
+    server.push({
+      type: "message.part.updated",
+      part: { messageID: "msg_a", sessionID: "ses_test", id: "p1", type: "text", text: "hi" },
+    })
+    // Let the watchdog fire; its poll is now in flight (delayed 120 ms).
+    await wait(70)
+    expect(server.statusPollCount()).toBeGreaterThanOrEqual(1)
+
+    // A new turn's events arrive while the poll is airborne. Keep the
+    // stream visibly alive past the poll's resolution — the stale "idle"
+    // answer must be discarded, not emitted into the running turn.
+    for (let i = 0; i < 8; i++) {
+      server.push({
+        type: "message.part.updated",
+        part: { messageID: "msg_b", sessionID: "ses_test", id: `q${i}`, type: "text", text: `x${i}` },
+      })
+      await wait(30)
+    }
+    subscription.abort()
+    expect(idleCount).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

- `message.updated` only counts as watchdog activity for an in-flight assistant message (`role === "assistant" && !finish`). The trailing bookkeeping opencode sends after `session.idle` (finished-message updates, user-row rewrites) used to re-arm the tracker, producing one spurious `/session/status` poll plus a duplicate `onSessionIdle` 30 s after every settled turn (observed live).
- `message.removed` (revert bookkeeping) no longer marks activity; the send that follows a revert arms the watchdog through its own busy `session.status` and part events — visible in the same live log within ~150 ms of dispatch.
- Race guard: `runWatchdog` snapshots a monotonic activity generation before polling and discards the answer if events (or a real idle) arrived while the poll was in flight — a stale "idle" can no longer be emitted into a just-started turn. The mock server gained a `setStatusDelay` knob to make this testable.

## Test plan

- [x] New: post-idle bookkeeping (finished `message.updated`, user update, `message.removed`) across several watchdog windows → still exactly one idle, zero polls.
- [x] New: a stream dying right after an in-flight assistant `message.updated` is still recovered (keep-green pin for the tightened predicate).
- [x] New: a new turn's part events resume tracking after an idle (no over-latching).
- [x] New: a delayed status poll racing new activity is discarded — zero idles emitted into the live stream.
- [x] Stash-run: exactly the two defect tests fail on old source; both keep-green pins pass on both.
- [x] Full suite: 81 files / 1184 tests pass; host tsc clean; build succeeds.

Closes #453