### PR TITLE
fix(review): Keep verifies only the newest record per file

### DIFF
--- a/src/chat/review-actions.ts
+++ b/src/chat/review-actions.ts
@@ -25,21 +25,21 @@ export type ReviewAllForPathOptions = {
 }
 
 /**
- * Apply Keep / Undo to every per-tool record matching a single path.
+ * Apply Keep / Undo for a single path. The two actions walk different record
+ * sets on purpose:
  *
- * Why iterate per-tool records instead of the aggregated row: aggregateChanges
- * collapses multiple ReviewChange records into one row by KEEPING ONLY the
- * last contributing record's `patch`. Acting on the aggregated patch alone
- * silently skips every earlier tool call's hunks — a half-undo the user
- * never sees. We act on the un-aggregated extract so every hunk reaches
- * `reviewHunk()`, then key the UI state on the aggregated row so the panel,
- * decorations, and snapshots stay coherent.
+ * Undo iterates EVERY per-tool record, newest first: aggregateChanges keeps
+ * only the last record's `patch`, so undoing the aggregated row alone would
+ * silently skip every earlier tool call's hunks, and only newest-first
+ * iteration leaves each record's `newText` anchor matchable when records
+ * layered edits on the same lines (A: orig → rev1, B: rev1 → final).
  *
- * Reverse order for Undo: when two records edited the same lines (A: orig →
- * rev1, B: rev1 → final), only newest-first iteration leaves each record's
- * `newText` anchor matchable. For non-overlapping edits the order still
- * matters because reverting a downstream hunk first keeps upstream line
- * anchors unshifted.
+ * Keep verifies ONLY the newest record: it mutates nothing, and once a later
+ * tool call touched the file again, earlier records describe intermediate
+ * states that by definition no longer exist — verifying them against the
+ * final file reported the agent's own follow-up edits as "file has changed"
+ * conflicts (#508). Hunks are marked accepted per-result, so a genuinely
+ * drifted hunk stays pending instead of being swept up by a wholesale mark.
  */
 export async function reviewAllForPath(
   records: ReviewChange[],
@@ -56,7 +56,10 @@ export async function reviewAllForPath(
     return { applied: 0, conflicts: 0, hunkUpdates: [] }
   }
   const runner = options.runReviewHunk ?? defaultReviewHunk
-  const ordered = action === "rejected" ? records.slice().reverse() : records
+  if (action === "accepted") {
+    return acceptNewestRecord(records[records.length - 1]!, aggregated, runner, options)
+  }
+  const ordered = records.slice().reverse()
   let applied = 0
   let conflicts = 0
   for (const record of ordered) {
@@ -71,7 +74,7 @@ export async function reviewAllForPath(
     // fragment of its content and report success.
     const hunks = record.kind === "updated" ? parsed : parsed.slice(0, 1)
     for (const hunk of hunks) {
-      if (action === "rejected" && !hunk.reversible) {
+      if (!hunk.reversible) {
         conflicts += 1
         continue
       }
@@ -89,6 +92,53 @@ export async function reviewAllForPath(
       if (options.reviewedKeys[key]) continue
       hunkUpdates.push({ key, state: action })
     }
+  }
+  return { applied, conflicts, hunkUpdates }
+}
+
+/**
+ * The newest record's kind (not the aggregated row's sticky kind) picks the
+ * check: a create-then-edit turn aggregates as "created", but the final state
+ * on disk is the edit's, and the text verification is the stronger claim.
+ * Hunk keys are computed against the aggregated row because that is what the
+ * panel and reviewedKeys are keyed on — the ids line up since aggregateChanges
+ * takes the aggregated `patch` from this same newest record.
+ */
+async function acceptNewestRecord(
+  newest: ReviewChange,
+  aggregated: ReviewChange,
+  runner: ReviewHunkRunner,
+  options: ReviewAllForPathOptions,
+): Promise<ReviewAllForPathResult> {
+  const parsed = splitReviewDiff(newest.patch).hunks
+  const hunkUpdates: HunkUpdate[] = []
+  // Create / delete / move verify the file as a unit: one runner call, and
+  // success settles every hunk of the row.
+  if (newest.kind !== "updated") {
+    const hunk = parsed[0]
+    if (!hunk) return { applied: 0, conflicts: 0, hunkUpdates }
+    const outcome = await runner(newest, hunk, "accepted", { silent: true, root: options.root })
+    if (outcome.status !== "applied" && outcome.status !== "no-op") {
+      return { applied: 0, conflicts: 1, hunkUpdates }
+    }
+    for (const key of splitReviewDiff(aggregated.patch).hunks.map((h) => reviewKey(aggregated, h.id))) {
+      if (options.reviewedKeys[key]) continue
+      hunkUpdates.push({ key, state: "accepted" })
+    }
+    return { applied: 1, conflicts: 0, hunkUpdates }
+  }
+  let applied = 0
+  let conflicts = 0
+  for (const hunk of parsed) {
+    const key = reviewKey(aggregated, hunk.id)
+    if (options.reviewedKeys[key]) continue
+    const outcome = await runner(newest, hunk, "accepted", { silent: true, root: options.root })
+    if (outcome.status === "applied" || outcome.status === "no-op") {
+      applied += 1
+      hunkUpdates.push({ key, state: "accepted" })
+      continue
+    }
+    conflicts += 1
   }
   return { applied, conflicts, hunkUpdates }
 }

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -2131,9 +2131,11 @@ export class ChatView implements vscode.WebviewViewProvider {
       this.post({ type: "reviewHunkState", key: update.key, state: update.state })
     }
     if (result.conflicts > 0) {
-      const verb = action === "accepted" ? "accept" : "undo"
+      const count = `${result.conflicts} hunk${result.conflicts === 1 ? "" : "s"}`
       vscode.window.showWarningMessage(
-        `OpenCode Panel: couldn't ${verb} ${result.conflicts} hunk${result.conflicts === 1 ? "" : "s"} in ${requestedPath} — the file has changed since the diff was produced.`,
+        action === "accepted"
+          ? `OpenCode Panel: couldn't confirm ${count} in ${requestedPath} — the file has changed since opencode's last edit. Unconfirmed hunks stay in the review list.`
+          : `OpenCode Panel: couldn't undo ${count} in ${requestedPath} — the file has changed since the diff was produced.`,
       )
     }
     // No explicit sync here: applied > 0 guarantees at least one

--- a/test/host/review-actions.test.ts
+++ b/test/host/review-actions.test.ts
@@ -469,7 +469,7 @@ describe("reviewAllForPath: multi-tool turn", () => {
     expect(files.get("/workspace/foo.ts")?.content).toBe("one\ntwo\nthree\nfour\nfive\n")
   })
 
-  it("undo iterates per-tool records in REVERSE order; keep iterates forward", async () => {
+  it("undo iterates per-tool records in REVERSE order; keep verifies only the newest", async () => {
     const seen: Array<{ source: string; action: ReviewHunkState }> = []
     const runner = vi.fn(async (change: ReviewChange, _hunk, action) => {
       seen.push({ source: change.source, action })
@@ -484,7 +484,7 @@ describe("reviewAllForPath: multi-tool turn", () => {
 
     seen.length = 0
     await reviewAllForPath([recordA, recordB], aggregated, "accepted", { reviewedKeys: {}, runReviewHunk: runner })
-    expect(seen.map((s) => s.source)).toEqual(["callA", "callB"])
+    expect(seen.map((s) => s.source)).toEqual(["callB"])
   })
 
   it("is idempotent: a re-click with all aggregated hunks already marked is a no-op", async () => {
@@ -593,6 +593,90 @@ describe("reviewAllForPath: multi-tool turn", () => {
     expect(result.applied).toBe(0)
     expect(result.conflicts).toBe(0)
     expect(result.hunkUpdates).toHaveLength(0)
+  })
+
+  // #508: a multi-edit turn made Keep verify every record's intermediate diff
+  // against the final file, reporting the agent's own follow-up edits as
+  // "file has changed" conflicts.
+  describe("Keep on stacked records", () => {
+    it("layered edits on the same line confirm cleanly instead of conflicting", async () => {
+      files.set("/workspace/foo.ts", { content: "alpha\nfinal\ngamma\n" })
+      const recordA = buildUpdate({ source: "callA", path: "foo.ts", oldText: "beta", newText: "rev1", line: 2 })
+      const recordB = buildUpdate({ source: "callB", path: "foo.ts", oldText: "rev1", newText: "final", line: 2 })
+      const aggregated = aggregateLike([recordA, recordB])
+      const result = await reviewAllForPath([recordA, recordB], aggregated, "accepted", { reviewedKeys: {} })
+      expect(result.conflicts).toBe(0)
+      expect(result.applied).toBe(1)
+      expect(result.hunkUpdates.length).toBeGreaterThan(0)
+      for (const update of result.hunkUpdates) {
+        expect(update.state).toBe("accepted")
+      }
+    })
+
+    it("marks hunks per-result: a drifted hunk stays pending while the intact one settles", async () => {
+      files.set("/workspace/foo.ts", { content: "one\ntwo-rev\nthree\nfour\nDRIFTED\n" })
+      const patch = [
+        "@@ -2,1 +2,1 @@",
+        "-two",
+        "+two-rev",
+        "@@ -5,1 +5,1 @@",
+        "-five",
+        "+five-rev",
+      ].join("\n")
+      const record: ReviewChange = {
+        source: "callA", path: "foo.ts", kind: "updated", additions: 2, deletions: 2, patch,
+      }
+      const result = await reviewAllForPath([record], record, "accepted", { reviewedKeys: {} })
+      expect(result.applied).toBe(1)
+      expect(result.conflicts).toBe(1)
+      const hunks = splitReviewDiff(patch).hunks
+      expect(result.hunkUpdates).toEqual([{ key: reviewKey(record, hunks[0]!.id), state: "accepted" }])
+    })
+
+    it("skips hunks already confirmed on a re-click", async () => {
+      const runner = vi.fn(async () => ({ status: "applied" }) satisfies ReviewHunkOutcome)
+      const patch = ["@@ -1,1 +1,1 @@", "-a", "+a2", "@@ -3,1 +3,1 @@", "-b", "+b2"].join("\n")
+      const record: ReviewChange = {
+        source: "callA", path: "foo.ts", kind: "updated", additions: 2, deletions: 2, patch,
+      }
+      const hunks = splitReviewDiff(patch).hunks
+      const reviewedKeys: Record<string, ReviewHunkState> = {
+        [reviewKey(record, hunks[0]!.id)]: "accepted",
+      }
+      const result = await reviewAllForPath([record], record, "accepted", { reviewedKeys, runReviewHunk: runner })
+      expect(runner).toHaveBeenCalledTimes(1)
+      expect(result.hunkUpdates).toEqual([{ key: reviewKey(record, hunks[1]!.id), state: "accepted" }])
+    })
+
+    it("the newest record's kind picks the check, not the aggregated row's sticky kind", async () => {
+      // Create-then-edit aggregates as "created"; Keep must still verify the
+      // edit's text, so a drifted file conflicts instead of passing on bare
+      // existence.
+      files.set("/workspace/new.ts", { content: "drifted\n" })
+      const createRecord: ReviewChange = {
+        source: "callA", path: "new.ts", kind: "created", additions: 1, deletions: 0,
+        patch: "@@ -0,0 +1,1 @@\n+hello",
+      }
+      const editRecord = buildUpdate({ source: "callB", path: "new.ts", oldText: "hello", newText: "hello-edited", line: 1 })
+      const aggregated: ReviewChange = { ...editRecord, kind: "created" }
+      const result = await reviewAllForPath([createRecord, editRecord], aggregated, "accepted", { reviewedKeys: {} })
+      expect(result.applied).toBe(0)
+      expect(result.conflicts).toBe(1)
+      expect(result.hunkUpdates).toHaveLength(0)
+    })
+
+    it("a unit-kind newest record settles every hunk of the row on success", async () => {
+      // File gone as the deleted record claims: one runner call, all keys marked.
+      const record: ReviewChange = {
+        source: "callA", path: "gone.ts", kind: "deleted", additions: 0, deletions: 1,
+        patch: "@@ -1,1 +0,0 @@\n-line1",
+      }
+      const result = await reviewAllForPath([record], record, "accepted", { reviewedKeys: {} })
+      expect(result.applied).toBe(1)
+      expect(result.conflicts).toBe(0)
+      const hunks = splitReviewDiff(record.patch).hunks
+      expect(result.hunkUpdates).toEqual([{ key: reviewKey(record, hunks[0]!.id), state: "accepted" }])
+    })
   })
 })
 


### PR DESCRIPTION
Part of #508 (the "couldn't accept 21 hunks" error; the diff view request stays open).

## Summary

A multi-edit turn produces one `ReviewChange` record per tool call, each diffing an intermediate file state. Keep verified **every** record's hunks against the **final** file, so hunks superseded by the agent's own later edits were counted as conflicts and toasted as "the file has changed since the diff was produced" — while `reviewAllForPath` simultaneously marked the whole row accepted because at least one hunk had verified.

- Keep now verifies only the newest record per path. It mutates nothing, and once a later tool call touched the file, earlier records describe states that by definition no longer exist — the final state is the only checkable claim.
- Hunks are marked accepted per-result instead of wholesale: a genuinely drifted hunk stays pending in the review list instead of being swept up, so the toast and the row no longer contradict each other.
- The newest record's kind picks the check (create-then-edit still verifies the edit's text rather than passing on bare existence); create/delete/move verify as a unit as before.
- Accept toast reworded to "couldn't confirm N hunks — the file has changed since opencode's last edit"; Undo message and Undo's all-records newest-first iteration are unchanged.

## Test plan

- [x] `bun run test` — 1309 passed (5 new: stacked-records Keep repro, per-hunk marking on partial drift, re-click skips confirmed hunks, newest-kind-wins over sticky aggregated kind, unit-kind settling)
- [x] `bun run check-types` + `cd webview && bunx tsc --noEmit`
- [x] `bun run compile`
- [ ] Extension Development Host: multi-edit turn on one file, Keep settles the row with no conflict toast; manual drift after the last edit leaves the drifted hunk pending with the new toast