### PR TITLE
fix(chat): hint busy-blocked slash commands; allow /new /mcp /provider

### DIFF
--- a/src/chat/builtin-commands.ts
+++ b/src/chat/builtin-commands.ts
@@ -21,12 +21,16 @@ export const BUILTIN_COMMANDS: ReadonlyArray<CommandInfo> = [
   { name: "init", description: "Analyze the codebase and write AGENTS.md", takesArguments: false },
   { name: "share", description: "Create a shareable link for this session", takesArguments: false },
   { name: "unshare", description: "Disable sharing for this session", takesArguments: false },
-  { name: "mcp", description: "Manage MCP servers", takesArguments: false },
-  { name: "provider", description: "Manage AI providers", takesArguments: false },
+  // allowedWhileBusy: /mcp and /provider only open native pickers, and /new
+  // takes the same path as the + New chat button (not busy-gated) — none of
+  // them touch the running session turn, so the composer's busy block that
+  // swallows turn-bound commands must not apply to them.
+  { name: "mcp", description: "Manage MCP servers", takesArguments: false, allowedWhileBusy: true },
+  { name: "provider", description: "Manage AI providers", takesArguments: false, allowedWhileBusy: true },
   { name: "undo", description: "Revert the last turn", takesArguments: false },
   { name: "redo", description: "Re-apply the last reverted turn", takesArguments: false },
   { name: "fork", description: "Duplicate this conversation", takesArguments: false },
-  { name: "new", description: "Start a new chat", takesArguments: false },
+  { name: "new", description: "Start a new chat", takesArguments: false, allowedWhileBusy: true },
 ]
 
 export const BUILTIN_COMMAND_NAMES: ReadonlySet<string> = new Set(BUILTIN_COMMANDS.map((c) => c.name))

--- a/test/host/builtin-commands.test.ts
+++ b/test/host/builtin-commands.test.ts
@@ -40,6 +40,11 @@ describe("withBuiltinCommands", () => {
       expect(BUILTIN_COMMAND_NAMES.has(name)).toBe(true)
     }
   })
+
+  it("flags exactly the session-neutral built-ins as allowedWhileBusy", () => {
+    const allowed = BUILTIN_COMMANDS.filter((c) => c.allowedWhileBusy).map((c) => c.name)
+    expect(allowed.sort()).toEqual(["mcp", "new", "provider"])
+  })
 })
 
 describe("generateMessageID", () => {

--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -1509,6 +1509,7 @@ describe("PromptBox / command picker", () => {
     { name: "deploy", description: "Ship it", takesArguments: true },
     { name: "compact", description: "Compact the session", takesArguments: false },
     { name: "review", description: "Review changes", takesArguments: true },
+    { name: "new", description: "Start a new chat", takesArguments: false, allowedWhileBusy: true },
   ]
 
   it("opens the command picker listing all commands when you type /", async () => {
@@ -1600,7 +1601,7 @@ describe("PromptBox / command picker", () => {
     expect(onRunCommand).not.toHaveBeenCalled()
   })
 
-  it("does not run a command while busy", async () => {
+  it("does not run a turn-bound command while busy and shows a hint instead", async () => {
     const user = userEvent.setup()
     const onRunCommand = vi.fn()
     render(<PromptBox busy={true} onSend={vi.fn()} onAbort={vi.fn()} commands={COMMANDS} onRunCommand={onRunCommand} />)
@@ -1609,6 +1610,52 @@ describe("PromptBox / command picker", () => {
     await screen.findByRole("listbox", { name: /Commands/i })
     await user.keyboard("{Enter}")
     expect(onRunCommand).not.toHaveBeenCalled()
+    expect(screen.getByText(/\/compact can't run while a turn is in progress/)).toBeInTheDocument()
+    // The typed command stays put — nothing ran, nothing was queued.
+    expect(textarea.value).toBe("/compact")
+  })
+
+  it("runs an allowedWhileBusy command while busy", async () => {
+    const user = userEvent.setup()
+    const onRunCommand = vi.fn()
+    render(<PromptBox busy={true} onSend={vi.fn()} onAbort={vi.fn()} commands={COMMANDS} onRunCommand={onRunCommand} />)
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    await user.type(textarea, "/new")
+    await screen.findByRole("listbox", { name: /Commands/i })
+    await user.keyboard("{Enter}")
+    expect(onRunCommand).toHaveBeenCalledWith("new", "")
+    expect(textarea.value).toBe("")
+    expect(screen.queryByText(/can't run while a turn is in progress/)).toBeNull()
+  })
+
+  it("clears the busy hint when the turn ends", async () => {
+    const user = userEvent.setup()
+    const onRunCommand = vi.fn()
+    const { rerender } = render(
+      <PromptBox busy={true} onSend={vi.fn()} onAbort={vi.fn()} commands={COMMANDS} onRunCommand={onRunCommand} />,
+    )
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    await user.type(textarea, "/compact")
+    await screen.findByRole("listbox", { name: /Commands/i })
+    await user.keyboard("{Enter}")
+    expect(screen.getByText(/can't run while a turn is in progress/)).toBeInTheDocument()
+    rerender(
+      <PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} commands={COMMANDS} onRunCommand={onRunCommand} />,
+    )
+    expect(screen.queryByText(/can't run while a turn is in progress/)).toBeNull()
+  })
+
+  it("clears the busy hint when the user edits the text", async () => {
+    const user = userEvent.setup()
+    const onRunCommand = vi.fn()
+    render(<PromptBox busy={true} onSend={vi.fn()} onAbort={vi.fn()} commands={COMMANDS} onRunCommand={onRunCommand} />)
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    await user.type(textarea, "/compact")
+    await screen.findByRole("listbox", { name: /Commands/i })
+    await user.keyboard("{Enter}")
+    expect(screen.getByText(/can't run while a turn is in progress/)).toBeInTheDocument()
+    await user.type(textarea, "x")
+    expect(screen.queryByText(/can't run while a turn is in progress/)).toBeNull()
   })
 })
 

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -134,7 +134,16 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
   const canQueue = sendBlocked && variant === "send" && Boolean(onQueue)
   const [selectedChipStart, setSelectedChipStart] = useState<number | undefined>(undefined)
   const [attachError, setAttachError] = useState<string | undefined>(undefined)
+  // Feedback for a turn-bound command submitted while busy: it neither runs
+  // nor queues (queueing would send the literal "/compact" as prose), and
+  // without a hint the Enter press looks dead.
+  const [busyHint, setBusyHint] = useState<string | undefined>(undefined)
   const [attaching, setAttaching] = useState(false)
+  // The hint's claim ("can't run while a turn is in progress") stops being
+  // true the moment the turn ends, so it must not outlive the busy state.
+  useEffect(() => {
+    if (!sendBlocked) setBusyHint(undefined)
+  }, [sendBlocked])
   const blurTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   // Cancel the deferred blur-dismiss on unmount: a timer surviving unmount
   // setStates into a torn-down tree — the flaky "window is not defined" CI
@@ -287,6 +296,7 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
   const updateText = (next: string, caret: number) => {
     setText(next)
     setSelectedChipStart(undefined)
+    setBusyHint(undefined)
     // The `/` and `@` pickers are mutually exclusive: a leading slash command
     // wins, and we close the mention picker so they never render together.
     if (detectCommandAtCaret(next, caret)) {
@@ -305,13 +315,20 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
     clearImageAttachments()
     setSelectedChipStart(undefined)
     setAttachError(undefined)
+    setBusyHint(undefined)
     closeMention()
     closeCommand()
   }
 
   const runCommandAndClear = (command: string, args: string) => {
-    // Respect busy/aborting on the picker-run path too (submit guards both).
-    if (sendBlocked || !onRunCommand) return
+    if (!onRunCommand) return
+    // Turn-bound commands are blocked while busy/aborting (they must not race
+    // the running turn, and queueing would send the literal "/name" as prose).
+    // Commands flagged allowedWhileBusy never touch the turn and pass through.
+    if (sendBlocked && !commands.find((c) => c.name === command)?.allowedWhileBusy) {
+      setBusyHint(`/${command} can't run while a turn is in progress — wait for it to finish or press Stop.`)
+      return
+    }
     onRunCommand(command, args)
     clearComposer()
   }
@@ -331,13 +348,12 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
     // Route a typed `/name args` to the command path when the name matches a
     // known command. Unknown slashes (and prose like `/etc/hosts`) fall through
     // to a normal prompt send. Edit composers never route (no onRunCommand).
-    // While a turn runs, a known command neither runs NOR queues — commands
-    // are immediate session operations, not prompts; queueing one as prose
-    // would send the literal "/compact" text to the model.
+    // runCommandAndClear owns the busy gate: turn-bound commands show a hint
+    // instead of running or queueing; allowedWhileBusy ones run immediately.
     if (variant === "send" && onRunCommand) {
       const parsed = parseCommandInput(trimmed)
       if (parsed && commands.some((c) => c.name === parsed.name)) {
-        if (!sendBlocked) runCommandAndClear(parsed.name, parsed.args)
+        runCommandAndClear(parsed.name, parsed.args)
         return
       }
     }
@@ -687,6 +703,7 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
   return (
     <div className={classes}>
       {attachError && <div className="attachment-error">{attachError}</div>}
+      {busyHint && <div className="promptbox-busy-hint">{busyHint}</div>}
       {imageAttachments.length > 0 && (
         <ul className="promptbox-thumbs" aria-label="Image attachments">
           {imageAttachments.map((a) => (

--- a/webview/src/protocol.ts
+++ b/webview/src/protocol.ts
@@ -232,8 +232,11 @@ export type DirEntry = { name: string; path: string; kind: "file" | "folder" }
  * template containing `$ARGUMENTS` waits for the user to type args, otherwise
  * the command runs the moment it is selected. `agent` is a display-only hint;
  * the agent/model actually used are read host-side from prefs at run time.
+ * `allowedWhileBusy` marks commands that never touch the running session turn
+ * (they open native pickers or switch conversations), so the composer lets
+ * them through the busy block that swallows turn-bound commands.
  */
-export type CommandInfo = { name: string; description?: string; agent?: string; takesArguments: boolean }
+export type CommandInfo = { name: string; description?: string; agent?: string; takesArguments: boolean; allowedWhileBusy?: boolean }
 
 /**
  * Status snapshot of the optional semantic index — Phase 6 of the

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -2588,6 +2588,12 @@ button:focus-visible {
   color: var(--color-error);
   margin-bottom: 4px;
 }
+/* Not an error — the command was understood, it just can't run mid-turn. */
+.promptbox-busy-hint {
+  font-size: 11px;
+  color: var(--color-fg-muted);
+  margin-bottom: 4px;
+}
 /* Pasted-image thumbnail strip above the prompt textarea. Synthesised
    paste names ("pasted-image.png") carry no signal, so the strip is
    name-less by design — the screenshot itself is the affordance, with


### PR DESCRIPTION
## Summary

- Submitting a known, turn-bound slash command while `busy || aborting` now shows a muted hint in the composer ("/compact can't run while a turn is in progress — wait for it to finish or press Stop.") instead of silently doing nothing. The typed text stays in the composer; commands still never queue (queueing would send the literal command text to the model as prose).
- The hint clears when the user edits the text, when the turn ends (`sendBlocked` flips false), and on any successful run/send.
- New optional `CommandInfo.allowedWhileBusy` protocol field, set host-side on the builtin definitions for `/new`, `/mcp`, `/provider` — none of them touch the running session turn (`/new` is the same code path as the un-gated + New chat button; the other two only open native pickers). These now run immediately while busy from both the typed path and the picker path.
- The busy gate moved from `submit()` into `runCommandAndClear`, so the typed and picker paths share one gate.

## Test plan

- [x] `bun run test` — 81 files, 1195 tests green (4 new: busy hint shown + text preserved, `allowedWhileBusy` runs while busy, hint clears on turn end, hint clears on edit; host: exact `allowedWhileBusy` flag set on `mcp`/`new`/`provider`)
- [x] `bun run check-types` + webview `tsc --noEmit` — both clean
- [ ] Visual check of the hint styling in a running VS Code (muted description color, sits in the attachment-error slot above the input)

Closes #459