### PR TITLE
perf(file-search): share in-flight scan, debounce mention picker input

### DIFF
--- a/src/file-search.ts
+++ b/src/file-search.ts
@@ -7,11 +7,18 @@ const MAX_HITS = 30
 
 let cache: FileSearchHit[] | undefined
 let cacheLoadedAt = 0
+let inFlight: Promise<FileSearchHit[]> | undefined
+let scanGeneration = 0
 const CACHE_TTL_MS = 30_000
 
 function invalidateCache(): void {
   cache = undefined
   cacheLoadedAt = 0
+  // Also detach any scan currently running: its listing predates the change
+  // that fired the invalidation, so it must not publish into the cache. The
+  // generation bump makes the detached scan's guards miss.
+  inFlight = undefined
+  scanGeneration++
 }
 
 /**
@@ -31,16 +38,32 @@ export function initFileSearch(context: vscode.ExtensionContext): void {
   )
 }
 
-async function loadFiles(): Promise<FileSearchHit[]> {
-  const now = Date.now()
-  if (cache && now - cacheLoadedAt < CACHE_TTL_MS) return cache
-  const uris = await vscode.workspace.findFiles("**/*", "**/{node_modules,.git,dist,build,out,coverage,.next,.turbo,.cache}/**", MAX_FILES)
-  cache = uris.map((uri) => ({
-    path: vscode.workspace.asRelativePath(uri),
-    name: path.basename(uri.fsPath),
-  }))
-  cacheLoadedAt = now
-  return cache
+function loadFiles(): Promise<FileSearchHit[]> {
+  if (cache && Date.now() - cacheLoadedAt < CACHE_TTL_MS) return Promise.resolve(cache)
+  // Share one scan across concurrent cold-cache callers — the picker fires a
+  // request per keystroke, and without this each one starts its own full
+  // findFiles enumeration of the workspace.
+  if (inFlight) return inFlight
+  const generation = scanGeneration
+  inFlight = (async () => {
+    try {
+      const uris = await vscode.workspace.findFiles("**/*", "**/{node_modules,.git,dist,build,out,coverage,.next,.turbo,.cache}/**", MAX_FILES)
+      const hits = uris.map((uri) => ({
+        path: vscode.workspace.asRelativePath(uri),
+        name: path.basename(uri.fsPath),
+      }))
+      // invalidateCache() mid-scan bumps the generation; publishing anyway
+      // would resurrect a listing that predates the invalidating change.
+      if (generation === scanGeneration) {
+        cache = hits
+        cacheLoadedAt = Date.now()
+      }
+      return hits
+    } finally {
+      if (generation === scanGeneration) inFlight = undefined
+    }
+  })()
+  return inFlight
 }
 
 export async function searchWorkspaceFiles(query: string): Promise<FileSearchHit[]> {

--- a/test/host/file-search.test.ts
+++ b/test/host/file-search.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import * as vscode from "vscode"
-import { rankHits, dirEntriesFrom, initFileSearch, searchWorkspaceFiles } from "../../src/file-search"
+import { rankHits, dirEntriesFrom, initFileSearch, searchWorkspaceFiles, listWorkspaceDir } from "../../src/file-search"
 
 const fixtures = [
   { path: "src/foo.ts", name: "foo.ts" },
@@ -144,6 +144,89 @@ describe("cache invalidation", () => {
     deleted.forEach((cb) => cb())
     const fresh = await searchWorkspaceFiles("")
     expect(fresh.map((h) => h.path)).toEqual(["a.ts", "b.ts"])
+    expect(findFiles).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe("in-flight scan sharing", () => {
+  function uri(p: string) {
+    return vscode.Uri.file(`/workspace/${p}`)
+  }
+
+  /** Install a watcher mock, register it, and return a fn that fires cache
+   *  invalidation — used to force a cold cache since the index is module state. */
+  function installInvalidator(): () => void {
+    const callbacks: Array<() => void> = []
+    vi.spyOn(vscode.workspace, "createFileSystemWatcher").mockReturnValue({
+      onDidCreate: (cb: () => void) => (callbacks.push(cb), { dispose: vi.fn() }),
+      onDidDelete: (cb: () => void) => (callbacks.push(cb), { dispose: vi.fn() }),
+      onDidChange: () => ({ dispose: vi.fn() }),
+      dispose: vi.fn(),
+    } as unknown as vscode.FileSystemWatcher)
+    initFileSearch({ subscriptions: [] } as unknown as vscode.ExtensionContext)
+    return () => callbacks.forEach((cb) => cb())
+  }
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("concurrent cold-cache callers share one findFiles scan", async () => {
+    const invalidate = installInvalidator()
+    invalidate()
+    const findFiles = vi.spyOn(vscode.workspace, "findFiles").mockClear()
+    let resolveScan!: (uris: vscode.Uri[]) => void
+    findFiles.mockReturnValue(new Promise((r) => (resolveScan = r)) as never)
+
+    const p1 = searchWorkspaceFiles("a")
+    const p2 = searchWorkspaceFiles("")
+    const p3 = listWorkspaceDir("")
+    expect(findFiles).toHaveBeenCalledTimes(1)
+
+    resolveScan([uri("a.ts"), uri("b/c.ts")])
+    const [r1, r2, r3] = await Promise.all([p1, p2, p3])
+    expect(r1.map((h) => h.path)).toEqual(["a.ts"])
+    expect(r2.map((h) => h.path)).toEqual(["a.ts", "b/c.ts"])
+    expect(r3).toEqual([
+      { name: "b", path: "b", kind: "folder" },
+      { name: "a.ts", path: "a.ts", kind: "file" },
+    ])
+
+    // The shared scan populated the cache — a follow-up call doesn't rescan.
+    await searchWorkspaceFiles("")
+    expect(findFiles).toHaveBeenCalledTimes(1)
+  })
+
+  it("a scan invalidated mid-flight does not publish into the cache", async () => {
+    const invalidate = installInvalidator()
+    invalidate()
+    const findFiles = vi.spyOn(vscode.workspace, "findFiles").mockClear()
+    let resolveScan!: (uris: vscode.Uri[]) => void
+    findFiles.mockReturnValueOnce(new Promise((r) => (resolveScan = r)) as never)
+
+    const stale = searchWorkspaceFiles("")
+    invalidate()
+    resolveScan([uri("stale.ts")])
+    // The caller that started the scan still gets its listing...
+    expect((await stale).map((h) => h.path)).toEqual(["stale.ts"])
+
+    // ...but the cache stayed cold: the next call runs a fresh scan.
+    findFiles.mockResolvedValue([uri("fresh.ts")] as never)
+    const fresh = await searchWorkspaceFiles("")
+    expect(fresh.map((h) => h.path)).toEqual(["fresh.ts"])
+    expect(findFiles).toHaveBeenCalledTimes(2)
+  })
+
+  it("a failed scan clears the in-flight slot so the next call retries", async () => {
+    const invalidate = installInvalidator()
+    invalidate()
+    const findFiles = vi.spyOn(vscode.workspace, "findFiles").mockClear()
+    findFiles.mockRejectedValueOnce(new Error("boom") as never)
+    await expect(searchWorkspaceFiles("")).rejects.toThrow("boom")
+
+    findFiles.mockResolvedValue([uri("a.ts")] as never)
+    const out = await searchWorkspaceFiles("")
+    expect(out.map((h) => h.path)).toEqual(["a.ts"])
     expect(findFiles).toHaveBeenCalledTimes(2)
   })
 })

--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -349,6 +349,21 @@ describe("PromptBox @file autocomplete", () => {
     expect(screen.getByText("bar.ts")).toBeInTheDocument()
   })
 
+  it("debounces rapid keystrokes into one search for the settled query", async () => {
+    const searchFiles = vi.fn().mockResolvedValue([{ path: "src/bar.ts", name: "bar.ts" }])
+    render(
+      <PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} searchFiles={searchFiles} />,
+    )
+    const textarea = screen.getByRole("textbox")
+    // Three changes inside the debounce window — only the settled query fires.
+    fireEvent.change(textarea, { target: { value: "@b" } })
+    fireEvent.change(textarea, { target: { value: "@ba" } })
+    fireEvent.change(textarea, { target: { value: "@bar" } })
+    await waitFor(() => expect(searchFiles).toHaveBeenCalledWith("bar"))
+    expect(searchFiles).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(screen.getByText("bar.ts")).toBeInTheDocument())
+  })
+
   it("Enter inside the picker inserts the selected path and closes the picker", async () => {
     const user = userEvent.setup()
     const searchFiles = vi.fn().mockResolvedValue([

--- a/webview/src/hooks/useMentionPicker.ts
+++ b/webview/src/hooks/useMentionPicker.ts
@@ -3,6 +3,7 @@ import type { FileSearchHit } from "../protocol"
 import { detectMention, type MentionState } from "../mention-tokens"
 
 const MAX_VISIBLE_HITS = 8
+const SEARCH_DEBOUNCE_MS = 100
 
 /**
  * Owns the `@`-mention picker state: detection (does the caret sit
@@ -39,15 +40,20 @@ export function useMentionPicker(opts: {
     }
     queryRef.current = mention.query
     let cancelled = false
-    void searchFiles(mention.query).then((results) => {
-      if (cancelled) return
-      // Drop stale results — the user may have kept typing while we awaited.
-      if (queryRef.current !== mention.query) return
-      setHits(results.slice(0, MAX_VISIBLE_HITS))
-      setActiveIndex(0)
-    })
+    // Each keystroke re-runs this effect; the cleanup cancels the previous
+    // timer, so only the query the user settles on costs a host round-trip.
+    const timer = setTimeout(() => {
+      void searchFiles(mention.query).then((results) => {
+        if (cancelled) return
+        // Drop stale results — the user may have kept typing while we awaited.
+        if (queryRef.current !== mention.query) return
+        setHits(results.slice(0, MAX_VISIBLE_HITS))
+        setActiveIndex(0)
+      })
+    }, SEARCH_DEBOUNCE_MS)
     return () => {
       cancelled = true
+      clearTimeout(timer)
     }
   }, [mention, searchFiles])
 


### PR DESCRIPTION
## Summary

- `loadFiles()` in `src/file-search.ts` now parks the in-flight scan promise: concurrent cold-cache `fileSearch` / `listDir` requests (the picker fires one per keystroke) share a single `findFiles` enumeration instead of each starting their own full-workspace scan.
- A generation counter guards cache publication: a scan that the FileSystemWatcher invalidated mid-flight no longer writes its stale listing into the cache (the caller that started it still gets its result), and a failed scan clears the in-flight slot so the next call retries.
- `useMentionPicker` debounces the search effect by 100 ms, so rapid typing collapses into one host round-trip for the settled query. The existing stale-result drop and picker UX (category menu, folder browse, arrow-key nav) are unchanged.

## Test plan

- [x] `bun run test` — 81 files / 1191 tests pass, including 3 new host tests (shared scan, mid-flight invalidation, failure retry) and 1 new webview test (keystroke debounce)
- [x] `bun run check-types` — host tree clean
- [x] `cd webview && bunx tsc --noEmit` — webview tree clean
- [ ] Visual: typing a query in the `@` picker still filters live and the debounce is imperceptible

Closes #457