### PR TITLE
perf(review): Map-keyed change aggregation, debounced hunk sync

### DIFF
--- a/src/chat/builtin-runners.ts
+++ b/src/chat/builtin-runners.ts
@@ -37,7 +37,6 @@ export type BuiltinRunnerDeps = {
   clearReviewHunks: () => void
   saveActive: () => void
   sendConversationState: () => void
-  queueReviewDecorationsSync: () => void
   resetSessionState: () => void
   applyActiveSnapshot: () => void
   refreshContextUsage: (backend: Backend) => Promise<void>
@@ -229,8 +228,9 @@ export class BuiltinRunners {
     this.deps.setMessages(messages.slice(0, idx))
     this.deps.clearReviewHunks()
     this.deps.saveActive()
+    // sendConversationState posts a `restore`, which queues the review-hunk
+    // sync on the ChatView side — no separate trigger needed.
     this.deps.sendConversationState()
-    this.deps.queueReviewDecorationsSync()
     // Restore the undone prompt so the user can edit and resend. Plain text only:
     // mentions/attachments are not re-hydrated.
     this.deps.post({ type: "setComposerText", text: userMessageText(target) })
@@ -275,7 +275,6 @@ export class BuiltinRunners {
     this.deps.setMessages([...this.deps.getMessages(), ...tail])
     this.deps.saveActive()
     this.deps.sendConversationState()
-    this.deps.queueReviewDecorationsSync()
     this.deps.post({ type: "setComposerText", text: "" })
   }
 

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -184,7 +184,6 @@ export class ChatView implements vscode.WebviewViewProvider {
       },
       saveActive: () => this.saveActive(),
       sendConversationState: () => this.sendConversationState(),
-      queueReviewDecorationsSync: () => this.queueReviewDecorationsSync(),
       resetSessionState: () => this.resetSessionState(),
       applyActiveSnapshot: () => this.applyActiveSnapshot(),
       refreshContextUsage: (backend) => this.refreshContextUsage(backend),
@@ -245,7 +244,7 @@ export class ChatView implements vscode.WebviewViewProvider {
 
     vscode.window.onDidChangeActiveTextEditor(() => {
       this.pushContext()
-      this.queueReviewDecorationsSync()
+      this.queueReviewHunkSync()
     }, null, this.context.subscriptions)
     vscode.window.onDidChangeTextEditorSelection(
       () => this.pushContext(),
@@ -323,6 +322,10 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.subscription = undefined
     this.aborting = false
     this.clearPendingDeltas()
+    if (this.reviewSyncTimer) {
+      clearTimeout(this.reviewSyncTimer)
+      this.reviewSyncTimer = undefined
+    }
     this.taskStoreUnsub?.dispose()
     this.taskStoreUnsub = undefined
     // Write any debounced tail before the view (and its context) goes away,
@@ -621,7 +624,7 @@ export class ChatView implements vscode.WebviewViewProvider {
       case "restore":
         this.messages = msg.messages.map((m) => ({ ...m, pending: false }))
         this.reviewHunks = msg.reviewHunks ?? {}
-        this.queueReviewDecorationsSync()
+        this.queueReviewHunkSync()
         return
       case "clear":
         this.messages = []
@@ -689,7 +692,10 @@ export class ChatView implements vscode.WebviewViewProvider {
       case "tool":
         this.messages = upsertTool(this.messages, msg.id, msg.update, msg.actor)
         this.saveActive()
-        this.queueReviewDecorationsSync()
+        // Only a completed tool can change the review set — extractChanges
+        // skips every other status, so pending/running ticks would sync for
+        // nothing.
+        if (msg.update.status === "completed") this.queueReviewHunkSync()
         return
       case "patch":
         this.messages = this.messages.map((m) =>
@@ -698,14 +704,14 @@ export class ChatView implements vscode.WebviewViewProvider {
             : m,
         )
         this.saveActive()
-        this.queueReviewDecorationsSync()
+        this.queueReviewHunkSync()
         return
       case "reviewHunkState":
         this.reviewHunks = { ...this.reviewHunks }
         if (msg.state) this.reviewHunks[msg.key] = msg.state
         else delete this.reviewHunks[msg.key]
         this.saveActive()
-        this.queueReviewDecorationsSync()
+        this.queueReviewHunkSync()
         return
       case "assistantError":
         this.messages = this.messages.map((m) =>
@@ -1633,7 +1639,6 @@ export class ChatView implements vscode.WebviewViewProvider {
       this.reviewHunks = {}
       this.saveActive()
       this.sendConversationState()
-      this.queueReviewDecorationsSync()
     }
 
     await this.handleSend(trimmed, mentions, attachments, conversationMentions)
@@ -1945,7 +1950,6 @@ export class ChatView implements vscode.WebviewViewProvider {
     if (event.type === "tool") {
       const wire = toWire(event.update, cwd)
       this.post({ type: "tool", id: parentWebviewID, update: wire, actor })
-      this.queueReviewDecorationsSync()
       return
     }
     this.post({
@@ -1955,7 +1959,6 @@ export class ChatView implements vscode.WebviewViewProvider {
       diff: event.diff,
       actor,
     })
-    this.queueReviewDecorationsSync()
   }
 
   private resolveSubagentActor(childSessionID: string) {
@@ -2002,10 +2005,10 @@ export class ChatView implements vscode.WebviewViewProvider {
       if (active !== doc.uri.toString()) {
         await vscode.window.showTextDocument(doc, { viewColumn: vscode.ViewColumn.One, preview: false })
       }
-      // Decoration sync (purging missing-file hunks) is independent of where
-      // the editor is pointed — run it AFTER the editor swap so the visible
-      // pane updates immediately rather than waiting on fs.stat I/O.
-      void this.syncReviewDecorations()
+      // Hunk-state reconciliation (purging missing-file hunks) is independent
+      // of where the editor is pointed — queue it so the editor swap never
+      // waits on fs.stat I/O.
+      this.queueReviewHunkSync()
     } catch (e) {
       log(`could not open review file ${change.path}`, e)
       vscode.window.showWarningMessage(`OpenCode Panel: could not open ${change.path} as text.`)
@@ -2073,19 +2076,37 @@ export class ChatView implements vscode.WebviewViewProvider {
         `OpenCode Panel: couldn't ${verb} ${result.conflicts} hunk${result.conflicts === 1 ? "" : "s"} in ${requestedPath} — the file has changed since the diff was produced.`,
       )
     }
-    if (result.applied > 0) await this.syncReviewDecorations()
-    else log("reviewAllInChange: no hunks applied", { source, path: requestedPath, action, conflicts: result.conflicts })
+    // No explicit sync here: applied > 0 guarantees at least one
+    // reviewHunkState post above (the all-reviewed case returned early inside
+    // reviewAllForPath), and each of those already queued the debounced sync.
+    if (result.applied === 0) {
+      log("reviewAllInChange: no hunks applied", { source, path: requestedPath, action, conflicts: result.conflicts })
+    }
   }
 
   private backendDirectory(): string | undefined {
     return this.servers.currentWorkspace()?.fsPath
   }
 
-  private queueReviewDecorationsSync() {
-    void this.syncReviewDecorations().catch((e) => log("review decorations sync failed", e))
+  private reviewSyncTimer?: ReturnType<typeof setTimeout>
+  private static readonly REVIEW_SYNC_DEBOUNCE_MS = 100
+
+  /**
+   * Debounced entry to syncReviewHunks. Review-relevant events arrive in
+   * bursts — tool closures during a streaming turn, one reviewHunkState post
+   * per hunk from Keep/Undo-all — and each pass costs a full extract +
+   * aggregate plus an fs.stat per changed path, so bursts must collapse into
+   * one pass. Same first-call-arms idiom as queueDelta: events landing inside
+   * the window ride the pending timer.
+   */
+  private queueReviewHunkSync() {
+    this.reviewSyncTimer ??= setTimeout(() => {
+      this.reviewSyncTimer = undefined
+      this.syncReviewHunks().catch((e) => log("review hunk sync failed", e))
+    }, ChatView.REVIEW_SYNC_DEBOUNCE_MS)
   }
 
-  private async syncReviewDecorations() {
+  private async syncReviewHunks() {
     // All editor-side review UI (line highlights, ghost-text deletions,
     // unlocatable banner) was removed — review actions live exclusively in
     // the Review Card now. This sync only purges hunks for files that have

--- a/test/host/builtin-runners.test.ts
+++ b/test/host/builtin-runners.test.ts
@@ -79,7 +79,6 @@ function makeHarness(opts: HarnessOpts = {}) {
     }),
     saveActive: vi.fn(),
     sendConversationState: vi.fn(),
-    queueReviewDecorationsSync: vi.fn(),
     resetSessionState: vi.fn(),
     applyActiveSnapshot: vi.fn(),
     refreshContextUsage: vi.fn().mockResolvedValue(undefined),

--- a/test/host/chatview-harness.test.ts
+++ b/test/host/chatview-harness.test.ts
@@ -103,7 +103,10 @@ beforeEach(async () => {
   server = await startMockOpencode()
   const client = createOpencodeClient({ baseUrl: server.url })
   const backend = { url: server.url, client, directory: "/ws" } as unknown as Backend
-  const servers = { ensure: vi.fn(async () => backend) } as unknown as ServerManager
+  const servers = {
+    ensure: vi.fn(async () => backend),
+    currentWorkspace: vi.fn(() => undefined),
+  } as unknown as ServerManager
   const prefs = {
     get: () => ({}),
     onChange: vi.fn(() => ({ dispose: vi.fn() })),
@@ -745,6 +748,71 @@ describe("ChatView harness: host-side delta coalescing", () => {
     const lines = appendLine.mock.calls.map((c) => String(c[0]))
     expect(lines.some((l) => l.includes("[sse] message.part.delta"))).toBe(false)
     expect(lines.some((l) => l.includes("[sse] session.idle"))).toBe(true)
+  })
+})
+
+describe("ChatView harness: review-hunk sync debounce", () => {
+  function editToolEvent(callID: string, status: "running" | "completed", filePath: string) {
+    return {
+      type: "message.part.updated",
+      part: {
+        id: `part_${callID}`,
+        messageID: "msg_a",
+        sessionID: SESSION_ID,
+        type: "tool",
+        callID,
+        tool: "edit",
+        state: {
+          status,
+          input: { filePath },
+          ...(status === "completed"
+            ? { metadata: { filediff: { patch: "@@ -1 +1 @@\n-old\n+new", additions: 1, deletions: 1 } } }
+            : {}),
+        },
+      },
+    }
+  }
+
+  async function startAssistantTurn(prompt: string) {
+    await harness.send({ type: "mounted" })
+    await harness.send({ type: "send", text: prompt })
+    server.push({ type: "message.updated", info: { id: "msg_a", role: "assistant", sessionID: SESSION_ID } })
+    await until(() => harness.posted.some((m) => m.type === "assistantStart"))
+  }
+
+  // The send pipeline stats other paths (context collectors), so counts are
+  // filtered to the test's own file rather than cleared globally.
+  function statCallsFor(name: string) {
+    return vi
+      .mocked(vscode.workspace.fs.stat)
+      .mock.calls.filter((c) => String((c[0] as vscode.Uri | undefined)?.fsPath ?? c[0]).includes(name))
+      .length
+  }
+
+  it("coalesces a burst of completed tool closures into one hunk-sync pass", async () => {
+    await startAssistantTurn("edit a file five times")
+    for (let i = 0; i < 5; i++) server.push(editToolEvent(`call_${i}`, "completed", "src/burst.ts"))
+
+    // Each sync pass stats the changed path exactly once (the default fs.stat
+    // mock resolves, so the first workspace candidate wins and nothing gets
+    // purged or re-queued). Five closures inside one debounce window must
+    // collapse to one pass — allow two in case a closure straddles the timer.
+    await until(() => statCallsFor("burst.ts") > 0)
+    await new Promise((r) => setTimeout(r, 250))
+    expect(statCallsFor("burst.ts")).toBeLessThanOrEqual(2)
+  })
+
+  it("does not run the sync for non-completed tool ticks", async () => {
+    await startAssistantTurn("edit a file")
+    // Seed one completed change, then wait for its debounced pass: with a
+    // change present, a sync pass — if one were wrongly queued later — would
+    // stat this path again.
+    server.push(editToolEvent("call_seed", "completed", "src/seed.ts"))
+    await until(() => statCallsFor("seed.ts") === 1)
+
+    for (let i = 0; i < 3; i++) server.push(editToolEvent(`call_run_${i}`, "running", "src/seed.ts"))
+    await new Promise((r) => setTimeout(r, 250))
+    expect(statCallsFor("seed.ts")).toBe(1)
   })
 })
 

--- a/test/webview/turn-changes.test.ts
+++ b/test/webview/turn-changes.test.ts
@@ -10,6 +10,7 @@ import {
   samePath,
   normalizePath,
 } from "../../webview/src/components/ReviewPanel"
+import { aggregateChanges, type ReviewChange } from "../../webview/src/review-extract"
 import type { Message } from "../../webview/src/hooks/useChatState"
 
 describe("synthesizeCreatePatch", () => {
@@ -228,6 +229,76 @@ describe("turnChanges", () => {
       { id: "a1", role: "assistant", blocks: [{ type: "text", text: "hi" }] },
     ]
     expect(turnChanges(messages)).toHaveLength(0)
+  })
+})
+
+describe("aggregateChanges", () => {
+  function change(over: Partial<ReviewChange>): ReviewChange {
+    return {
+      source: "s",
+      path: "a.ts",
+      kind: "updated",
+      additions: 1,
+      deletions: 0,
+      patch: "@@\n+x",
+      ...over,
+    }
+  }
+
+  it("keeps rows in first-appearance order, merging onto the original row", () => {
+    const result = aggregateChanges([
+      change({ path: "a.ts", source: "s1" }),
+      change({ path: "b.ts", source: "s2" }),
+      change({ path: "a.ts", source: "s3" }),
+      change({ path: "c.ts", source: "s4" }),
+    ])
+    expect(result.map((c) => c.path)).toEqual(["a.ts", "b.ts", "c.ts"])
+  })
+
+  it("merges records whose paths differ only by normalization", () => {
+    const result = aggregateChanges([
+      change({ path: "./src/foo.ts", additions: 2 }),
+      change({ path: "src\\foo.ts", additions: 3 }),
+    ])
+    expect(result).toHaveLength(1)
+    expect(result[0]!.additions).toBe(5)
+  })
+
+  it("takes source and patch from the most recent record and sums counts", () => {
+    const result = aggregateChanges([
+      change({ source: "first", patch: "@@\n+a", additions: 1, deletions: 1 }),
+      change({ source: "last", patch: "@@\n+b", additions: 2, deletions: 3 }),
+    ])
+    expect(result[0]).toMatchObject({ source: "last", patch: "@@\n+b", additions: 3, deletions: 4 })
+  })
+
+  it("prefers the later sticky kind when two sticky kinds conflict", () => {
+    const result = aggregateChanges([change({ kind: "created" }), change({ kind: "deleted" })])
+    expect(result[0]!.kind).toBe("deleted")
+  })
+
+  it("keeps the first oldPath and the latest absolutePath", () => {
+    const result = aggregateChanges([
+      change({ kind: "moved", oldPath: "old.ts", absolutePath: "/w/1.ts" }),
+      change({ absolutePath: "/w/2.ts" }),
+    ])
+    expect(result[0]!.oldPath).toBe("old.ts")
+    expect(result[0]!.absolutePath).toBe("/w/2.ts")
+  })
+
+  it("dedupes actors across merged records", () => {
+    const main = { kind: "main" as const }
+    const sub = { kind: "subagent" as const, sessionID: "child_1", subagent: "explore" }
+    const result = aggregateChanges([
+      change({ actors: [main] }),
+      change({ actors: [sub, main] }),
+    ])
+    expect(result[0]!.actors).toEqual([main, sub])
+  })
+
+  it("drops the actors field entirely when no record carries one", () => {
+    const result = aggregateChanges([change({}), change({})])
+    expect(result[0]!.actors).toBeUndefined()
   })
 })
 

--- a/webview/src/review-extract.ts
+++ b/webview/src/review-extract.ts
@@ -294,13 +294,20 @@ export function extractChanges(messages: ChatMessage[]): ReviewChange[] {
  * - `oldPath` (move) propagates through if any contributing record had it
  */
 export function aggregateChanges(changes: ReviewChange[]): ReviewChange[] {
-  return changes.reduce<ReviewChange[]>((acc, change) => {
-    const existingIndex = acc.findIndex((item) => samePath(item.path, change.path))
-    if (existingIndex < 0) {
-      return [...acc, { ...change, actors: dedupActors(change.actors) }]
+  // Map keyed on the normalized path (the same equivalence `samePath` uses).
+  // Map.set on an existing key keeps its original insertion position, so rows
+  // stay in first-appearance order. This runs per delta flush in the webview's
+  // ReviewPanel memo — it must stay a single pass, not a findIndex-per-record
+  // scan.
+  const byPath = new Map<string, ReviewChange>()
+  for (const change of changes) {
+    const key = normalizePath(change.path)
+    const prev = byPath.get(key)
+    if (!prev) {
+      byPath.set(key, { ...change, actors: dedupActors(change.actors) })
+      continue
     }
-    const prev = acc[existingIndex]!
-    const merged: ReviewChange = {
+    byPath.set(key, {
       ...change,
       additions: prev.additions + change.additions,
       deletions: prev.deletions + change.deletions,
@@ -308,11 +315,9 @@ export function aggregateChanges(changes: ReviewChange[]): ReviewChange[] {
       oldPath: prev.oldPath ?? change.oldPath,
       absolutePath: change.absolutePath ?? prev.absolutePath,
       actors: dedupActors([...(prev.actors ?? []), ...(change.actors ?? [])]),
-    }
-    const copy = acc.slice()
-    copy[existingIndex] = merged
-    return copy
-  }, [])
+    })
+  }
+  return [...byPath.values()]
 }
 
 function priorityKind(prev: ReviewChange["kind"], next: ReviewChange["kind"]): ReviewChange["kind"] {
@@ -338,7 +343,7 @@ function dedupActors(actors: ReviewChangeActor[] | undefined): ReviewChangeActor
 /**
  * The canonical "what does this turn contain?" function. Used by:
  *  - webview ReviewPanel to render the review card
- *  - host syncReviewDecorations / handleReviewAllInChange to drive actions
+ *  - host syncReviewHunks / handleReviewAllInChange to drive actions
  *
  * Both sides MUST produce the same list — keep this the only place that
  * collapses multiple records for the same path.


### PR DESCRIPTION
## Summary

- **`aggregateChanges` is now a single Map-keyed pass** (`webview/src/review-extract.ts`). It was a `findIndex`-per-record reduce with a full array copy per merge — quadratic in change records — and it runs on every host review sync *and* in the webview `ReviewPanel` memo on every coalesced delta flush (~40x/s while streaming). The Map is keyed on the normalized path (the same equivalence `samePath` used), preserves first-appearance row order, and keeps the exact merge semantics: summed counts, sticky-kind priority with later-wins on conflict, latest `source`/`patch`, first `oldPath`, latest `absolutePath`, deduped actors. All pinned by new tests.
- **The host review sync is debounced (100ms)** using the same first-call-arms idiom as the delta coalescer, so bursts — tool closures during a streaming turn, the one-`reviewHunkState`-post-per-hunk loop from Keep/Undo-all — collapse into one extract + aggregate + fs.stat pass instead of one pass per event. The timer is cleared on dispose.
- **Only `completed` tool updates queue the sync.** `extractChanges` skips every other status, so pending/running ticks were syncing for nothing.
- **Redundant triggers removed**: `appendSubagentBlock` and `editMessage` queued explicitly right after a `post()` whose `applyLocal` case already queues; `handleReviewAllInChange`'s final explicit sync is covered by its own `reviewHunkState` posts (`applied > 0` guarantees at least one — the all-reviewed case returns early); the `BuiltinRunners` dep is gone entirely since both uses immediately followed `sendConversationState`, whose `restore` post queues the sync.
- **Renamed** `queueReviewDecorationsSync` / `syncReviewDecorations` → `queueReviewHunkSync` / `syncReviewHunks`: editor decorations no longer exist; the sync reconciles review-hunk state with disk (purging hunks for deleted files).

## Test plan

- [x] `bun run test` — 82 files, 1227 tests pass (9 new: 7 `aggregateChanges` semantics tests pinning order/merge behavior, 2 ChatView harness tests proving burst coalescing and the completed-only gate via per-path fs.stat counts)
- [x] Harness file re-run 5x to shake out timing flakiness — stable
- [x] `bun run check-types` (host) — clean
- [x] `cd webview && bunx tsc --noEmit` — clean

Closes #473