### PR TITLE
chore(agents): remove unreachable render states from the Agents pill

### DIFF
--- a/test/host/agent-task-wiring.test.ts
+++ b/test/host/agent-task-wiring.test.ts
@@ -82,6 +82,20 @@ describe("summarizeAgentTasks", () => {
     expect(result.tasks.map((t) => t.id).sort()).toEqual(["a", "b", "c", "d"])
   })
 
+  it("keeps total === tasks.length and total === running + waiting + error", () => {
+    // AgentActivity renders nothing at total 0 and renders the popover rows
+    // unconditionally past that guard — both rely on these two identities.
+    const result = summarizeAgentTasks([
+      task({ id: "a", status: "running" }),
+      task({ id: "b", status: "waiting" }),
+      task({ id: "c", status: "error" }),
+      task({ id: "d", status: "completed" }),
+      task({ id: "e", status: "cancelled" }),
+    ])
+    expect(result.total).toBe(result.tasks.length)
+    expect(result.total).toBe(result.running + result.waiting + result.error)
+  })
+
   it("drops completed tasks — the popover shows only what's currently active", () => {
     const result = summarizeAgentTasks([
       task({ id: "a", status: "completed", startedAt: 1000, updatedAt: 5000 }),

--- a/webview/src/components/AgentActivity.tsx
+++ b/webview/src/components/AgentActivity.tsx
@@ -18,7 +18,9 @@ export function AgentActivity({ status }: { status?: AgentsStatusInfo }) {
     (errorOnly ? " is-error" : "") +
     (waitingOnly ? " is-waiting" : "")
 
-  const tasks = status.tasks ?? []
+  // total === tasks.length by construction in summarizeAgentTasks (pinned
+  // by test), so past the total-0 guard above the popover always has rows.
+  const tasks = status.tasks
   const main = tasks.filter((t) => t.kind === "main")
   const sub = tasks.filter((t) => t.kind === "subagent")
 
@@ -40,27 +42,24 @@ export function AgentActivity({ status }: { status?: AgentsStatusInfo }) {
       {open && (
         <div className="agents-popover agent-activity-popover" role="menu">
           <div className="agents-popover-title">Agents in this response</div>
-          {tasks.length === 0 && <div className="agents-popover-empty">No active agent details</div>}
-          {tasks.length > 0 && (
-            <div className="agents-popover-scroll">
-              {main.length > 0 && (
-                <>
-                  <div className="agents-popover-section">Main</div>
-                  {main.map((task) => (
-                    <AgentsRow key={task.id} task={task} />
-                  ))}
-                </>
-              )}
-              {sub.length > 0 && (
-                <>
-                  <div className="agents-popover-section">Subagents</div>
-                  {sub.map((task) => (
-                    <AgentsRow key={task.id} task={task} />
-                  ))}
-                </>
-              )}
-            </div>
-          )}
+          <div className="agents-popover-scroll">
+            {main.length > 0 && (
+              <>
+                <div className="agents-popover-section">Main</div>
+                {main.map((task) => (
+                  <AgentsRow key={task.id} task={task} />
+                ))}
+              </>
+            )}
+            {sub.length > 0 && (
+              <>
+                <div className="agents-popover-section">Subagents</div>
+                {sub.map((task) => (
+                  <AgentsRow key={task.id} task={task} />
+                ))}
+              </>
+            )}
+          </div>
         </div>
       )}
     </div>
@@ -100,17 +99,15 @@ function AgentsRow({ task }: { task: AgentsTaskInfo }) {
   )
 }
 
+// Both helpers render only behind the total-0 guard, and total is the sum
+// of running + waiting + error — at least one count is always non-zero.
 function activitySummary(status: AgentsStatusInfo): string {
   if (status.running > 0) return `${status.running} running`
   if (status.waiting > 0) return `${status.waiting} waiting`
-  if (status.error > 0) return `${status.error} error${status.error === 1 ? "" : "s"}`
-  return `${status.total} active`
+  return `${status.error} error${status.error === 1 ? "" : "s"}`
 }
 
-export function buildAgentsTitle(status?: AgentsStatusInfo): string {
-  if (!status || status.total === 0) {
-    return "No agents in this response"
-  }
+function buildAgentsTitle(status: AgentsStatusInfo): string {
   const lines: string[] = []
   if (status.running > 0)
     lines.push(`${status.running} agent${status.running === 1 ? "" : "s"} running`)

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -395,11 +395,6 @@ button:focus-visible {
 .agents-row-running .agents-row-title { color: var(--color-agent-running); }
 .agents-row-error .agents-row-meta { color: var(--color-error); }
 .agents-row-waiting .agents-row-meta { color: var(--color-warn); }
-.agents-popover-empty {
-  padding: 6px 12px;
-  opacity: 0.6;
-  font-style: italic;
-}
 
 .selector-menu {
   flex: 0 1 auto;


### PR DESCRIPTION
Closes #480

## Summary

`AgentActivity` returns `null` whenever `status.total === 0`, and `summarizeAgentTasks` computes `total` as the sum of the same counts it increments while building `tasks` — so `total === tasks.length` by construction. Finding 3 of the agents-pipeline audit: several branches were unreachable and are now removed.

- The `"No active agent details"` popover empty-state and its single-consumer `.agents-popover-empty` CSS rule. It predates the popover going active-only — today the whole pill unmounts when the last row settles, so an open popover always has rows.
- The `tasks.length > 0` wrapper around the row list (the scroll container now renders unconditionally inside the open popover).
- The `?? []` fallback on `status.tasks`, a required field of `AgentsStatusInfo`.
- `buildAgentsTitle`'s `!status || total === 0` branch — its only call site sits below the component's early return, and the export had no consumer anywhere; it is now a private helper with a required parameter.
- `activitySummary`'s `"N active"` fallback — with `total > 0`, one of running/waiting/error is non-zero, so the error line becomes the final return.

The identities the render now leans on (`total === tasks.length`, `total === running + waiting + error`) are pinned by a new `summarizeAgentTasks` test, so a future producer change fails a test instead of silently rendering a blank popover.

No behavior change for any reachable state: pill hidden at `total === 0`, popover lists rows whenever open, tooltip and summary strings identical for every status mix that can occur.

## Test plan

- [x] `bun run test` — 1240 pass (1 new invariant test)
- [x] `bun run check-types` — clean
- [x] `cd webview && bunx tsc --noEmit` — clean
- [ ] Visual: pill/popover during a live subagent turn (running, waiting, error mixes) renders exactly as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)