### PR TITLE
feat(chat): linkify pasted URLs in user bubbles and composer

### DIFF
--- a/test/webview/link-tokens.test.ts
+++ b/test/webview/link-tokens.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest"
+import { findLinkRanges, findTokenRanges } from "../../webview/src/mention-tokens"
+
+describe("findLinkRanges", () => {
+  it("finds a plain https URL with exact bounds", () => {
+    const text = "see https://example.com/docs for details"
+    expect(findLinkRanges(text)).toEqual([
+      { start: 4, end: 28, url: "https://example.com/docs" },
+    ])
+  })
+
+  it("finds http and uppercase-scheme URLs", () => {
+    expect(findLinkRanges("http://a.io")).toEqual([{ start: 0, end: 11, url: "http://a.io" }])
+    expect(findLinkRanges("HTTPS://A.IO")).toEqual([{ start: 0, end: 12, url: "HTTPS://A.IO" }])
+  })
+
+  it("trims sentence punctuation off the end", () => {
+    expect(findLinkRanges("go to https://example.com.")[0]!.url).toBe("https://example.com")
+    expect(findLinkRanges("https://example.com, then...")[0]!.url).toBe("https://example.com")
+    expect(findLinkRanges("really? https://example.com!?")[0]!.url).toBe("https://example.com")
+    expect(findLinkRanges("<https://example.com>")[0]!.url).toBe("https://example.com")
+  })
+
+  it("trims an unbalanced closing paren but keeps a balanced one", () => {
+    expect(findLinkRanges("(see https://example.com/a)")[0]!.url).toBe("https://example.com/a")
+    expect(findLinkRanges("https://en.wikipedia.org/wiki/Foo_(bar)")[0]!.url).toBe(
+      "https://en.wikipedia.org/wiki/Foo_(bar)",
+    )
+    expect(findLinkRanges("(https://en.wikipedia.org/wiki/Foo_(bar))")[0]!.url).toBe(
+      "https://en.wikipedia.org/wiki/Foo_(bar)",
+    )
+  })
+
+  it("keeps query strings and fragments intact", () => {
+    expect(findLinkRanges("https://a.io/p?x=1&y=2#frag ok")[0]!.url).toBe(
+      "https://a.io/p?x=1&y=2#frag",
+    )
+  })
+
+  it("finds multiple URLs", () => {
+    const ranges = findLinkRanges("first https://a.io then http://b.io.")
+    expect(ranges.map((r) => r.url)).toEqual(["https://a.io", "http://b.io"])
+  })
+
+  it("rejects a bare scheme and matches nothing in plain prose", () => {
+    expect(findLinkRanges("https:// is a scheme")).toEqual([])
+    expect(findLinkRanges("https://.")).toEqual([])
+    expect(findLinkRanges("no links here, not even ftp://x")).toEqual([])
+  })
+})
+
+describe("findTokenRanges", () => {
+  it("interleaves mention and link tokens sorted by position", () => {
+    const text = "@src/foo.ts see https://example.com please"
+    const ranges = findTokenRanges(text, new Set(["src/foo.ts"]))
+    expect(ranges).toEqual([
+      { start: 0, end: 11, kind: "mention" },
+      { start: 16, end: 35, kind: "link", url: "https://example.com" },
+    ])
+  })
+
+  it("keeps a URL whole when a known mention token appears inside it", () => {
+    const text = "https://example.com/@src/foo.ts"
+    const ranges = findTokenRanges(text, new Set(["src/foo.ts"]))
+    expect(ranges).toEqual([{ start: 0, end: 31, kind: "link", url: text }])
+  })
+
+  it("keeps a chip whole when its label is itself a URL", () => {
+    const label = "chat:https://example.com"
+    const text = `@${label} hi`
+    const ranges = findTokenRanges(text, new Set([label]))
+    expect(ranges).toEqual([{ start: 0, end: 1 + label.length, kind: "mention" }])
+  })
+
+  it("returns links even with no known mentions", () => {
+    const ranges = findTokenRanges("https://a.io", new Set())
+    expect(ranges).toEqual([{ start: 0, end: 12, kind: "link", url: "https://a.io" }])
+  })
+})

--- a/test/webview/message-view.test.tsx
+++ b/test/webview/message-view.test.tsx
@@ -79,6 +79,47 @@ describe("MessageView (user role)", () => {
     expect(screen.getByRole("button", { name: "Save & regenerate" })).toBeInTheDocument()
   })
 
+  it("renders a pasted URL as a real link, excluding trailing punctuation", () => {
+    const { container } = render(
+      <MessageView
+        message={userMessage("check https://example.com/docs, thanks")}
+        processOpen={false}
+        processOnly={false}
+      />,
+    )
+    const link = container.querySelector(".user-text a.user-link") as HTMLAnchorElement
+    expect(link).not.toBeNull()
+    expect(link.getAttribute("href")).toBe("https://example.com/docs")
+    expect(link.textContent).toBe("https://example.com/docs")
+    // Same anchor shape as Markdown.tsx: the webview swallows same-tab
+    // navigations, so _blank is what makes the click actually open.
+    expect(link.getAttribute("target")).toBe("_blank")
+    expect(link.getAttribute("rel")).toBe("noreferrer noopener")
+  })
+
+  it("clicking a link does not flip the bubble into edit mode", async () => {
+    const user = userEvent.setup()
+    const { container } = render(
+      <MessageView
+        message={userMessage("see https://example.com", { backendID: "b1" })}
+        processOpen={false}
+        processOnly={false}
+        onEditMessage={vi.fn()}
+      />,
+    )
+    const link = container.querySelector("a.user-link") as HTMLAnchorElement
+    // jsdom can't navigate; block the default action but let propagation run
+    // so the click still reaches the bubble's click-to-edit handler if the
+    // anchor fails to stopPropagation.
+    link.addEventListener("click", (e) => e.preventDefault())
+    await user.click(link)
+    expect(container.querySelector("textarea")).toBeNull()
+
+    // The bubble itself still enters edit mode when clicked outside the link.
+    await user.click(container.querySelector(".msg.role-user") as HTMLElement)
+    expect(container.querySelector("textarea")).not.toBeNull()
+  })
+
   it("restores past-chat mention chips when editing a sent message", async () => {
     const user = userEvent.setup()
     const message = userMessage("@chat:Old_chat revisit", { backendID: "b1" })

--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -944,6 +944,15 @@ describe("PromptBox mention chip rendering", () => {
     expect(backdrop).not.toBeNull()
     expect(backdrop!.getAttribute("aria-hidden")).toBe("true")
   })
+
+  it("highlights a typed URL in the backdrop, excluding trailing punctuation", async () => {
+    const user = userEvent.setup()
+    const { container } = render(<PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} />)
+    await user.type(screen.getByRole("textbox"), "see https://example.com. ok")
+    const token = container.querySelector(".promptbox-backdrop .link-token")
+    expect(token).not.toBeNull()
+    expect(token!.textContent).toBe("https://example.com")
+  })
 })
 
 describe("findChipAtCaret", () => {

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -1,7 +1,7 @@
 import { memo, useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react"
 import type { Block, Message } from "../hooks/useChatState"
 import type { AgentsStatusInfo, Attachment, ConversationMention, ConversationSummary, DirEntry, FileSearchHit } from "../protocol"
-import { findMentionRanges, makeAttachmentLabel } from "../mention-tokens"
+import { findTokenRanges, makeAttachmentLabel } from "../mention-tokens"
 import {
   answerStartIndex,
   hasProcessBlocks,
@@ -361,7 +361,7 @@ function UserMessageView({
             </ul>
           )}
           {originalText && (
-            <div className="user-text">{renderMentionedText(originalText, knownLabels)}</div>
+            <div className="user-text">{renderUserText(originalText, knownLabels)}</div>
           )}
           {canEdit && (
             <span className="user-edit-hint" aria-hidden="true">
@@ -406,22 +406,40 @@ function badgeForFilename(filename: string): string {
 
 /**
  * Wrap @path tokens (whose target is in `knownLabels`) in `.mention-chip`
- * spans, mirroring the in-editor chip styling so the rendered user bubble
- * reads as the same content the user composed.
+ * spans and http(s) URLs in real anchors, mirroring the in-editor styling so
+ * the rendered user bubble reads as the same content the user composed.
+ * target="_blank" for the same reason as Markdown.tsx's anchor override: the
+ * webview swallows same-tab navigations, so a plain href would look dead.
  */
-export function renderMentionedText(text: string, knownLabels: Set<string>): ReactNode[] {
-  if (knownLabels.size === 0) return [text]
-  const ranges = findMentionRanges(text, knownLabels)
+export function renderUserText(text: string, knownLabels: Set<string>): ReactNode[] {
+  const ranges = findTokenRanges(text, knownLabels)
   if (ranges.length === 0) return [text]
   const out: ReactNode[] = []
   let cursor = 0
   for (const r of ranges) {
     if (r.start > cursor) out.push(text.slice(cursor, r.start))
-    out.push(
-      <span key={r.start} className="mention-chip">
-        {text.slice(r.start, r.end)}
-      </span>,
-    )
+    if (r.kind === "link") {
+      out.push(
+        <a
+          key={r.start}
+          className="user-link"
+          href={r.url}
+          target="_blank"
+          rel="noreferrer noopener"
+          // The surrounding .msg.role-user listens for click-to-edit; without
+          // this, opening a link also flips the bubble into edit mode.
+          onClick={(e) => e.stopPropagation()}
+        >
+          {text.slice(r.start, r.end)}
+        </a>,
+      )
+    } else {
+      out.push(
+        <span key={r.start} className="mention-chip">
+          {text.slice(r.start, r.end)}
+        </span>,
+      )
+    }
     cursor = r.end
   }
   if (cursor < text.length) out.push(text.slice(cursor))

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -4,6 +4,7 @@ import {
   extractMentions,
   findChipAtCaret,
   findMentionRanges,
+  findTokenRanges,
   makeAttachmentLabel,
   makeConversationLabel,
 } from "../mention-tokens"
@@ -1080,33 +1081,41 @@ function ChevronIcon() {
 /**
  * Render `text` for the backdrop layer: known @path tokens are wrapped in a
  * `.mention-chip` span so they get a colored background through the
- * transparent textarea above. The rendered text width must remain
- * character-for-character identical to the textarea, so the chip is purely
- * a colored background — no padding/border that would shift glyph positions.
+ * transparent textarea above, and http(s) URLs in a `.link-token` span for a
+ * link-colored underline. The rendered text width must remain
+ * character-for-character identical to the textarea, so both are purely
+ * paint — no padding/border that would shift glyph positions.
  */
 export function renderHighlightedText(
   text: string,
   known: Set<string>,
   selectedChipStart?: number,
 ): ReactNode[] {
-  const ranges = findMentionRanges(text, known)
+  const ranges = findTokenRanges(text, known)
   if (ranges.length === 0) {
     return [text + "\n"]
   }
   const out: ReactNode[] = []
   let cursor = 0
-  for (let i = 0; i < ranges.length; i++) {
-    const r = ranges[i]!
+  for (const r of ranges) {
     if (r.start > cursor) out.push(text.slice(cursor, r.start))
-    const selected = selectedChipStart === r.start
-    out.push(
-      <span
-        key={r.start}
-        className={"mention-chip" + (selected ? " mention-chip-selected" : "")}
-      >
-        {text.slice(r.start, r.end)}
-      </span>,
-    )
+    if (r.kind === "link") {
+      out.push(
+        <span key={r.start} className="link-token">
+          {text.slice(r.start, r.end)}
+        </span>,
+      )
+    } else {
+      const selected = selectedChipStart === r.start
+      out.push(
+        <span
+          key={r.start}
+          className={"mention-chip" + (selected ? " mention-chip-selected" : "")}
+        >
+          {text.slice(r.start, r.end)}
+        </span>,
+      )
+    }
     cursor = r.end
   }
   if (cursor < text.length) out.push(text.slice(cursor))

--- a/webview/src/mention-tokens.ts
+++ b/webview/src/mention-tokens.ts
@@ -1,7 +1,9 @@
 /**
- * Pure helpers for the @-mention / attachment-chip system. Kept separate from
- * PromptBox.tsx so the component file is just JSX + state, and so these
- * functions can be tested without rendering anything.
+ * Pure helpers for the inline-token system (@-mention / attachment chips and
+ * web links). Kept separate from PromptBox.tsx so the component file is just
+ * JSX + state, and so these functions can be tested without rendering
+ * anything. PromptBox (composer backdrop) and MessageView (rendered bubble)
+ * both consume findTokenRanges so the two surfaces highlight identically.
  */
 
 export type MentionState = {
@@ -109,6 +111,78 @@ export function findMentionRanges(text: string, known: Set<string>): Array<{ sta
   const out: Array<{ start: number; end: number }> = []
   let prevEnd = -1
   for (const r of ranges) {
+    if (r.start >= prevEnd) {
+      out.push(r)
+      prevEnd = r.end
+    }
+  }
+  return out
+}
+
+export type LinkRange = { start: number; end: number; url: string }
+
+const CLOSERS: Record<string, string> = { ")": "(", "]": "[", "}": "{" }
+
+/**
+ * Locate http(s) URLs in prose. The regex takes everything up to whitespace,
+ * then trailing punctuation that reads as sentence structure is trimmed off —
+ * `see https://example.com.` must not link the final dot. Closing brackets are
+ * only trimmed when unbalanced within the match, so a Wikipedia-style
+ * `/wiki/Foo_(bar)` keeps its paren while `(see https://example.com)` drops
+ * it. http(s)-only by construction: no scheme like `javascript:` can ever
+ * reach an href through this.
+ */
+export function findLinkRanges(text: string): LinkRange[] {
+  const out: LinkRange[] = []
+  const re = /https?:\/\/\S+/gi
+  let m: RegExpExecArray | null
+  while ((m = re.exec(text))) {
+    let url = m[0]
+    while (url.length > 0) {
+      const last = url[url.length - 1]!
+      if (/[.,;:!?'"`<>]/.test(last)) {
+        url = url.slice(0, -1)
+        continue
+      }
+      const opener = CLOSERS[last]
+      if (opener) {
+        let balance = 0
+        for (const ch of url) {
+          if (ch === opener) balance++
+          else if (ch === last) balance--
+        }
+        if (balance < 0) {
+          url = url.slice(0, -1)
+          continue
+        }
+      }
+      break
+    }
+    if (url.replace(/^https?:\/\//i, "").length === 0) continue
+    out.push({ start: m.index, end: m.index + url.length, url })
+  }
+  return out
+}
+
+export type TokenRange =
+  | { start: number; end: number; kind: "mention" }
+  | { start: number; end: number; kind: "link"; url: string }
+
+/**
+ * Merge mention and link ranges into one non-overlapping, sorted token list.
+ * On overlap the earlier start wins: a URL containing `/@known/path` stays one
+ * link (the mention inside it is incidental), while a chat chip whose label is
+ * itself a URL (`@chat:https://…`) stays a chip (the user inserted it from
+ * the picker; the URL inside is incidental).
+ */
+export function findTokenRanges(text: string, known: Set<string>): TokenRange[] {
+  const merged: TokenRange[] = [
+    ...findLinkRanges(text).map((r) => ({ ...r, kind: "link" as const })),
+    ...findMentionRanges(text, known).map((r) => ({ ...r, kind: "mention" as const })),
+  ].sort((a, b) => a.start - b.start)
+  const out: TokenRange[] = []
+  let prevEnd = -1
+  for (const r of merged) {
     if (r.start >= prevEnd) {
       out.push(r)
       prevEnd = r.end

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -1057,6 +1057,16 @@ button:focus-visible {
 .msg.role-user .user-text:active::-webkit-scrollbar-thumb {
   background-color: var(--vscode-scrollbarSlider-background, var(--color-scrollbar-thumb));
 }
+/* Pasted web links in the sent bubble — theme link color like .md a, plus an
+   explicit underline so the affordance survives themes where link color is
+   close to the foreground. */
+.msg.role-user .user-text .user-link {
+  color: var(--vscode-textLink-foreground);
+  text-decoration: underline;
+}
+.msg.role-user .user-text .user-link:hover {
+  color: var(--vscode-textLink-activeForeground);
+}
 /* Hover / focus rules are scoped to `[data-edit-phase="view"]` so they
    physically cannot fire while the edit overlay is mounted. */
 .msg.role-user.is-editable[data-edit-phase="view"] {
@@ -2207,6 +2217,15 @@ button:focus-visible {
 .promptbox-backdrop .mention-chip-selected {
   background: var(--vscode-editor-selectionBackground, rgba(80, 140, 255, 0.45));
   box-shadow: 0 0 0 1px var(--vscode-focusBorder, rgba(80, 140, 255, 0.9));
+}
+/* Web links while composing. The backdrop's glyphs are transparent (the
+   textarea above paints them), so the underline is the only paint we can add —
+   and text-decoration-color must be explicit because it defaults to
+   currentColor, which is transparent here. Decoration never shifts glyph
+   metrics, so textarea/backdrop alignment is preserved. */
+.promptbox-backdrop .link-token {
+  text-decoration: underline;
+  text-decoration-color: var(--vscode-textLink-foreground, rgba(80, 140, 255, 0.9));
 }
 .promptbox textarea {
   width: 100%;


### PR DESCRIPTION
## Summary

A URL pasted into the conversation now behaves like it does in Word: highlighted while composing, and a real clickable link in the sent bubble that opens in the external browser. Previously it was inert on the whole user side, while the identical URL in an assistant message already autolinked via remark-gfm.

Implementation follows the existing token architecture:

- **`mention-tokens.ts`** gains two pure helpers. `findLinkRanges` matches `http(s)://` runs and trims trailing sentence punctuation — bracket-balanced, so `(see https://example.com/a)` drops the paren but Wikipedia's `/wiki/Foo_(bar)` keeps it. Scheme-restricted by construction: nothing like `javascript:` can ever reach an href. `findTokenRanges` merges link and mention ranges with earlier-start-wins, which resolves both overlap directions correctly: a URL containing a known `@path` stays one link, and a chat chip whose label is itself a URL stays a chip.
- **`MessageView`**: `renderMentionedText` becomes `renderUserText` and renders link ranges as anchors in the same `target="_blank" rel="noreferrer noopener"` shape as `Markdown.tsx` (the webview swallows same-tab navigations — this is what "opens properly" requires). `stopPropagation` on the anchor keeps a link click from also flipping the bubble into edit mode, same pattern as the image-thumbnail preview button.
- **`PromptBox` backdrop**: link ranges get a `.link-token` span. The backdrop's glyphs are transparent (the textarea above paints them), so the affordance is an underline with an explicit `text-decoration-color` — decoration-color defaults to currentColor, which is transparent there. Decoration never shifts glyph metrics, so textarea/backdrop alignment is untouched.

Assistant messages are deliberately untouched — remark-gfm already covers them.

## Test plan

- [x] `bun run test` — 82 files / 1213 tests pass (14 new: 10 pure-helper cases, 2 MessageView, 1 PromptBox backdrop, plus interleave/overlap cases)
- [x] `bun run check-types` clean
- [x] `cd webview && bunx tsc --noEmit` clean
- [x] Regression tests verified real: with the three source files stashed, all 14 new tests fail; with only the anchor's `stopPropagation` removed, exactly the "clicking a link does not flip the bubble into edit mode" test fails
- [x] Overlap semantics covered both directions (URL containing `@path` / chip label that is a URL)
- [ ] Visual check in a running VS Code: paste a URL, confirm the underline appears while typing, and the sent bubble's link opens in the default browser without entering edit mode

Closes #465