### PR TITLE
fix(review): reveal once, restore the terminator, close the whole-file guard

### DIFF
--- a/src/chat/diff.ts
+++ b/src/chat/diff.ts
@@ -30,6 +30,14 @@ export type ReviewDiffHunk = {
   /** Context lines that follow the change, used as a secondary anchor. */
   trailingContext: string[]
   /**
+   * True when the diff carried a `\ No newline at end of file` marker for the
+   * ORIGINAL side. `oldText` is newline-joined and so never ends in one; a
+   * unified diff only records the ABSENCE of the terminator, which makes this
+   * the only way to tell "the file ended without a newline" from "the join
+   * dropped it". Read when restoring a deleted file.
+   */
+  oldNoNewlineAtEof: boolean
+  /**
    * True when we have enough information to reconstruct the original state.
    * False for malformed hunks (no @@ header parsed) — the UI hides Undo for
    * those rather than letting it silently fail.
@@ -84,7 +92,14 @@ export function splitReviewDiff(patch: string): { hunks: ReviewDiffHunk[] } {
       index += 1
     }
 
-    const { oldText, newText, anchorText, leadingContext, trailingContext } = hunkText(hunkLines)
+    const {
+      oldText,
+      newText,
+      anchorText,
+      leadingContext,
+      trailingContext,
+      oldNoNewlineAtEof,
+    } = hunkText(hunkLines)
     const headerInfo = parseHunkHeader(hunkHeader) ?? {
       oldStart: 0,
       oldCount: 0,
@@ -104,6 +119,7 @@ export function splitReviewDiff(patch: string): { hunks: ReviewDiffHunk[] } {
       newCount: headerInfo.newCount,
       leadingContext,
       trailingContext,
+      oldNoNewlineAtEof,
       reversible: HUNK_HEADER_RE.test(hunkHeader),
     })
   }
@@ -122,6 +138,7 @@ export function splitReviewDiff(patch: string): { hunks: ReviewDiffHunk[] } {
       newCount: 0,
       leadingContext: [],
       trailingContext: [],
+      oldNoNewlineAtEof: false,
       reversible: false,
     })
   }
@@ -145,14 +162,25 @@ export function hunkText(lines: string[]) {
   const leadingContext: string[] = []
   const trailingContext: string[] = []
   let sawChange = false
+  let oldNoNewlineAtEof = false
+  // Whether the line the NEXT `\ No newline at end of file` marker would apply
+  // to belongs to the original side: the marker annotates the line right above
+  // it, so it means "the old file had no terminator" after a `-` or context
+  // line, and only "the new file has none" after a `+`.
+  let previousLineIsOld = false
   const diff = diffLines(lines.join("\n"), { fileHeaders: false })
   for (const line of lines) {
-    if (line.startsWith("\\ No newline")) continue
+    if (line.startsWith("\\ No newline")) {
+      if (previousLineIsOld) oldNoNewlineAtEof = true
+      continue
+    }
     if (line.startsWith("+")) {
       sawChange = true
       newLines.push(line.slice(1))
+      previousLineIsOld = false
       continue
     }
+    previousLineIsOld = true
     if (line.startsWith("-")) {
       sawChange = true
       oldLines.push(line.slice(1))
@@ -170,6 +198,7 @@ export function hunkText(lines: string[]) {
     anchorText: firstReviewAnchor(diff, newLines.join("\n")),
     leadingContext,
     trailingContext,
+    oldNoNewlineAtEof,
   }
 }
 

--- a/src/chat/fs-ops.ts
+++ b/src/chat/fs-ops.ts
@@ -48,6 +48,22 @@ export async function openFileDocument(relPath: string, root?: string) {
   return vscode.workspace.openTextDocument(uri)
 }
 
+/**
+ * Show `doc` unless its editor is already the active one — `showTextDocument`
+ * pulls focus out of the chat panel and flashes the editor pane, so re-showing
+ * what the user is already looking at is pure noise. Every review action routes
+ * its reveal through here: "Undo all in file" calls the hunk runner once per
+ * hunk per per-tool record, and without the guard each of those N calls yanked
+ * focus again.
+ */
+export async function revealDocument(
+  doc: vscode.TextDocument,
+  options?: vscode.TextDocumentShowOptions,
+) {
+  if (vscode.window.activeTextEditor?.document.uri.toString() === doc.uri.toString()) return
+  await vscode.window.showTextDocument(doc, options)
+}
+
 export async function workspaceFileUri(relPath: string, root?: string) {
   const existing = await existingWorkspaceFileUri(relPath, root)
   if (existing) return existing
@@ -354,7 +370,7 @@ async function undoDelete(
   }
   const uri = await workspaceFileUri(change.path, root)
   try {
-    const data = new TextEncoder().encode(hunk.oldText)
+    const data = new TextEncoder().encode(restoredFileContent(hunk))
     await vscode.workspace.fs.writeFile(uri, data)
     return { status: "applied" }
   } catch (e) {
@@ -364,6 +380,19 @@ async function undoDelete(
       silent,
     )
   }
+}
+
+/**
+ * Whole-file content to write when restoring a deleted file. `hunk.oldText` is
+ * newline-JOINED, so the terminator the original file ended with is not in it —
+ * and a unified diff only ever records the ABSENCE of one, as a `\ No newline
+ * at end of file` marker. Writing `oldText` raw therefore stripped the final
+ * newline off every restored file, which git then reported as a real change to
+ * a file we claimed to have put back untouched.
+ */
+function restoredFileContent(hunk: ReviewDiffHunk): string {
+  if (!hunk.oldText || hunk.oldNoNewlineAtEof) return hunk.oldText
+  return `${hunk.oldText}\n`
 }
 
 async function undoMove(
@@ -454,7 +483,7 @@ async function undoUpdate(
     return reportConflict(change.path, `Could not undo hunk in ${change.path}.`, silent)
   }
   // Reveal the file so the user sees the revert immediately; previous behavior.
-  await vscode.window.showTextDocument(doc)
+  await revealDocument(doc)
   return { status: "applied" }
 }
 

--- a/src/chat/review-actions.ts
+++ b/src/chat/review-actions.ts
@@ -60,18 +60,22 @@ export async function reviewAllForPath(
   let applied = 0
   let conflicts = 0
   for (const record of ordered) {
-    const hunks = splitReviewDiff(record.patch).hunks
-    let firstHunk = true
+    const parsed = splitReviewDiff(record.patch).hunks
+    // Create / delete / move revert the file as a unit, so one runner call
+    // covers the whole record and only its first hunk is ever attempted.
+    // Slicing up front rather than tracking "have we called the runner yet" is
+    // what makes an unreversible first hunk consume that single attempt: while
+    // the guard keyed off a flag set only AFTER a successful call, an
+    // unparseable first `@@` left the slot open and hunk 2 ran too — for a
+    // `deleted` record that had `undoDelete` restore the file from a partial
+    // fragment of its content and report success.
+    const hunks = record.kind === "updated" ? parsed : parsed.slice(0, 1)
     for (const hunk of hunks) {
       if (action === "rejected" && !hunk.reversible) {
         conflicts += 1
         continue
       }
-      if (!firstHunk && record.kind !== "updated") {
-        continue
-      }
       const outcome = await runner(record, hunk, action, { silent: true, root: options.root })
-      firstHunk = false
       if (outcome.status === "applied" || outcome.status === "no-op") {
         applied += 1
         continue

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -57,6 +57,7 @@ import {
   applyCode,
   openFile,
   openFileDocument,
+  revealDocument,
   reviewPathExists,
 } from "./fs-ops"
 
@@ -2058,14 +2059,11 @@ export class ChatView implements vscode.WebviewViewProvider {
     try {
       const root = this.backendDirectory()
       const doc = await openFileDocument(change.path, root)
-      // If the requested file is already the active editor, don't re-show it —
-      // showTextDocument would steal focus + flash the editor pane for no
-      // reason. (Common when the user just clicked a different row and the
-      // editor already moved there.)
-      const active = vscode.window.activeTextEditor?.document.uri.toString()
-      if (active !== doc.uri.toString()) {
-        await vscode.window.showTextDocument(doc, { viewColumn: vscode.ViewColumn.One, preview: false })
-      }
+      // Skips the re-show when this file is already the active editor — common
+      // when the user just clicked a different row and the editor already moved
+      // there. `revealDocument` owns that guard; the Undo path needs the same
+      // one, and having each side spell it out is how they drifted apart.
+      await revealDocument(doc, { viewColumn: vscode.ViewColumn.One, preview: false })
       // Hunk-state reconciliation (purging missing-file hunks) is independent
       // of where the editor is pointed — queue it so the editor swap never
       // waits on fs.stat I/O.

--- a/test/host/diff-utils.test.ts
+++ b/test/host/diff-utils.test.ts
@@ -205,6 +205,35 @@ describe("splitReviewDiff", () => {
     expect(hunk.newText).toBe("title\nbody")
   })
 
+  // `oldText` is newline-joined and so never carries the original file's
+  // terminator; the marker is the only record that there wasn't one.
+  it("reports oldNoNewlineAtEof only when the marker follows an old-side line", () => {
+    const marker = "\\ No newline at end of file"
+    const oldSide = splitReviewDiff(["@@ -1,1 +0,0 @@", "-only", marker].join("\n")).hunks[0]!
+    expect(oldSide.oldNoNewlineAtEof).toBe(true)
+    expect(oldSide.oldText).toBe("only")
+
+    // After a `+` line the marker describes the POST-change file — the original
+    // still ended with a newline, so a restore must put one back.
+    const newSide = splitReviewDiff(["@@ -1,1 +1,1 @@", "-old", "+new", marker].join("\n")).hunks[0]!
+    expect(newSide.oldNoNewlineAtEof).toBe(false)
+
+    // Both sides ended at a shared context line.
+    const ctx = splitReviewDiff(["@@ -1,2 +1,1 @@", "-gone", " last", marker].join("\n")).hunks[0]!
+    expect(ctx.oldNoNewlineAtEof).toBe(true)
+
+    // Replacing the final line marks each side separately.
+    const bothMarked = splitReviewDiff(
+      ["@@ -1,1 +1,1 @@", "-old", marker, "+new", marker].join("\n"),
+    ).hunks[0]!
+    expect(bothMarked.oldNoNewlineAtEof).toBe(true)
+  })
+
+  it("defaults oldNoNewlineAtEof to false when no marker is present", () => {
+    expect(splitReviewDiff("@@ -1,1 +0,0 @@\n-only").hunks[0]!.oldNoNewlineAtEof).toBe(false)
+    expect(splitReviewDiff("no @@ here").hunks[0]!.oldNoNewlineAtEof).toBe(false)
+  })
+
   it("still reads --- / +++ as file headers in the no-hunk fallback path", () => {
     // No `@@` anywhere, so splitReviewDiff falls back to classifying the whole
     // patch — there the prefixes really are unified-diff file headers.

--- a/test/host/review-actions.test.ts
+++ b/test/host/review-actions.test.ts
@@ -80,6 +80,11 @@ beforeEach(() => {
       return true
     },
   )
+  // The reveal tests below assert call counts and drive `activeTextEditor`, and
+  // neither is cleared between tests by default (no `clearMocks` in the vitest
+  // config), so reset both here rather than at the end of each test.
+  ;(vscode.window as { activeTextEditor?: unknown }).activeTextEditor = undefined
+  ;(vscode.window.showTextDocument as ReturnType<typeof vi.fn>).mockReset()
   ;(vscode.window.showTextDocument as ReturnType<typeof vi.fn>).mockResolvedValue(undefined)
   ;(vscode.window.showWarningMessage as ReturnType<typeof vi.fn>).mockReturnValue(undefined)
   ;(vscode.window.showInformationMessage as ReturnType<typeof vi.fn>).mockReturnValue(undefined)
@@ -151,12 +156,32 @@ describe("reviewHunk: created files", () => {
 })
 
 describe("reviewHunk: deleted files", () => {
-  it("Undo: recreates the file using oldText from the diff", async () => {
+  it("Undo: recreates the file using oldText from the diff, terminator included", async () => {
     const patch = ["@@ -1,2 +0,0 @@", "-line1", "-line2"].join("\n")
     const { change, hunk } = makeChange({ path: "gone.ts", kind: "deleted", patch })
     const outcome = await reviewHunk(change, hunk, "rejected", { silent: true })
     expect(outcome.status).toBe("applied")
+    // `oldText` is newline-JOINED, so it stops after "line2"; a diff records
+    // only the ABSENCE of a trailing newline, and this one didn't. Writing
+    // oldText raw stripped the terminator off every restored file.
+    expect(writes[0]?.content).toBe("line1\nline2\n")
+  })
+
+  it("Undo: omits the terminator when the diff carried a no-newline marker", async () => {
+    const patch = ["@@ -1,2 +0,0 @@", "-line1", "-line2", "\\ No newline at end of file"].join("\n")
+    const { change, hunk } = makeChange({ path: "gone.ts", kind: "deleted", patch })
+    const outcome = await reviewHunk(change, hunk, "rejected", { silent: true })
+    expect(outcome.status).toBe("applied")
     expect(writes[0]?.content).toBe("line1\nline2")
+  })
+
+  it("Undo: preserves a blank final line", async () => {
+    // "line1\n\n" diffs as `-line1` plus a bare `-`, so the join already ends
+    // in "\n" and the restored terminator makes it two.
+    const patch = ["@@ -1,2 +0,0 @@", "-line1", "-"].join("\n")
+    const { change, hunk } = makeChange({ path: "gone.ts", kind: "deleted", patch })
+    expect((await reviewHunk(change, hunk, "rejected", { silent: true })).status).toBe("applied")
+    expect(writes[0]?.content).toBe("line1\n\n")
   })
 
   it("Undo: conflicts when a file is already at that path", async () => {
@@ -507,6 +532,59 @@ describe("reviewAllForPath: multi-tool turn", () => {
     expect(result.conflicts).toBe(0)
     expect(deletes.map((u) => u.fsPath)).toContain("/workspace/new.ts")
     expect(files.has("/workspace/new.ts")).toBe(false)
+  })
+
+  it("a whole-file record with an unreversible first hunk writes nothing", async () => {
+    // Two hunks, the first with an unparseable header. The whole-file guard
+    // used to key off a flag set only after a SUCCESSFUL runner call, so
+    // skipping hunk 1 left the record's single attempt open and hunk 2 ran —
+    // restoring the file from its own fragment ("line2") and reporting success.
+    const record: ReviewChange = {
+      source: "callA",
+      path: "gone.ts",
+      kind: "deleted",
+      additions: 0,
+      deletions: 2,
+      patch: ["@@ broken @@", "-line1", "@@ -2,1 +0,0 @@", "-line2"].join("\n"),
+    }
+    const result = await reviewAllForPath([record], record, "rejected", { reviewedKeys: {} })
+    expect(result.applied).toBe(0)
+    expect(result.conflicts).toBe(1)
+    expect(writes).toHaveLength(0)
+    expect(files.has("/workspace/gone.ts")).toBe(false)
+    // Nothing landed, so the row stays pending for the user to inspect.
+    expect(result.hunkUpdates).toHaveLength(0)
+  })
+
+  it("reveals the reverted file once for the whole batch, not once per hunk", async () => {
+    // `showTextDocument` yanks focus out of the chat panel, and the runner is
+    // called once per hunk per record — so the reveal has to notice that the
+    // first call already made this document active.
+    ;(vscode.window.showTextDocument as ReturnType<typeof vi.fn>).mockImplementation(
+      async (doc: { uri: vscode.Uri }) => {
+        ;(vscode.window as { activeTextEditor?: unknown }).activeTextEditor = { document: doc }
+        return {}
+      },
+    )
+    files.set("/workspace/foo.ts", { content: "one\ntwo-revA\nthree\nfour\nfive-revB\n" })
+    const recordA = buildUpdate({ source: "callA", path: "foo.ts", oldText: "two", newText: "two-revA", line: 2 })
+    const recordB = buildUpdate({ source: "callB", path: "foo.ts", oldText: "five", newText: "five-revB", line: 5 })
+    const result = await reviewAllForPath([recordA, recordB], aggregateLike([recordA, recordB]), "rejected", {
+      reviewedKeys: {},
+    })
+    expect(result.applied).toBe(2)
+    expect(vscode.window.showTextDocument).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not reveal at all when the file is already the active editor", async () => {
+    files.set("/workspace/foo.ts", { content: "one\ntwo-revA\n" })
+    ;(vscode.window as { activeTextEditor?: unknown }).activeTextEditor = {
+      document: { uri: vscode.Uri.file("/workspace/foo.ts") },
+    }
+    const record = buildUpdate({ source: "callA", path: "foo.ts", oldText: "two", newText: "two-revA", line: 2 })
+    const result = await reviewAllForPath([record], aggregateLike([record]), "rejected", { reviewedKeys: {} })
+    expect(result.applied).toBe(1)
+    expect(vscode.window.showTextDocument).not.toHaveBeenCalled()
   })
 
   it("returns zeros when no records match (defensive)", async () => {


### PR DESCRIPTION
Closes #486.

## Summary

Audit findings 4, 5 and 6 — three defects on the review Keep/Undo path. `reviewAllForPath` is the only production caller of `reviewHunk` and drives the runner once per hunk per per-tool record, which is what makes all three observable from a single "Undo all in file" click.

**1. Focus thrash (`undoUpdate`).** The reveal at the end of `undoUpdate` was unconditional — the `silent` option `reviewAllForPath` passes only ever gated warning toasts — so a row with N hunks yanked focus out of the chat panel N times, each an await round-trip.

Extracted `revealDocument(doc, options?)` in `fs-ops.ts`: it no-ops when the document is already the active editor, which collapses the batch to one reveal and to zero when the user is already looking at the file. `openReviewChange` had the same guard spelled out inline and now uses the helper instead — each side carrying its own copy is how they came to contradict each other.

**2. Lost trailing newline (`undoDelete`).** It wrote `hunk.oldText` verbatim. That value is `oldLines.join("\n")`, and a unified diff records only the *absence* of a terminator (a `\ No newline at end of file` marker), so there is no way to distinguish "the original had no final newline" from "the join dropped it". Every restored file therefore lost its terminator and showed up as a real change in `git diff` against a file we claimed to have put back untouched.

`hunkText` now captures that marker per side — it annotates the line above it, so after a `-` or context line it describes the original, after a `+` only the post-change file — and exposes `ReviewDiffHunk.oldNoNewlineAtEof`. `undoDelete` appends the separator unless the diff said there wasn't one. Empty `oldText` is left alone (it can't reach the write anyway; the no-content guard returns `unsupported` first).

**3. Leaked whole-file guard (`reviewAllForPath`).** Create/delete/move records get a single runner call, since one call reverts the file as a unit. But the guard keyed off a flag assigned only *after* a successful call, and the `!hunk.reversible` branch `continue`d before reaching it — so a whole-file record whose first `@@` doesn't parse left the slot open and hunk 2 ran too. For a `deleted` record that meant `undoDelete` restoring the file from hunk 2's `oldText` — a partial fragment of the original — and reporting `applied`, so the row was marked reviewed and the truncation never surfaced. The record was also counted as both a conflict and an application.

Now the hunk list is sliced to the first entry up front, so the skipped hunk consumes the record's one attempt: nothing is written, one conflict is reported, and the row stays pending for the user to inspect.

### Scope

No protocol change and no webview change. `ReviewDiffHunk` gains one field, read only by `undoDelete`; the webview's own `splitDiff` derives hunk IDs only and is untouched, so `reviewKey` and persisted review state are unaffected. `openFile` (the chat file-link path) keeps its unconditional show — clicking a link should focus the editor.

## Test plan

- [x] `bun run test` — 1259 passed / 82 files (was 1252; 7 new)
- [x] `bun run check-types` clean
- [x] `cd webview && bunx tsc --noEmit` clean
- [x] All 7 new assertions verified to fail against the unfixed source (stashed the four `src/` files and re-ran)
- [x] `reveals the reverted file once for the whole batch, not once per hunk` — two records on one file, `showTextDocument` called exactly once (was 2)
- [x] `does not reveal at all when the file is already the active editor` — 0 calls
- [x] `Undo: recreates the file using oldText from the diff, terminator included` — the existing expectation moved from `"line1\nline2"` to `"line1\nline2\n"`
- [x] `Undo: omits the terminator when the diff carried a no-newline marker`
- [x] `Undo: preserves a blank final line` — `-line1` + a bare `-` restores `"line1\n\n"`, so the appended separator can't double up on a real blank last line
- [x] `reports oldNoNewlineAtEof only when the marker follows an old-side line` — covers the marker after `-`, after `+`, after a shared context line, and marked on both sides of a final-line replacement
- [x] `a whole-file record with an unreversible first hunk writes nothing` — 0 applied, 1 conflict, no writes, no hunk updates
- [ ] Not verified in a running editor: that Undo-all on a real multi-hunk row visibly stops flipping the editor pane, and that a restored deleted file is byte-identical in `git diff`

🤖 Generated with [Claude Code](https://claude.com/claude-code)