### PR TITLE
fix(chat): keep edit-mode backdrop padding in sync with the textarea

### DIFF
--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -967,6 +967,16 @@ button:focus-visible {
   min-height: 24px;
   padding: var(--bubble-text-padding);
 }
+/* The backdrop must keep character-for-character wrap parity with the
+   textarea it paints behind. Its base padding is the bottom composer's
+   6px 8px; when the edit-mode rule above narrows the textarea's padding,
+   the two layers get different content widths and wrap long lines at
+   different points — chip backgrounds drift off their tokens and a link
+   underline breaks up mid-URL. Any padding change to the edit-mode
+   textarea must be mirrored here. */
+.msg.role-user:not([data-edit-phase="view"]) .promptbox .promptbox-backdrop {
+  padding: var(--bubble-text-padding);
+}
 /* Fade + slide the action row in when entering edit mode so the buttons
    don't pop into existence below the textarea. The animation only runs
    on mount (the row stays mounted while editing), and is scoped to


### PR DESCRIPTION
## Summary

In the edit-in-place composer, a link's underline rendered as broken segments that didn't sit under the URL, while the bottom composer underlined the same text continuously.

The backdrop technique requires the transparent textarea and the paint layer behind it to wrap **identically** — that's what makes chips and underlines land under the right glyphs. Edit mode broke that contract on one side only: the edit-mode rule narrows the textarea's padding to `var(--bubble-text-padding)` (4px, so glyphs keep their display-mode pixel position), but `.promptbox-backdrop` kept its base `6px 8px` in every mode. Different horizontal padding → different content widths → long lines wrap at different points, and everything the backdrop paints drifts off the visible text. Mention chips have had this exact drift in edit mode all along — their fat backgrounds masked it; the 1px underline made it visible.

Fix is one mirrored rule: the same `[data-edit-phase]`-scoped selector now applies `--bubble-text-padding` to the backdrop too, with a comment stating the invariant (any padding change to the edit-mode textarea must be mirrored). The bottom composer is untouched — both its layers already use `6px 8px`.

No JS changes, so no new unit tests: jsdom applies no real stylesheet, and a text-match test against styles.css would assert the diff, not the behavior.

## Test plan

- [x] `bun run test` — 82 files / 1218 tests pass (regression guard; CSS-only change)
- [x] `bun run check-types` clean
- [ ] Visual check in a running VS Code: edit a sent message containing a long URL — the underline is continuous and identical to the bottom composer's, chips sit exactly behind their tokens, and glyphs don't jump when entering edit mode (the textarea side is unchanged)

Closes #469