### PR TITLE
chore(release): 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-07-22
+
+### Added
+- URLs in your own messages are now live links. While composing, a pasted `http(s)://` URL is underlined in place, and in the sent bubble it renders as a real link that opens in your default browser — clicking it no longer flips the bubble into edit mode. Trailing punctuation stays out of the link, and Wikipedia-style URLs ending in `(...)` keep their closing paren. Assistant messages already auto-linked bare URLs; this brings your side of the conversation to parity (#465, #466).
+- Cmd+Click (Ctrl+Click on Windows/Linux) on an underlined URL inside the composer — the bottom send box or an in-place edit — opens it in the external browser without moving focus out of the text (#467, #468).
+
+### Changed
+- The `@` mention picker responds faster in large workspaces: concurrent lookups now share a single in-flight file scan instead of each starting their own, and filtering debounces keystrokes by 100ms instead of re-querying per character (#457, #458).
+
+### Fixed
+- Slash commands typed while a turn is running are no longer silently swallowed — the composer shows a muted hint that the command has to wait for the turn to finish, and the session-neutral `/new`, `/mcp`, and `/provider` now run immediately even mid-turn (#459, #460).
+- A send that failed just after dispatch could leave a phantom "running" Main row in the Agents popover that survived window reloads; the row now settles as soon as the turn fails (#461, #462).
+- Arrow-key navigation in the prompt-box pickers no longer snaps back to the row under a resting mouse cursor — scrolling the highlight used to fire a synthetic hover event that stole the selection, making Up/Down appear stuck while the mouse rested over the list (#463, #464).
+- Editing a sent message no longer paints mention-chip backgrounds and link underlines slightly off the text. The edit composer's highlight backdrop kept the bottom composer's padding while the textarea used the bubble's, so the two layers wrapped long lines at different points — most visibly breaking a link underline mid-URL (#469, #470).
+
 ## [1.9.0] - 2026-07-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Release **v1.10.0**. Bumps `package.json` to `1.10.0` and adds the `## [1.10.0]` CHANGELOG entry covering everything merged since v1.9.0.

Since v1.9.0 (#458 through #470, 7 PRs):
- Share one in-flight workspace file scan and debounce mention-picker input by 100ms (#457, #458).
- Hint instead of silently swallowing slash commands while busy; allow `/new` `/mcp` `/provider` mid-turn (#459, #460).
- Settle the Main task row when a dispatch fails post-start instead of leaving a phantom running row across reloads (#461, #462).
- Stop a resting mouse cursor from hijacking arrow-key picker navigation (#463, #464).
- Linkify pasted URLs in user bubbles and the composer backdrop (#465, #466).
- Open composer links with Cmd/Ctrl+Click, via a new `openExternal` protocol variant with host-side scheme re-validation (#467, #468).
- Keep edit-mode backdrop padding in sync with the textarea so chip/underline paint stays on the glyphs (#469, #470).

After this merges, the tag `v1.10.0` + GitHub Release are created from `main`, which triggers `release.yml` to publish to the VS Code Marketplace and Open VSX.

## Test plan

- [x] Version bumped to 1.10.0 in `package.json`
- [x] `CHANGELOG.md` `## [1.10.0]` entry added (dated 2026-07-22)
- [x] `bun run test` — 82 files / 1218 tests pass
- [x] `bun run check-types` (host) clean
- [x] `cd webview && bunx tsc --noEmit` clean
- [ ] `release.yml` tag-vs-version gate passes and both Marketplace + Open VSX publish steps go green (verified post-tag)

Closes #471