### PR TITLE
feat(chat): open composer links with Cmd/Ctrl+Click

### DIFF
--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -930,6 +930,14 @@ export class ChatView implements vscode.WebviewViewProvider {
       case "openFile":
         await openFile(msg.path)
         return
+      case "openExternal":
+        // The webview only ever sends regex-matched http(s) URLs, but this is
+        // a trust boundary — re-check the scheme so no other kind of URI can
+        // reach openExternal through a forged message.
+        if (/^https?:\/\//i.test(msg.url)) {
+          await vscode.env.openExternal(vscode.Uri.parse(msg.url))
+        }
+        return
       case "openReviewChange":
         void this.openReviewChange(msg.change)
         return

--- a/test/host/chatview-harness.test.ts
+++ b/test/host/chatview-harness.test.ts
@@ -161,6 +161,23 @@ describe("ChatView harness: mounted handshake", () => {
   })
 })
 
+describe("ChatView harness: openExternal", () => {
+  it("routes an http(s) URL to vscode.env.openExternal", async () => {
+    vi.mocked(vscode.env.openExternal).mockClear()
+    await harness.send({ type: "openExternal", url: "https://example.com/docs" })
+    expect(vscode.env.openExternal).toHaveBeenCalledTimes(1)
+    const uri = vi.mocked(vscode.env.openExternal).mock.calls[0]![0]
+    expect(String(uri)).toContain("https://example.com/docs")
+  })
+
+  it("refuses non-http schemes at the trust boundary", async () => {
+    vi.mocked(vscode.env.openExternal).mockClear()
+    await harness.send({ type: "openExternal", url: "javascript:alert(1)" })
+    await harness.send({ type: "openExternal", url: "file:///etc/passwd" })
+    expect(vscode.env.openExternal).not.toHaveBeenCalled()
+  })
+})
+
 describe("ChatView harness: send round-trip", () => {
   it("creates a session, dispatches the prompt, streams the reply, and persists the turn", async () => {
     await harness.send({ type: "mounted" })

--- a/test/webview/message-view.test.tsx
+++ b/test/webview/message-view.test.tsx
@@ -120,6 +120,26 @@ describe("MessageView (user role)", () => {
     expect(container.querySelector("textarea")).not.toBeNull()
   })
 
+  it("passes onOpenLink through to the edit composer for Cmd+Click", async () => {
+    const user = userEvent.setup()
+    const onOpenLink = vi.fn()
+    const { container } = render(
+      <MessageView
+        message={userMessage("see https://example.com ok", { backendID: "b1" })}
+        processOpen={false}
+        processOnly={false}
+        onEditMessage={vi.fn()}
+        onOpenLink={onOpenLink}
+      />,
+    )
+    await user.click(container.querySelector(".msg.role-user") as HTMLElement)
+    const textarea = container.querySelector("textarea") as HTMLTextAreaElement
+    expect(textarea.value).toBe("see https://example.com ok")
+    textarea.setSelectionRange(10, 10)
+    fireEvent.click(textarea, { metaKey: true })
+    expect(onOpenLink).toHaveBeenCalledWith("https://example.com")
+  })
+
   it("restores past-chat mention chips when editing a sent message", async () => {
     const user = userEvent.setup()
     const message = userMessage("@chat:Old_chat revisit", { backendID: "b1" })

--- a/test/webview/promptbox.test.tsx
+++ b/test/webview/promptbox.test.tsx
@@ -953,6 +953,42 @@ describe("PromptBox mention chip rendering", () => {
     expect(token).not.toBeNull()
     expect(token!.textContent).toBe("https://example.com")
   })
+
+  it("opens the URL under the caret on Cmd/Ctrl+Click", async () => {
+    const user = userEvent.setup()
+    const onOpenLink = vi.fn()
+    render(
+      <PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} onOpenLink={onOpenLink} />,
+    )
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    await user.type(textarea, "see https://example.com. ok")
+    // By click time the browser has placed the caret at the clicked spot;
+    // jsdom has no layout, so position the caret explicitly.
+    textarea.setSelectionRange(10, 10)
+    fireEvent.click(textarea, { metaKey: true })
+    expect(onOpenLink).toHaveBeenCalledWith("https://example.com")
+
+    onOpenLink.mockClear()
+    fireEvent.click(textarea, { ctrlKey: true })
+    expect(onOpenLink).toHaveBeenCalledWith("https://example.com")
+  })
+
+  it("does not open on plain click, caret outside the URL, or a drag selection", async () => {
+    const user = userEvent.setup()
+    const onOpenLink = vi.fn()
+    render(
+      <PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} onOpenLink={onOpenLink} />,
+    )
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    await user.type(textarea, "see https://example.com. ok")
+    textarea.setSelectionRange(10, 10)
+    fireEvent.click(textarea)
+    textarea.setSelectionRange(1, 1)
+    fireEvent.click(textarea, { metaKey: true })
+    textarea.setSelectionRange(5, 12)
+    fireEvent.click(textarea, { metaKey: true })
+    expect(onOpenLink).not.toHaveBeenCalled()
+  })
 })
 
 describe("findChipAtCaret", () => {

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -39,6 +39,7 @@ export default function App() {
     attachFile,
     startIndex,
     stopIndex,
+    openLink,
   } = useChatState()
   const scrollRef = useRef<HTMLDivElement>(null)
   const dockRef = useRef<HTMLDivElement>(null)
@@ -276,6 +277,7 @@ export default function App() {
           commands={state.commands}
           onRunCommand={runCommandAndPinTop}
           inject={state.injectedText}
+          onOpenLink={openLink}
         />
       )}
       <div
@@ -332,6 +334,7 @@ export default function App() {
                 attachFile={attachFile}
                 conversations={state.conversations}
                 activeConversationID={state.conversationID}
+                onOpenLink={openLink}
               />
             )}
             {turn.assistants.map((m, i) => (
@@ -394,6 +397,7 @@ export default function App() {
               commands={state.commands}
               onRunCommand={runCommandAndPinTop}
               inject={state.injectedText}
+              onOpenLink={openLink}
             />
           </div>
         )}

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -52,6 +52,7 @@ type MessageViewProps = {
   attachFile?: () => Promise<{ attachments: Attachment[]; error?: string }>
   conversations?: ConversationSummary[]
   activeConversationID?: string
+  onOpenLink?: (url: string) => void
 }
 
 /**
@@ -93,6 +94,7 @@ function MessageViewComponent({
   attachFile,
   conversations,
   activeConversationID,
+  onOpenLink,
 }: MessageViewProps) {
   if (message.role === "user") {
     return (
@@ -107,6 +109,7 @@ function MessageViewComponent({
         attachFile={attachFile}
         conversations={conversations}
         activeConversationID={activeConversationID}
+        onOpenLink={onOpenLink}
       />
     )
   }
@@ -190,6 +193,7 @@ function UserMessageView({
   attachFile,
   conversations,
   activeConversationID,
+  onOpenLink,
 }: {
   message: Message
   busy?: boolean
@@ -201,6 +205,7 @@ function UserMessageView({
   attachFile?: () => Promise<{ attachments: Attachment[]; error?: string }>
   conversations?: ConversationSummary[]
   activeConversationID?: string
+  onOpenLink?: (url: string) => void
 }) {
   const originalText = message.blocks
     .filter((b): b is Extract<Block, { type: "text" }> => b.type === "text")
@@ -328,6 +333,7 @@ function UserMessageView({
             attachFile={attachFile}
             conversations={conversations}
             activeConversationID={activeConversationID}
+            onOpenLink={onOpenLink}
             variant="edit"
             initial={{
               text: originalText,

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -92,6 +92,8 @@ type Props = {
    * or conversation switch so a re-mounted composer never re-applies stale text.
    */
   inject?: { text: string; nonce: number }
+  /** Open a highlighted URL (Cmd/Ctrl+Click in the textarea) externally. */
+  onOpenLink?: (url: string) => void
 }
 
 function buildInitialAttachments(initial: Props["initial"]): Map<string, Attachment> {
@@ -125,7 +127,7 @@ function buildInitialConversations(initial: Props["initial"]): Map<string, strin
   return map
 }
 
-export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, searchFiles, listDir, attachFile, initial, variant = "send", position = "bottom", conversations, activeConversationID, contextUsage, commands = [], onRunCommand, inject }: Props) {
+export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, searchFiles, listDir, attachFile, initial, variant = "send", position = "bottom", conversations, activeConversationID, contextUsage, commands = [], onRunCommand, inject, onOpenLink }: Props) {
   const { text, setText, ref, backdropRef, pendingCursor } = usePromptText(initial?.text ?? "")
   // The Send button renders a disabled "Stopping…" while aborting, but Enter
   // routes through submit() — both must honor the same block, or a prompt
@@ -493,6 +495,25 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
     if (result.error) setAttachError(result.error)
   }
 
+  // Cmd+Click (Ctrl+Click off macOS) opens a highlighted URL, matching the
+  // VS Code editor convention — a plain click must keep placing the caret.
+  // On macOS Ctrl+Click raises the context menu instead of a click event, so
+  // accepting ctrlKey here is harmless. By click time the browser has already
+  // set the caret to the clicked position, which is what locates the link.
+  const onTextareaClick = (e: React.MouseEvent<HTMLTextAreaElement>) => {
+    if (!onOpenLink || (!e.metaKey && !e.ctrlKey)) return
+    const el = e.currentTarget
+    const caret = el.selectionStart
+    // A collapsed selection distinguishes a click from a modifier-drag select.
+    if (caret === null || caret !== el.selectionEnd) return
+    for (const r of findTokenRanges(text, allKnownLabels())) {
+      if (r.kind === "link" && r.start <= caret && caret <= r.end) {
+        onOpenLink(r.url)
+        return
+      }
+    }
+  }
+
   const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     // If an IME composition is in progress (e.g. typing Chinese pinyin),
     // Enter belongs to the IME — it commits the candidate, NOT submits the
@@ -751,6 +772,7 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
           placeholder={canQueue ? "@ for files, Enter to queue" : "/ for commands, @ for files, Enter to send"}
           onChange={(e) => updateText(e.target.value, e.target.selectionStart ?? e.target.value.length)}
           onKeyDown={onKeyDown}
+          onClick={onTextareaClick}
           onPaste={onPaste}
           onSelect={onSelect}
           onScroll={(e) => {

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -591,6 +591,9 @@ export function useChatState() {
     stopIndex() {
       vscode.post({ type: "stopIndex" })
     },
+    openLink(url: string) {
+      vscode.post({ type: "openExternal", url })
+    },
     }),
     [],
   )

--- a/webview/src/protocol.ts
+++ b/webview/src/protocol.ts
@@ -476,6 +476,7 @@ export type Inbound =
   | { type: "deleteConversation"; id: string }
   | { type: "apply"; code: string; language?: string }
   | { type: "openFile"; path: string }
+  | { type: "openExternal"; url: string }
   | { type: "openReviewChange"; change: ReviewChange }
   | { type: "reviewAllInChange"; source: string; path: string; action: ReviewHunkState }
   | { type: "selectAgent" }


### PR DESCRIPTION
## Summary

Follow-up to #466: a highlighted URL in the composer can now actually be opened — Cmd+Click on macOS, Ctrl+Click elsewhere — matching the VS Code editor and Word convention. Plain click keeps placing the caret.

How it works, end to end:

- **Locating the link**: by the time `click` fires, the browser has already set the textarea caret to the clicked position, so the handler just looks up which token range contains `selectionStart`. It reuses `findTokenRanges`, which means only ranges *rendered* as links open — a chat chip whose label contains a URL stays inert — and the paint and the behavior can never disagree. A non-collapsed selection (modifier-drag) bails: that's a select gesture, not a click.
- **Opening properly**: a programmatic `window.open` is not a thing inside a webview, so this adds the first `openExternal` variant to the Inbound protocol union; the host routes it to `vscode.env.openExternal`. The host **re-validates the `http(s)` scheme at the message boundary** — the webview only ever sends regex-matched URLs, but a webview message is a trust boundary, and the guard keeps a forged message from smuggling `file:` or anything else into `openExternal`.
- **Coverage**: wired to the top and bottom send composers and threaded through `MessageView` to the edit-in-place composer, so a link in a message being edited behaves the same. `openLink` lives inside `useChatState`'s single memoized API object, so identity stability is preserved (the `sameMessageViewProps` comparator already excludes function props).
- macOS Ctrl+Click natively raises the context menu instead of a click event, so accepting `ctrlKey` in the handler is harmless there while giving Windows/Linux their conventional chord.

## Test plan

- [x] `bun run test` — 82 files / 1218 tests pass (5 new: harness routes/refuses `openExternal`; composer opens on Cmd and Ctrl click; plain click / caret-outside / drag-selection all inert; edit composer plumbing)
- [x] `bun run check-types` clean
- [x] `cd webview && bunx tsc --noEmit` clean
- [x] Regression tests verified real: with the six source files stashed, exactly the three positive tests fail (the two negative ones pass either way, as designed)
- [x] Scheme guard covered: `javascript:` and `file:` URLs never reach `vscode.env.openExternal`
- [ ] Visual check in a running VS Code: paste a URL, Cmd+Click it in the composer and in an in-place edit, confirm it opens in the default browser and plain click still just moves the caret

Closes #467