### PR TITLE
fix(permissions): route permission.replied to clear an external answer

### DIFF
--- a/src/chat/stream.ts
+++ b/src/chat/stream.ts
@@ -75,6 +75,8 @@ export type StreamHandlers = {
   onPatch?: (messageID: string, files: string[], diff?: string) => void
   onFileRead?: (messageID: string, filename: string) => void
   onPermissionNeeded?: (permission: PermissionRequest) => void
+  /** Fired when a permission is answered — by us, or by anything else holding the session. */
+  onPermissionResolved?: (permissionID: string) => void
   onQuestionAsked?: (question: QuestionRequest) => void
   /** Fired when a question is answered (by us or another client) or rejected. */
   onQuestionResolved?: (requestID: string) => void
@@ -325,9 +327,12 @@ export function subscribeSession(
         onPartDelta(props)
         markActivity(props?.sessionID)
         return
-      case "permission.asked":
       case "permission.updated":
         onPermissionUpdated(props)
+        markActivity(props?.sessionID)
+        return
+      case "permission.replied":
+        onPermissionResolved(props)
         markActivity(props?.sessionID)
         return
       case "question.asked":
@@ -761,6 +766,16 @@ export function subscribeSession(
       pattern: p.pattern ?? p.patterns,
       type: p.permission ?? p.type,
     })
+  }
+
+  function onPermissionResolved(p: any) {
+    if (!p || p.sessionID !== sessionID) return
+    // `permission.updated` carries a full Permission (keyed `id`) while
+    // `permission.replied` carries only `{sessionID, permissionID, response}`,
+    // so the two events name the same permission differently.
+    const id = p.permissionID ?? p.id
+    if (!id) return
+    handlers.onPermissionResolved?.(id)
   }
 
   function onQuestionAsked(p: any) {

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -1813,9 +1813,10 @@ export class ChatView implements vscode.WebviewViewProvider {
         })
       },
       onPermissionNeeded: (perm) => {
-        // Same ignore-while-aborting gate as the other non-terminal events:
-        // a permission raised mid-Stop targets a session being torn down,
-        // and no resolution event exists that would ever clear the dialog.
+        // Same ignore-while-aborting gate as the other non-terminal events: a
+        // permission raised mid-Stop targets a session being torn down, and
+        // nothing will ever answer it, so no `permission.replied` is coming to
+        // clear the dialog either.
         if (this.aborting) return
         this.activePermissions.set(perm.id, perm)
         this.syncAgentWaitState()
@@ -1825,6 +1826,13 @@ export class ChatView implements vscode.WebviewViewProvider {
           title: perm.title,
           pattern: perm.pattern,
         })
+      },
+      onPermissionResolved: (id) => {
+        // Fires for our own reply too, where `permissionReply` already did
+        // this — both sides are id-keyed, so the echo is a no-op.
+        this.activePermissions.delete(id)
+        this.syncAgentWaitState()
+        this.post({ type: "permissionResolved", id })
       },
       onQuestionAsked: (q) => {
         if (this.aborting) return

--- a/test/host/chatview-harness.test.ts
+++ b/test/host/chatview-harness.test.ts
@@ -825,11 +825,11 @@ describe("ChatView harness: waiting-for-input Main status", () => {
       .at(-1)?.status
   }
 
-  it("flips the Main row to waiting on permission.asked and back to running on reply", async () => {
+  it("flips the Main row to waiting on permission.updated and back to running on reply", async () => {
     await harness.send({ type: "mounted" })
     await harness.send({ type: "send", text: "guarded edit" })
 
-    server.push({ type: "permission.asked", id: "perm_1", sessionID: SESSION_ID, title: "Edit file" })
+    server.push({ type: "permission.updated", id: "perm_1", sessionID: SESSION_ID, title: "Edit file" })
     await until(() => lastMainStatus() === "waiting")
     const snap = harness.posted.filter((m) => m.type === "agentsStatus").at(-1)
     expect(snap && "status" in snap ? snap.status.waiting : 0).toBe(1)
@@ -841,7 +841,7 @@ describe("ChatView harness: waiting-for-input Main status", () => {
   it("Stop clears pending prompts so the next turn cannot wedge on waiting", async () => {
     await harness.send({ type: "mounted" })
     await harness.send({ type: "send", text: "first try" })
-    server.push({ type: "permission.asked", id: "perm_stale", sessionID: SESSION_ID, title: "T" })
+    server.push({ type: "permission.updated", id: "perm_stale", sessionID: SESSION_ID, title: "T" })
     await until(() => lastMainStatus() === "waiting")
 
     await harness.send({ type: "abort" })
@@ -849,12 +849,40 @@ describe("ChatView harness: waiting-for-input Main status", () => {
     await until(() => harness.posted.some((m) => m.type === "sessionIdle"))
 
     await harness.send({ type: "send", text: "second try" })
-    server.push({ type: "permission.asked", id: "perm_2", sessionID: SESSION_ID, title: "T2" })
+    server.push({ type: "permission.updated", id: "perm_2", sessionID: SESSION_ID, title: "T2" })
     await until(() => lastMainStatus() === "waiting")
     await harness.send({ type: "permissionReply", id: "perm_2", response: "once" })
     // Without the abort-time map clear, perm_stale would keep the pending
     // count above zero and the row would stay `waiting` forever.
     await until(() => lastMainStatus() === "running")
+  })
+
+  it("a permission answered outside the panel releases the row and dismisses the dialog", async () => {
+    await harness.send({ type: "mounted" })
+    await harness.send({ type: "send", text: "guarded edit" })
+
+    server.push({ type: "permission.updated", id: "perm_ext", sessionID: SESSION_ID, title: "Edit file" })
+    await until(() => lastMainStatus() === "waiting")
+
+    // Nobody sent `permissionReply` — this is opencode reporting that something
+    // else (a plugin, an `always` rule) answered. `permission.replied` keys the
+    // permission as `permissionID`, not `id`.
+    server.push({ type: "permission.replied", sessionID: SESSION_ID, permissionID: "perm_ext", response: "once" })
+    await until(() => lastMainStatus() === "running")
+    await until(() => harness.posted.some((m) => m.type === "permissionResolved" && m.id === "perm_ext"))
+  })
+
+  it("ignores a reply for another session", async () => {
+    await harness.send({ type: "mounted" })
+    await harness.send({ type: "send", text: "guarded edit" })
+
+    server.push({ type: "permission.updated", id: "perm_mine", sessionID: SESSION_ID, title: "Edit file" })
+    await until(() => lastMainStatus() === "waiting")
+
+    server.push({ type: "permission.replied", sessionID: "ses_other", permissionID: "perm_mine", response: "once" })
+    await new Promise((r) => setTimeout(r, 50))
+    expect(lastMainStatus()).toBe("waiting")
+    expect(harness.posted.some((m) => m.type === "permissionResolved")).toBe(false)
   })
 })
 

--- a/test/webview/permission-flow.test.ts
+++ b/test/webview/permission-flow.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest"
+import { reducer, initialChatState } from "../../webview/src/hooks/useChatState"
+
+function opened(id = "perm_1") {
+  return reducer(initialChatState, { type: "permission", id, title: "Edit file" })
+}
+
+describe("reducer — permission flow", () => {
+  it("permissionResolved clears the matching pendingPermission", () => {
+    const closed = reducer(opened(), { type: "permissionResolved", id: "perm_1" })
+    expect(closed.pendingPermission).toBeUndefined()
+  })
+
+  it("permissionResolved with a non-matching id is a no-op", () => {
+    // The echo of our own reply to A can land after B is already showing;
+    // dismissing on arrival alone would drop a prompt nobody answered.
+    const stale = reducer(opened("perm_active"), { type: "permissionResolved", id: "perm_other" })
+    expect(stale.pendingPermission?.id).toBe("perm_active")
+  })
+
+  it("clearPermission clears the matching pendingPermission", () => {
+    const closed = reducer(opened(), { type: "clearPermission", id: "perm_1" })
+    expect(closed.pendingPermission).toBeUndefined()
+  })
+
+  it("ignores a permission raised while aborting", () => {
+    const aborting = reducer(initialChatState, { type: "aborted" })
+    const after = reducer(aborting, { type: "permission", id: "perm_1", title: "Edit file" })
+    expect(after.pendingPermission).toBeUndefined()
+  })
+})

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -91,7 +91,7 @@ export type ChatState = {
 export type Action =
   | Outbound
   | { type: "reset" }
-  | { type: "clearPermission" }
+  | { type: "clearPermission"; id: string }
   | { type: "clearQuestion"; id: string }
   | { type: "queueMessage"; message: QueuedMessage }
   | { type: "unqueueMessage"; id: string }
@@ -387,16 +387,22 @@ export function reducer(state: ChatState, action: Action): ChatState {
     case "continuationPending":
       return { ...state, continuationPending: action.pending }
     case "permission":
-      // Ignore-while-aborting, like the other non-terminal events: there is
-      // no permission-resolved wire event, so a dialog raised mid-Stop could
-      // never be cleared once the session dies.
+      // Ignore-while-aborting, like the other non-terminal events: nothing
+      // will answer a permission raised mid-Stop, so no `permissionResolved`
+      // is coming for it and the dialog would sit there once the session dies.
       if (state.aborting) return state
       return {
         ...state,
         pendingPermission: { id: action.id, title: action.title, pattern: action.pattern },
       }
+    case "permissionResolved":
     case "clearPermission":
-      return { ...state, pendingPermission: undefined }
+      // Same id guard as questions: our reply clears the dialog locally, and
+      // opencode's echoing `permission.replied` lands after a new permission
+      // may already be showing — dismissing that one would drop a live prompt.
+      return state.pendingPermission?.id === action.id
+        ? { ...state, pendingPermission: undefined }
+        : state
     case "question":
       if (state.aborting) return state
       return {
@@ -575,7 +581,7 @@ export function useChatState() {
     },
     replyPermission(id: string, response: "once" | "always" | "reject") {
       vscode.post({ type: "permissionReply", id, response })
-      dispatch({ type: "clearPermission" })
+      dispatch({ type: "clearPermission", id })
     },
     replyQuestion(id: string, answers: string[][]) {
       vscode.post({ type: "questionReply", id, answers })

--- a/webview/src/protocol.ts
+++ b/webview/src/protocol.ts
@@ -449,6 +449,12 @@ export type Outbound =
    */
   | { type: "continuationPending"; pending: boolean }
   | { type: "permission"; id: string; title: string; pattern?: string | string[] }
+  /**
+   * A permission was answered. Also fires for our own reply (opencode echoes
+   * `permission.replied` back), which the webview has already acted on — the
+   * point of the event is the answer that came from somewhere else.
+   */
+  | { type: "permissionResolved"; id: string }
   | { type: "question"; id: string; questions: QuestionInfo[] }
   | { type: "questionResolved"; id: string }
   | { type: "messageRemoved"; id: string }


### PR DESCRIPTION
## Summary

`src/chat/stream.ts` routed `permission.asked` and `permission.updated`. Checked against `@opencode-ai/sdk`'s generated `Event` union, `permission.asked` **does not exist** — the two permission members are `EventPermissionUpdated` and `EventPermissionReplied`. The routed case was dead and the real resolution event fell through to `default` ("unhandled type").

Because of that, `activePermissions` was only ever cleared by our own reply, an abort, or turn end:

- `syncAgentWaitState` derives the Main agent row's `waiting` status from `activePermissions.size + activeQuestions.size`, so a permission answered anywhere else pinned the row to "waiting for input" for the rest of the turn.
- There was no `permissionResolved` Outbound at all, so the webview dialog also stayed up — asymmetric with questions, which had the full path wired.

The change mirrors the question path end to end:

- `permission.replied` routes to a new `onPermissionResolved` handler. It reads `permissionID ?? id`, since `permission.replied` carries `{sessionID, permissionID, response}` while `permission.updated` carries a full `Permission` keyed `id` — the two events name the same permission differently.
- `ChatView` deletes from `activePermissions`, re-syncs the wait state, and posts the new `permissionResolved` Outbound.
- The reducer clears `pendingPermission` **only on an id match**. Opencode echoes `permission.replied` for our own reply too, and that echo can land after a new permission is already showing; dismissing on arrival alone would drop a live prompt. `clearPermission` now carries its id and shares the case, so the two dismissal paths cannot drift.
- The dead `permission.asked` case is gone.

The three existing harness tests pushed `permission.asked`, so they exercised an event opencode never sends — which is why the gap stayed invisible. They now push `permission.updated`.

Closes #492

## Test plan

- [x] `bun run test` — 1271 passed / 83 files, three consecutive clean runs
- [x] `bun run check-types` — clean
- [x] `cd webview && bunx tsc --noEmit` — clean
- [x] `bun run compile` — clean
- [x] Each new assertion verified to fail without the source fix (source stashed, tests kept): the reducer's `permissionResolved` clear and the harness's external-answer test both fail; the renamed `permission.updated` tests pass either way, confirming that rename is behavior-preserving
- [x] New host tests: an externally answered permission releases the row and posts `permissionResolved`; a reply for another session is ignored
- [x] New `test/webview/permission-flow.test.ts`: id-matched clear, non-matching no-op, `clearPermission`, ignore-while-aborting
- [ ] Not verified by hand: the end-to-end dialog dismissal needs a server-side auto-approver to emit `permission.replied` without a panel reply

### Unrelated pre-existing flake

The first full run failed one assertion in `test/webview/codeblock.test.tsx` ("highlights alias languages"), a 5s `waitFor` on shiki's async grammar load that a cold run (transform 17.9s vs ~2s on later runs) blew through. Not reproducible in three subsequent full runs or three isolated runs, and untouched by this change. Left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)