### PR TITLE
perf(webview): lazy-load shiki grammars instead of inlining 2.2MB

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,5 +1,6 @@
-# Source — only the bundled `dist/extension.js` and `dist/webview/index.html`
-# need to ship in the .vsix; all source TS/TSX/HTML stays out.
+# Source — only the bundled `dist/extension.js`, `dist/webview/index.html`,
+# and the lazily-fetched `dist/webview/grammars/*.json` need to ship in the
+# .vsix; all source TS/TSX/HTML stays out.
 src/**
 webview/**
 **/*.ts

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -2186,10 +2186,20 @@ export class ChatView implements vscode.WebviewViewProvider {
       `script-src 'unsafe-inline' 'unsafe-eval' ${webview.cspSource}`,
       `img-src ${webview.cspSource} https: data: blob:`,
       `font-src ${webview.cspSource} data:`,
-      `connect-src data: blob:`,
+      // cspSource lets the webview fetch the on-demand shiki grammars.
+      `connect-src ${webview.cspSource} data: blob:`,
       `worker-src blob:`,
     ].join("; ")
-    html = html.replace("<head>", `<head><meta http-equiv="Content-Security-Policy" content="${csp}">`)
+    // Grammars are fetched lazily from dist/webview/grammars/ (grammar-loader
+    // in the webview); the base URI only exists host-side, so inject it.
+    const grammarsBase = webview.asWebviewUri(
+      vscode.Uri.joinPath(this.context.extensionUri, "dist", "webview", "grammars"),
+    )
+    html = html.replace(
+      "<head>",
+      `<head><meta http-equiv="Content-Security-Policy" content="${csp}">` +
+        `<script>window.__opencuiGrammarsBase=${JSON.stringify(grammarsBase.toString())}</script>`,
+    )
     return html
   }
 }

--- a/test/host/chatview-harness.test.ts
+++ b/test/host/chatview-harness.test.ts
@@ -960,3 +960,22 @@ describe("ChatView harness: stale-row reconcile on conversation entry", () => {
     expect(rows.find((t) => t.id === "subagent:child:ses_child_ghost")!.status).toBe("running")
   })
 })
+
+describe("ChatView harness: webview HTML", () => {
+  it("injects the grammars base URI and lets connect-src reach it", async () => {
+    const fsFiles = (vscode as unknown as { __fsFiles: Map<string, Uint8Array> }).__fsFiles
+    const key = "file:///ext/dist/webview/index.html"
+    fsFiles.set(key, new TextEncoder().encode("<!doctype html><html><head></head><body></body></html>"))
+    try {
+      const fake = makeFakeWebviewView()
+      await harness.chatView.resolveWebviewView(fake.view)
+      const html = (fake.view.webview as { html?: string }).html ?? ""
+      // The webview fetches dist/webview/grammars/*.json lazily; both halves —
+      // the injected base and the CSP allowance — must survive edits together.
+      expect(html).toContain('window.__opencuiGrammarsBase="file:///ext/dist/webview/grammars"')
+      expect(html).toContain("connect-src vscode-resource: data: blob:")
+    } finally {
+      fsFiles.delete(key)
+    }
+  })
+})

--- a/test/webview/codeblock.test.tsx
+++ b/test/webview/codeblock.test.tsx
@@ -4,6 +4,19 @@ import userEvent from "@testing-library/user-event"
 import { CodeBlock } from "../../webview/src/components/CodeBlock"
 import { vscode } from "../../webview/src/vscode"
 
+// In production grammars are fetched from dist/webview/grammars (built by
+// vite.config.ts's emitGrammars); here the loader is bridged straight to the
+// real @shikijs/langs modules so highlighting runs against the same grammar
+// data without a dist/ build. `fail` simulates a fetch outage.
+const grammarCtl = vi.hoisted(() => ({ fail: false }))
+vi.mock("../../webview/src/grammar-loader", () => ({
+  loadGrammar: async (file: string) => {
+    if (grammarCtl.fail) throw new Error("grammar fetch failed")
+    const mod = await import(`../../webview/node_modules/@shikijs/langs/dist/${file}.mjs`)
+    return mod.default
+  },
+}))
+
 // Stub clipboard for the Copy button
 const writeText = vi.fn().mockResolvedValue(undefined)
 beforeEach(() => {
@@ -82,5 +95,27 @@ describe("CodeBlock", () => {
     const { container } = render(<CodeBlock code="x" language="some-fake-lang" />)
     await screen.findByRole("button", { name: /^Apply$/ })
     expect(container.querySelector(".codeblock-lang")?.textContent).toBe("text")
+  })
+
+  it("falls back to plaintext when the grammar fetch fails, then recovers on the next block", async () => {
+    // Must use a language no other test loads — successful loads are cached
+    // module-wide, and a cached grammar would bypass the failing loader.
+    grammarCtl.fail = true
+    const first = render(<CodeBlock code="package main" language="go" />)
+    // The escaped-fallback branch renders div.codeblock-body > pre; the
+    // pre-highlight placeholder is pre.codeblock-body. Waiting for the former
+    // proves the catch ran rather than passing on the placeholder.
+    await waitFor(() => {
+      expect(first.container.querySelector("div.codeblock-body pre code")?.textContent).toBe("package main")
+    }, { timeout: 5000 })
+    expect(first.container.querySelector(".shiki")).toBeNull()
+    first.unmount()
+
+    // The failed load must have been evicted, not cached as a rejection.
+    grammarCtl.fail = false
+    const second = render(<CodeBlock code="package main" language="go" />)
+    await waitFor(() => expect(second.container.querySelector(".codeblock-body .shiki")).not.toBeNull(), {
+      timeout: 5000,
+    })
   })
 })

--- a/test/webview/grammar-loader.test.ts
+++ b/test/webview/grammar-loader.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+/**
+ * The loader keeps module-level caches (manifest + per-registration fetches),
+ * so each test re-imports a fresh copy via resetModules.
+ */
+const MANIFEST = {
+  html: ["javascript", "css", "html"],
+  javascript: ["javascript"],
+}
+
+function reg(name: string) {
+  return { name, scopeName: `source.${name}`, patterns: [] }
+}
+
+let failing: Set<string>
+const fetchMock = vi.fn(async (url: string) => {
+  const name = url.split("/").at(-1)!.replace(/\.json$/, "")
+  if (failing.has(name)) return { ok: false, status: 500 } as Response
+  const body = name === "manifest" ? MANIFEST : reg(name)
+  return { ok: true, json: async () => body } as unknown as Response
+})
+
+async function freshLoader() {
+  vi.resetModules()
+  return await import("../../webview/src/grammar-loader")
+}
+
+function fetchesOf(name: string) {
+  return fetchMock.mock.calls.filter(([url]) => url.endsWith(`/${name}.json`)).length
+}
+
+beforeEach(() => {
+  failing = new Set()
+  fetchMock.mockClear()
+  vi.stubGlobal("fetch", fetchMock)
+  window.__opencuiGrammarsBase = "https://webview.test/grammars"
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  delete window.__opencuiGrammarsBase
+})
+
+describe("loadGrammar", () => {
+  it("rejects when the host did not inject the base URI", async () => {
+    delete window.__opencuiGrammarsBase
+    const { loadGrammar } = await freshLoader()
+    await expect(loadGrammar("html")).rejects.toThrow(/not injected/)
+  })
+
+  it("returns the entry's registrations in manifest order", async () => {
+    const { loadGrammar } = await freshLoader()
+    const regs = await loadGrammar("html")
+    expect(regs.map((r) => r.name)).toEqual(["javascript", "css", "html"])
+  })
+
+  it("fetches the manifest once and shares registrations across entries", async () => {
+    const { loadGrammar } = await freshLoader()
+    await loadGrammar("html")
+    await loadGrammar("javascript")
+    expect(fetchesOf("manifest")).toBe(1)
+    // javascript already came in with html's dependency set.
+    expect(fetchesOf("javascript")).toBe(1)
+  })
+
+  it("rejects an entry the manifest does not know", async () => {
+    const { loadGrammar } = await freshLoader()
+    await expect(loadGrammar("cobol")).rejects.toThrow(/not in manifest/)
+  })
+
+  it("evicts a failed registration fetch so the next attempt retries it alone", async () => {
+    const { loadGrammar } = await freshLoader()
+    failing.add("css")
+    await expect(loadGrammar("html")).rejects.toThrow(/css: HTTP 500/)
+    failing.delete("css")
+    const regs = await loadGrammar("html")
+    expect(regs.map((r) => r.name)).toEqual(["javascript", "css", "html"])
+    // Only the failed fetch re-ran; its successful siblings stayed cached.
+    expect(fetchesOf("css")).toBe(2)
+    expect(fetchesOf("javascript")).toBe(1)
+    expect(fetchesOf("html")).toBe(1)
+  })
+
+  it("evicts a failed manifest fetch", async () => {
+    const { loadGrammar } = await freshLoader()
+    failing.add("manifest")
+    await expect(loadGrammar("html")).rejects.toThrow(/manifest: HTTP 500/)
+    failing.delete("manifest")
+    await expect(loadGrammar("html")).resolves.toHaveLength(3)
+    expect(fetchesOf("manifest")).toBe(2)
+  })
+})

--- a/test/webview/shiki-langs.test.ts
+++ b/test/webview/shiki-langs.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest"
+import { GRAMMAR_FILE, GRAMMAR_FILES } from "../../webview/src/shiki-langs"
+
+// Resolved by path because @shikijs/langs lives in webview/node_modules,
+// which bare specifiers in this test tree do not reach.
+type Registration = { name: string; aliases?: string[] }
+async function loadEntry(file: string): Promise<Registration[]> {
+  const mod = await import(`../../webview/node_modules/@shikijs/langs/dist/${file}.mjs`)
+  return mod.default
+}
+
+describe("shiki-langs map vs the real grammar set", () => {
+  it("every mapped language is registered by its entry, as a name or alias", async () => {
+    // Pins shiki upgrades: if a grammar drops an alias this map relies on
+    // (bash on shellscript, docker on dockerfile), the fetch would succeed
+    // but codeToHtml would throw on the unknown language.
+    for (const file of GRAMMAR_FILES) {
+      const regs = await loadEntry(file)
+      const known = new Set(regs.flatMap((r) => [r.name, ...(r.aliases ?? [])]))
+      for (const [lang, mapped] of Object.entries(GRAMMAR_FILE)) {
+        if (mapped !== file) continue
+        expect(known.has(lang), `"${lang}" is not registered by @shikijs/langs/${file}`).toBe(true)
+      }
+    }
+  })
+
+  it("registration names are usable as fetch paths and never collide with the manifest", async () => {
+    // Mirrors the build-time guard in vite.config.ts's emitGrammars.
+    for (const file of GRAMMAR_FILES) {
+      for (const { name } of await loadEntry(file)) {
+        expect(name).toMatch(/^[\w-]+$/)
+        expect(name).not.toBe("manifest")
+      }
+    }
+  })
+})

--- a/webview/src/components/CodeBlock.tsx
+++ b/webview/src/components/CodeBlock.tsx
@@ -1,26 +1,20 @@
 import { memo, useEffect, useMemo, useState } from "react"
 import { createHighlighterCore, type HighlighterCore } from "shiki/core"
 import { createJavaScriptRegexEngine } from "shiki/engine/javascript"
+import { loadGrammar } from "../grammar-loader"
+import { GRAMMAR_FILE } from "../shiki-langs"
 import { vscode } from "../vscode"
 
 type Props = { code: string; language?: string }
 
-const SUPPORTED = new Set<string>([
-  "typescript", "tsx", "javascript", "jsx", "python", "bash", "shell",
-  "json", "html", "css", "yaml", "markdown", "md", "go", "rust", "java",
-  "sql", "c", "cpp", "csharp", "ruby", "php", "swift", "kotlin", "toml",
-  "xml", "docker", "dockerfile", "ini", "diff",
-])
-
 /**
- * Fine-grained shiki: only the SUPPORTED grammars and the two GitHub themes
- * get bundled — `shiki/bundle/web` shipped every web language, every theme,
- * and the oniguruma wasm (~5.3 MB of bundle input). The JavaScript regex
- * engine replaces the wasm; `forgiving` skips grammar patterns it cannot
- * compile instead of failing the whole highlight. Constructed lazily on the
- * first fenced code block; aliases (bash/shell/md/docker/…) ride along on
- * their canonical grammar registrations, and `text` is shiki's built-in
- * plaintext passthrough.
+ * The highlighter starts with the two GitHub themes and NO grammars — the
+ * grammar set was ~2.2MB of the 3.7MB single-file bundle, re-parsed on every
+ * panel open. Grammars now ship as dist/webview/grammars/*.json and load on
+ * the first block that needs one (see grammar-loader.ts). The JavaScript
+ * regex engine replaces the oniguruma wasm; `forgiving` skips patterns it
+ * cannot compile instead of failing the whole highlight. `text` is shiki's
+ * built-in plaintext passthrough.
  */
 let highlighterPromise: Promise<HighlighterCore> | undefined
 function getHighlighter(): Promise<HighlighterCore> {
@@ -29,38 +23,25 @@ function getHighlighter(): Promise<HighlighterCore> {
       import("@shikijs/themes/github-dark-default"),
       import("@shikijs/themes/github-light-default"),
     ],
-    langs: [
-      import("@shikijs/langs/typescript"),
-      import("@shikijs/langs/tsx"),
-      import("@shikijs/langs/javascript"),
-      import("@shikijs/langs/jsx"),
-      import("@shikijs/langs/python"),
-      import("@shikijs/langs/shellscript"),
-      import("@shikijs/langs/json"),
-      import("@shikijs/langs/html"),
-      import("@shikijs/langs/css"),
-      import("@shikijs/langs/yaml"),
-      import("@shikijs/langs/markdown"),
-      import("@shikijs/langs/go"),
-      import("@shikijs/langs/rust"),
-      import("@shikijs/langs/java"),
-      import("@shikijs/langs/sql"),
-      import("@shikijs/langs/c"),
-      import("@shikijs/langs/cpp"),
-      import("@shikijs/langs/csharp"),
-      import("@shikijs/langs/ruby"),
-      import("@shikijs/langs/php"),
-      import("@shikijs/langs/swift"),
-      import("@shikijs/langs/kotlin"),
-      import("@shikijs/langs/toml"),
-      import("@shikijs/langs/xml"),
-      import("@shikijs/langs/dockerfile"),
-      import("@shikijs/langs/ini"),
-      import("@shikijs/langs/diff"),
-    ],
+    langs: [],
     engine: createJavaScriptRegexEngine({ forgiving: true }),
   })
   return highlighterPromise
+}
+
+// One fetch+register per grammar file, shared across blocks. A failed load is
+// evicted so a later block retries instead of inheriting the rejection.
+const grammarLoads = new Map<string, Promise<void>>()
+function ensureLang(highlighter: HighlighterCore, lang: string): Promise<void> {
+  if (lang === "text") return Promise.resolve()
+  const file = GRAMMAR_FILE[lang]!
+  let load = grammarLoads.get(file)
+  if (!load) {
+    load = loadGrammar(file).then((regs) => highlighter.loadLanguage(...regs))
+    grammarLoads.set(file, load)
+    load.catch(() => grammarLoads.delete(file))
+  }
+  return load
 }
 
 // While a fenced block streams in, `code` grows on every delta. Debounce the
@@ -82,7 +63,10 @@ function CodeBlockImpl({ code, language }: Props) {
     const lang = normaliseLang(language)
     const timer = setTimeout(() => {
       getHighlighter()
-        .then((highlighter) => highlighter.codeToHtml(code, { lang, theme }))
+        .then(async (highlighter) => {
+          await ensureLang(highlighter, lang)
+          return highlighter.codeToHtml(code, { lang, theme })
+        })
         .then((h) => {
           if (!cancelled) setHtml(h)
         })
@@ -152,7 +136,7 @@ function normaliseLang(l?: string): string {
   if (!l) return "text"
   const map: Record<string, string> = { ts: "typescript", js: "javascript", py: "python", sh: "bash", shell: "bash", md: "markdown" }
   const normalised = map[l] ?? l
-  return SUPPORTED.has(normalised) ? normalised : "text"
+  return Object.hasOwn(GRAMMAR_FILE, normalised) ? normalised : "text"
 }
 
 function isDarkColor(c: string): boolean {

--- a/webview/src/grammar-loader.ts
+++ b/webview/src/grammar-loader.ts
@@ -1,0 +1,56 @@
+import type { LanguageRegistration } from "shiki/core"
+
+/**
+ * Fetches grammars emitted by the build into dist/webview/grammars/: one JSON
+ * per unique registration plus manifest.json mapping each `@shikijs/langs`
+ * entry to the registration names it needs (entries share dependencies —
+ * ruby alone pulls ~30 — so fetching per-registration avoids shipping and
+ * re-downloading duplicates). The host injects the base URI (`asWebviewUri`
+ * of the directory) as an inline script in buildHtml — a webview's HTML is
+ * set as a string, so relative URLs have nothing to resolve against.
+ *
+ * Every cache evicts on failure so one bad fetch degrades that block to
+ * plaintext instead of poisoning all later highlights.
+ */
+declare global {
+  interface Window {
+    __opencuiGrammarsBase?: string
+  }
+}
+
+async function fetchJson<T>(name: string): Promise<T> {
+  const base = window.__opencuiGrammarsBase
+  if (!base) throw new Error("grammars base URI not injected")
+  const res = await fetch(`${base}/${name}.json`)
+  if (!res.ok) throw new Error(`grammar ${name}: HTTP ${res.status}`)
+  return (await res.json()) as T
+}
+
+type Manifest = Record<string, string[]>
+
+let manifestPromise: Promise<Manifest> | undefined
+function getManifest(): Promise<Manifest> {
+  if (!manifestPromise) {
+    manifestPromise = fetchJson<Manifest>("manifest")
+    manifestPromise.catch(() => (manifestPromise = undefined))
+  }
+  return manifestPromise
+}
+
+const registrationLoads = new Map<string, Promise<LanguageRegistration>>()
+function loadRegistration(name: string): Promise<LanguageRegistration> {
+  let load = registrationLoads.get(name)
+  if (!load) {
+    load = fetchJson<LanguageRegistration>(name)
+    registrationLoads.set(name, load)
+    load.catch(() => registrationLoads.delete(name))
+  }
+  return load
+}
+
+export async function loadGrammar(file: string): Promise<LanguageRegistration[]> {
+  const manifest = await getManifest()
+  const names = manifest[file]
+  if (!names) throw new Error(`grammar ${file}: not in manifest`)
+  return Promise.all(names.map(loadRegistration))
+}

--- a/webview/src/shiki-langs.ts
+++ b/webview/src/shiki-langs.ts
@@ -1,0 +1,44 @@
+/**
+ * Language → grammar-file map, shared by CodeBlock (what to fetch at runtime)
+ * and vite.config.ts (what to emit into dist/webview/grammars/ at build time).
+ * Keys are the languages CodeBlock supports after normaliseLang folds its
+ * shorthands (ts/js/py/sh/shell/md); values name the `@shikijs/langs` module
+ * whose registration covers them — aliases ride along on it (bash/sh/shell on
+ * shellscript, docker on dockerfile).
+ *
+ * Never import `@shikijs/langs/*` from webview source: `inlineDynamicImports`
+ * would fold the grammar straight back into the single-file bundle, which this
+ * map exists to keep it out of.
+ */
+export const GRAMMAR_FILE: Record<string, string> = {
+  typescript: "typescript",
+  tsx: "tsx",
+  javascript: "javascript",
+  jsx: "jsx",
+  python: "python",
+  bash: "shellscript",
+  json: "json",
+  html: "html",
+  css: "css",
+  yaml: "yaml",
+  markdown: "markdown",
+  go: "go",
+  rust: "rust",
+  java: "java",
+  sql: "sql",
+  c: "c",
+  cpp: "cpp",
+  csharp: "csharp",
+  ruby: "ruby",
+  php: "php",
+  swift: "swift",
+  kotlin: "kotlin",
+  toml: "toml",
+  xml: "xml",
+  docker: "dockerfile",
+  dockerfile: "dockerfile",
+  ini: "ini",
+  diff: "diff",
+}
+
+export const GRAMMAR_FILES = [...new Set(Object.values(GRAMMAR_FILE))]

--- a/webview/vite.config.ts
+++ b/webview/vite.config.ts
@@ -2,6 +2,8 @@ import { defineConfig, type Plugin } from "vite"
 import react from "@vitejs/plugin-react"
 import { viteSingleFile } from "vite-plugin-singlefile"
 import path from "node:path"
+import fs from "node:fs/promises"
+import { GRAMMAR_FILES } from "./src/shiki-langs"
 
 /**
  * KaTeX declares every font in woff2 + woff + ttf; with everything inlined
@@ -28,8 +30,47 @@ function katexWoff2Only(): Plugin {
   }
 }
 
+/**
+ * Grammars are NOT bundled — `inlineDynamicImports` would fold ~2.2MB of them
+ * into the single-file HTML. Instead this emits dist/webview/grammars/ for
+ * the webview to fetch on demand (grammar-loader.ts): one JSON per unique
+ * registration, deduped across entries (they share dependencies; per-entry
+ * files would ship 5.2MB where 2.0MB suffices), plus manifest.json mapping
+ * each entry to the registration names it needs. Runs on closeBundle so
+ * watch-mode rebuilds re-emit.
+ */
+function emitGrammars(): Plugin {
+  return {
+    name: "emit-shiki-grammars",
+    apply: "build",
+    async closeBundle() {
+      const dir = path.resolve(__dirname, "../dist/webview/grammars")
+      await fs.mkdir(dir, { recursive: true })
+      const manifest: Record<string, string[]> = {}
+      const written = new Set<string>()
+      for (const file of GRAMMAR_FILES) {
+        const mod = await import(`@shikijs/langs/${file}`)
+        const names: string[] = []
+        for (const reg of mod.default as Array<{ name: string }>) {
+          // Registration names become fetch paths; "manifest" would collide.
+          if (!/^[\w-]+$/.test(reg.name) || reg.name === "manifest") {
+            throw new Error(`unsafe grammar registration name: ${reg.name}`)
+          }
+          if (!names.includes(reg.name)) names.push(reg.name)
+          if (!written.has(reg.name)) {
+            written.add(reg.name)
+            await fs.writeFile(path.join(dir, `${reg.name}.json`), JSON.stringify(reg))
+          }
+        }
+        manifest[file] = names
+      }
+      await fs.writeFile(path.join(dir, "manifest.json"), JSON.stringify(manifest))
+    },
+  }
+}
+
 export default defineConfig({
-  plugins: [react(), katexWoff2Only(), viteSingleFile()],
+  plugins: [react(), katexWoff2Only(), viteSingleFile(), emitGrammars()],
   build: {
     outDir: path.resolve(__dirname, "../dist/webview"),
     emptyOutDir: true,


### PR DESCRIPTION
## Summary

The webview bundle drops **3.7MB → 1.46MB raw** (874KB → 620KB gzip). The 27 grammar `import()`s in `CodeBlock.tsx` looked lazy, but singlefile's `inlineDynamicImports` folded all of them into the inline bundle — every panel open parsed 28 languages' grammars whether or not a code block ever rendered. Nothing grammar-shaped remains in the bundle (verified by grepping the build output for grammar scopes).

**Build** — `emitGrammars` in `webview/vite.config.ts` writes `dist/webview/grammars/`: one JSON per unique registration plus `manifest.json` mapping each `@shikijs/langs` entry to the registration names it needs. The dedup is not optional tidiness: entries share dependencies (ruby pulls 20 registrations, html carries javascript+css; 79 entry registrations collapse to 33 unique), so naive per-entry JSONs weigh 5.2MB where 2.0MB suffices. The emitted set is slightly *smaller* than the grammars' old inlined form, so total VSIX payload does not grow. Runs on `closeBundle`, so `bun run watch` re-emits too.

**Runtime** — the highlighter starts with the two themes and zero grammars. The first block in a language loads it through `grammar-loader.ts`: manifest fetched once, each registration fetched once across all entries (a `javascript` block after an `html` block fetches nothing). Every cache layer — entry, manifest, registration — evicts on failure, so a failed fetch degrades that one block to the existing plaintext fallback and the next attempt retries only what actually failed.

**Host** — a webview's HTML is set as a string, so relative URLs resolve against nothing; `buildHtml` injects `asWebviewUri(dist/webview/grammars)` as `window.__opencuiGrammarsBase` and widens CSP `connect-src` to `cspSource`. `localResourceRoots` already covered `dist/`.

**Single source of truth** — `shiki-langs.ts` holds the lang → entry map consumed by both `CodeBlock` and the emit plugin. It also retires two dead entries the old `SUPPORTED` set carried (`shell`, `md` — unreachable because `normaliseLang` folds them first). Never import `@shikijs/langs` from webview source; that folds the grammar straight back into the bundle.

## Tests (+10, total 1304)

- `codeblock.test.tsx` — the loader is bridged to the real `@shikijs/langs` modules, so the alias test still runs against real grammar data. New: fetch failure renders the escaped-`<pre>` fallback (asserted via the catch branch's DOM shape, not the placeholder), then the *same language* recovers on the next block — pinning the eviction semantics.
- `grammar-loader.test.ts` (new) — manifest fetched once across entries; registrations shared (`javascript` after `html` → one fetch); failed registration retries alone while successful siblings stay cached; failed manifest evicts; missing base URI and unknown entry reject.
- `shiki-langs.test.ts` (new) — pins every mapped language to a name/alias actually registered by its entry (bash→shellscript, docker→dockerfile) and mirrors the build guard that registration names are fetch-path-safe and never collide with `manifest`. A shiki upgrade that drops an alias fails CI instead of failing at render time.
- `chatview-harness.test.ts` — `buildHtml` injects the base URI and the `connect-src` allowance together.

## Test plan

- [x] `bun run test` — 84→86 files, 1304 passed
- [x] `bun run check-types` + `cd webview && bunx tsc --noEmit` — clean
- [x] `bun run compile` and `bun run package` — build; grammars emitted (34 files, 2.1MB)
- [x] `vsce ls` shows `dist/webview/grammars/*.json` in the package
- [x] Node smoke test against the emitted files: shellscript→`bash`, ruby (20-registration chain), dockerfile→`docker` all highlight through the manifest path
- [ ] Extension Development Host: open a chat with fenced blocks (ts, bash, ruby), confirm highlight appears after the brief plaintext frame and the network tab shows per-registration fetches

## Notes

First-highlight latency now includes 1–2 small fetches (local extension files, not network); the block shows the existing plaintext fallback for that frame, which is the same progressive behavior the old lazy-looking imports suggested. KaTeX (~640K JS + fonts) is the next candidate for the same treatment but needs async plumbing in the markdown pipeline — separate issue if wanted.

Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)