### PR TITLE
perf(agents): stop per-token task-store writes from child busy events

### DIFF
--- a/src/agents/subagent-tracker.ts
+++ b/src/agents/subagent-tracker.ts
@@ -289,11 +289,18 @@ export class SubagentTracker {
     const now = Date.now()
     switch (event.type) {
       case "busy":
-        // Refresh updatedAt but don't bounce a terminal task back to
-        // running — once errored/completed, a stray busy is ignored.
+        // Don't bounce a terminal task back to running — once
+        // errored/completed, a stray busy is ignored.
         if (existing.status === "error" || existing.status === "completed" || existing.status === "cancelled") {
           return
         }
+        // Already running: skip the write. Busy signals arrive per streamed
+        // token (message.part.delta et al.), and each store.update() is a
+        // full workspaceState persist + onDidChange broadcast + agentsStatus
+        // IPC post. Nothing reads updatedAt on a live row (AgentsRow derives
+        // elapsed from startedAt) — the only transition left to make here is
+        // waiting -> running.
+        if (existing.status === "running") return
         await this.store.update(taskID, { status: "running", updatedAt: now })
         return
       case "idle":
@@ -370,12 +377,12 @@ export class SubagentTracker {
     const conversationID = this.getConversationID()
     const taskID = subagentTaskIDByChildSession(info.id)
     const existing = this.store.get(taskID)
+    // Already known — nothing to learn. session.updated re-fires this on
+    // every child title/time change, and an updatedAt-only refresh is a full
+    // persist + broadcast that feeds no consumer; on a settled row it would
+    // even drift the popover's frozen runtime (updatedAt - startedAt).
+    if (existing) return
     const now = Date.now()
-    if (existing) {
-      // Already known — refresh updatedAt only.
-      await this.store.update(taskID, { updatedAt: now })
-      return
-    }
     // If the parent's `task` tool dispatch already created a callID-keyed row
     // and is sitting waiting on a child sessionID, promote it now rather than
     // creating a second row. The "exactly one unclaimed dispatch" guard

--- a/src/agents/task-store.ts
+++ b/src/agents/task-store.ts
@@ -370,6 +370,14 @@ function isTerminal(status: AgentTaskStatus): boolean {
   return status === "completed" || status === "error" || status === "cancelled"
 }
 
+/**
+ * Deliberately ignores `updatedAt`: a write whose only difference is the
+ * clock is not a change, and treating it as one turned high-frequency
+ * callers (repeated `running` tool events, child busy signals) into a
+ * workspaceState persist + broadcast per event. `updatedAt` is a
+ * consequence of a material change — it lands whenever any compared field
+ * differs, which every terminal transition does via `status`.
+ */
 function sameTask(a: AgentTask, b: AgentTask): boolean {
   return (
     a.status === b.status &&
@@ -387,8 +395,7 @@ function sameTask(a: AgentTask, b: AgentTask): boolean {
     a.kind === b.kind &&
     a.conversationID === b.conversationID &&
     a.sessionID === b.sessionID &&
-    a.startedAt === b.startedAt &&
-    a.updatedAt === b.updatedAt
+    a.startedAt === b.startedAt
   )
 }
 

--- a/test/host/agent-task-store.test.ts
+++ b/test/host/agent-task-store.test.ts
@@ -93,6 +93,19 @@ describe("AgentTaskStore", () => {
     expect(store.list()).toHaveLength(1)
   })
 
+  it("drops a write whose only change is updatedAt (no persist, no emit)", async () => {
+    const store = new AgentTaskStore(memento)
+    await store.upsert(fixedTask({ updatedAt: 1000 }))
+    let fires = 0
+    store.onDidChange(() => (fires += 1))
+    await store.update("main:conv:sess", { updatedAt: 2000 })
+    await store.upsert(fixedTask({ updatedAt: 3000 }))
+    expect(fires).toBe(0)
+    expect(store.get("main:conv:sess")!.updatedAt).toBe(1000)
+    const persisted = memento.get<AgentTask[]>(AGENT_TASKS_KEY)
+    expect(persisted?.[0]?.updatedAt).toBe(1000)
+  })
+
   it("upsert preserves startedAt across mutations", async () => {
     const store = new AgentTaskStore(memento)
     await store.upsert(fixedTask({ startedAt: 1000, updatedAt: 1000 }))

--- a/test/host/subagent-tracker.test.ts
+++ b/test/host/subagent-tracker.test.ts
@@ -436,6 +436,30 @@ describe("SubagentTracker.handleChildSessionEvent", () => {
     expect(store.get(subagentTaskIDByChildSession("ses_child_1"))!.status).toBe("completed")
   })
 
+  it("repeated `busy` events on an already-running task perform no store writes", async () => {
+    const { tracker, store } = await bootstrapPromoted()
+    const before = store.get(subagentTaskIDByChildSession("ses_child_1"))!
+    let fires = 0
+    store.onDidChange(() => (fires += 1))
+    // Per-token traffic: routeChildSessionEvent maps every
+    // message.part.delta on the child to a `busy` signal.
+    for (let i = 0; i < 25; i++) {
+      await tracker.handleChildSessionEvent({ type: "busy", sessionID: "ses_child_1" })
+    }
+    expect(fires).toBe(0)
+    const after = store.get(subagentTaskIDByChildSession("ses_child_1"))!
+    expect(after.status).toBe("running")
+    expect(after.updatedAt).toBe(before.updatedAt)
+  })
+
+  it("a `busy` event still promotes a waiting task back to running", async () => {
+    const { tracker, store } = await bootstrapPromoted()
+    const taskID = subagentTaskIDByChildSession("ses_child_1")
+    await store.update(taskID, { status: "waiting" })
+    await tracker.handleChildSessionEvent({ type: "busy", sessionID: "ses_child_1" })
+    expect(store.get(taskID)!.status).toBe("running")
+  })
+
   it("an `assistantEnd` event backfills the model when omo metadata didn't carry one", async () => {
     const { tracker, store, subscription } = setupTracker()
     // Dispatch without model in metadata.
@@ -719,6 +743,30 @@ describe("SubagentTracker.registerChildSession", () => {
     const { tracker, store } = setupTracker({ sessionID: "ses_parent" })
     await tracker.registerChildSession({ id: "ses_orphan", parentID: "ses_someone_else" })
     expect(store.get(subagentTaskIDByChildSession("ses_orphan"))).toBeUndefined()
+  })
+
+  it("performs no store write when the child is already known", async () => {
+    const { tracker, store } = setupTracker()
+    await tracker.registerChildSession({ id: "ses_child_x", parentID: "ses_parent", title: "First" })
+    const before = store.get(subagentTaskIDByChildSession("ses_child_x"))!
+    let fires = 0
+    store.onDidChange(() => (fires += 1))
+    // session.updated re-fires discovery on every child title/time change.
+    await tracker.registerChildSession({ id: "ses_child_x", parentID: "ses_parent", title: "Renamed" })
+    expect(fires).toBe(0)
+    expect(store.get(subagentTaskIDByChildSession("ses_child_x"))!.updatedAt).toBe(before.updatedAt)
+  })
+
+  it("does not drift a settled row's frozen runtime when the session stays warm", async () => {
+    const { tracker, store } = setupTracker()
+    await tracker.registerChildSession({ id: "ses_child_w", parentID: "ses_parent" })
+    await tracker.handleChildSessionEvent({ type: "idle", sessionID: "ses_child_w" })
+    const settled = store.get(subagentTaskIDByChildSession("ses_child_w"))!
+    expect(settled.status).toBe("completed")
+    // Some plugins keep the child session warm — a late session.updated
+    // must not move the terminal row's endedAt (updatedAt - startedAt).
+    await tracker.registerChildSession({ id: "ses_child_w", parentID: "ses_parent" })
+    expect(store.get(subagentTaskIDByChildSession("ses_child_w"))!.updatedAt).toBe(settled.updatedAt)
   })
 
   it("does not overwrite an existing richer record", async () => {


### PR DESCRIPTION
Closes #478

## Summary

While a subagent streamed, every busy signal from its child session (`message.part.delta`, `message.part.updated`, assistant `message.updated`, non-idle `session.status`) rewrote the task row with `{status: "running", updatedAt: now}`. The row was already `running`, but `sameTask` compared `updatedAt`, so the clock tick alone turned each event into a full workspaceState persist of the whole task array + `onDidChange` fire + `[agents-status]` log line + `agentsStatus` IPC post + webview pill re-render — once per streamed token, per running subagent.

Fix, in three layers:

- **Tracker busy case** early-returns when the row is already `running`. The only live transition left there is `waiting -> running`, which still works (pinned by test).
- **`registerChildSession`** no longer refreshes `updatedAt` on already-known rows. `session.updated` re-fires discovery on every child title/time change, and on a *settled* row the refresh drifted the popover's frozen runtime (`updatedAt - startedAt`) whenever a plugin kept the session warm.
- **`sameTask` stops comparing `updatedAt`**, so any write whose only difference is the clock is dropped at the store boundary. This also covers repeated `running` tool-part events for dispatch tools (title/metadata evolution with nothing material changed). `updatedAt` still lands with every material change — terminal transitions always differ on `status`, so terminal rows keep an accurate frozen `endedAt`.

Nothing reads `updatedAt` on a live row — `AgentsRow` derives elapsed time from `startedAt`; the sole consumer is the frozen runtime of terminal rows. With the trigger fixed at the source, the `postAgentsStatus` log fires proportionate to material transitions, so it needs no gating (the audit had suggested muting it as a symptom fix).

## Test plan

- [x] `bun run test` — 1239 pass (5 new: repeated-busy performs no writes with `onDidChange` fire counter, busy still promotes `waiting -> running`, known-child re-discovery performs no write, settled row's frozen runtime doesn't drift on warm-session re-discovery, store drops an `updatedAt`-only write with persist + emit both asserted)
- [x] `bun run check-types` — clean
- [x] `cd webview && bunx tsc --noEmit` — clean
- [ ] Visual: Agents popover during a live subagent turn — elapsed timer ticks (startedAt-driven), status transitions still render, terminal rows keep frozen runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)