### PR TITLE
fix(review): stop the header counts painting over the bulk buttons

### DIFF
--- a/test/webview/review-panel.test.tsx
+++ b/test/webview/review-panel.test.tsx
@@ -211,6 +211,25 @@ describe("ReviewPanel", () => {
     expect(screen.getByRole("button", { name: /Undo all/i })).toBeInTheDocument()
   })
 
+  it("keeps each bulk button's word in its own span so a narrow card can hide it", () => {
+    // The `review-card` container query drops these labels below 420px, which
+    // is what stops the head's counts from colliding with the buttons. A bare
+    // text node would be unhideable and the collision would come back.
+    const messages = [
+      editMessage("m1", { filePath: "a.ts", patch: "@@\n+a", additions: 1, deletions: 0 }),
+      editMessage("m2", { filePath: "b.ts", patch: "@@\n+b", additions: 1, deletions: 0 }),
+    ]
+    const { container } = render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
+    expect([...container.querySelectorAll(".review-bulk-label")].map((n) => n.textContent)).toEqual([
+      "Keep all",
+      "Undo all",
+    ])
+    // Hiding the word must not cost the button its name — that comes from
+    // aria-label, not the text.
+    expect(screen.getByRole("button", { name: "Keep all changes" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Undo all changes" })).toBeInTheDocument()
+  })
+
   it("hides the bulk buttons when there is only a single file (the row button suffices)", () => {
     const messages = [
       editMessage("m1", { filePath: "only.ts", patch: "@@\n+a", additions: 1, deletions: 0 }),

--- a/webview/src/components/ReviewPanel.tsx
+++ b/webview/src/components/ReviewPanel.tsx
@@ -121,7 +121,7 @@ export function ReviewPanel({
                 aria-label="Keep all changes"
               >
                 <span className="codicon codicon-check" aria-hidden="true" />
-                Keep all
+                <span className="review-bulk-label">Keep all</span>
               </button>
               <button
                 className="review-bulk-action reject"
@@ -131,7 +131,7 @@ export function ReviewPanel({
                 aria-label="Undo all changes"
               >
                 <span className="codicon codicon-discard" aria-hidden="true" />
-                Undo all
+                <span className="review-bulk-label">Undo all</span>
               </button>
             </>
           )}

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -1804,6 +1804,9 @@ button:focus-visible {
   --review-file-target-height: 24px;
   --review-head-text-line: var(--review-head-target-height);
   --review-file-text-line: var(--review-file-target-height);
+  /* The header degrades on the card's width, not the window's — see the
+     `review-card` query below. */
+  container: review-card / inline-size;
   position: relative;
   margin: 0 12px;
   /* Keep top and bottom padding equal. Each row already centers its own text,
@@ -1842,6 +1845,13 @@ button:focus-visible {
   gap: 8px;
   flex: 1 1 180px;
   min-width: 0;
+  /* The basis is deliberately below the head's content width so a long
+     filename in the summary ellipsizes instead of wrapping the row — which
+     means the head is routinely handed less space than its content wants.
+     Without this the overflow was *painted*, and the diff counts landed on top
+     of the "Keep all" icon next to it. Clip instead; the shrink order below
+     decides what gives way first. */
+  overflow: hidden;
   height: var(--review-head-target-height);
   padding: 0 6px 0 3px;
   border: 0;
@@ -1881,6 +1891,17 @@ button:focus-visible {
   line-height: var(--review-head-target-height);
   cursor: pointer;
   transition: background-color 0.12s ease, color 0.12s ease;
+}
+/* Under this the head's own content plus two worded buttons stops fitting on
+   one line, and something has to give: the counts would overflow the head, or
+   the row would wrap. The buttons shed their words instead — the same
+   icon-only shape the single-change header already uses, with `title` and
+   `aria-label` still carrying the full wording. Set a little above the real
+   threshold so font and zoom variation lands on the safe side. */
+@container review-card (max-width: 420px) {
+  .review-bulk-label {
+    display: none;
+  }
 }
 .review-bulk-action:hover {
   background: var(--hover-bg-icon);
@@ -1930,11 +1951,24 @@ button:focus-visible {
   --review-text-line: var(--review-file-text-line);
 }
 .review-title {
-  flex: 0 0 auto;
+  /* Shrinks only once the summary is gone, and truncates rather than clipping
+     — the counts must never lose a digit, which would read as a wrong number. */
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   font-size: 12px;
   font-weight: 600;
 }
 .review-summary {
+  /* The summary is the least load-bearing thing in the head, so it gives way
+     first. Flex has no strict priority — it splits a deficit by shrink factor
+     x base size — so the factor has to be big enough that the title's share
+     rounds away below Chromium's 1/64px layout unit. At 100 the title still
+     leaked a quarter pixel on a wide deficit, which is enough to trip its
+     ellipsis and drop a character from a label that visually fits. */
+  flex: 0 10000 auto;
   min-width: 0;
   color: var(--vscode-descriptionForeground);
   font-size: 11px;
@@ -2405,8 +2439,17 @@ button:focus-visible {
   background: transparent;
   pointer-events: none;
 }
-.bottom-dock > .review-panel + .bottom-composer {
+/* A card stacked directly above the composer leaves only this 4px seam between
+   the two. Unlike the composer's wider edge gap — where the transcript sliding
+   behind reads as depth — a 4px slit shows nothing but the clipped tops of
+   glyphs, which looks like a paint fault. Fill exactly the seam (hard gradient
+   stop, so the rest of the composer's padding stays see-through) and the stack
+   reads as one surface. The review card's `::after` peek is a positioned
+   descendant, so it still paints over this. */
+.bottom-dock > .review-panel + .bottom-composer,
+.bottom-dock > .queued-messages + .bottom-composer {
   padding-top: var(--space-1);
+  background: linear-gradient(var(--color-bg-panel) var(--space-1), transparent var(--space-1));
 }
 .bottom-composer > .promptbox {
   pointer-events: auto;
@@ -2419,9 +2462,6 @@ button:focus-visible {
   flex-direction: column;
   gap: 4px;
   margin: 0 12px;
-}
-.queued-messages + .bottom-composer {
-  padding-top: var(--space-1);
 }
 .queued-row {
   display: flex;


### PR DESCRIPTION
## Summary

Closes #496.

Two layering faults in the review card.

**Header overlap.** `.review-head` has a deliberately small flex basis (180px) so a long filename in the summary ellipsizes instead of wrapping the row - which means the head is routinely handed less width than its content wants. That overflow was *painted*, so in the band of panel widths where the row still counts as fitting on one line but the head does not fit its own content, the diff counts rendered on top of the neighbouring check icon.

The fix is three parts:

- `overflow: hidden` on the head. This is the hard guarantee - nothing inside can paint over a sibling at any width.
- A shrink order, so clipping never costs a digit: the file count collapses first, then the title truncates, and the counts are never touched. Flex splits a deficit by shrink factor x base size rather than by priority, so the summary's factor has to be large enough that the title's share rounds away below Chromium's 1/64px layout unit. At `100` the title still leaked a quarter pixel on a wide deficit, which was enough to trip its ellipsis and drop a character from a label that visually fits; `10000` clears it.
- A `review-card` container query: below 420px of card width the bulk buttons shed their words and show just their icons - the same shape the single-change header already uses, with `title`/`aria-label` unchanged. This is what keeps the header on one row at sidebar widths, and it brings the "N files" count back (it had been silently collapsing to zero to make room).

**Seam bleed.** The dock stacks the review card directly above the composer with a 4px transparent gap, and the transcript scrolling behind showed through it as a row of clipped glyph tops. Unlike the composer's wider edge gap - where content behind reads as depth - a 4px slit only ever reads as a paint fault. Filled with a hard-stop gradient so exactly the seam is opaque and the rest of the composer's padding stays see-through; the card's `::after` peek strip is a positioned descendant and still paints over it. Same rule now covers the queued-messages seam, which had the identical gap.

## Verification

Layout and container queries have no meaning in jsdom, so this was measured by rendering the real `webview/src/styles.css` against reconstructed markup in headless Chrome and reading back geometry via the DOM.

Head overflow (`scrollWidth - clientWidth`), multi-file header, viewport 200 -> 700px:

| | before | after |
|---|---|---|
| head overflow | up to **+13px** (counts over the icon) | **+0.0px at every width** |
| title truncated | n/a | only below 320px, after the count is gone |
| counts truncated | n/a | never |
| "9 files" at 371px | hidden | shown |

Single-change header with a 24-char filename, same sweep: title never truncates, filename ellipsizes exactly as before, no wrap introduced - confirming the fix does not regress that variant.

## Test plan

- [x] `bun run test` - 1294 passed / 84 files
- [x] `bun run check-types` clean
- [x] `cd webview && bunx tsc --noEmit` clean
- [x] `bun run compile` clean
- [x] New test pins the `.review-bulk-label` span the container query depends on, and that the buttons keep their accessible names; mutation-checked (fails when the span is inlined back to a bare text node)
- [x] Headless-Chrome geometry sweep, both header variants, 200-700px - no overflow at any width
- [x] Seam pixels sampled after the fix: uniform across the card width, card shadow and peek strip still painting
- [ ] Not driven by hand in a running VS Code window - worth eyeballing the 420px breakpoint and the icon-only buttons live

🤖 Generated with [Claude Code](https://claude.com/claude-code)