### PR TITLE
fix(review): share the text-path filter and stop misparsing hunk bodies

### DIFF
--- a/src/chat/diff.ts
+++ b/src/chat/diff.ts
@@ -1,4 +1,3 @@
-import * as path from "path"
 import type { ReviewChange } from "../protocol"
 import { reviewKey as sharedReviewKey } from "../../webview/src/review-extract"
 
@@ -36,21 +35,6 @@ export type ReviewDiffHunk = {
    * those rather than letting it silently fail.
    */
   reversible: boolean
-}
-
-const BINARY_EXTENSIONS = new Set([
-  ".ai", ".avif", ".bin", ".bmp", ".class", ".db", ".dmg", ".doc", ".docx",
-  ".ds_store", ".eot", ".exe", ".gif", ".heic", ".icns", ".ico", ".jar",
-  ".jpeg", ".jpg", ".mov", ".mp3", ".mp4", ".otf", ".pdf", ".png", ".pyc",
-  ".so", ".sqlite", ".ttf", ".webp", ".woff", ".woff2", ".zip",
-])
-
-export function isTextReviewPath(value: string) {
-  const name = path.basename(value).toLowerCase()
-  if (!name || name === ".ds_store" || name === "thumbs.db") return false
-  const ext = path.extname(name)
-  if (!ext && name.startsWith(".")) return false
-  return !BINARY_EXTENSIONS.has(ext)
 }
 
 export function countDiff(patch: string, prefix: "+" | "-") {
@@ -110,7 +94,7 @@ export function splitReviewDiff(patch: string): { hunks: ReviewDiffHunk[] } {
     hunks.push({
       id: `${hunks.length}-${hunkHeader}`,
       header: hunkHeader,
-      lines: diffLines(hunkLines.join("\n")),
+      lines: diffLines(hunkLines.join("\n"), { fileHeaders: false }),
       anchorText,
       oldText,
       newText,
@@ -145,21 +129,31 @@ export function splitReviewDiff(patch: string): { hunks: ReviewDiffHunk[] } {
   return { hunks }
 }
 
+/**
+ * Split a hunk BODY into its pre-change and post-change text. `lines` never
+ * contains unified-diff file headers — splitReviewDiff only collects lines
+ * after the `@@` header — so a leading `---` / `+++` here is content, not a
+ * header, and must not be exempted from the +/- prefix strip. Guarding on it
+ * pushed a deleted `-- sql comment` (diff line `--- sql comment`) into BOTH
+ * oldText and newText with its prefix intact, which broke Undo (restored the
+ * extra dash) and Keep (searched for a newText containing a line that was
+ * actually deleted, so it reported a phantom conflict).
+ */
 export function hunkText(lines: string[]) {
   const oldLines: string[] = []
   const newLines: string[] = []
   const leadingContext: string[] = []
   const trailingContext: string[] = []
   let sawChange = false
-  const diff = diffLines(lines.join("\n"))
+  const diff = diffLines(lines.join("\n"), { fileHeaders: false })
   for (const line of lines) {
     if (line.startsWith("\\ No newline")) continue
-    if (line.startsWith("+") && !line.startsWith("+++")) {
+    if (line.startsWith("+")) {
       sawChange = true
       newLines.push(line.slice(1))
       continue
     }
-    if (line.startsWith("-") && !line.startsWith("---")) {
+    if (line.startsWith("-")) {
       sawChange = true
       oldLines.push(line.slice(1))
       continue
@@ -179,12 +173,22 @@ export function hunkText(lines: string[]) {
   }
 }
 
-export function diffLines(patch: string) {
+/**
+ * Classify each line of `patch`.
+ *
+ * `fileHeaders` (default true) treats `---` / `+++` as unified-diff file
+ * headers rather than content. Pass `false` for a HUNK BODY: file headers only
+ * ever precede the first `@@`, so inside a body those prefixes are real content
+ * (`-` prefixing `-- sql comment`, `+` prefixing `++x`) and skipping them
+ * silently reclassifies a deletion as context.
+ */
+export function diffLines(patch: string, options: { fileHeaders?: boolean } = {}) {
+  const fileHeaders = options.fileHeaders ?? true
   return patch.split("\n").map((text) => ({
     text,
-    kind: text.startsWith("+") && !text.startsWith("+++")
+    kind: text.startsWith("+") && !(fileHeaders && text.startsWith("+++"))
       ? "add"
-      : text.startsWith("-") && !text.startsWith("---")
+      : text.startsWith("-") && !(fileHeaders && text.startsWith("---"))
         ? "del"
         : text.startsWith("@@")
           ? "hunk"

--- a/src/chat/review-changes.ts
+++ b/src/chat/review-changes.ts
@@ -8,6 +8,7 @@ import type { ChatMessage, ReviewChange, ToolUpdate as WireToolUpdate } from "..
 import {
   displayPath,
   extractChanges,
+  isTextReviewPathName,
   patchChanges,
   patchKind,
   patchPath,
@@ -30,6 +31,7 @@ export function toolChanges(update: WireToolUpdate, source: string): ReviewChang
 export {
   displayPath,
   extractChanges,
+  isTextReviewPathName,
   patchChanges,
   patchKind,
   patchPath,

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -40,8 +40,8 @@ import { ContinuationState, isContinuationToast } from "./continuation-state"
 import { sweepAbortTree, drainAbortTree } from "./abort-tree"
 import { SubagentDispatch } from "./subagent-dispatch"
 import { relativeToCwd, samePath } from "./paths"
-import { isTextReviewPath, reviewKey, splitReviewDiff } from "./diff"
-import { extractChanges, reviewChanges } from "./review-changes"
+import { reviewKey, splitReviewDiff } from "./diff"
+import { extractChanges, isTextReviewPathName, reviewChanges } from "./review-changes"
 import { reviewAllForPath } from "./review-actions"
 import { attachableConversationIDs, buildPrompt, readMentions, readConversationMentions } from "./prompt-builder"
 import { buildManifest } from "../workspace-context/manifest"
@@ -2051,7 +2051,7 @@ export class ChatView implements vscode.WebviewViewProvider {
   }
 
   private async openReviewChange(change: ReviewChange) {
-    if (!isTextReviewPath(change.path)) {
+    if (!isTextReviewPathName(change.path)) {
       vscode.window.showWarningMessage(`OpenCode Panel: ${change.path} cannot be reviewed as text.`)
       return
     }
@@ -2172,7 +2172,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     // unlocatable banner) was removed — review actions live exclusively in
     // the Review Card now. This sync only purges hunks for files that have
     // been deleted on disk so they don't linger in the panel.
-    const changes = reviewChanges(this.messages).filter((change) => isTextReviewPath(change.path))
+    const changes = reviewChanges(this.messages).filter((change) => isTextReviewPathName(change.path))
     if (!changes.length) return
     await this.purgeMissingFileHunks(changes)
   }

--- a/test/host/diff-utils.test.ts
+++ b/test/host/diff-utils.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from "vitest"
 import { samePath, normalizePath, isRecord, unique } from "../../src/chat/paths"
 import {
-  isTextReviewPath,
   countDiff,
   findHunkText,
   splitReviewDiff,
@@ -11,7 +10,13 @@ import {
   reviewKey,
   diffLines,
 } from "../../src/chat/diff"
-import { patchKind, patchPath, synthesizeCreatePatch } from "../../src/chat/review-changes"
+import {
+  isTextReviewPathName,
+  patchKind,
+  patchPath,
+  synthesizeCreatePatch,
+} from "../../src/chat/review-changes"
+import { isTextReviewPathName as webviewIsTextReviewPathName } from "../../webview/src/review-extract"
 
 describe("samePath / normalizePath", () => {
   it("compares identical paths", () => {
@@ -31,31 +36,49 @@ describe("samePath / normalizePath", () => {
   })
 })
 
-describe("isTextReviewPath", () => {
+describe("isTextReviewPathName", () => {
   it("accepts standard source files", () => {
-    expect(isTextReviewPath("src/index.ts")).toBe(true)
-    expect(isTextReviewPath("README.md")).toBe(true)
-    expect(isTextReviewPath("config.yaml")).toBe(true)
+    expect(isTextReviewPathName("src/index.ts")).toBe(true)
+    expect(isTextReviewPathName("README.md")).toBe(true)
+    expect(isTextReviewPathName("config.yaml")).toBe(true)
   })
 
   it("rejects binary extensions", () => {
-    expect(isTextReviewPath("logo.png")).toBe(false)
-    expect(isTextReviewPath("clip.mp4")).toBe(false)
-    expect(isTextReviewPath("dump.bin")).toBe(false)
-    expect(isTextReviewPath("archive.zip")).toBe(false)
+    expect(isTextReviewPathName("logo.png")).toBe(false)
+    expect(isTextReviewPathName("clip.mp4")).toBe(false)
+    expect(isTextReviewPathName("dump.bin")).toBe(false)
+    expect(isTextReviewPathName("archive.zip")).toBe(false)
   })
 
   it("rejects .DS_Store / Thumbs.db", () => {
-    expect(isTextReviewPath(".DS_Store")).toBe(false)
-    expect(isTextReviewPath("Thumbs.db")).toBe(false)
+    expect(isTextReviewPathName(".DS_Store")).toBe(false)
+    expect(isTextReviewPathName("Thumbs.db")).toBe(false)
   })
 
   it("accepts dotfiles with extensions", () => {
-    expect(isTextReviewPath(".eslintrc.json")).toBe(true)
+    expect(isTextReviewPathName(".eslintrc.json")).toBe(true)
   })
 
-  it("rejects extensionless dotfiles", () => {
-    expect(isTextReviewPath(".nonexistent")).toBe(false)
+  it("accepts extensionless dotfiles", () => {
+    // The host used to run its own `path.extname`-based copy, which returns ""
+    // for these and rejected them while the webview accepted them — the panel
+    // rendered the row and openReviewChange refused to open it.
+    for (const name of [".gitignore", ".env", ".npmrc", ".editorconfig", ".gitattributes"]) {
+      expect(isTextReviewPathName(name)).toBe(true)
+    }
+  })
+
+  it("answers identically to the webview copy for every path shape", () => {
+    // One implementation, not two: the host re-exports the shared helper. If a
+    // host-local copy is ever reintroduced, these diverge on the dotfiles.
+    const paths = [
+      "src/index.ts", "README.md", "Makefile", "LICENSE", "archive.tar.gz",
+      ".gitignore", ".env", ".env.local", ".eslintrc.json", ".babelrc",
+      ".DS_Store", "Thumbs.db", "logo.png", "dump.bin", "nested/dir/.nvmrc",
+    ]
+    for (const p of paths) {
+      expect([p, isTextReviewPathName(p)]).toEqual([p, webviewIsTextReviewPathName(p)])
+    }
   })
 })
 
@@ -154,6 +177,40 @@ describe("splitReviewDiff", () => {
     expect(hunk!.oldText).toContain("old")
     expect(hunk!.newText).toContain("new")
     expect(hunk!.newText).toContain("extra")
+  })
+
+  // Inside a hunk body `---` / `+++` are content, not file headers: file
+  // headers only ever precede the first `@@`. Treating them as headers pushed
+  // the line into BOTH sides with its prefix intact.
+  it("treats a deleted line starting with -- as a deletion, not context", () => {
+    const patch = "@@ -1,2 +1,1 @@\n--- old comment\n keep"
+    const hunk = splitReviewDiff(patch).hunks[0]!
+    expect(hunk.oldText).toBe("-- old comment\nkeep")
+    expect(hunk.newText).toBe("keep")
+    expect(hunk.lines.map((l) => l.kind)).toEqual(["del", "ctx"])
+  })
+
+  it("treats an added line starting with ++ as an addition, not context", () => {
+    const patch = "@@ -1,1 +1,2 @@\n keep\n+++counter"
+    const hunk = splitReviewDiff(patch).hunks[0]!
+    expect(hunk.oldText).toBe("keep")
+    expect(hunk.newText).toBe("keep\n++counter")
+    expect(hunk.lines.map((l) => l.kind)).toEqual(["ctx", "add"])
+  })
+
+  it("handles a removed markdown --- separator", () => {
+    const patch = "@@ -1,3 +1,2 @@\n title\n----\n body"
+    const hunk = splitReviewDiff(patch).hunks[0]!
+    expect(hunk.oldText).toBe("title\n---\nbody")
+    expect(hunk.newText).toBe("title\nbody")
+  })
+
+  it("still reads --- / +++ as file headers in the no-hunk fallback path", () => {
+    // No `@@` anywhere, so splitReviewDiff falls back to classifying the whole
+    // patch — there the prefixes really are unified-diff file headers.
+    const patch = "--- a/foo.md\n+++ b/foo.md"
+    const hunk = splitReviewDiff(patch).hunks[0]!
+    expect(hunk.lines.map((l) => l.kind)).toEqual(["ctx", "ctx"])
   })
 })
 

--- a/test/host/review-undo.test.ts
+++ b/test/host/review-undo.test.ts
@@ -236,4 +236,30 @@ describe("splitReviewDiff round-trip with findHunkInFile", () => {
     // It must point at the b() copy, not a().
     expect(afterEdit.slice(result!.start, result!.end)).toBe("function b() {\n  do_other_thing()\n}")
   })
+
+  it("locates and reverts a hunk that deletes a line starting with --", () => {
+    // A `-` prefixing `-- sql comment` yields the diff line `--- sql comment`.
+    // While that was mistaken for a file header the line landed in newText too,
+    // so findHunkInFile searched the post-edit file for a line that had just
+    // been deleted: Keep reported a phantom conflict and Undo restored a dash.
+    const before = ["SELECT 1;", "-- legacy note", "SELECT 2;"].join("\n")
+    const afterEdit = ["SELECT 1;", "SELECT 2;"].join("\n")
+    const patch = [
+      "@@ -1,3 +1,2 @@",
+      " SELECT 1;",
+      "--- legacy note",
+      " SELECT 2;",
+    ].join("\n")
+    const hunk = splitReviewDiff(patch).hunks[0]!
+    expect(hunk.oldText).toBe(before)
+    expect(hunk.newText).toBe(afterEdit)
+
+    // Keep: the post-change text is locatable, so no conflict is raised.
+    const located = findHunkInFile(afterEdit, hunk)
+    expect(located).toBeDefined()
+    // Undo: replacing that span with oldText restores the original byte-for-byte.
+    const reverted =
+      afterEdit.slice(0, located!.start) + hunk.oldText + afterEdit.slice(located!.end)
+    expect(reverted).toBe(before)
+  })
 })


### PR DESCRIPTION
Closes #484

## Summary

Two defects in the review-diff layer, both in `src/chat/diff.ts`.

### 1. Dotfiles rendered in the panel but refused by the host

The host ran its own `path.extname`-based copy of the reviewable-file predicate. `path.extname(".gitignore")` returns `""`, so every extensionless dotfile hit the `!ext && name.startsWith(".")` guard and was rejected — while the webview's copy computed `".gitignore"` and accepted it. The panel rendered the row and `openReviewChange` refused to open it with a warning toast ("`.gitignore` cannot be reviewed as text"). The same files were skipped by `syncReviewHunks`' missing-file purge.

Fixed by deleting the host copy and re-exporting the shared `isTextReviewPathName` from `review-changes.ts` — the module whose stated job is keeping host and webview in agreement, and which already does this for `extractChanges` / `turnChanges` / `patchPath`. One implementation instead of two. The local `BINARY_EXTENSIONS` set (byte-identical to the webview's, 33 entries) and the now-unused `path` import go with it.

**Behavior change:** extensionless dotfiles are now reviewable. `.gitignore`, `.env`, `.npmrc`, `.editorconfig`, `.nvmrc`, `.gitattributes`, `.dockerignore`, `.vscodeignore`, `.prettierrc`, `.babelrc` are text the agent routinely edits, and the webview already treated them as such — the host was the outlier. The existing `rejects extensionless dotfiles` test encoded the old behavior and is flipped accordingly. `.DS_Store` / `Thumbs.db` are still rejected, by the explicit name check and by the binary-extension list.

### 2. Hunk bodies misparsed content lines starting with `---` / `+++`

`hunkText` and `diffLines` exempted `---` / `+++` as unified-diff file headers. Those only ever precede the first `@@`, and `splitReviewDiff` hands `hunkText` nothing but post-`@@` lines, so the guard could only ever misfire on real content.

Removing `-- legacy note` produces the diff line `--- legacy note`, which was classified as context and pushed into **both** sides with its `-` prefix intact:

```
oldText: "--- legacy note\nkeep\n"   (expected "-- legacy note\nkeep")
newText: contains the deleted line   (expected "keep")
```

Downstream in `fs-ops.ts`: **Undo** (`undoUpdate`) restored `hunk.oldText`, bringing the line back with an extra dash; **Keep** (`acceptHunk`) verified via `findHunkInFile`, searching the post-edit file for a `newText` containing a line that had just been deleted, so it could not match and raised a phantom "the file has been modified since" conflict. Triggers on Markdown `---` (front matter, horizontal rules, setext headings), YAML document separators, SQL `--` comments, C `--x`.

`diffLines` now takes a `fileHeaders` option (default `true`). The two hunk-body call sites pass `false`; the no-hunk fallback path, which does parse real file headers, keeps the old behavior.

Scope note: `ReviewDiffHunk.lines`, `anchorText`, `leadingContext` and `trailingContext` have no production consumers today (tests only), so the user-visible damage was confined to `oldText` / `newText`. Left in place rather than pruned — out of scope here. The webview's own `splitDiff` derives hunk IDs only and does not classify lines, so `reviewKey` values are unchanged and no persisted review state is invalidated.

## Test plan

- [x] `bun run test` — 1252 pass / 82 files (was 1246; 6 new)
- [x] `bun run check-types` — clean
- [x] `cd webview && bunx tsc --noEmit` — clean
- [x] New: `accepts extensionless dotfiles` — `.gitignore` `.env` `.npmrc` `.editorconfig` `.gitattributes`
- [x] New: `answers identically to the webview copy for every path shape` — 15 path shapes; fails if a host-local copy is ever reintroduced
- [x] New: `treats a deleted line starting with -- as a deletion, not context` — asserts `oldText` / `newText` / per-line `kind`
- [x] New: `treats an added line starting with ++ as an addition, not context`
- [x] New: `handles a removed markdown --- separator`
- [x] New: `still reads --- / +++ as file headers in the no-hunk fallback path` — pins the untouched branch
- [x] New: `locates and reverts a hunk that deletes a line starting with --` — full round trip, asserts Keep locates the span and Undo restores the original byte-for-byte
- [x] Bug 2 reproduced against the pre-fix code before writing the fix (scratch test produced `"--- old comment\nkeep\n"`); bug 1 reproduced by comparing the two extension extractions across 17 path shapes
- [ ] Not verified in a running editor: clicking a `.gitignore` row in the Review panel now opens the file instead of warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)