### PR TITLE
feat(statusbar): show connection state as a dot only

### DIFF
--- a/test/webview/status-indicator.test.tsx
+++ b/test/webview/status-indicator.test.tsx
@@ -1,21 +1,10 @@
 import { describe, it, expect, afterEach } from "vitest"
-import { render, screen, cleanup } from "@testing-library/react"
+import { render, cleanup } from "@testing-library/react"
 import { StatusIndicator } from "../../webview/src/components/StatusIndicator"
 
 afterEach(cleanup)
 
 describe("StatusIndicator", () => {
-  it("renders dot only when no label is provided", () => {
-    const { container } = render(<StatusIndicator kind="ok" />)
-    expect(container.querySelector(".status-indicator-dot.ok")).not.toBeNull()
-    expect(container.querySelector(".status-indicator-label")).toBeNull()
-  })
-
-  it("renders dot + label together when label is provided", () => {
-    render(<StatusIndicator kind="warn" label="connecting…" />)
-    expect(screen.getByText("connecting…")).toBeInTheDocument()
-  })
-
   it.each([
     ["default", "default"],
     ["ok", "ok"],
@@ -27,24 +16,15 @@ describe("StatusIndicator", () => {
     expect(container.querySelector(`.status-indicator-dot.${expectedClass}`)).not.toBeNull()
   })
 
-  it("forwards the title attribute to the wrapper for native tooltips", () => {
-    const { container } = render(
-      <StatusIndicator kind="err" label="boom" title="error · boom" />,
-    )
-    const wrapper = container.querySelector(".status-indicator")
-    expect(wrapper?.getAttribute("title")).toBe("error · boom")
+  it("renders the dot alone, with no status text", () => {
+    const { container } = render(<StatusIndicator kind="warn" title="connecting…" />)
+    expect(container.querySelector(".status-indicator-dot")).not.toBeNull()
+    expect(container.textContent).toBe("")
   })
 
-  it("co-locates dot + label so they share one inline line-box (regression: previously they were sibling flex children that misaligned vertically)", () => {
-    const { container } = render(<StatusIndicator kind="warn" label="connecting…" />)
-    const wrapper = container.querySelector(".status-indicator")
+  it("puts the title on the dot itself — it is the only surface for the status text", () => {
+    const { container } = render(<StatusIndicator kind="err" title="error · boom" />)
     const dot = container.querySelector(".status-indicator-dot")
-    const label = container.querySelector(".status-indicator-label")
-    expect(wrapper).not.toBeNull()
-    // Both must be children of the same wrapper element — that's the structural
-    // guarantee that prevents the bar's flex layout from centering them
-    // independently and misaligning them.
-    expect(dot?.parentElement).toBe(wrapper)
-    expect(label?.parentElement).toBe(wrapper)
+    expect(dot?.getAttribute("title")).toBe("error · boom")
   })
 })

--- a/test/webview/statusbar.test.tsx
+++ b/test/webview/statusbar.test.tsx
@@ -54,19 +54,33 @@ describe("StatusBar", () => {
     expect(screen.getAllByText("default").length).toBeGreaterThanOrEqual(1)
   })
 
-  it("hides connecting text when connected", () => {
-    render(<StatusBar {...baseProps} connected={true} />)
+  it("shows the healthy connected state as the ok dot, titled", () => {
+    const { container } = render(<StatusBar {...baseProps} connected={true} />)
+    expect(container.querySelector(".status-indicator-dot.ok")?.getAttribute("title")).toBe(
+      "connected",
+    )
+  })
+
+  it("shows the disconnected state as a dot only — never as text in the bar", () => {
+    const { container } = render(<StatusBar {...baseProps} connected={false} />)
+    expect(container.querySelector(".status-indicator-dot.warn")).not.toBeNull()
     expect(screen.queryByText("connecting…")).not.toBeInTheDocument()
   })
 
-  it("shows 'connecting…' when not connected", () => {
-    render(<StatusBar {...baseProps} connected={false} />)
-    expect(screen.getByText("connecting…")).toBeInTheDocument()
+  it("shows a pending continuation as the pulsing dot, not as text", () => {
+    const { container } = render(
+      <StatusBar {...baseProps} connected={true} continuationPending={true} />,
+    )
+    expect(container.querySelector(".status-indicator-dot.pending")).not.toBeNull()
+    expect(screen.queryByText("continuing…")).not.toBeInTheDocument()
   })
 
-  it("shows error text when error is set", () => {
-    render(<StatusBar {...baseProps} connected={false} error="boom" />)
-    expect(screen.getByText(/error · boom/)).toBeInTheDocument()
+  it("keeps the error message reachable in the tooltip once the label is gone", () => {
+    const { container } = render(<StatusBar {...baseProps} connected={false} error="boom" />)
+    expect(container.querySelector(".status-indicator-dot.err")?.getAttribute("title")).toBe(
+      "error · boom",
+    )
+    expect(screen.queryByText(/error · boom/)).not.toBeInTheDocument()
   })
 
   it("opens the selector popover on trigger click and shows Model, Effort, Agent rows", async () => {

--- a/webview/src/components/StatusBar.tsx
+++ b/webview/src/components/StatusBar.tsx
@@ -52,14 +52,6 @@ export function StatusBar({
     setCurrentPopover((current) => open ? id : current === id ? null : current)
   }
 
-  const showStatus = !connected || Boolean(error) || Boolean(continuationPending)
-  const statusLabel: string | undefined = error
-    ? `error · ${error}`
-    : !connected
-      ? "connecting…"
-      : continuationPending
-        ? "continuing…"
-        : undefined
   const dotKind: StatusIndicatorKind = error
     ? "err"
     : continuationPending
@@ -76,11 +68,7 @@ export function StatusBar({
         : "connecting…"
   return (
     <div className="statusbar">
-      <StatusIndicator
-        kind={dotKind}
-        label={showStatus ? statusLabel : undefined}
-        title={statusTitle}
-      />
+      <StatusIndicator kind={dotKind} title={statusTitle} />
       <div className="spacer" />
       <SelectorMenu
         agent={agent}

--- a/webview/src/components/StatusIndicator.tsx
+++ b/webview/src/components/StatusIndicator.tsx
@@ -1,14 +1,7 @@
 /**
- * Small marker (coloured dot) + optional label, locked together so they
- * always sit on the same visual line.
- *
- * Why a dedicated component instead of rendering the dot + label as
- * siblings of whatever parent needs them: flex parents centre each child
- * by its own box centre, which makes a small (8 px) dot look detached
- * from the larger text glyph next to it. Inside this component the two
- * pieces share an inline line-box and align via `vertical-align: middle`,
- * which centres by font x-height (the perceived text midpoint). Callers
- * just place a `<StatusIndicator …>` and never see the alignment seams.
+ * Coloured marker dot. The colour IS the message — the human-readable
+ * status rides along as a native tooltip so the header stays a single
+ * glyph wide in a narrow sidebar.
  */
 
 export type StatusIndicatorKind = "default" | "ok" | "warn" | "err" | "pending"
@@ -16,17 +9,10 @@ export type StatusIndicatorKind = "default" | "ok" | "warn" | "err" | "pending"
 type Props = {
   /** Drives the dot colour. `pending` additionally animates a pulse. */
   kind: StatusIndicatorKind
-  /** Optional inline label shown to the right of the dot. */
-  label?: string
-  /** Native tooltip applied to the wrapper. */
+  /** Native tooltip — the only place the status text is shown. */
   title?: string
 }
 
-export function StatusIndicator({ kind, label, title }: Props) {
-  return (
-    <span className="status-indicator" title={title}>
-      <span className={`status-indicator-dot ${kind}`} />
-      {label && <span className="status-indicator-label">{label}</span>}
-    </span>
-  )
+export function StatusIndicator({ kind, title }: Props) {
+  return <span className={`status-indicator-dot ${kind}`} title={title} />
 }

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -170,25 +170,10 @@ button:focus-visible {
 .statusbar .spacer { flex: 1; }
 
 /* ===== StatusIndicator =====
-   Coloured marker dot + optional label. Component-scoped so any surface
-   (status bar, permission badge, etc.) can drop one in without redoing
-   the alignment dance.
-
-   Why the inline-block wrapper + `vertical-align: middle` on children:
-   sibling flex children get centred by their own box centres, which
-   makes a small 8 px dot visually sit below the larger text glyph next
-   to it. Giving the pair a shared inline line-box (`display: inline-block`
-   with `line-height: 1` to hug the glyph height) and using
-   `vertical-align: middle` aligns by font x-height — the perceived text
-   midpoint — instead. The two pieces stay locked together regardless of
-   what the parent flex layout does. */
-.status-indicator {
-  display: inline-block;
-  white-space: nowrap;
-  line-height: 1;
-}
+   Coloured marker dot. Carries no text — the status string is a native
+   tooltip — so it is a single element and the header's flex centring
+   places it directly. */
 .status-indicator-dot {
-  vertical-align: middle;
   display: inline-block;
   width: 8px;
   height: 8px;
@@ -209,13 +194,6 @@ button:focus-visible {
 @media (prefers-reduced-motion: reduce) {
   .status-indicator-dot.pending { animation: none; }
 }
-.status-indicator-label {
-  vertical-align: middle;
-  margin-left: var(--space-3);
-  opacity: 0.75;
-  white-space: nowrap;
-}
-
 /* ===== AgentActivity =====
    Message-flow activity surface for live main-agent + subagent work. It
    renders inside the active assistant message, next to the Process panel,
@@ -592,8 +570,8 @@ button:focus-visible {
    hardcoded git-add green.
    `line-height: 1` collapses the icon (13px) and label (11px) onto a single
    tight line box so they center on the same horizontal line instead of each
-   sitting at its own default-line-height box centre (see .status-indicator and
-   .review-bulk-action for the same glyph-pair alignment treatment). */
+   sitting at its own default-line-height box centre (see .review-bulk-action
+   for the same glyph-pair alignment treatment). */
 .history-new {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary

The chat panel header's status indicator no longer paints its state as text. Every state — connected, connecting, continuing, error — now renders as the coloured dot alone.

- `StatusIndicator` loses its `label` prop and the wrapper `<span>` that existed only to lock the dot and label onto a shared inline line-box. With no text to align against, it is a single element and the header's `align-items: center` places it directly.
- `StatusBar` drops `showStatus` / `statusLabel`. `statusTitle` is untouched and was already unconditional, so the tooltip reports the same string it always did — including the error message, which is the one state whose text was not otherwise reachable.
- `.status-indicator` and `.status-indicator-label` are deleted, along with the CSS comment explaining the alignment dance they existed for. The `.history-new` comment that cross-referenced `.status-indicator` now points only at `.review-bulk-action`.
- The dot keeps all four states it can actually reach (`ok` green / `warn` amber / `pending` blue + pulse / `err` red) and the `prefers-reduced-motion` opt-out on the pulse.

Net -54 lines.

## Note

The error string is now hover-only in the header. Every host post that sets `error` also sets `connected: false` (`src/chat/view.ts:916,1277,1550,1637`), so a failure still turns the dot red — but the message itself is only in the tooltip. That is the intended trade here; flagging it since it is the one bit of information that was on screen and now is not.

## Test plan

- [x] `bun run test` — 84 files, 1294 passed (was 1295; net -1 test, the label-specific cases replaced by dot + tooltip assertions)
- [x] `bun run check-types` — clean
- [x] `cd webview && bunx tsc --noEmit` — clean
- [x] `bun run compile` — builds
- [x] New assertions cover all four states: each maps to the right dot class, none paints its string into the bar, and the error message is asserted present in the dot's `title` and absent from the DOM text
- [ ] Eyeball in a running Extension Development Host: dot sits centred against the selector pill now that it is a direct flex child rather than an inline-block wrapper

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)