### PR TITLE
fix(agents): show waiting-for-input when a permission or question is pending

### DIFF
--- a/src/chat/subagent-dispatch.ts
+++ b/src/chat/subagent-dispatch.ts
@@ -127,4 +127,27 @@ export class SubagentDispatch {
       updatedAt: Date.now(),
     })
   }
+
+  /**
+   * Flip the current turn's Main row between `running` and `waiting`.
+   * Driven by ChatView's pending permission/question count — "waiting"
+   * means opencode is blocked on the user's answer, which is exactly when
+   * the popover should stop claiming work is running. Only the two
+   * expected transitions are applied (running → waiting, waiting →
+   * running); a settled row keeps its terminal status and a stray call
+   * after the turn ended no-ops on the cleared `currentMainTaskID`.
+   */
+  async setMainWaiting(waiting: boolean): Promise<void> {
+    if (!this.deps.taskStore) return
+    const id = this.currentMainTaskID
+    if (!id) return
+    const existing = this.deps.taskStore.get(id)
+    if (!existing) return
+    const from = waiting ? "running" : "waiting"
+    if (existing.status !== from) return
+    await this.deps.taskStore.update(id, {
+      status: waiting ? "waiting" : "running",
+      updatedAt: Date.now(),
+    })
+  }
 }

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -206,6 +206,11 @@ export class ChatView implements vscode.WebviewViewProvider {
     if (this.sessionID && this.taskStore) {
       void this.taskStore.markSessionIdle(this.sessionID)
     }
+    // A pending permission/question cannot outlive its turn — opencode
+    // blocks the turn on it. An entry surviving here would wedge the NEXT
+    // turn's Main row on `waiting` (syncAgentWaitState counts these maps).
+    this.activePermissions.clear()
+    this.activeQuestions.clear()
     this.subagentDispatch.clearMainTaskID()
     this.post({ type: "sessionIdle" })
     void this.manager.flushPersist()
@@ -218,6 +223,19 @@ export class ChatView implements vscode.WebviewViewProvider {
       `[agents-status] post snapshot conv=${activeID} total=${status.total} (running=${status.running} waiting=${status.waiting} error=${status.error}) ids=[${status.tasks.map((t) => `${t.kind}:${t.id}`).join(", ")}]`,
     )
     this.post({ type: "agentsStatus", status })
+  }
+
+  /**
+   * Recompute "is this turn blocked on the user?" from the pending
+   * permission + question maps and mirror it onto the Main task row.
+   * Must be called after every mutation of either map — the popover
+   * renders `waiting` as "waiting for input", and before this wiring
+   * nothing ever set that status, so a permission-blocked turn showed
+   * as `running`.
+   */
+  private syncAgentWaitState() {
+    const pending = this.activePermissions.size + this.activeQuestions.size
+    void this.subagentDispatch.setMainWaiting(pending > 0)
   }
 
   async resolveWebviewView(view: vscode.WebviewView) {
@@ -964,6 +982,7 @@ export class ChatView implements vscode.WebviewViewProvider {
         return
       case "permissionReply": {
         this.activePermissions.delete(msg.id)
+        this.syncAgentWaitState()
         if (!this.sessionID) return
         try {
           const backend = await this.servers.ensure()
@@ -978,11 +997,13 @@ export class ChatView implements vscode.WebviewViewProvider {
       }
       case "questionReply": {
         this.activeQuestions.delete(msg.id)
+        this.syncAgentWaitState()
         await this.replyQuestion(msg.id, msg.answers)
         return
       }
       case "questionReject": {
         this.activeQuestions.delete(msg.id)
+        this.syncAgentWaitState()
         await this.rejectQuestion(msg.id)
         return
       }
@@ -1106,6 +1127,11 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.aborting = true
     this.pendingUserBackendID = undefined
     this.post({ type: "aborted" })
+    // The webview reducer drops its permission/question dialogs on
+    // `aborted`; mirror that here or the dead prompts wedge the next
+    // turn's waiting computation in syncAgentWaitState.
+    this.activePermissions.clear()
+    this.activeQuestions.clear()
     void this.subagentDispatch.recordMainTaskFinish("cancelled")
 
     // Tear down the tracker's local view of the subagent tree first.
@@ -1759,6 +1785,7 @@ export class ChatView implements vscode.WebviewViewProvider {
         // and no resolution event exists that would ever clear the dialog.
         if (this.aborting) return
         this.activePermissions.set(perm.id, perm)
+        this.syncAgentWaitState()
         this.post({
           type: "permission",
           id: perm.id,
@@ -1769,6 +1796,7 @@ export class ChatView implements vscode.WebviewViewProvider {
       onQuestionAsked: (q) => {
         if (this.aborting) return
         this.activeQuestions.set(q.id, q)
+        this.syncAgentWaitState()
         this.post({
           type: "question",
           id: q.id,
@@ -1777,6 +1805,7 @@ export class ChatView implements vscode.WebviewViewProvider {
       },
       onQuestionResolved: (id) => {
         this.activeQuestions.delete(id)
+        this.syncAgentWaitState()
         this.post({ type: "questionResolved", id })
       },
       onMessageRemoved: (backendID) => {

--- a/test/host/agent-task-wiring.test.ts
+++ b/test/host/agent-task-wiring.test.ts
@@ -4,9 +4,9 @@ import {
   summarizeAgentTasks,
   isSubagentTool,
 } from "../../src/agents/summary"
-import { summarizePrompt } from "../../src/chat/subagent-dispatch"
+import { SubagentDispatch, summarizePrompt } from "../../src/chat/subagent-dispatch"
 import type { ToolUpdate } from "../../src/chat/stream"
-import type { AgentTask } from "../../src/agents/task-store"
+import { AgentTaskStore, type AgentTask, type Memento } from "../../src/agents/task-store"
 
 function makeUpdate(overrides: Partial<ToolUpdate> = {}): ToolUpdate {
   return {
@@ -275,5 +275,67 @@ describe("summarizePrompt", () => {
   it("falls back to 'Main agent' when text is empty", () => {
     expect(summarizePrompt("")).toBe("Main agent")
     expect(summarizePrompt("   ")).toBe("Main agent")
+  })
+})
+
+describe("SubagentDispatch.setMainWaiting", () => {
+  function makeDispatch() {
+    const backing = new Map<string, unknown>()
+    const memento = {
+      get: (key: string, defaultValue?: unknown) =>
+        backing.has(key) ? backing.get(key) : defaultValue,
+      update: async (key: string, value: unknown) => {
+        backing.set(key, value)
+      },
+    }
+    const store = new AgentTaskStore(memento as unknown as Memento)
+    const dispatch = new SubagentDispatch({
+      taskStore: store,
+      getSessionID: () => "sess_1",
+      getActiveConversationID: () => "conv_1",
+      collapseToGraceIfSettled: () => {},
+    })
+    return { store, dispatch }
+  }
+
+  it("flips the current Main row running -> waiting -> running", async () => {
+    const { store, dispatch } = makeDispatch()
+    await dispatch.recordMainTaskStart("guarded work")
+    await dispatch.setMainWaiting(true)
+    expect(store.list()[0]!.status).toBe("waiting")
+    await dispatch.setMainWaiting(false)
+    expect(store.list()[0]!.status).toBe("running")
+  })
+
+  it("is idempotent in both directions", async () => {
+    const { store, dispatch } = makeDispatch()
+    await dispatch.recordMainTaskStart("x")
+    await dispatch.setMainWaiting(false)
+    expect(store.list()[0]!.status).toBe("running")
+    await dispatch.setMainWaiting(true)
+    await dispatch.setMainWaiting(true)
+    expect(store.list()[0]!.status).toBe("waiting")
+  })
+
+  it("still settles a waiting row on finish", async () => {
+    const { store, dispatch } = makeDispatch()
+    await dispatch.recordMainTaskStart("x")
+    await dispatch.setMainWaiting(true)
+    await dispatch.recordMainTaskFinish("completed")
+    expect(store.list()[0]!.status).toBe("completed")
+  })
+
+  it("never touches a settled row (stray sync after finish)", async () => {
+    const { store, dispatch } = makeDispatch()
+    await dispatch.recordMainTaskStart("x")
+    await dispatch.recordMainTaskFinish("completed")
+    await dispatch.setMainWaiting(true)
+    expect(store.list()[0]!.status).toBe("completed")
+  })
+
+  it("no-ops when no turn is in flight", async () => {
+    const { store, dispatch } = makeDispatch()
+    await dispatch.setMainWaiting(true)
+    expect(store.list()).toHaveLength(0)
   })
 })

--- a/test/host/chatview-harness.test.ts
+++ b/test/host/chatview-harness.test.ts
@@ -816,6 +816,47 @@ describe("ChatView harness: review-hunk sync debounce", () => {
   })
 })
 
+describe("ChatView harness: waiting-for-input Main status", () => {
+  function lastMainStatus() {
+    return harness.taskStore
+      .list()
+      .filter((t) => t.kind === "main")
+      .at(-1)?.status
+  }
+
+  it("flips the Main row to waiting on permission.asked and back to running on reply", async () => {
+    await harness.send({ type: "mounted" })
+    await harness.send({ type: "send", text: "guarded edit" })
+
+    server.push({ type: "permission.asked", id: "perm_1", sessionID: SESSION_ID, title: "Edit file" })
+    await until(() => lastMainStatus() === "waiting")
+    const snap = harness.posted.filter((m) => m.type === "agentsStatus").at(-1)
+    expect(snap && "status" in snap ? snap.status.waiting : 0).toBe(1)
+
+    await harness.send({ type: "permissionReply", id: "perm_1", response: "once" })
+    await until(() => lastMainStatus() === "running")
+  })
+
+  it("Stop clears pending prompts so the next turn cannot wedge on waiting", async () => {
+    await harness.send({ type: "mounted" })
+    await harness.send({ type: "send", text: "first try" })
+    server.push({ type: "permission.asked", id: "perm_stale", sessionID: SESSION_ID, title: "T" })
+    await until(() => lastMainStatus() === "waiting")
+
+    await harness.send({ type: "abort" })
+    server.push({ type: "session.idle", sessionID: SESSION_ID })
+    await until(() => harness.posted.some((m) => m.type === "sessionIdle"))
+
+    await harness.send({ type: "send", text: "second try" })
+    server.push({ type: "permission.asked", id: "perm_2", sessionID: SESSION_ID, title: "T2" })
+    await until(() => lastMainStatus() === "waiting")
+    await harness.send({ type: "permissionReply", id: "perm_2", response: "once" })
+    // Without the abort-time map clear, perm_stale would keep the pending
+    // count above zero and the row would stay `waiting` forever.
+    await until(() => lastMainStatus() === "running")
+  })
+})
+
 describe("ChatView harness: errored Main task clears on next turn", () => {
   it("keeps the error row visible until the next send, then drops it", async () => {
     await harness.send({ type: "mounted" })


### PR DESCRIPTION
## Summary

- **`SubagentDispatch.setMainWaiting(waiting)`**: flips the current turn's Main task row `running → waiting` and back. Guarded transitions only — it acts solely when the row is in the expected source state, so terminal rows are never resurrected and a stray call after `recordMainTaskFinish` no-ops on the cleared `currentMainTaskID`. A finish that arrives while the row is `waiting` still settles it (`waiting` is not terminal).
- **`ChatView.syncAgentWaitState()`** derives "blocked on the user" from `activePermissions.size + activeQuestions.size` and runs after every mutation of either map: `onPermissionNeeded`, `onQuestionAsked`, `onQuestionResolved` (external resolution), and the webview's `permissionReply` / `questionReply` / `questionReject` messages. Permissions and questions are parent-session-filtered in `stream.ts`, so the Main row is the correct (and only) target.
- **Stale-map hygiene**: `activePermissions` / `activeQuestions` now clear on abort and at session idle, mirroring the webview reducer's own dialog-drop on `aborted`. With `waiting` computed from map sizes, a dead entry from a stopped turn would otherwise wedge every subsequent turn on `waiting` the moment its own prompt resolved — the second harness test locks in exactly that scenario.

The webview needs no changes: the `is-waiting` pill state, "N waiting" summary, "waiting for input" tooltip lines, and live row timers (`isLive` includes `waiting`) all existed already — they were unreachable because nothing ever produced the status (#475).

## Test plan

- [x] `bun run test` — 82 files, 1234 tests (7 new: 5 unit tests for the `setMainWaiting` transition guards; 2 ChatView harness tests driving `permission.asked` → `waiting` → `permissionReply` → `running`, and the Stop-with-pending-prompt → next-turn case)
- [x] Harness file re-run 3× — stable
- [x] `bun run check-types` — clean
- [x] `cd webview && bunx tsc --noEmit` — clean

Closes #475