### PR TITLE
fix(agents): settle the Main task when a dispatch fails post-start

### DIFF
--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -171,7 +171,7 @@ export class ChatView implements vscode.WebviewViewProvider {
       hasSubscription: () => this.subscription !== undefined,
       attachSubscription: (backend, sessionID) => this.attachSubscription(backend, sessionID),
       beginBuiltinTurn: (display) => this.beginBuiltinTurn(display),
-      failTurn: (message) => this.failBuiltinTurn(message),
+      failTurn: (message) => this.failTurnUnstick(message, "Command failed"),
       post: (msg) => this.post(msg),
       getMessages: () => this.messages,
       setMessages: (messages) => {
@@ -1396,29 +1396,28 @@ export class ChatView implements vscode.WebviewViewProvider {
   }
 
   /**
-   * A send that never reached opencode produces no SSE events, so nothing
-   * would ever clear the webview's `busy` — unstick it explicitly and tell
-   * the user instead of failing silently into a permanent "Working…".
+   * Unstick a turn that failed without producing SSE events. A send that
+   * never reached opencode emits no session.idle, so two things would
+   * otherwise hang: the webview's `busy` never clears (permanent "Working…"),
+   * and — if `recordMainTaskStart` already ran — the popover Main row stays
+   * "running" forever. Settle that row FIRST so the terminal-state guard
+   * freezes its status against any later idle sweep, then post idle + toast.
+   * `recordMainTaskFinish` is a no-op when no Main task was recorded (the
+   * pre-dispatch failure sites: server-ensure / session-create), so this is
+   * safe from every failure path. classifyTerminal keeps an "Aborted" outcome
+   * quiet (no toast), mirroring onSessionError.
    */
-  private failSend(message: string) {
-    this.post({ type: "sessionIdle" })
-    this.surfaceToast({ variant: "error", title: "Send failed", message })
-  }
-
-  /**
-   * failSend for builtin turns: by the time /compact or /init fails,
-   * beginBuiltinTurn has already recorded a popover Main task, so that row
-   * must settle too — before anything else, so the terminal-state guard
-   * protects the status from a later idle sweep. classifyTerminal keeps an
-   * "Aborted" outcome quiet (no toast), mirroring onSessionError.
-   */
-  private failBuiltinTurn(message: string) {
+  private failTurnUnstick(message: string, toastTitle: string) {
     const classified = classifyTerminal(message)
     void this.subagentDispatch.recordMainTaskFinish(classified.status, classified.error)
     this.post({ type: "sessionIdle" })
     if (classified.status === "error") {
-      this.surfaceToast({ variant: "error", title: "Command failed", message })
+      this.surfaceToast({ variant: "error", title: toastTitle, message })
     }
+  }
+
+  private failSend(message: string) {
+    this.failTurnUnstick(message, "Send failed")
   }
 
   /**

--- a/test/host/chatview-harness.test.ts
+++ b/test/host/chatview-harness.test.ts
@@ -389,6 +389,66 @@ describe("ChatView harness: pre-dispatch send failures", () => {
   })
 })
 
+describe("ChatView harness: post-dispatch send failures", () => {
+  // Unlike the pre-dispatch failures above, the session already exists here, so
+  // recordMainTaskStart has recorded a "running" Main row by the time the
+  // dispatch fails. Nothing else would ever settle it — a turn that never
+  // started produces no session.idle — so the unstick path must, or the Agents
+  // popover shows a phantom running agent forever.
+
+  beforeEach(() => {
+    vi.mocked(vscode.window.showErrorMessage).mockClear()
+  })
+
+  function mainTasks() {
+    return harness.taskStore.list().filter((t) => t.kind === "main")
+  }
+
+  async function expectMainSettledAsError(): Promise<void> {
+    await until(() => {
+      const mains = mainTasks()
+      return mains.length > 0 && mains.every((t) => t.status !== "running")
+    })
+    expect(mainTasks().some((t) => t.status === "error")).toBe(true)
+  }
+
+  it("settles the Main task when prompt_async reports an error", async () => {
+    await harness.send({ type: "mounted" })
+    server.setPromptStatus(500)
+
+    await harness.send({ type: "send", text: "doomed prompt" })
+
+    // The dispatch reached a real session — this is the post-recordMainTaskStart
+    // path, not one of the pre-dispatch bails above.
+    expect(server.prompts).toHaveLength(1)
+    expect(harness.posted.some((m) => m.type === "sessionIdle")).toBe(true)
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining("Send failed"))
+    await expectMainSettledAsError()
+  })
+
+  it("settles the Main task when the prompt call throws (connection drop)", async () => {
+    await harness.send({ type: "mounted" })
+    server.setPromptStatus(0)
+
+    await harness.send({ type: "send", text: "doomed prompt" })
+
+    expect(harness.posted.some((m) => m.type === "sessionIdle")).toBe(true)
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(expect.stringContaining("Send failed"))
+    await expectMainSettledAsError()
+  })
+
+  it("settles the Main task when a custom command's dispatch reports an error", async () => {
+    await harness.send({ type: "mounted" })
+    server.setCommandStatus(500)
+
+    await harness.send({ type: "runCommand", command: "definitely-custom", arguments: "" })
+
+    expect(server.commandCalls).toHaveLength(1)
+    expect(harness.posted.some((m) => m.type === "sessionIdle")).toBe(true)
+    await expectMainSettledAsError()
+  })
+})
+
 describe("ChatView harness: builtin command failures", () => {
   // beginBuiltinTurn has already posted the bubble (webview busy) and recorded
   // a Main task by the time /compact's summarize call fails; failBuiltinTurn's

--- a/test/host/mock-opencode-server.ts
+++ b/test/host/mock-opencode-server.ts
@@ -50,6 +50,19 @@ export type MockOpencodeServer = {
    * 0 destroys the socket without replying, so the client-side call throws.
    */
   setSummarizeStatus: (status: number) => void
+  /**
+   * HTTP status POST /session/{id}/prompt_async replies with (default 204).
+   * A 4xx/5xx makes the SDK surface `res.error`; 0 destroys the socket so the
+   * call throws. Both drive the post-dispatch failSend path (session already
+   * created, Main task already recorded).
+   */
+  setPromptStatus: (status: number) => void
+  /**
+   * HTTP status POST /session/{id}/command replies with (default 200).
+   * A 4xx/5xx makes the SDK surface `res.error`; 0 destroys the socket so the
+   * call throws. Both drive the post-dispatch custom-command failSend path.
+   */
+  setCommandStatus: (status: number) => void
   /** Records of every unrevert (redo) call's sessionID. */
   unreverts: string[]
   /** Records of every fork call. */
@@ -96,6 +109,8 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
   let revertStatus = 200
   let sessionCreateStatus = 200
   let summarizeStatus = 200
+  let promptStatus = 204
+  let commandStatus = 200
   const unreverts: string[] = []
   const forks: Array<{ sessionID: string; body: unknown }> = []
   const aborts: string[] = []
@@ -206,8 +221,16 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
     if (promptMatch && req.method === "POST") {
       const body = await readBody(req)
       prompts.push({ sessionID: promptMatch[1]!, body })
-      res.statusCode = 204
-      res.end()
+      if (promptStatus === 0) {
+        req.socket.destroy()
+        return
+      }
+      if (promptStatus === 204) {
+        res.statusCode = 204
+        res.end()
+      } else {
+        reply(res, promptStatus, { error: "scripted prompt failure" })
+      }
       return
     }
 
@@ -216,7 +239,15 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
     if (commandMatch && req.method === "POST") {
       const body = await readBody(req)
       commandCalls.push({ sessionID: commandMatch[1]!, body })
-      reply(res, 200, { info: { id: "msg_cmd", role: "assistant", sessionID: commandMatch[1] }, parts: [] })
+      if (commandStatus === 0) {
+        req.socket.destroy()
+        return
+      }
+      if (commandStatus === 200) {
+        reply(res, 200, { info: { id: "msg_cmd", role: "assistant", sessionID: commandMatch[1] }, parts: [] })
+      } else {
+        reply(res, commandStatus, { error: "scripted command failure" })
+      }
       return
     }
 
@@ -397,6 +428,12 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
     },
     setSummarizeStatus(status) {
       summarizeStatus = status
+    },
+    setPromptStatus(status) {
+      promptStatus = status
+    },
+    setCommandStatus(status) {
+      commandStatus = status
     },
     unreverts,
     forks,


### PR DESCRIPTION
## Summary

`recordMainTaskStart` records a `running` Main row for the Agents popover *before* the prompt / custom-command dispatch. When that dispatch failed (`res.error` or a throw on a dropped connection), `failSend` only posted `sessionIdle` and toasted — it never settled the row. Since a turn that never started produces no SSE `session.idle`, the only host-side sweep (`settleSessionIdle`) never runs either, so the popover showed a phantom running agent indefinitely, persisted in `workspaceState` across reloads.

The builtin path already handled this in `failBuiltinTurn`. This folds both into a single `failTurnUnstick(message, toastTitle)` that:
1. settles the Main row **first**, so the store's terminal-state guard freezes its status against any later idle sweep,
2. posts `sessionIdle` to unstick the composer,
3. toasts, gated on `classifyTerminal` so an "Aborted" outcome stays quiet.

`recordMainTaskFinish` is a no-op when no Main task was recorded, so the four pre-dispatch failure sites (server ensure, session create) behave exactly as before. `failSend` is now a thin wrapper preserving its "Send failed" title; the builtin deps closure passes "Command failed".

Also adds `setPromptStatus` / `setCommandStatus` knobs to the mock opencode server, mirroring the existing `setSummarizeStatus` pattern — there was previously no way to fail a dispatch *after* session creation.

## Test plan

- [x] `bun run test` — 81 files, 1198 tests green (3 new)
- [x] **Verified the new tests fail without the fix**: reverted `view.ts` via `git stash` and all three time out in `until()` waiting for the row to leave `running` — the exact phantom symptom — then pass again with it restored
- [x] `bun run check-types` + webview `tsc --noEmit` — both clean
- [x] Pre-dispatch failure tests still pass unchanged (no Main task recorded → settle is a no-op)
- [ ] Visual check in a running VS Code: kill the opencode server mid-send and confirm the Agents pill goes idle instead of showing a stuck agent

Closes #461