### PR TITLE
fix(test): buffer mock SSE events pushed before a client connects

### DIFF
--- a/test/host/mock-opencode-server.ts
+++ b/test/host/mock-opencode-server.ts
@@ -104,6 +104,8 @@ export type MockOpencodeServer = {
 
 export async function startMockOpencode(): Promise<MockOpencodeServer> {
   const sseClients: ServerResponse[] = []
+  /** Events pushed while no client was connected; flushed on the next connect. */
+  const pendingEvents: string[] = []
   const prompts: Array<{ sessionID: string; body: unknown }> = []
   const reverts: Array<{ sessionID: string; body: unknown }> = []
   let revertStatus = 200
@@ -167,6 +169,7 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
       res.setHeader("cache-control", "no-cache")
       res.setHeader("connection", "keep-alive")
       sseClients.push(res)
+      for (const line of pendingEvents.splice(0)) res.write(line)
       if (clientResolver) {
         clientResolver()
         clientResolver = undefined
@@ -410,6 +413,19 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
     push(event) {
       // SSE format: "data: {json}\n\n"
       const line = `data: ${JSON.stringify({ type: event.type, properties: event })}\n\n`
+      if (sseClients.length === 0) {
+        // Buffer instead of dropping. ChatView attaches its SSE subscription
+        // on the send paths, and awaiting the Inbound message only guarantees
+        // the subscribe call was issued — not that its HTTP request reached
+        // this server. A test scripting an event right after `send` races
+        // that request; losing the race silently discarded the event and left
+        // the assertion waiting on an effect that could never arrive, which
+        // read as an intermittent "condition not met in time" under load.
+        // Replaying to the first client to connect closes the window without
+        // every call site having to know which Inbound message subscribes.
+        pendingEvents.push(line)
+        return
+      }
       for (const client of sseClients) client.write(line)
     },
     awaitClient() {


### PR DESCRIPTION
Closes #490.

## Summary

`chatview-harness.test.ts` fails intermittently under full-suite load with `condition not met in time`, and passes in isolation.

`MockOpencodeServer.push` wrote each event only to clients already connected. `ChatView` attaches its SSE subscription on the **send** paths, so awaiting the Inbound `send` guarantees the subscribe call was *issued*, not that its HTTP request reached the mock server. A test scripting an event immediately after `send` races that request, and losing the race dropped the event permanently — the `until()` polling for its effect then had nothing to wait for and burned its 4 s timeout.

Events pushed with no client connected are now buffered and flushed to the first client that connects.

### Diagnosis

I chased a wrong lead first — that pushes were being dropped outright — and three clean full-suite runs with drop instrumentation showed nothing, so that wasn't it on its own. Two measurements settled it:

- Instrumenting `until()` showed **no healthy wait exceeds 100 ms**, while the failure blocks **past 4000 ms**. A 40x gap is "never arrives", not "slow" — which rules out simply raising the timeout.
- Inserting a 50 ms delay before `sseClients.push(res)` reproduces it **deterministically**: 15 of the file's 31 tests fail, including the reported one, at the same line with the same message.

### Why buffering rather than `awaitClient()` at the call sites

Every other file driving this server already gates on `await server.awaitClient()` — `e2e-mock-opencode`, `stream-watchdog`, `child-session-discovery`, `child-session-tool-routing`. `chatview-harness.test.ts` has 41 `push` calls and zero `awaitClient()` calls; it never adopted the workaround.

I tried adding the gate there first and it was the wrong shape: I assumed `mounted` attached the subscription, but it attaches on *send*, and from several different Inbound messages (send, command, edit-resend). Gating at the mount sites made 29 tests hang on a client that never arrives. Every future test would have to know which messages subscribe — so the sharp edge is better removed than worked around a 26th time.

Because the other four files await a client before pushing, they never reach the buffer at all; this is a no-op for them. No test depends on drop-on-disconnect — the only mid-test `disposeView()` calls are end-of-test cleanup in two tests that push nothing.

## Test plan

- [x] `bun run test` — 1265 passed / 82 files, green on **three consecutive full runs**
- [x] `bun run check-types` clean
- [x] Reproduced the failure deterministically before the fix (50 ms attach delay → 15 of 31 fail, including the reported test at the reported line)
- [x] Same 50 ms delay after the fix → all 31 pass
- [x] Stress: **300 ms** attach delay across all five files that drive the mock server → 94/94 pass, confirming the other files are unaffected
- [x] Artificial delay and all instrumentation removed; final diff is the buffer, the flush on connect, and the comment

Test-infrastructure only — no `src/` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)