### PR TITLE
fix(agents): settle ghost running rows on reload and conversation entry

### DIFF
--- a/src/agents/quickpick.ts
+++ b/src/agents/quickpick.ts
@@ -9,9 +9,15 @@ export type AgentsQuickPickItem = vscode.QuickPickItem & {
  * Open a compact QuickPick grouping active or attention-worthy agent work
  * into `Main` and `Subagents` sections. Selecting a row focuses the
  * OpenCode Panel chat; we don't currently surface retry / abort actions.
+ * Scoped to the active conversation like the Agents popover — the focus
+ * action lands on the active chat, so listing other conversations' rows
+ * here would point at work the click can't reach.
  */
-export async function showAgentsQuickPick(taskStore: AgentTaskStore): Promise<void> {
-  const tasks = taskStore.active()
+export async function showAgentsQuickPick(
+  taskStore: AgentTaskStore,
+  conversationID: string,
+): Promise<void> {
+  const tasks = taskStore.active().filter((task) => task.conversationID === conversationID)
   if (tasks.length === 0) {
     await vscode.window.showQuickPick([{ label: "No active agents" }], {
       title: "OpenCode Panel: Agents",

--- a/src/agents/task-store.ts
+++ b/src/agents/task-store.ts
@@ -180,6 +180,27 @@ export class AgentTaskStore {
     this.tasks = sanitize(storage.get<AgentTask[]>(AGENT_TASKS_KEY))
     this.emitter = new vscode.EventEmitter<AgentTask[]>()
     this.onDidChange = this.emitter.event
+    this.settleLoadedActive()
+  }
+
+  /**
+   * Rows loaded as running/waiting belong to a previous extension-host
+   * process. The panel spawns its own opencode server, so no turn survives
+   * the host — whatever these rows were tracking died with it. Settle them
+   * to `cancelled` at load; without this, a reload mid-turn left the pill
+   * pulsing "N running" with live growing timers until the next send in
+   * that conversation. Terminal rows (including `error`, which the popover
+   * deliberately keeps until the next turn) are untouched.
+   */
+  private settleLoadedActive(): void {
+    const now = Date.now()
+    let changed = false
+    this.tasks = this.tasks.map((task) => {
+      if (!ACTIVE_STATUSES.includes(task.status)) return task
+      changed = true
+      return { ...task, status: "cancelled" as const, updatedAt: now }
+    })
+    if (changed) void this.persistAndEmit()
   }
 
   list(): AgentTask[] {

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -477,6 +477,37 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.post({ type: "contextUsage", usage: undefined })
     if (this.sessionID) void this.refreshContextUsage()
     if (this.taskStore) this.postAgentsStatus(this.taskStore.list())
+    this.reconcileOnConversationEntry()
+  }
+
+  /**
+   * Settle stale task rows when the user lands on a conversation without
+   * sending anything. attachSubscription's reconcile only runs on send
+   * paths, and switching away aborts the SSE subscription but not the
+   * server-side turn — so a conversation abandoned mid-turn kept its rows
+   * `running` (pulsing pill, growing timers) until the next send here.
+   * Uses a throwaway tracker with a no-op subscription: there is no live
+   * stream to resume still-busy children into, so genuinely-busy sessions
+   * keep their rows running (truthful) and idle/absent ones settle. Only
+   * consults an already-running backend — never cold-starts one.
+   */
+  private reconcileOnConversationEntry(): void {
+    if (!this.taskStore || !this.sessionID) return
+    const backend = this.servers.currentBackend()
+    if (!backend) return
+    const sessionID = this.sessionID
+    const tracker = new SubagentTracker({
+      store: this.taskStore,
+      getActiveConversationID: () => this.manager.getActiveID(),
+      getParentSessionID: () => sessionID,
+      subscription: { addChildSession: () => {}, removeChildSession: () => {} },
+    })
+    void tracker.reconcile(backend, sessionID)
+  }
+
+  /** Active conversation ID for host-side consumers outside the webview (agents QuickPick). */
+  activeConversationID(): string {
+    return this.manager.getActiveID()
   }
 
   private async renameConversation(id: string, title: string) {
@@ -512,6 +543,7 @@ export class ChatView implements vscode.WebviewViewProvider {
       this.sendConversationState()
       this.post({ type: "contextUsage", usage: undefined })
       if (this.sessionID) void this.refreshContextUsage()
+      this.reconcileOnConversationEntry()
       return
     }
     await this.manager.flushPersist()

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,7 +58,9 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand("opencui.selectVariant", () => picker.pickVariantForCurrent()),
     vscode.commands.registerCommand("opencui.manageMcp", () => mcp.run()),
     vscode.commands.registerCommand("opencui.manageProviders", () => providers.run()),
-    vscode.commands.registerCommand("opencui.agents.open", () => showAgentsQuickPick(agentTaskStore!)),
+    vscode.commands.registerCommand("opencui.agents.open", () =>
+      showAgentsQuickPick(agentTaskStore!, chat.activeConversationID()),
+    ),
     vscode.commands.registerCommand("opencui.server.restart", async () => {
       status.set("starting", "restarting backend")
       await servers!.restart().then(

--- a/src/server.ts
+++ b/src/server.ts
@@ -115,6 +115,16 @@ export class ServerManager {
     return this.workspace
   }
 
+  /**
+   * The already-running backend, or undefined if none — never spawns one.
+   * For best-effort callers (e.g. stale-task reconciliation on conversation
+   * switch) that should stay silent rather than cold-start a server.
+   */
+  currentBackend(): Backend | undefined {
+    if (!this.server || !this.client) return undefined
+    return this.toBackend(this.server, this.client)
+  }
+
   private toBackend(server: ServerHandle, client: OpencodeClient): Backend {
     return {
       url: server.url,

--- a/test/host/agent-task-store.test.ts
+++ b/test/host/agent-task-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest"
+import { describe, it, expect, beforeEach, vi } from "vitest"
 import {
   AGENT_TASKS_KEY,
   AgentTaskStore,
@@ -80,6 +80,43 @@ describe("AgentTaskStore", () => {
     const store = new AgentTaskStore(memento)
     expect(store.list()).toHaveLength(1)
     expect(store.list()[0]!.kind).toBe("main")
+  })
+
+  it("settles active rows to cancelled at construction — no turn survives the extension host", async () => {
+    memento.setSeed(AGENT_TASKS_KEY, [
+      fixedTask({ id: "m1", status: "running" }),
+      fixedTask({ id: "m2", status: "waiting", sessionID: "s2" }),
+      fixedTask({ id: "m3", status: "completed", sessionID: "s3", updatedAt: 2000 }),
+      fixedTask({ id: "m4", status: "error", error: "boom", sessionID: "s4", updatedAt: 2000 }),
+    ])
+    const store = new AgentTaskStore(memento)
+    expect(store.get("m1")!.status).toBe("cancelled")
+    expect(store.get("m2")!.status).toBe("cancelled")
+    expect(store.get("m1")!.updatedAt).toBeGreaterThan(1000)
+    // Terminal rows keep their status: error stays visible until the next
+    // turn's clearErrored, and settled rows keep their frozen endedAt.
+    expect(store.get("m3")!.status).toBe("completed")
+    expect(store.get("m3")!.updatedAt).toBe(2000)
+    expect(store.get("m4")!.status).toBe("error")
+    expect(store.get("m4")!.error).toBe("boom")
+    expect(store.hasRunning()).toBe(false)
+    // The settlement persists so an early host exit can't resurrect them.
+    await new Promise((r) => setTimeout(r, 0))
+    const persisted = memento.get<AgentTask[]>(AGENT_TASKS_KEY)!
+    expect(persisted.find((t) => t.id === "m1")!.status).toBe("cancelled")
+    expect(persisted.find((t) => t.id === "m2")!.status).toBe("cancelled")
+  })
+
+  it("performs no write at construction when no loaded row is active", async () => {
+    memento.setSeed(AGENT_TASKS_KEY, [
+      fixedTask({ id: "m1", status: "completed", updatedAt: 2000 }),
+      fixedTask({ id: "m2", status: "cancelled", sessionID: "s2", updatedAt: 3000 }),
+    ])
+    const spy = vi.spyOn(memento, "update")
+    const store = new AgentTaskStore(memento)
+    await new Promise((r) => setTimeout(r, 0))
+    expect(spy).not.toHaveBeenCalled()
+    expect(store.list()).toHaveLength(2)
   })
 
   it("upsert is idempotent for an unchanged task", async () => {

--- a/test/host/agents-quickpick.test.ts
+++ b/test/host/agents-quickpick.test.ts
@@ -112,7 +112,7 @@ describe("Agents QuickPick", () => {
     const store = new AgentTaskStore(memento)
     const showQuickPick = vscode.window.showQuickPick as unknown as ReturnType<typeof vi.fn>
     showQuickPick.mockResolvedValueOnce(undefined)
-    await showAgentsQuickPick(store)
+    await showAgentsQuickPick(store, "c")
     const args = showQuickPick.mock.calls[0]![0] as Array<{ label: string }>
     expect(args[0]!.label).toBe("No active agents")
   })
@@ -124,7 +124,7 @@ describe("Agents QuickPick", () => {
     const showQuickPick = vscode.window.showQuickPick as unknown as ReturnType<typeof vi.fn>
     const exec = vscode.commands.executeCommand as unknown as ReturnType<typeof vi.fn>
     showQuickPick.mockResolvedValueOnce({ label: "Main", taskID: "main:c:s" })
-    await showAgentsQuickPick(store)
+    await showAgentsQuickPick(store, "c")
     expect(exec).toHaveBeenCalledWith("opencui.chat.focus")
   })
 
@@ -135,7 +135,40 @@ describe("Agents QuickPick", () => {
     const showQuickPick = vscode.window.showQuickPick as unknown as ReturnType<typeof vi.fn>
     const exec = vscode.commands.executeCommand as unknown as ReturnType<typeof vi.fn>
     showQuickPick.mockResolvedValueOnce(undefined)
-    await showAgentsQuickPick(store)
+    await showAgentsQuickPick(store, "c")
     expect(exec).not.toHaveBeenCalled()
+  })
+
+  it("lists only the active conversation's tasks", async () => {
+    const memento = new FakeMemento()
+    const store = new AgentTaskStore(memento)
+    await store.upsert(task({ id: "main:c:s", conversationID: "c", title: "Mine", status: "running" }))
+    await store.upsert(
+      task({
+        id: "main:other:s2",
+        conversationID: "other",
+        sessionID: "s2",
+        title: "Other chat",
+        status: "running",
+      }),
+    )
+    const showQuickPick = vscode.window.showQuickPick as unknown as ReturnType<typeof vi.fn>
+    showQuickPick.mockResolvedValueOnce(undefined)
+    await showAgentsQuickPick(store, "c")
+    const items = showQuickPick.mock.calls[0]![0] as Array<{ label: string }>
+    expect(items.map((i) => i.label)).toEqual(["Main", "Mine"])
+  })
+
+  it("shows the empty state when only other conversations have active work", async () => {
+    const memento = new FakeMemento()
+    const store = new AgentTaskStore(memento)
+    await store.upsert(
+      task({ id: "main:other:s2", conversationID: "other", sessionID: "s2", status: "running" }),
+    )
+    const showQuickPick = vscode.window.showQuickPick as unknown as ReturnType<typeof vi.fn>
+    showQuickPick.mockResolvedValueOnce(undefined)
+    await showAgentsQuickPick(store, "c")
+    const args = showQuickPick.mock.calls[0]![0] as Array<{ label: string }>
+    expect(args[0]!.label).toBe("No active agents")
   })
 })

--- a/test/host/chatview-harness.test.ts
+++ b/test/host/chatview-harness.test.ts
@@ -106,6 +106,7 @@ beforeEach(async () => {
   const servers = {
     ensure: vi.fn(async () => backend),
     currentWorkspace: vi.fn(() => undefined),
+    currentBackend: vi.fn(() => backend),
   } as unknown as ServerManager
   const prefs = {
     get: () => ({}),
@@ -874,5 +875,60 @@ describe("ChatView harness: errored Main task clears on next turn", () => {
     expect(mains).toHaveLength(1)
     expect(mains[0]!.status).toBe("running")
     expect(mains[0]!.title).toContain("second try")
+  })
+})
+
+describe("ChatView harness: stale-row reconcile on conversation entry", () => {
+  it("settles a ghost running row when re-entering a conversation whose session ended", async () => {
+    await harness.send({ type: "mounted" })
+    await harness.send({ type: "send", text: "start a turn" })
+    await until(() => harness.taskStore.list().some((t) => t.kind === "main" && t.status === "running"))
+    const ghostConvID = harness.chatView.activeConversationID()
+
+    // Switch away mid-turn: this aborts the SSE subscription but not the
+    // server-side turn, so the Main row stays running with nothing left
+    // to settle it — the audit's ghost-row scenario.
+    await harness.send({ type: "createConversation" })
+    expect(harness.taskStore.list().some((t) => t.status === "running")).toBe(true)
+
+    // By the time the user returns, the abandoned turn has ended.
+    server.setSessionStatus(SESSION_ID, { type: "idle" })
+    await harness.send({ type: "openConversation", id: ghostConvID })
+    await until(() =>
+      harness.taskStore.list().every((t) => t.status !== "running" && t.status !== "waiting"),
+    )
+  })
+
+  it("leaves rows running when the abandoned session is still busy server-side", async () => {
+    await harness.send({ type: "mounted" })
+    await harness.send({ type: "send", text: "long turn" })
+    await until(() => harness.taskStore.list().some((t) => t.kind === "main" && t.status === "running"))
+    const ghostConvID = harness.chatView.activeConversationID()
+    await harness.send({ type: "createConversation" })
+
+    // A child row too: the still-busy branch re-registers the child into
+    // the entry-reconcile's no-op subscription — pin that this leaves the
+    // row alone instead of crashing or settling it.
+    await harness.taskStore.upsert({
+      id: "subagent:child:ses_child_ghost",
+      kind: "subagent",
+      conversationID: ghostConvID,
+      sessionID: SESSION_ID,
+      childSessionID: "ses_child_ghost",
+      title: "Ghost child",
+      status: "running",
+      startedAt: Date.now(),
+      updatedAt: Date.now(),
+    })
+    server.setSessionStatus(SESSION_ID, { type: "busy" })
+    server.setSessionStatus("ses_child_ghost", { type: "busy" })
+
+    const pollsBefore = server.statusPollCount()
+    await harness.send({ type: "openConversation", id: ghostConvID })
+    await until(() => server.statusPollCount() > pollsBefore)
+    await new Promise((r) => setTimeout(r, 50))
+    const rows = harness.taskStore.list().filter((t) => t.conversationID === ghostConvID)
+    expect(rows.some((t) => t.kind === "main" && t.status === "running")).toBe(true)
+    expect(rows.find((t) => t.id === "subagent:child:ses_child_ghost")!.status).toBe("running")
   })
 })


### PR DESCRIPTION
Closes #482

## Summary

Finding 1 of the agents-pipeline audit — the last user-visible bug from it. `reconcile()` only ran inside `attachSubscription` (send paths), so two ghost classes survived: a **reload mid-turn** brought persisted `running` rows back with live growing timers and a pulsing pill on a conversation doing nothing, and **switching away mid-turn** (which aborts the SSE subscription, not the server-side turn) left the abandoned conversation's rows running until the next send there. The agents QuickPick additionally read `taskStore.active()` unscoped, showing stale actives from other conversations forever.

Three layers, matching where each ghost class is cheapest to kill:

- **Settle at load**: `AgentTaskStore` settles `running`/`waiting` rows to `cancelled` at construction. The panel spawns its own opencode server, so no turn survives the extension host — whatever those rows tracked died with it. Covers every conversation at once, needs no backend (aligned with the future lazy-start goal), persists immediately, and leaves terminal rows (including `error`, which the popover deliberately keeps until the next turn) untouched.
- **Reconcile on conversation entry**: `selectConversation` and `deleteConversation`'s switch-to-next branch run the existing `reconcile` via a throwaway tracker with a no-op subscription, gated on `ServerManager.currentBackend()` — a new accessor that returns the already-running backend and never spawns one. Sessions reported idle/absent settle (the turn genuinely ended); still-busy sessions keep their rows running, which is truthful — with no live stream to resume children into, the no-op subscription registers nothing.
- **QuickPick scoping**: `showAgentsQuickPick` now takes the active conversation ID (via a new `ChatView.activeConversationID()`) and filters to it, matching the popover's model and the picker's own focus-the-chat action.

## Test plan

- [x] `bun run test` — 1246 pass (6 new: store settles active rows at construction + persists / performs no write when nothing is active; QuickPick lists only the active conversation / shows the empty state when only other conversations are active; harness: re-entering a conversation whose session ended settles the ghost row, still-busy sessions keep main + seeded child rows running through the no-op subscription)
- [x] Harness + store test files stable across 3 consecutive runs
- [x] `bun run check-types` — clean
- [x] `cd webview && bunx tsc --noEmit` — clean
- [ ] Visual: reload VS Code mid-turn — pill goes idle instead of pulsing with a growing timer; switch away mid-turn, wait for the turn to finish, switch back — rows settle without sending

🤖 Generated with [Claude Code](https://claude.com/claude-code)