### PR TITLE
fix(promptbox): stop hover from hijacking arrow-key picker nav

### DIFF
--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -427,6 +427,9 @@ describe("PromptBox @file autocomplete", () => {
 
       scrolled.length = 0
       const lastRow = screen.getByText("c.ts").closest("li")!
+      // mouseMove first: arrow keys suppress hover until the pointer really
+      // moves, so a bare mouseEnter is the scroll-synthesized kind we ignore.
+      fireEvent.mouseMove(lastRow, { clientX: 10, clientY: 90 })
       fireEvent.mouseEnter(lastRow)
       expect(lastRow.getAttribute("aria-selected")).toBe("true")
       expect(scrolled).toHaveLength(0)
@@ -462,6 +465,7 @@ describe("PromptBox @file autocomplete", () => {
       await user.keyboard("{ArrowRight}")
       expect(scrolled).toHaveLength(0)
       const lastRow = screen.getByText("c.ts").closest("li")!
+      fireEvent.mouseMove(lastRow, { clientX: 10, clientY: 90 })
       fireEvent.mouseEnter(lastRow)
       expect(lastRow.getAttribute("aria-selected")).toBe("true")
       expect(scrolled).toHaveLength(0)
@@ -469,6 +473,44 @@ describe("PromptBox @file autocomplete", () => {
       if (original) proto.scrollIntoView = original
       else delete proto.scrollIntoView
     }
+  })
+
+  it("ignores the mouseenter a scroll fires under a resting cursor", async () => {
+    const user = userEvent.setup()
+    const searchFiles = vi.fn().mockResolvedValue([
+      { path: "src/a.ts", name: "a.ts" },
+      { path: "src/b.ts", name: "b.ts" },
+      { path: "src/c.ts", name: "c.ts" },
+    ])
+    render(
+      <PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} searchFiles={searchFiles} />,
+    )
+    await user.type(screen.getByRole("textbox"), "@a")
+    await waitFor(() => expect(screen.getByText("b.ts")).toBeInTheDocument())
+
+    // Park the cursor on the last row, then drive selection with the keyboard.
+    const lastRow = screen.getByText("c.ts").closest("li")!
+    fireEvent.mouseMove(lastRow, { clientX: 10, clientY: 90 })
+    fireEvent.mouseEnter(lastRow)
+    expect(lastRow.getAttribute("aria-selected")).toBe("true")
+
+    await user.keyboard("{ArrowDown}")
+    const firstRow = screen.getByText("a.ts").closest("li")!
+    expect(firstRow.getAttribute("aria-selected")).toBe("true")
+
+    // scrollIntoView slid a different row under the stationary pointer: the
+    // browser re-fires mouseenter, and Blink's post-scroll synthetic mousemove
+    // repeats the last real coordinates. Neither is user intent, so the
+    // keyboard's selection must survive both.
+    fireEvent.mouseMove(lastRow, { clientX: 10, clientY: 90 })
+    fireEvent.mouseEnter(lastRow)
+    expect(firstRow.getAttribute("aria-selected")).toBe("true")
+    expect(lastRow.getAttribute("aria-selected")).toBe("false")
+
+    // A real pointer move hands control back to the mouse.
+    fireEvent.mouseMove(lastRow, { clientX: 10, clientY: 91 })
+    fireEvent.mouseEnter(lastRow)
+    expect(lastRow.getAttribute("aria-selected")).toBe("true")
   })
 
   it("Click on a hit inserts that path", async () => {

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -154,12 +154,29 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
   // moves the index (onMouseEnter), but scrolling on hover would shift rows
   // under the cursor — so the scroll-into-view effect only acts on key moves.
   const keyboardNavRef = useRef(false)
+  // Arrow keys suppress hover until the pointer physically moves again. The
+  // popovers scroll (max-height 220px), so scrollIntoView slides rows under a
+  // resting cursor; the browser then re-evaluates hover and fires mouseenter on
+  // whichever row landed there, which would drag the active index back and make
+  // Up/Down feel stuck wherever the mouse happens to rest.
+  const hoverEnabledRef = useRef(true)
+  const lastPointerRef = useRef<{ x: number; y: number } | undefined>(undefined)
+  // Blink dispatches a synthetic mousemove after a scroll to refresh hover
+  // state, so "a mousemove arrived" is not proof the user moved — that fake
+  // event carries the last real coordinates. Only changed coordinates count.
+  const onPopoverMouseMove = (e: React.MouseEvent) => {
+    const last = lastPointerRef.current
+    if (last && last.x === e.clientX && last.y === e.clientY) return
+    lastPointerRef.current = { x: e.clientX, y: e.clientY }
+    hoverEnabledRef.current = true
+  }
   // Hover claims the index move by clearing the flag first. An arrow press
   // that changed no index (ArrowRight on a file row, Left/Right where only
   // Up/Down are handled, wrap on a single-row list, arrows over an empty
   // popover) never reaches the effect that consumes the flag, and the next
   // hover-driven index change would otherwise scroll the row under the cursor.
   const hoverMove = (apply: () => void) => {
+    if (!hoverEnabledRef.current) return
     keyboardNavRef.current = false
     apply()
   }
@@ -485,6 +502,7 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
     if (e.nativeEvent.isComposing || e.keyCode === 229) return
     if (e.key.startsWith("Arrow") && (command || showCategoryMenu || showChatList || showFileHits || showBrowse)) {
       keyboardNavRef.current = true
+      hoverEnabledRef.current = false
     }
     if (command) {
       // When nothing matches we only handle Escape — Enter must fall through to
@@ -721,7 +739,7 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
         onClose={() => setPreviewImage(null)}
       />
       <div className="promptbox-input">
-        <div ref={popoverHostRef} className="promptbox-textarea-wrap">
+        <div ref={popoverHostRef} className="promptbox-textarea-wrap" onMouseMove={onPopoverMouseMove}>
         <div ref={backdropRef} className="promptbox-backdrop" aria-hidden="true">
           {renderHighlightedText(text, allKnownLabels(), selectedChipStart)}
         </div>


### PR DESCRIPTION
## Summary

With the pointer resting over an open picker popover, arrow keys fought the mouse: `scrollIntoView` slid rows under the stationary cursor, the browser re-fired `mouseenter` on the row that landed there, and `hoverMove` dragged the active index back to the pointer. Up/Down felt stuck near wherever the mouse sat.

Arrow keys now suppress hover until the pointer physically moves again. The non-obvious part is why "a mousemove arrived" is not sufficient proof of movement: Blink dispatches a synthetic mousemove after a scroll to refresh hover state, and that fake event carries the *last real* coordinates. So the guard re-enables hover only when the coordinates actually change.

`keyboardNavRef` already handled the opposite direction (hover must not trigger a scroll); that behavior is untouched, and the two guards now cover both directions.

Scope is the one shared `hoverMove` helper plus the shared popover host, so all four popovers (files, folder browser, past chats, commands) are covered without per-list changes.

### Note on the two modified tests

Both existing hover tests fired a bare `mouseEnter` with no preceding `mouseMove`. In a real browser that sequence only occurs for the scroll-synthesized hover this PR deliberately ignores — a user moving onto a row always generates `mousemove` first. They now include that pointer motion. Their subject (hover must not scroll) and their `scrolled` assertions are unchanged; the `aria-selected` line was only confirming the hover landed.

## Test plan

- [x] `bun run test` — 81 files / 1199 tests pass (1 new)
- [x] `bun run check-types` clean
- [x] `cd webview && bunx tsc --noEmit` clean
- [x] New test verified to be a real regression test: with `PromptBox.tsx` reverted via `git stash`, `ignores the mouseenter a scroll fires under a resting cursor` fails on the stray hover stealing the selection; passes with the fix restored
- [x] Covers both directions — keyboard selection survives a synthetic hover, and a real pointer move still hands control back to the mouse
- [ ] Visual check in a running VS Code: open `@` with the mouse parked over the list, hold Down, confirm the selection walks the list smoothly instead of snapping back to the cursor

Closes #463