### PR TITLE
feat(composer): recall previous prompts with Up/Down

### DIFF
--- a/test/webview/prompt-history.test.tsx
+++ b/test/webview/prompt-history.test.tsx
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { PromptBox } from "../../webview/src/components/PromptBox"
+import { promptHistory, caretAtFirstLine, caretAtLastLine } from "../../webview/src/prompt-history"
+import type { ChatMessage } from "../../webview/src/protocol"
+
+afterEach(cleanup)
+
+function userMessage(id: string, text: string, extra: Partial<ChatMessage> = {}): ChatMessage {
+  return { id, role: "user", blocks: [{ type: "text", text }], ...extra }
+}
+
+/** Oldest first, matching the prop contract. */
+const HISTORY = [{ text: "first prompt" }, { text: "second prompt" }, { text: "third prompt" }]
+
+function renderComposer(props: Partial<React.ComponentProps<typeof PromptBox>> = {}) {
+  const result = render(
+    <PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} history={HISTORY} {...props} />,
+  )
+  return { ...result, textarea: screen.getByRole("textbox") as HTMLTextAreaElement }
+}
+
+function press(textarea: HTMLTextAreaElement, key: string, init: Record<string, unknown> = {}) {
+  fireEvent.keyDown(textarea, { key, ...init })
+}
+
+describe("promptHistory", () => {
+  it("collects user prompts oldest-first and ignores assistant turns", () => {
+    const entries = promptHistory([
+      userMessage("u1", "one"),
+      { id: "a1", role: "assistant", blocks: [{ type: "text", text: "reply" }] },
+      userMessage("u2", "two"),
+    ])
+    expect(entries.map((e) => e.text)).toEqual(["one", "two"])
+  })
+
+  it("skips blank prompts", () => {
+    // An attachment-only turn has no recallable text; offering an empty entry
+    // would make Up look broken.
+    const entries = promptHistory([userMessage("u1", "   "), userMessage("u2", "real")])
+    expect(entries.map((e) => e.text)).toEqual(["real"])
+  })
+
+  it("collapses an immediately repeated prompt", () => {
+    const entries = promptHistory([
+      userMessage("u1", "retry me"),
+      userMessage("u2", "retry me"),
+      userMessage("u3", "different"),
+    ])
+    expect(entries.map((e) => e.text)).toEqual(["retry me", "different"])
+  })
+
+  it("carries mention bindings so recall can re-register them", () => {
+    const entries = promptHistory([
+      userMessage("u1", "look @src/a.ts", {
+        mentions: ["src/a.ts"],
+        conversationMentions: [{ label: "Past chat", id: "conv_1" }],
+      }),
+    ])
+    expect(entries[0]!.mentions).toEqual(["src/a.ts"])
+    expect(entries[0]!.conversationMentions).toEqual([{ label: "Past chat", id: "conv_1" }])
+  })
+
+  it("joins multiple text blocks the way the edit flow does", () => {
+    const entries = promptHistory([
+      { id: "u1", role: "user", blocks: [{ type: "text", text: "a" }, { type: "text", text: "b" }] },
+    ])
+    expect(entries[0]!.text).toBe("a\n\nb")
+  })
+})
+
+describe("caret edge predicates", () => {
+  it("treats a soft-wrapped single logical line as the first and last line", () => {
+    const long = "x".repeat(400)
+    expect(caretAtFirstLine(long, 200)).toBe(true)
+    expect(caretAtLastLine(long, 200)).toBe(true)
+  })
+
+  it("locates the caret between logical lines", () => {
+    const text = "line one\nline two"
+    expect(caretAtFirstLine(text, 4)).toBe(true)
+    expect(caretAtLastLine(text, 4)).toBe(false)
+    expect(caretAtFirstLine(text, 12)).toBe(false)
+    expect(caretAtLastLine(text, 12)).toBe(true)
+  })
+})
+
+describe("PromptBox prompt history", () => {
+  it("Up recalls the most recent prompt, then walks further back", () => {
+    const { textarea } = renderComposer()
+    press(textarea, "ArrowUp")
+    expect(textarea.value).toBe("third prompt")
+    press(textarea, "ArrowUp")
+    expect(textarea.value).toBe("second prompt")
+    press(textarea, "ArrowUp")
+    expect(textarea.value).toBe("first prompt")
+  })
+
+  it("stops at the oldest entry instead of wrapping", () => {
+    const { textarea } = renderComposer()
+    for (let i = 0; i < 6; i += 1) press(textarea, "ArrowUp")
+    expect(textarea.value).toBe("first prompt")
+  })
+
+  it("Down walks forward and restores the stashed draft at the end", async () => {
+    const user = userEvent.setup()
+    const { textarea } = renderComposer()
+    await user.type(textarea, "half-written")
+
+    press(textarea, "ArrowUp")
+    press(textarea, "ArrowUp")
+    expect(textarea.value).toBe("second prompt")
+
+    press(textarea, "ArrowDown")
+    expect(textarea.value).toBe("third prompt")
+    press(textarea, "ArrowDown")
+    // Past the newest entry: the draft comes back rather than being destroyed.
+    expect(textarea.value).toBe("half-written")
+  })
+
+  it("leaves Down alone in a composer that never entered history", async () => {
+    const user = userEvent.setup()
+    const { textarea } = renderComposer()
+    await user.type(textarea, "typing")
+    press(textarea, "ArrowDown")
+    expect(textarea.value).toBe("typing")
+  })
+
+  it("typing after a recall re-stashes, so the next Up starts from the newest again", async () => {
+    const user = userEvent.setup()
+    const { textarea } = renderComposer()
+    press(textarea, "ArrowUp")
+    press(textarea, "ArrowUp")
+    expect(textarea.value).toBe("second prompt")
+
+    await user.type(textarea, "!")
+    expect(textarea.value).toBe("second prompt!")
+    press(textarea, "ArrowUp")
+    expect(textarea.value).toBe("third prompt")
+  })
+})
+
+describe("PromptBox prompt history — keys it must not steal", () => {
+  it("moves the caret instead of recalling when another line is above", async () => {
+    const user = userEvent.setup()
+    const { textarea } = renderComposer()
+    await user.type(textarea, "line one{Shift>}{Enter}{/Shift}line two")
+    expect(textarea.value).toBe("line one\nline two")
+
+    // Caret sits in the second line, so Up belongs to the textarea.
+    textarea.setSelectionRange(12, 12)
+    press(textarea, "ArrowUp")
+    expect(textarea.value).toBe("line one\nline two")
+  })
+
+  it("recalls once the caret reaches the first line of a multi-line draft", async () => {
+    const user = userEvent.setup()
+    const { textarea } = renderComposer()
+    await user.type(textarea, "line one{Shift>}{Enter}{/Shift}line two")
+    textarea.setSelectionRange(3, 3)
+    press(textarea, "ArrowUp")
+    expect(textarea.value).toBe("third prompt")
+  })
+
+  it("ignores modifier chords", () => {
+    const { textarea } = renderComposer()
+    press(textarea, "ArrowUp", { shiftKey: true })
+    expect(textarea.value).toBe("")
+    press(textarea, "ArrowUp", { altKey: true })
+    expect(textarea.value).toBe("")
+    press(textarea, "ArrowUp", { metaKey: true })
+    expect(textarea.value).toBe("")
+  })
+
+  it("ignores Up while text is selected", async () => {
+    const user = userEvent.setup()
+    const { textarea } = renderComposer()
+    await user.type(textarea, "selected")
+    textarea.setSelectionRange(0, 8)
+    press(textarea, "ArrowUp")
+    expect(textarea.value).toBe("selected")
+  })
+
+  it("is inert during IME composition", () => {
+    const { textarea } = renderComposer()
+    fireEvent.keyDown(textarea, { key: "ArrowUp", keyCode: 229 })
+    expect(textarea.value).toBe("")
+  })
+
+  it("does not apply to the edit composer", () => {
+    render(
+      <PromptBox
+        busy={false}
+        onSend={vi.fn()}
+        onAbort={vi.fn()}
+        variant="edit"
+        initial={{ text: "editing this" }}
+        history={HISTORY}
+      />,
+    )
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    press(textarea, "ArrowUp")
+    expect(textarea.value).toBe("editing this")
+  })
+
+  it("yields the arrows to an open picker", async () => {
+    const user = userEvent.setup()
+    const searchFiles = vi.fn().mockResolvedValue([{ path: "src/foo.ts", name: "foo.ts" }])
+    const { textarea } = renderComposer({ searchFiles })
+    await user.type(textarea, "@")
+    await waitFor(() => expect(screen.getByText("Files")).toBeInTheDocument())
+    // The category menu owns Up/Down while it is open — history must not fire.
+    press(textarea, "ArrowUp")
+    expect(textarea.value).toBe("@")
+  })
+})
+
+describe("PromptBox prompt history — mention fidelity", () => {
+  it("re-registers recalled mentions so the chip paints", async () => {
+    const { container, textarea } = renderComposer({
+      history: [{ text: "look @src/a.ts", mentions: ["src/a.ts"] }],
+    })
+    press(textarea, "ArrowUp")
+    expect(textarea.value).toBe("look @src/a.ts")
+    await waitFor(() => expect(container.querySelector(".mention-chip")).not.toBeNull())
+    expect(container.querySelector(".mention-chip")!.textContent).toContain("src/a.ts")
+  })
+
+  it("re-sends a recalled prompt with its file mentions attached", async () => {
+    const onSend = vi.fn()
+    const { textarea } = renderComposer({
+      onSend,
+      history: [{ text: "look @src/a.ts", mentions: ["src/a.ts"] }],
+    })
+    press(textarea, "ArrowUp")
+    fireEvent.keyDown(textarea, { key: "Enter" })
+    expect(onSend).toHaveBeenCalledTimes(1)
+    expect(onSend.mock.calls[0]![0]).toBe("look @src/a.ts")
+    expect(onSend.mock.calls[0]![1]).toEqual(["src/a.ts"])
+  })
+})
+
+describe("PromptBox prompt history — position resets", () => {
+  it("drops the browse position when the conversation changes", () => {
+    const { rerender } = render(
+      <PromptBox
+        busy={false}
+        onSend={vi.fn()}
+        onAbort={vi.fn()}
+        history={HISTORY}
+        activeConversationID="conv_a"
+      />,
+    )
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    press(textarea, "ArrowUp")
+    expect(textarea.value).toBe("third prompt")
+
+    rerender(
+      <PromptBox
+        busy={false}
+        onSend={vi.fn()}
+        onAbort={vi.fn()}
+        history={[{ text: "other conversation" }]}
+        activeConversationID="conv_b"
+      />,
+    )
+    // Not index 1 of the old list — the position restarted with the new one.
+    press(textarea, "ArrowUp")
+    expect(textarea.value).toBe("other conversation")
+  })
+
+  it("drops the browse position when the host injects text", () => {
+    const { rerender } = render(
+      <PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} history={HISTORY} inject={{ text: "", nonce: 0 }} />,
+    )
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+    press(textarea, "ArrowUp")
+    expect(textarea.value).toBe("third prompt")
+
+    rerender(
+      <PromptBox busy={false} onSend={vi.fn()} onAbort={vi.fn()} history={HISTORY} inject={{ text: "restored by /undo", nonce: 1 }} />,
+    )
+    expect(textarea.value).toBe("restored by /undo")
+    // Down must not resurrect the pre-recall draft over the injected text.
+    press(textarea, "ArrowDown")
+    expect(textarea.value).toBe("restored by /undo")
+  })
+})

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -12,6 +12,7 @@ import { PermissionDialog } from "./components/PermissionDialog"
 import { QuestionDialog } from "./components/QuestionDialog"
 import { ReviewPanel } from "./components/ReviewPanel"
 import { IndexStatus } from "./components/IndexStatus"
+import { promptHistory } from "./prompt-history"
 
 export default function App() {
   const {
@@ -162,6 +163,7 @@ export default function App() {
   // Rebuild the turn structure only when the message list actually changes,
   // not on every coalesced streaming frame.
   const turns = useMemo(() => groupTurns(state.messages), [state.messages])
+  const promptHistoryEntries = useMemo(() => promptHistory(state.messages), [state.messages])
 
   // Active exactly when the Stop button is clickable.
   useEscapeToStop(busy && !state.aborting, abort)
@@ -277,6 +279,7 @@ export default function App() {
           commands={state.commands}
           onRunCommand={runCommandAndPinTop}
           inject={state.injectedText}
+          history={promptHistoryEntries}
           onOpenLink={openLink}
         />
       )}
@@ -397,6 +400,7 @@ export default function App() {
               commands={state.commands}
               onRunCommand={runCommandAndPinTop}
               inject={state.injectedText}
+              history={promptHistoryEntries}
               onOpenLink={openLink}
             />
           </div>

--- a/webview/src/components/PromptBox.tsx
+++ b/webview/src/components/PromptBox.tsx
@@ -25,6 +25,7 @@ import { ImagePreviewModal } from "./ImagePreviewModal"
 import { ImageThumbnail } from "./ImageThumbnail"
 import { ICON_SIZE } from "../design-tokens"
 import { fileTypeCodicon } from "../file-icons"
+import { caretAtFirstLine, caretAtLastLine, type PromptHistoryEntry } from "../prompt-history"
 
 // Re-export so existing consumers (tests, integrators) keep working through PromptBox.
 export {
@@ -67,6 +68,12 @@ type Props = {
    * stripped-down textarea.
    */
   initial?: { text?: string; mentions?: string[]; attachments?: Attachment[]; conversationMentions?: ConversationMention[] }
+  /**
+   * Prompts recallable with Up/Down, oldest first. Send composers only — the
+   * edit composer keeps plain caret movement, since the message it is editing
+   * is itself a history entry and swapping it out would look like data loss.
+   */
+  history?: PromptHistoryEntry[]
   /**
    * "send" (default) renders the standard Send/Stop bottom row. "edit"
    * renders Cancel + Save & regenerate, plus a warning that subsequent
@@ -127,7 +134,7 @@ function buildInitialConversations(initial: Props["initial"]): Map<string, strin
   return map
 }
 
-export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, searchFiles, listDir, attachFile, initial, variant = "send", position = "bottom", conversations, activeConversationID, contextUsage, commands = [], onRunCommand, inject, onOpenLink }: Props) {
+export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, searchFiles, listDir, attachFile, initial, history, variant = "send", position = "bottom", conversations, activeConversationID, contextUsage, commands = [], onRunCommand, inject, onOpenLink }: Props) {
   const { text, setText, ref, backdropRef, pendingCursor } = usePromptText(initial?.text ?? "")
   // The Send button renders a disabled "Stopping…" while aborting, but Enter
   // routes through submit() — both must honor the same block, or a prompt
@@ -136,6 +143,14 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
   const sendBlocked = busy || aborting
   const canQueue = sendBlocked && variant === "send" && Boolean(onQueue)
   const [selectedChipStart, setSelectedChipStart] = useState<number | undefined>(undefined)
+  // How far back the user has walked the prompt history: -1 is "composing a
+  // new prompt", 0 the newest recalled entry, 1 the one before it. Kept
+  // component-local rather than in the reducer — it is caret-adjacent UI state
+  // that means nothing outside this composer instance.
+  const [historyIndex, setHistoryIndex] = useState(-1)
+  // The in-progress draft, stashed on the first Up so walking back Down past
+  // the newest entry returns it instead of destroying unsent typing.
+  const historyDraft = useRef<string | null>(null)
   const [attachError, setAttachError] = useState<string | undefined>(undefined)
   // Feedback for a turn-bound command submitted while busy: it neither runs
   // nor queues (queueing would send the literal "/compact" as prose), and
@@ -220,8 +235,21 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
     if (!inject) return
     setText(inject.text)
     pendingCursor.current = inject.text.length
+    // The injected text replaces whatever was recalled, so the browse position
+    // and its stashed draft no longer describe the box — leaving them set would
+    // have the next Down restore a draft the user can no longer see.
+    setHistoryIndex(-1)
+    historyDraft.current = null
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [inject?.nonce])
+
+  // The composer outlives a conversation switch, but the history behind it is
+  // replaced wholesale — a position counted against the old conversation would
+  // index into the new one's prompts.
+  useEffect(() => {
+    setHistoryIndex(-1)
+    historyDraft.current = null
+  }, [activeConversationID])
 
   type MentionCategory = "files" | "chats"
   const [mentionCategory, setMentionCategory] = useState<MentionCategory | null>(null)
@@ -313,10 +341,47 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
     closeMention()
   }
 
+  /**
+   * Load history position `index` into the composer (-1 restores the stashed
+   * draft). Re-registers the entry's mentions before setting the text so the
+   * backdrop paints chips on the same commit the text lands — registering
+   * after would flash one frame of unstyled `@path` prose.
+   */
+  const applyHistory = (index: number) => {
+    const entries = history ?? []
+    if (index < 0) {
+      const draft = historyDraft.current ?? ""
+      historyDraft.current = null
+      setHistoryIndex(-1)
+      setSelectedChipStart(undefined)
+      pendingCursor.current = draft.length
+      setText(draft)
+      return
+    }
+    const entry = entries[entries.length - 1 - index]
+    if (!entry) return
+    if (historyIndex < 0) historyDraft.current = text
+    for (const label of entry.mentions ?? []) knownMentions.current.add(label)
+    for (const { label, id } of entry.conversationMentions ?? []) {
+      if (!label || !id) continue
+      knownConversations.current.set(label, id)
+      knownMentions.current.add(label)
+    }
+    setHistoryIndex(index)
+    setSelectedChipStart(undefined)
+    pendingCursor.current = entry.text.length
+    setText(entry.text)
+  }
+
   const updateText = (next: string, caret: number) => {
     setText(next)
     setSelectedChipStart(undefined)
     setBusyHint(undefined)
+    // Typing forks off whatever was recalled: the draft becomes what is in the
+    // box now, so the stash is dead and the next Up starts from the newest
+    // entry again.
+    if (historyIndex >= 0) setHistoryIndex(-1)
+    historyDraft.current = null
     // The `/` and `@` pickers are mutually exclusive: a leading slash command
     // wins, and we close the mention picker so they never render together.
     if (detectCommandAtCaret(next, caret)) {
@@ -329,6 +394,8 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
   /** Clear the composer to its empty state after a send or command run. */
   const clearComposer = () => {
     setText("")
+    setHistoryIndex(-1)
+    historyDraft.current = null
     knownMentions.current.clear()
     knownAttachments.current.clear()
     knownConversations.current.clear()
@@ -670,6 +737,32 @@ export function PromptBox({ busy, aborting = false, onSend, onQueue, onAbort, se
         e.preventDefault()
         closeMention()
         return
+      }
+    }
+    // Prompt history. MUST stay below every picker branch above: while a
+    // popover is open the arrows drive its selection and those branches return
+    // before reaching here, so an open picker keeps first claim on the key.
+    if ((e.key === "ArrowUp" || e.key === "ArrowDown") && variant === "send" && (history?.length ?? 0) > 0) {
+      const ta = e.currentTarget
+      const caret = ta.selectionStart ?? 0
+      // Modifier chords are the textarea's (Shift extends a selection, Alt/Cmd
+      // jump by word or line), and with a live selection the user is selecting,
+      // not navigating — leave all of those alone.
+      const plainPress = !e.shiftKey && !e.metaKey && !e.altKey && !e.ctrlKey
+      if (plainPress && ta.selectionStart === ta.selectionEnd) {
+        if (e.key === "ArrowUp" && caretAtFirstLine(text, caret)) {
+          e.preventDefault()
+          applyHistory(Math.min(historyIndex + 1, (history?.length ?? 0) - 1))
+          return
+        }
+        // Down only claims the key while actually browsing. In a fresh
+        // composer there is nothing newer than the draft, so swallowing it
+        // would make the key feel broken for no gain.
+        if (e.key === "ArrowDown" && historyIndex >= 0 && caretAtLastLine(text, caret)) {
+          e.preventDefault()
+          applyHistory(historyIndex - 1)
+          return
+        }
       }
     }
     if (e.key === "Backspace" && !e.shiftKey && !e.metaKey && !e.altKey) {

--- a/webview/src/prompt-history.ts
+++ b/webview/src/prompt-history.ts
@@ -1,0 +1,58 @@
+import type { ChatBlock, ChatMessage, ConversationMention } from "./protocol"
+
+/**
+ * One recallable prompt. Carries the mention bindings alongside the text
+ * because the composer only paints an `@path` as a chip — and only re-sends it
+ * as file context — when the label is registered in its known-mention refs.
+ * Recalling bare text would render the chips as plain prose and silently drop
+ * the attached files.
+ */
+export type PromptHistoryEntry = {
+  text: string
+  mentions?: string[]
+  conversationMentions?: ConversationMention[]
+}
+
+/**
+ * Recallable prompts for the active conversation, oldest first. Derived from
+ * the rendered user messages rather than tracked as separate state: those
+ * already survive a window reload and already reset on conversation switch, so
+ * deriving gets both properties for free and cannot drift from what the user
+ * sees in the transcript.
+ */
+export function promptHistory(messages: ChatMessage[]): PromptHistoryEntry[] {
+  const entries: PromptHistoryEntry[] = []
+  for (const message of messages) {
+    if (message.role !== "user") continue
+    const text = message.blocks
+      .filter((b): b is Extract<ChatBlock, { type: "text" }> => b.type === "text")
+      .map((b) => b.text)
+      .join("\n\n")
+    if (!text.trim()) continue
+    // Collapse an immediately repeated prompt (a resend after an error, or an
+    // edit re-submitted unchanged) so Up doesn't stall on the same text twice.
+    if (entries.at(-1)?.text === text) continue
+    entries.push({
+      text,
+      mentions: message.mentions,
+      conversationMentions: message.conversationMentions,
+    })
+  }
+  return entries
+}
+
+/**
+ * Whether Up at `caret` should recall history instead of moving the caret.
+ * Arrow keys belong to the textarea as long as there is another line to move
+ * to; history only takes over at the outer edge — the rule shells and
+ * multi-line REPLs use. Logical lines, not visual: a soft-wrapped long line
+ * counts as one, so wrapping width never changes which key does what.
+ */
+export function caretAtFirstLine(text: string, caret: number): boolean {
+  return !text.slice(0, caret).includes("\n")
+}
+
+/** Mirror of {@link caretAtFirstLine} for Down. */
+export function caretAtLastLine(text: string, caret: number): boolean {
+  return !text.slice(caret).includes("\n")
+}


### PR DESCRIPTION
## Summary

Up/Down in the send composer now walk this conversation's prompt history, the way a shell does.

- **Up** loads the previous prompt; further presses walk back and stop at the oldest rather than wrapping.
- **Down** walks forward, and past the newest entry restores the draft stashed on the first Up — unsent typing is never destroyed.
- Typing after a recall forks off: the box becomes the new draft and the next Up restarts from the newest entry.

**History is derived, not tracked.** `promptHistory()` reads the rendered user messages, so it survives a window reload and resets on conversation switch for free, and can't drift from what's in the transcript. No new persisted state and no protocol change; the browse position is component-local because it's caret-adjacent UI state that means nothing outside the composer.

**Entries carry their mention bindings.** The composer only paints an `@path` as a chip — and only re-sends it as file context — when the label is registered in its known-mention refs. Recalling bare text would have rendered chips as prose and silently dropped the files off the re-sent prompt, so recall re-registers `mentions` and `conversationMentions` before setting the text.

**Arrow keys only mean "history" at the edges.** The handler sits below every picker branch, so an open `/` or `@` popover keeps first claim (those branches `return` before reaching it). It also defers to the textarea when another logical line exists to move to, on modifier chords, on an active selection, and during IME composition. Down does nothing when not already browsing, so it never swallows a keystroke for nothing. The edit-in-place composer is excluded — the message it's editing is itself a history entry, and swapping it out would read as data loss.

Closes #494

## Test plan

- [x] `bun run test` — 1294 passed / 84 files (23 new)
- [x] `bun run check-types` — clean
- [x] `cd webview && bunx tsc --noEmit` — clean
- [x] `bun run compile` — clean
- [x] Mutation-checked the subtlest guard: dropping the `caretAtFirstLine` check fails exactly the multi-line caret test, and nothing else
- [x] Guards covered: open picker, multi-line caret above/at first line, Shift/Alt/Cmd chords, active selection, IME (`keyCode 229`), edit variant
- [x] Fidelity covered: recalled `@path` paints a `.mention-chip` and re-sends with `mentions` attached
- [x] Resets covered: conversation switch and host text injection (`/undo`) both drop the browse position
- [ ] **Not verified by hand** — I have not driven this in a running VS Code window; the feel of the caret-edge rule is worth a real try before merging

## Design calls worth a look

Three things I picked rather than derived from the request:

1. **Trigger rule** — Up recalls when the caret is on the first *logical* line (soft wrapping doesn't change which key does what). The conservative alternative is "only when the composer is empty"; this is a one-line change if the current rule feels too eager.
2. **Scope** — history is per-conversation, not global across chats.
3. **Fidelity** — text + file/conversation mentions are restored. Pasted-image attachments are not; they'd need the thumbnail strip rehydrated from `storageID`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)