### PR TITLE
chore(release): 1.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.10.2] - 2026-08-04
+
+### Changed
+- The connection status in the chat panel header is now the coloured dot alone. `connecting…`, `continuing…` and `error · <message>` no longer print beside it, which frees width in a header that also carries the model/effort/agent selector and two buttons. All four states keep their own colour — green connected, amber connecting, blue pulsing while a turn continues, red on error — and the full status string, error message included, is still there on hover (#500, #501).
+
 ## [1.10.1] - 2026-08-02
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Cuts 1.10.2. One PR has merged since `v1.10.1`.

| PR | Title |
|---|---|
| #501 | feat(statusbar): show connection state as a dot only |

- `package.json` → `1.10.2`
- `CHANGELOG.md` gains a `## [1.10.2] - 2026-08-04` section with a single **Changed** entry carrying `(#500, #501)`

Patch rather than minor: #501 removes a piece of header text rather than adding a capability, and the information it dropped is still reachable on hover.

## Test plan

- [x] `bun run test` — 84 files, 1294 passed
- [x] `bun run check-types` — clean
- [x] `cd webview && bunx tsc --noEmit` — clean
- [x] `bun run package` — production build succeeds
- [x] Version in `package.json` matches the CHANGELOG heading and the `v1.10.2` tag to be minted (`release.yml` gates on this)

After merge: `gh release create v1.10.2 --target main` with the CHANGELOG section as the notes, which mints the tag and triggers the Marketplace + Open VSX publish.

Closes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)