### PR TITLE
feat(picker): in-panel model picker with recents and per-model effort memory

### DIFF
--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -16,6 +16,7 @@ import { pickAttachments, bytesToDataUrl } from "../attachments"
 import { AttachmentStore, dataUrlToBytes } from "./attachment-store"
 import { log } from "../output"
 import { getWorkspaceRoots, primaryWorkspaceRoot } from "../workspace-root"
+import { buildModelCatalog, listModels, validVariant, type ModelInfo, type ProviderShape } from "../picker"
 import type { WorkspaceInfo } from "../protocol"
 import type {
   Attachment,
@@ -111,6 +112,13 @@ export class ChatView implements vscode.WebviewViewProvider {
   private contextUsageRequest = 0
   /** Names from the last `command.list` fetch — lets a custom command shadow a built-in. */
   private customCommandNames = new Set<string>()
+  /**
+   * Cached provider fetch backing the in-panel model picker. Refetched on
+   * webview mount and on `refreshModels` (picker open); prefs changes only
+   * re-post from this cache (recents / variant memory moved, models didn't).
+   */
+  private modelCatalogModels?: ModelInfo[]
+  private modelCatalogFetch?: Promise<void>
   /**
    * True between user-pressed Stop and the subsequent `session.idle` event.
    * While true, drop incoming SSE message/tool deltas — opencode keeps draining
@@ -276,7 +284,12 @@ export class ChatView implements vscode.WebviewViewProvider {
       null,
       this.context.subscriptions,
     )
-    this.prefs.onChange(() => this.postSelection())
+    this.prefs.onChange(() => {
+      this.postSelection()
+      // Recents and per-model variant memory ride on the catalog message —
+      // re-post from cache so the picker reflects the pick it just made.
+      this.postModelCatalog()
+    })
   }
 
   focus() {
@@ -806,6 +819,42 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.post({ type: "selection", selection: this.buildSelection() })
   }
 
+  private postModelCatalog() {
+    if (!this.modelCatalogModels) return
+    const catalog = buildModelCatalog(
+      this.modelCatalogModels,
+      this.prefs.recentModels(),
+      (providerID, modelID) => this.prefs.variantFor(providerID, modelID),
+    )
+    this.post({ type: "modelCatalog", catalog })
+  }
+
+  /**
+   * Fetch the provider list and push the model catalog. The picker posts
+   * `refreshModels` on every open, so concurrent calls coalesce onto one
+   * in-flight fetch instead of stacking HTTP requests.
+   */
+  private refreshModelCatalog(backend?: Backend): Promise<void> {
+    if (this.modelCatalogFetch) return this.modelCatalogFetch
+    this.modelCatalogFetch = (async () => {
+      try {
+        const activeBackend = backend ?? (await this.servers.ensure())
+        const res = await activeBackend.client.config.providers()
+        if (res.error || !res.data) {
+          log("model catalog: config.providers failed", res.error)
+          return
+        }
+        this.modelCatalogModels = listModels((res.data.providers ?? []) as unknown as ProviderShape[])
+        this.postModelCatalog()
+      } catch (e) {
+        log("model catalog refresh failed", e)
+      } finally {
+        this.modelCatalogFetch = undefined
+      }
+    })()
+    return this.modelCatalogFetch
+  }
+
   private buildSelection(): Selection {
     const sel = this.prefs.get()
     const model = sel.modelProviderID && sel.modelID ? `${sel.modelProviderID}/${sel.modelID}` : undefined
@@ -907,6 +956,7 @@ export class ChatView implements vscode.WebviewViewProvider {
           const backend = await this.servers.ensure()
           this.post({ type: "connected", connected: true })
           void this.refreshCommands(backend)
+          void this.refreshModelCatalog(backend)
           if (this.sessionID) void this.refreshContextUsage(backend)
         } catch (e) {
           this.post({ type: "connected", connected: false, error: (e as Error).message })
@@ -998,13 +1048,19 @@ export class ChatView implements vscode.WebviewViewProvider {
         log("selectAgent → executing opencui.selectAgent")
         await vscode.commands.executeCommand("opencui.selectAgent")
         return
-      case "selectModel":
-        log("selectModel → executing opencui.selectModel")
-        await vscode.commands.executeCommand("opencui.selectModel")
+      case "setModel": {
+        if (!msg.providerID || !msg.modelID) {
+          await this.prefs.setModel(undefined, undefined, undefined)
+          return
+        }
+        const model = this.modelCatalogModels?.find(
+          (m) => m.providerID === msg.providerID && m.modelID === msg.modelID,
+        )
+        await this.prefs.setModel(msg.providerID, msg.modelID, validVariant(model, msg.variant))
         return
-      case "selectVariant":
-        log("selectVariant → executing opencui.selectVariant")
-        await vscode.commands.executeCommand("opencui.selectVariant")
+      }
+      case "refreshModels":
+        void this.refreshModelCatalog()
         return
       case "permissionReply": {
         this.activePermissions.delete(msg.id)

--- a/src/picker.ts
+++ b/src/picker.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode"
 import type { ServerManager } from "./server"
 import type { Preferences } from "./preferences"
+import type { ModelCatalogInfo } from "./protocol"
 import { log } from "./output"
 
 /**
@@ -58,17 +59,16 @@ export class Picker {
   }
 
   /**
-   * Single-step model picker — pick a model and you're done. Variant /
-   * effort tuning has moved entirely to the StatusBar's Effort row
-   * (`pickVariantForCurrent`) so picking a model never asks a second
-   * question; the dropdown is short and the two concerns stay
-   * orthogonal.
+   * Single-step model picker — pick a model and you're done. Effort is
+   * tuned separately (the panel's picker chips or `pickVariantForCurrent`)
+   * so picking a model never asks a second question.
    *
-   * Variant is always reset on a successful model change: variants are
-   * model-scoped (e.g. `max` exists on Sonnet 4.6 but not on Haiku
-   * 4.5), so carrying the prior variant string forward to a different
-   * model would silently produce an invalid combo. The Effort row in
-   * the StatusBar lets the user retune effort immediately afterward.
+   * The variant is never carried over from the PREVIOUS model (variants are
+   * model-scoped; e.g. `max` exists on Sonnet 4.6 but not on Haiku 4.5).
+   * Instead the last variant used with the PICKED model is restored from
+   * per-model memory, validated against its live variant list — switching
+   * away and back keeps the effort tuning without ever minting an invalid
+   * combo.
    */
   async pickModel() {
     try {
@@ -105,11 +105,12 @@ export class Picker {
         log("pickModel: no matching model for", cleaned)
         return
       }
-      await this.prefs.setModel(model.providerID, model.modelID, undefined)
-      const hint = model.variants.length > 0 ? " — tune effort from the StatusBar" : ""
-      vscode.window.showInformationMessage(
-        `OpenCode Panel: model → ${model.providerID}/${model.modelID}${hint}`,
-      )
+      const variant = validVariant(model, this.prefs.variantFor(model.providerID, model.modelID))
+      await this.prefs.setModel(model.providerID, model.modelID, variant)
+      const display = variant
+        ? `${model.providerID}/${model.modelID} · ${variant}`
+        : `${model.providerID}/${model.modelID}`
+      vscode.window.showInformationMessage(`OpenCode Panel: model → ${display}`)
     } catch (e) {
       log("pickModel failed", e)
       vscode.window.showErrorMessage(`OpenCode Panel: ${(e as Error).message}`)
@@ -213,7 +214,7 @@ export type ModelInfo = {
   variants: string[]
 }
 
-type ProviderShape = {
+export type ProviderShape = {
   id: string
   name?: string
   models?: Record<string, { variants?: Record<string, unknown> } | undefined>
@@ -237,5 +238,44 @@ export function listModels(providers: ProviderShape[]): ModelInfo[] {
     }
   }
   return models
+}
+
+/**
+ * A variant is only meaningful for the model it was declared on. With the
+ * model at hand, membership is enforced; without it (webview `setModel`
+ * arriving before the catalog loaded), the variant is trusted — opencode
+ * ignores unknown variant keys, and dropping it would lose a valid pick.
+ */
+export function validVariant(
+  model: ModelInfo | undefined,
+  variant: string | undefined,
+): string | undefined {
+  if (!variant) return undefined
+  if (!model) return variant
+  return model.variants.includes(variant) ? variant : undefined
+}
+
+/**
+ * Wire catalog for the in-panel picker. Recents are filtered to models that
+ * still exist (an opencode config change must not leave dead rows), and each
+ * entry carries the validated per-model variant memory so the webview can
+ * restore effort on selection without a round-trip.
+ */
+export function buildModelCatalog(
+  models: ModelInfo[],
+  recents: string[],
+  variantFor: (providerID: string, modelID: string) => string | undefined,
+): ModelCatalogInfo {
+  const keys = new Set(models.map((m) => `${m.providerID}/${m.modelID}`))
+  return {
+    models: models.map((m) => ({
+      providerID: m.providerID,
+      modelID: m.modelID,
+      providerName: m.providerName,
+      variants: m.variants,
+      lastVariant: validVariant(m, variantFor(m.providerID, m.modelID)),
+    })),
+    recents: recents.filter((key) => keys.has(key)),
+  }
 }
 

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -2,6 +2,14 @@ import * as vscode from "vscode"
 
 const KEY_AGENT = "opencui.agent"
 const KEY_MODEL = "opencui.model"
+const KEY_MODEL_RECENTS = "opencui.model.recents"
+const KEY_MODEL_VARIANT_MEMORY = "opencui.model.variantMemory"
+
+/**
+ * Enough to cover a "testing new LLM releases across 4-5 providers" rotation
+ * with one slot to spare; beyond that the picker's full list is close anyway.
+ */
+const MAX_RECENT_MODELS = 6
 
 export type Selection = {
   agent?: string
@@ -32,6 +40,18 @@ export class Preferences {
     }
   }
 
+  /** `providerID/modelID` keys, most recently selected first. */
+  recentModels(): string[] {
+    const raw = this.state.get<unknown>(KEY_MODEL_RECENTS)
+    if (!Array.isArray(raw)) return []
+    return raw.filter((v): v is string => typeof v === "string")
+  }
+
+  /** Last variant the user picked for this model; undefined = its default. */
+  variantFor(providerID: string, modelID: string): string | undefined {
+    return this.variantMemory()[`${providerID}/${modelID}`]
+  }
+
   async setAgent(agent: string | undefined) {
     await this.state.update(KEY_AGENT, agent ?? "")
     this.emitter.fire(this.get())
@@ -41,6 +61,28 @@ export class Preferences {
     await this.state.update(`${KEY_MODEL}.providerID`, providerID ?? "")
     await this.state.update(`${KEY_MODEL}.modelID`, modelID ?? "")
     await this.state.update(`${KEY_MODEL}.variant`, variant ?? "")
+    // Recents and per-model variant memory track concrete picks only — a
+    // reset to the opencode default says nothing about which models the
+    // user rotates between.
+    if (providerID && modelID) {
+      const key = `${providerID}/${modelID}`
+      const recents = [key, ...this.recentModels().filter((k) => k !== key)]
+      await this.state.update(KEY_MODEL_RECENTS, recents.slice(0, MAX_RECENT_MODELS))
+      const memory = { ...this.variantMemory() }
+      if (variant) memory[key] = variant
+      else delete memory[key]
+      await this.state.update(KEY_MODEL_VARIANT_MEMORY, memory)
+    }
     this.emitter.fire(this.get())
+  }
+
+  private variantMemory(): Record<string, string> {
+    const raw = this.state.get<unknown>(KEY_MODEL_VARIANT_MEMORY)
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {}
+    const memory: Record<string, string> = {}
+    for (const [key, value] of Object.entries(raw)) {
+      if (typeof value === "string") memory[key] = value
+    }
+    return memory
   }
 }

--- a/test/host/chatview-harness.test.ts
+++ b/test/host/chatview-harness.test.ts
@@ -97,6 +97,7 @@ let harness: {
   workspaceState: Memento
   servers: ServerManager
   taskStore: AgentTaskStore
+  prefs: Preferences
 }
 
 beforeEach(async () => {
@@ -111,6 +112,9 @@ beforeEach(async () => {
   const prefs = {
     get: () => ({}),
     onChange: vi.fn(() => ({ dispose: vi.fn() })),
+    recentModels: () => [] as string[],
+    variantFor: () => undefined,
+    setModel: vi.fn(async () => {}),
   } as unknown as Preferences
   const indexManager = {
     onStatusChange: vi.fn(() => ({ dispose: vi.fn() })),
@@ -138,7 +142,7 @@ beforeEach(async () => {
   )
   const fake = makeFakeWebviewView()
   await chatView.resolveWebviewView(fake.view)
-  harness = { chatView, posted: fake.posted, send: fake.send, disposeView: fake.disposeView, workspaceState, servers, taskStore }
+  harness = { chatView, posted: fake.posted, send: fake.send, disposeView: fake.disposeView, workspaceState, servers, taskStore, prefs }
 })
 
 afterEach(async () => {
@@ -977,5 +981,66 @@ describe("ChatView harness: webview HTML", () => {
     } finally {
       fsFiles.delete(key)
     }
+  })
+})
+
+describe("ChatView harness: model catalog", () => {
+  const GPT_PROVIDER = {
+    id: "openai",
+    name: "OpenAI",
+    models: { "gpt-5.5": { variants: { low: {}, high: {} } } },
+  }
+
+  function catalogs() {
+    return harness.posted.filter((m) => m.type === "modelCatalog")
+  }
+
+  it("pushes the model catalog after the mounted handshake", async () => {
+    server.setProviders([GPT_PROVIDER])
+    await harness.send({ type: "mounted" })
+    await until(() => catalogs().length > 0)
+    const msg = catalogs()[0]!
+    expect(msg.type === "modelCatalog" && msg.catalog).toEqual({
+      models: [
+        {
+          providerID: "openai",
+          modelID: "gpt-5.5",
+          providerName: "OpenAI",
+          variants: ["low", "high"],
+          lastVariant: undefined,
+        },
+      ],
+      recents: [],
+    })
+  })
+
+  it("refreshModels refetches the provider list and re-pushes the catalog", async () => {
+    await harness.send({ type: "mounted" })
+    await until(() => catalogs().length > 0)
+    server.setProviders([GPT_PROVIDER])
+    await harness.send({ type: "refreshModels" })
+    await until(() =>
+      catalogs().some(
+        (m) => m.type === "modelCatalog" && m.catalog.models.some((e) => e.modelID === "gpt-5.5"),
+      ),
+    )
+  })
+
+  it("setModel persists via prefs; the variant is validated against the live catalog", async () => {
+    server.setProviders([GPT_PROVIDER])
+    await harness.send({ type: "mounted" })
+    await until(() => catalogs().length > 0)
+    const setModel = vi.mocked(harness.prefs.setModel)
+
+    await harness.send({ type: "setModel", providerID: "openai", modelID: "gpt-5.5", variant: "high" })
+    expect(setModel).toHaveBeenLastCalledWith("openai", "gpt-5.5", "high")
+
+    // Stale variant from a changed config must not persist.
+    await harness.send({ type: "setModel", providerID: "openai", modelID: "gpt-5.5", variant: "bogus" })
+    expect(setModel).toHaveBeenLastCalledWith("openai", "gpt-5.5", undefined)
+
+    // All-undefined = reset to the opencode default.
+    await harness.send({ type: "setModel" })
+    expect(setModel).toHaveBeenLastCalledWith(undefined, undefined, undefined)
   })
 })

--- a/test/host/mock-opencode-server.ts
+++ b/test/host/mock-opencode-server.ts
@@ -75,6 +75,8 @@ export type MockOpencodeServer = {
   commandCalls: Array<{ sessionID: string; body: unknown }>
   /** Configure what GET /command returns. */
   setCommands: (commands: Array<Record<string, unknown>>) => void
+  /** Configure what GET /config/providers returns (default: none). */
+  setProviders: (providers: Array<Record<string, unknown>>) => void
   /**
    * Configure what GET /session/status returns. Pass `undefined` to clear
    * the entry. Tests use this to drive the watchdog's recovery path.
@@ -119,6 +121,7 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
   const childrenByParent = new Map<string, string[]>()
   const commandCalls: Array<{ sessionID: string; body: unknown }> = []
   let commands: Array<Record<string, unknown>> = []
+  let providers: Array<Record<string, unknown>> = []
   const sessionStatuses = new Map<string, { type: "idle" | "busy" | "retry" }>()
   let statusDelayMs = 0
   let statusPolls = 0
@@ -198,7 +201,7 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
 
     // Providers
     if (path === "/config/providers" && req.method === "GET") {
-      reply(res, 200, { providers: [], default: {} })
+      reply(res, 200, { providers, default: {} })
       return
     }
 
@@ -460,6 +463,9 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
     commandCalls,
     setCommands(next) {
       commands = next
+    },
+    setProviders(next) {
+      providers = next
     },
     setSessionStatus(sessionID, status) {
       if (status) sessionStatuses.set(sessionID, status)

--- a/test/host/picker.test.ts
+++ b/test/host/picker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { isUserSelectableAgent, listModels } from "../../src/picker"
+import { buildModelCatalog, isUserSelectableAgent, listModels, validVariant } from "../../src/picker"
 
 describe("isUserSelectableAgent", () => {
   it("accepts a normal primary agent", () => {
@@ -93,3 +93,48 @@ describe("listModels", () => {
   })
 })
 
+
+describe("validVariant", () => {
+  const model = { providerID: "openai", modelID: "gpt-5.5", variants: ["low", "high"] }
+
+  it("keeps a variant the model declares", () => {
+    expect(validVariant(model, "high")).toBe("high")
+  })
+
+  it("drops a variant the model does not declare (stale memory, changed config)", () => {
+    expect(validVariant(model, "max")).toBeUndefined()
+  })
+
+  it("passes undefined through", () => {
+    expect(validVariant(model, undefined)).toBeUndefined()
+  })
+
+  it("trusts the variant when the model is unknown (catalog not loaded yet)", () => {
+    expect(validVariant(undefined, "high")).toBe("high")
+  })
+})
+
+describe("buildModelCatalog", () => {
+  const models = [
+    { providerID: "anthropic", modelID: "sonnet", providerName: "Anthropic", variants: ["max"] },
+    { providerID: "openai", modelID: "gpt-5.5", providerName: "OpenAI", variants: ["low", "high"] },
+  ]
+
+  it("attaches validated per-model variant memory as lastVariant", () => {
+    const memory: Record<string, string | undefined> = {
+      "anthropic/sonnet": "max",
+      "openai/gpt-5.5": "xhigh", // no longer declared — must not survive
+    }
+    const catalog = buildModelCatalog(models, [], (p, m) => memory[`${p}/${m}`])
+    expect(catalog.models.map((m) => m.lastVariant)).toEqual(["max", undefined])
+  })
+
+  it("filters recents to models that still exist, preserving order", () => {
+    const catalog = buildModelCatalog(
+      models,
+      ["openai/gpt-5.5", "meta/removed-model", "anthropic/sonnet"],
+      () => undefined,
+    )
+    expect(catalog.recents).toEqual(["openai/gpt-5.5", "anthropic/sonnet"])
+  })
+})

--- a/test/host/preferences.test.ts
+++ b/test/host/preferences.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest"
+import * as vscode from "vscode"
+import { Preferences } from "../../src/preferences"
+
+function makePrefs() {
+  const store = new Map<string, unknown>()
+  const memento = {
+    keys: () => [...store.keys()],
+    get: (key: string, defaultValue?: unknown) => (store.has(key) ? store.get(key) : defaultValue),
+    update: async (key: string, value: unknown) => {
+      if (value === undefined) store.delete(key)
+      else store.set(key, value)
+    },
+  }
+  return new Preferences(memento as unknown as vscode.Memento)
+}
+
+describe("Preferences model recents", () => {
+  it("records picks most-recent-first and dedups re-picks", async () => {
+    const prefs = makePrefs()
+    await prefs.setModel("anthropic", "sonnet")
+    await prefs.setModel("openai", "gpt-5.5")
+    await prefs.setModel("anthropic", "sonnet")
+    expect(prefs.recentModels()).toEqual(["anthropic/sonnet", "openai/gpt-5.5"])
+  })
+
+  it("caps the list at six entries, dropping the oldest", async () => {
+    const prefs = makePrefs()
+    for (let i = 1; i <= 7; i++) await prefs.setModel("p", `model-${i}`)
+    const recents = prefs.recentModels()
+    expect(recents).toHaveLength(6)
+    expect(recents[0]).toBe("p/model-7")
+    expect(recents).not.toContain("p/model-1")
+  })
+
+  it("a reset to the opencode default records nothing", async () => {
+    const prefs = makePrefs()
+    await prefs.setModel("anthropic", "sonnet")
+    await prefs.setModel(undefined, undefined, undefined)
+    expect(prefs.recentModels()).toEqual(["anthropic/sonnet"])
+    expect(prefs.get().modelID).toBeUndefined()
+  })
+})
+
+describe("Preferences per-model variant memory", () => {
+  it("remembers the last variant per model, independently across models", async () => {
+    const prefs = makePrefs()
+    await prefs.setModel("anthropic", "sonnet", "max")
+    await prefs.setModel("openai", "gpt-5.5", "high")
+    expect(prefs.variantFor("anthropic", "sonnet")).toBe("max")
+    expect(prefs.variantFor("openai", "gpt-5.5")).toBe("high")
+  })
+
+  it("an explicit default-effort pick clears that model's memory", async () => {
+    const prefs = makePrefs()
+    await prefs.setModel("anthropic", "sonnet", "max")
+    await prefs.setModel("anthropic", "sonnet", undefined)
+    expect(prefs.variantFor("anthropic", "sonnet")).toBeUndefined()
+  })
+
+  it("memory survives switching to another model (the point of the feature)", async () => {
+    const prefs = makePrefs()
+    await prefs.setModel("anthropic", "sonnet", "max")
+    await prefs.setModel("openai", "gpt-5.5")
+    expect(prefs.variantFor("anthropic", "sonnet")).toBe("max")
+  })
+
+  it("tolerates corrupt persisted shapes for recents and memory", () => {
+    const store = new Map<string, unknown>([
+      ["opencui.model.recents", "not-an-array"],
+      ["opencui.model.variantMemory", [1, 2, 3]],
+    ])
+    const memento = {
+      keys: () => [...store.keys()],
+      get: (key: string) => store.get(key),
+      update: async (key: string, value: unknown) => void store.set(key, value),
+    }
+    const prefs = new Preferences(memento as unknown as vscode.Memento)
+    expect(prefs.recentModels()).toEqual([])
+    expect(prefs.variantFor("a", "b")).toBeUndefined()
+  })
+})

--- a/test/webview/model-picker.test.tsx
+++ b/test/webview/model-picker.test.tsx
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { fireEvent, render, screen, cleanup } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { ModelPicker, buildPickerItems } from "../../webview/src/components/ModelPicker"
+import { reducer, initialChatState } from "../../webview/src/hooks/useChatState"
+import type { ModelCatalogInfo } from "../../webview/src/protocol"
+
+beforeEach(() => {
+  cleanup()
+})
+afterEach(cleanup)
+
+const catalog: ModelCatalogInfo = {
+  models: [
+    {
+      providerID: "anthropic",
+      modelID: "claude-sonnet-4-6",
+      providerName: "Anthropic",
+      variants: ["max"],
+      lastVariant: "max",
+    },
+    { providerID: "anthropic", modelID: "claude-haiku-4-5", providerName: "Anthropic", variants: [] },
+    {
+      providerID: "openai",
+      modelID: "gpt-5.5",
+      providerName: "OpenAI",
+      variants: ["low", "medium", "high"],
+    },
+    { providerID: "google", modelID: "gemini-3-pro", providerName: "Google", variants: [] },
+  ],
+  recents: ["openai/gpt-5.5", "anthropic/claude-sonnet-4-6"],
+}
+
+const baseProps = {
+  catalog,
+  selection: {},
+  agentLabel: "default",
+  onSetModel: vi.fn(),
+  onSelectAgent: vi.fn(),
+  onRefresh: vi.fn(),
+  onClose: vi.fn(),
+}
+
+function rowNames(): string[] {
+  return screen.getAllByRole("option").map((r) => r.querySelector(".model-picker-name")!.textContent!)
+}
+
+describe("buildPickerItems", () => {
+  it("orders recents first (host order), then provider groups, then the default row", () => {
+    const items = buildPickerItems(catalog, "")
+    expect(items.map((i) => (i.kind === "model" ? `${i.section}:${i.entry.modelID}` : i.kind))).toEqual([
+      "Recent:gpt-5.5",
+      "Recent:claude-sonnet-4-6",
+      "Anthropic:claude-sonnet-4-6",
+      "Anthropic:claude-haiku-4-5",
+      "OpenAI:gpt-5.5",
+      "Google:gemini-3-pro",
+      "default",
+    ])
+  })
+
+  it("skips recents whose model is no longer in the catalog", () => {
+    const items = buildPickerItems({ ...catalog, recents: ["openai/gone", "google/gemini-3-pro"] }, "")
+    const recent = items.filter((i) => i.section === "Recent")
+    expect(recent).toHaveLength(1)
+  })
+
+  it("filters with every whitespace token matched against provider/model/name", () => {
+    const items = buildPickerItems(catalog, "anthropic sonnet")
+    expect(items).toHaveLength(1)
+    expect(items[0]!.kind === "model" && items[0]!.entry.modelID).toBe("claude-sonnet-4-6")
+    // Filtered mode drops sections and the default row.
+    expect(buildPickerItems(catalog, "gpt").some((i) => i.kind === "default")).toBe(false)
+  })
+
+  it("returns nothing while the catalog has not arrived", () => {
+    expect(buildPickerItems(undefined, "")).toEqual([])
+  })
+})
+
+describe("ModelPicker", () => {
+  it("asks the host for a fresh catalog on mount", () => {
+    const onRefresh = vi.fn()
+    render(<ModelPicker {...baseProps} onRefresh={onRefresh} />)
+    expect(onRefresh).toHaveBeenCalledOnce()
+  })
+
+  it("clicking a model row selects it WITH its remembered variant and closes", async () => {
+    const user = userEvent.setup()
+    const onSetModel = vi.fn()
+    const onClose = vi.fn()
+    render(<ModelPicker {...baseProps} onSetModel={onSetModel} onClose={onClose} />)
+    // Second recent row: sonnet, whose lastVariant is "max".
+    await user.click(screen.getAllByRole("option")[1]!)
+    expect(onSetModel).toHaveBeenCalledWith("anthropic", "claude-sonnet-4-6", "max")
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it("clicking the default row resets to the opencode default model", async () => {
+    const user = userEvent.setup()
+    const onSetModel = vi.fn()
+    render(<ModelPicker {...baseProps} onSetModel={onSetModel} />)
+    await user.click(screen.getByRole("option", { name: /opencode default/ }))
+    expect(onSetModel).toHaveBeenCalledWith(undefined, undefined, undefined)
+  })
+
+  it("marks the current model row with a check and starts keyboard focus on it", () => {
+    render(
+      <ModelPicker {...baseProps} selection={{ model: "openai/gpt-5.5" }} />,
+    )
+    const rows = screen.getAllByRole("option")
+    // First recent row is gpt-5.5 — current, checked, and the active row.
+    expect(rows[0]!.querySelector(".codicon-check")).toBeTruthy()
+    expect(rows[0]!.getAttribute("aria-selected")).toBe("true")
+  })
+
+  it("renders effort chips for the current model; a chip click re-picks with that variant", async () => {
+    const user = userEvent.setup()
+    const onSetModel = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <ModelPicker
+        {...baseProps}
+        selection={{ model: "openai/gpt-5.5", modelVariant: "high" }}
+        onSetModel={onSetModel}
+        onClose={onClose}
+      />,
+    )
+    const high = screen.getByRole("button", { name: "high" })
+    expect(high.className).toContain("is-active")
+    await user.click(screen.getByRole("button", { name: "medium" }))
+    expect(onSetModel).toHaveBeenCalledWith("openai", "gpt-5.5", "medium")
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it("the default chip clears the variant for the current model", async () => {
+    const user = userEvent.setup()
+    const onSetModel = vi.fn()
+    render(
+      <ModelPicker
+        {...baseProps}
+        selection={{ model: "openai/gpt-5.5", modelVariant: "high" }}
+        onSetModel={onSetModel}
+      />,
+    )
+    await user.click(screen.getByRole("button", { name: "default" }))
+    expect(onSetModel).toHaveBeenCalledWith("openai", "gpt-5.5", undefined)
+  })
+
+  it("hides the effort chips when the current model has no variants", () => {
+    render(<ModelPicker {...baseProps} selection={{ model: "google/gemini-3-pro" }} />)
+    expect(screen.queryByText("Effort")).not.toBeInTheDocument()
+  })
+
+  it("typing filters the list; Enter picks the active match", () => {
+    const onSetModel = vi.fn()
+    render(<ModelPicker {...baseProps} onSetModel={onSetModel} />)
+    const input = screen.getByRole("textbox", { name: "Search models" })
+    fireEvent.change(input, { target: { value: "haiku" } })
+    expect(rowNames()).toEqual(["claude-haiku-4-5"])
+    fireEvent.keyDown(input, { key: "Enter" })
+    expect(onSetModel).toHaveBeenCalledWith("anthropic", "claude-haiku-4-5", undefined)
+  })
+
+  it("ArrowDown/ArrowUp move the active row and wrap; Enter selects it", () => {
+    const onSetModel = vi.fn()
+    render(<ModelPicker {...baseProps} onSetModel={onSetModel} />)
+    const input = screen.getByRole("textbox", { name: "Search models" })
+    fireEvent.keyDown(input, { key: "ArrowUp" }) // wraps from 0 to the last row (default)
+    expect(screen.getByRole("option", { name: /opencode default/ }).getAttribute("aria-selected")).toBe("true")
+    fireEvent.keyDown(input, { key: "ArrowDown" })
+    fireEvent.keyDown(input, { key: "ArrowDown" })
+    fireEvent.keyDown(input, { key: "Enter" })
+    expect(onSetModel).toHaveBeenCalledWith("anthropic", "claude-sonnet-4-6", "max")
+  })
+
+  it("ignores Enter and arrows during IME composition", () => {
+    const onSetModel = vi.fn()
+    render(<ModelPicker {...baseProps} onSetModel={onSetModel} />)
+    const input = screen.getByRole("textbox", { name: "Search models" })
+    fireEvent.keyDown(input, { key: "Enter", keyCode: 229 })
+    fireEvent.keyDown(input, { key: "ArrowDown", keyCode: 229 })
+    expect(onSetModel).not.toHaveBeenCalled()
+    expect(screen.getAllByRole("option")[0]!.getAttribute("aria-selected")).toBe("true")
+  })
+
+  it("a bare mouseenter is ignored after arrow-keying; real pointer movement re-enables hover", () => {
+    render(<ModelPicker {...baseProps} />)
+    const input = screen.getByRole("textbox", { name: "Search models" })
+    fireEvent.keyDown(input, { key: "ArrowDown" })
+    const rows = screen.getAllByRole("option")
+    expect(rows[1]!.getAttribute("aria-selected")).toBe("true")
+    // Scroll-synthesized mouseenter (no preceding pointer movement): ignored.
+    fireEvent.mouseEnter(rows[3]!)
+    expect(rows[1]!.getAttribute("aria-selected")).toBe("true")
+    // Real movement: mousemove with changed coordinates, then enter.
+    const list = screen.getByRole("listbox", { name: "Models" })
+    fireEvent.mouseMove(list, { clientX: 10, clientY: 20 })
+    fireEvent.mouseEnter(rows[3]!)
+    expect(rows[3]!.getAttribute("aria-selected")).toBe("true")
+  })
+
+  it("shows a waiting state before the catalog arrives, still offering the agent row", () => {
+    render(<ModelPicker {...baseProps} catalog={undefined} />)
+    expect(screen.getByText(/Waiting for the model list/)).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Agent/ })).toBeInTheDocument()
+  })
+
+  it("agent footer row routes to onSelectAgent and closes", async () => {
+    const user = userEvent.setup()
+    const onSelectAgent = vi.fn()
+    const onClose = vi.fn()
+    render(<ModelPicker {...baseProps} onSelectAgent={onSelectAgent} onClose={onClose} />)
+    await user.click(screen.getByRole("button", { name: /Agent/ }))
+    expect(onSelectAgent).toHaveBeenCalledOnce()
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})
+
+describe("modelCatalog reducer wiring", () => {
+  it("stores the catalog and keeps it across reset/clear (workspace-scoped, like commands)", () => {
+    const withCatalog = reducer(initialChatState, { type: "modelCatalog", catalog })
+    expect(withCatalog.modelCatalog).toEqual(catalog)
+    expect(reducer(withCatalog, { type: "reset" }).modelCatalog).toEqual(catalog)
+    expect(reducer(withCatalog, { type: "clear" }).modelCatalog).toEqual(catalog)
+  })
+})

--- a/test/webview/statusbar.test.tsx
+++ b/test/webview/statusbar.test.tsx
@@ -15,8 +15,8 @@ const baseProps = {
   conversations: [],
   activeConversationID: undefined as string | undefined,
   onSelectAgent: vi.fn(),
-  onSelectModel: vi.fn(),
-  onSelectVariant: vi.fn(),
+  onSetModel: vi.fn(),
+  onRefreshModels: vi.fn(),
   onCreateConversation: vi.fn(),
   onOpenConversation: vi.fn(),
   onRenameConversation: vi.fn(),
@@ -83,41 +83,35 @@ describe("StatusBar", () => {
     expect(screen.queryByText(/error · boom/)).not.toBeInTheDocument()
   })
 
-  it("opens the selector popover on trigger click and shows Model, Effort, Agent rows", async () => {
+  it("opens the in-panel model picker on trigger click (no QuickPick handoff)", async () => {
     const user = userEvent.setup()
-    render(<StatusBar {...baseProps} selection={{ model: "claude-opus-4-7" }} />)
+    const onRefreshModels = vi.fn()
+    render(
+      <StatusBar
+        {...baseProps}
+        selection={{ model: "anthropic/claude-opus-4-7" }}
+        modelCatalog={{
+          models: [
+            { providerID: "anthropic", modelID: "claude-opus-4-7", providerName: "Anthropic", variants: [] },
+          ],
+          recents: [],
+        }}
+        onRefreshModels={onRefreshModels}
+      />,
+    )
     const trigger = screen.getByRole("button", { name: /change agent, model, and effort/i })
     await user.click(trigger)
-    expect(screen.getAllByRole("menuitem")).toHaveLength(3)
+    expect(screen.getByRole("listbox", { name: "Models" })).toBeInTheDocument()
+    // Opening asks the host for a fresh catalog (stale-while-revalidate).
+    expect(onRefreshModels).toHaveBeenCalledOnce()
   })
 
-  it("invokes onSelectModel when clicking the Model row in popover", async () => {
-    const user = userEvent.setup()
-    const onSelectModel = vi.fn()
-    render(<StatusBar {...baseProps} onSelectModel={onSelectModel} />)
-    await user.click(screen.getByRole("button", { name: /change agent, model, and effort/i }))
-    const items = screen.getAllByRole("menuitem")
-    await user.click(items[0]!)
-    expect(onSelectModel).toHaveBeenCalledOnce()
-  })
-
-  it("invokes onSelectVariant when clicking the Effort row in popover", async () => {
-    const user = userEvent.setup()
-    const onSelectVariant = vi.fn()
-    render(<StatusBar {...baseProps} onSelectVariant={onSelectVariant} />)
-    await user.click(screen.getByRole("button", { name: /change agent, model, and effort/i }))
-    const items = screen.getAllByRole("menuitem")
-    await user.click(items[1]!) // Order: Model, Effort, Agent
-    expect(onSelectVariant).toHaveBeenCalledOnce()
-  })
-
-  it("invokes onSelectAgent when clicking the Agent row in popover", async () => {
+  it("invokes onSelectAgent when clicking the Agent footer row in the picker", async () => {
     const user = userEvent.setup()
     const onSelectAgent = vi.fn()
     render(<StatusBar {...baseProps} onSelectAgent={onSelectAgent} />)
     await user.click(screen.getByRole("button", { name: /change agent, model, and effort/i }))
-    const items = screen.getAllByRole("menuitem")
-    await user.click(items[2]!)
+    await user.click(screen.getByRole("button", { name: /Agent/ }))
     expect(onSelectAgent).toHaveBeenCalledOnce()
   })
 
@@ -131,12 +125,24 @@ describe("StatusBar", () => {
     expect(screen.getByText("high")).toBeInTheDocument()
   })
 
-  it("Effort row shows 'default' when no variant is selected", async () => {
+  it("shows the current model's effort chips in the picker with 'default' active", async () => {
     const user = userEvent.setup()
-    render(<StatusBar {...baseProps} selection={{ model: "openai/gpt-5.5" }} />)
+    render(
+      <StatusBar
+        {...baseProps}
+        selection={{ model: "openai/gpt-5.5" }}
+        modelCatalog={{
+          models: [
+            { providerID: "openai", modelID: "gpt-5.5", providerName: "OpenAI", variants: ["low", "high"] },
+          ],
+          recents: [],
+        }}
+      />,
+    )
     await user.click(screen.getByRole("button", { name: /change agent, model, and effort/i }))
-    const items = screen.getAllByRole("menuitem")
-    expect(items[1]!.textContent).toMatch(/default/i)
+    const defaultChip = screen.getByRole("button", { name: "default" })
+    expect(defaultChip.className).toContain("is-active")
+    expect(screen.getByRole("button", { name: "high" })).toBeInTheDocument()
   })
 
   it("trigger shows the Effort segment with 'default' even when no variant is set", () => {

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -27,8 +27,8 @@ export default function App() {
     renameConversation,
     deleteConversation,
     selectAgent,
-    selectModel,
-    selectVariant,
+    setModel,
+    refreshModels,
     replyPermission,
     replyQuestion,
     rejectQuestion,
@@ -245,13 +245,14 @@ export default function App() {
         error={state.error}
         continuationPending={state.continuationPending}
         selection={state.selection}
+        modelCatalog={state.modelCatalog}
         conversations={state.conversations}
         activeConversationID={state.conversationID}
         activePopover={activeHeaderPopover}
         onActivePopoverChange={setActiveHeaderPopover}
         onSelectAgent={selectAgent}
-        onSelectModel={selectModel}
-        onSelectVariant={selectVariant}
+        onSetModel={setModel}
+        onRefreshModels={refreshModels}
         onCreateConversation={newSession}
         onOpenConversation={openConversation}
         onRenameConversation={renameConversation}

--- a/webview/src/components/ModelPicker.tsx
+++ b/webview/src/components/ModelPicker.tsx
@@ -1,0 +1,293 @@
+import { Fragment, useEffect, useMemo, useRef, useState } from "react"
+import type { ModelCatalogEntry, ModelCatalogInfo, Selection } from "../protocol"
+
+/**
+ * In-panel model + effort picker (issue #512). Replaces the old handoff to
+ * the native QuickPick, which opened at the top-center of the window (far
+ * from the sidebar click) after a blocking provider fetch. This popover
+ * renders from the host-pushed catalog, so opening it never waits on HTTP.
+ *
+ * Selecting a model sends its `lastVariant` along (per-model effort memory,
+ * maintained host-side), so switching away and back restores the effort the
+ * user last ran that model with.
+ */
+
+export type PickerItem =
+  | { kind: "model"; entry: ModelCatalogEntry; section: string }
+  /** Reset to the opencode default model. */
+  | { kind: "default"; section: string }
+
+export function modelKey(entry: ModelCatalogEntry): string {
+  return `${entry.providerID}/${entry.modelID}`
+}
+
+/**
+ * Flat, ordered row list for rendering AND keyboard navigation — one array
+ * so the active index can never point at a row the list isn't showing.
+ * Unfiltered: Recent (host-pushed order) → per-provider groups → the
+ * default-reset row. Filtered: a flat match list; every whitespace-separated
+ * token must appear in `providerID/modelID providerName`, so "openai mini"
+ * or "5.2" both narrow the way you'd expect.
+ */
+export function buildPickerItems(
+  catalog: ModelCatalogInfo | undefined,
+  query: string,
+): PickerItem[] {
+  if (!catalog) return []
+  const q = query.trim().toLowerCase()
+  if (q) {
+    const tokens = q.split(/\s+/)
+    return catalog.models
+      .filter((m) => {
+        const hay = `${modelKey(m)} ${m.providerName ?? ""}`.toLowerCase()
+        return tokens.every((t) => hay.includes(t))
+      })
+      .map((entry): PickerItem => ({ kind: "model", entry, section: "" }))
+  }
+  const byKey = new Map(catalog.models.map((m) => [modelKey(m), m]))
+  const items: PickerItem[] = []
+  for (const key of catalog.recents) {
+    const entry = byKey.get(key)
+    if (entry) items.push({ kind: "model", entry, section: "Recent" })
+  }
+  for (const entry of catalog.models) {
+    items.push({ kind: "model", entry, section: entry.providerName ?? entry.providerID })
+  }
+  if (catalog.models.length > 0) items.push({ kind: "default", section: "Default" })
+  return items
+}
+
+type Props = {
+  catalog?: ModelCatalogInfo
+  selection: Selection
+  /** Display label for the agent footer row. */
+  agentLabel: string
+  onSetModel: (providerID?: string, modelID?: string, variant?: string) => void
+  onSelectAgent: () => void
+  /** Posted on mount so a freshly opened picker re-syncs the catalog. */
+  onRefresh: () => void
+  onClose: () => void
+}
+
+export function ModelPicker({
+  catalog,
+  selection,
+  agentLabel,
+  onSetModel,
+  onSelectAgent,
+  onRefresh,
+  onClose,
+}: Props) {
+  const [query, setQuery] = useState("")
+  const items = useMemo(() => buildPickerItems(catalog, query), [catalog, query])
+  const currentKey = selection.model
+  const current = useMemo(
+    () => (currentKey ? catalog?.models.find((m) => modelKey(m) === currentKey) : undefined),
+    [catalog, currentKey],
+  )
+  const [activeIndex, setActiveIndex] = useState(0)
+
+  // Stale-while-revalidate: render the pushed catalog immediately, ask the
+  // host for a fresh one in the background (config may have changed).
+  useEffect(() => {
+    onRefresh()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Start on the current model so Enter with no arrows is a no-op re-pick,
+  // and the first ArrowDown moves to a neighbor instead of the list top.
+  useEffect(() => {
+    if (query) {
+      setActiveIndex(0)
+      return
+    }
+    const idx = items.findIndex(
+      (item) => item.kind === "model" && modelKey(item.entry) === currentKey,
+    )
+    setActiveIndex(idx >= 0 ? idx : 0)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query, catalog])
+
+  // Same two hover/keyboard guards as the PromptBox pickers: arrow keys
+  // suppress hover until the pointer actually moves (scrollIntoView slides
+  // rows under a resting cursor, and Blink re-fires mouseenter there), and
+  // hover never triggers scrollIntoView (rows would shift under the cursor).
+  const listRef = useRef<HTMLDivElement | null>(null)
+  const keyboardNavRef = useRef(false)
+  const hoverEnabledRef = useRef(true)
+  const lastPointerRef = useRef<{ x: number; y: number } | undefined>(undefined)
+  const onListMouseMove = (e: React.MouseEvent) => {
+    // Blink repeats the last real coordinates on its post-scroll synthetic
+    // mousemove — only changed coordinates prove the user moved.
+    const last = lastPointerRef.current
+    if (last && last.x === e.clientX && last.y === e.clientY) return
+    lastPointerRef.current = { x: e.clientX, y: e.clientY }
+    hoverEnabledRef.current = true
+  }
+  const hoverMove = (apply: () => void) => {
+    if (!hoverEnabledRef.current) return
+    keyboardNavRef.current = false
+    apply()
+  }
+  useEffect(() => {
+    const byKeyboard = keyboardNavRef.current
+    keyboardNavRef.current = false
+    if (!byKeyboard) return
+    const active = listRef.current?.querySelector('[aria-selected="true"]')
+    if (active && typeof active.scrollIntoView === "function") {
+      active.scrollIntoView({ block: "nearest" })
+    }
+  }, [activeIndex])
+
+  const selectItem = (item: PickerItem) => {
+    if (item.kind === "default") onSetModel(undefined, undefined, undefined)
+    else onSetModel(item.entry.providerID, item.entry.modelID, item.entry.lastVariant)
+    onClose()
+  }
+
+  const pickVariant = (variant?: string) => {
+    if (!current) return
+    onSetModel(current.providerID, current.modelID, variant)
+    onClose()
+  }
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    // IME composition owns Enter (commit candidate) and the arrows
+    // (navigate candidates) — never treat them as picker input.
+    if (e.nativeEvent.isComposing || e.keyCode === 229) return
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault()
+      if (items.length === 0) return
+      keyboardNavRef.current = true
+      hoverEnabledRef.current = false
+      const delta = e.key === "ArrowDown" ? 1 : -1
+      setActiveIndex((i) => (i + delta + items.length) % items.length)
+      return
+    }
+    if (e.key === "Enter") {
+      e.preventDefault()
+      const item = items[activeIndex]
+      if (item) selectItem(item)
+    }
+  }
+
+  return (
+    <div className="model-picker">
+      <input
+        className="model-picker-search"
+        type="text"
+        placeholder="Search models…"
+        aria-label="Search models"
+        value={query}
+        autoFocus
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={onKeyDown}
+      />
+      {current && current.variants.length > 0 && (
+        <div className="model-picker-effort">
+          <span className="model-picker-effort-label">Effort</span>
+          <div className="model-picker-chips">
+            <button
+              type="button"
+              className={`model-picker-chip ${selection.modelVariant ? "" : "is-active"}`}
+              title="Use the model's default effort"
+              onClick={() => pickVariant(undefined)}
+            >
+              default
+            </button>
+            {current.variants.map((v) => (
+              <button
+                key={v}
+                type="button"
+                className={`model-picker-chip ${selection.modelVariant === v ? "is-active" : ""}`}
+                onClick={() => pickVariant(v)}
+              >
+                {v}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+      <div
+        className="model-picker-list"
+        ref={listRef}
+        role="listbox"
+        aria-label="Models"
+        onMouseMove={onListMouseMove}
+      >
+        {!catalog && <div className="model-picker-empty">Waiting for the model list…</div>}
+        {catalog && items.length === 0 && (
+          <div className="model-picker-empty">
+            {query ? `No models match “${query.trim()}”` : "No models reported by opencode"}
+          </div>
+        )}
+        {items.map((item, i) => {
+          const showHeader =
+            item.section !== "" && (i === 0 || items[i - 1]!.section !== item.section)
+          if (item.kind === "default") {
+            return (
+              <Fragment key={`${item.section}:__default`}>
+                {showHeader && <div className="model-picker-section">{item.section}</div>}
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={i === activeIndex}
+                  className={`model-picker-row ${i === activeIndex ? "active" : ""}`}
+                  onMouseEnter={() => hoverMove(() => setActiveIndex(i))}
+                  onClick={() => selectItem(item)}
+                  title="Use opencode's configured default model"
+                >
+                  <span className="model-picker-name">opencode default</span>
+                  {!currentKey && <span className="codicon codicon-check" aria-hidden="true" />}
+                </button>
+              </Fragment>
+            )
+          }
+          const entry = item.entry
+          const key = modelKey(entry)
+          const isCurrent = key === currentKey
+          const tooltip = entry.lastVariant ? `${key} · ${entry.lastVariant}` : key
+          return (
+            <Fragment key={`${item.section}:${key}`}>
+              {showHeader && <div className="model-picker-section">{item.section}</div>}
+              <button
+                type="button"
+                role="option"
+                aria-selected={i === activeIndex}
+                className={`model-picker-row ${i === activeIndex ? "active" : ""}`}
+                onMouseEnter={() => hoverMove(() => setActiveIndex(i))}
+                onClick={() => selectItem(item)}
+                title={tooltip}
+              >
+                {/* Raw model id, not the prettified label: the picker is where
+                    date-suffix and point-release differences matter. */}
+                <span className="model-picker-name">{entry.modelID}</span>
+                {entry.lastVariant && (
+                  <span className="model-picker-last-variant">{entry.lastVariant}</span>
+                )}
+                <span className="model-picker-provider">
+                  {entry.providerName ?? entry.providerID}
+                </span>
+                {isCurrent && <span className="codicon codicon-check" aria-hidden="true" />}
+              </button>
+            </Fragment>
+          )
+        })}
+      </div>
+      <button
+        type="button"
+        className="selector-row model-picker-agent"
+        onClick={() => {
+          onSelectAgent()
+          onClose()
+        }}
+      >
+        <span className="selector-row-label">Agent</span>
+        <span className="selector-row-value" title={agentLabel}>
+          {agentLabel}
+        </span>
+        <span className="selector-row-arrow">›</span>
+      </button>
+    </div>
+  )
+}

--- a/webview/src/components/StatusBar.tsx
+++ b/webview/src/components/StatusBar.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState, type Dispatch, type SetStateAction } from "react"
-import type { ConversationSummary, Selection } from "../protocol"
+import type { ConversationSummary, ModelCatalogInfo, Selection } from "../protocol"
 import { useDismissableMenu } from "../hooks/useDismissableMenu"
 import { StatusIndicator, type StatusIndicatorKind } from "./StatusIndicator"
+import { ModelPicker } from "./ModelPicker"
 
 export type HeaderPopoverID = "selector" | "history"
 type HeaderPopoverSetter = Dispatch<SetStateAction<HeaderPopoverID | null>>
@@ -11,13 +12,14 @@ type Props = {
   error?: string
   continuationPending?: boolean
   selection: Selection
+  modelCatalog?: ModelCatalogInfo
   conversations: ConversationSummary[]
   activeConversationID?: string
   activePopover?: HeaderPopoverID | null
   onActivePopoverChange?: HeaderPopoverSetter
   onSelectAgent: () => void
-  onSelectModel: () => void
-  onSelectVariant: () => void
+  onSetModel: (providerID?: string, modelID?: string, variant?: string) => void
+  onRefreshModels: () => void
   onCreateConversation: () => void
   onOpenConversation: (id: string) => void
   onRenameConversation: (id: string, title: string) => void
@@ -29,21 +31,19 @@ export function StatusBar({
   error,
   continuationPending,
   selection,
+  modelCatalog,
   conversations,
   activeConversationID,
   activePopover,
   onActivePopoverChange,
   onSelectAgent,
-  onSelectModel,
-  onSelectVariant,
+  onSetModel,
+  onRefreshModels,
   onCreateConversation,
   onOpenConversation,
   onRenameConversation,
   onDeleteConversation,
 }: Props) {
-  const agent = selection.agent ?? "default"
-  const model = selection.model ?? "default"
-  const variant = selection.modelVariant
   const active = conversations.find((c) => c.id === activeConversationID)
   const [localActivePopover, setLocalActivePopover] = useState<HeaderPopoverID | null>(null)
   const currentPopover = activePopover === undefined ? localActivePopover : activePopover
@@ -71,14 +71,13 @@ export function StatusBar({
       <StatusIndicator kind={dotKind} title={statusTitle} />
       <div className="spacer" />
       <SelectorMenu
-        agent={agent}
-        model={model}
-        variant={variant}
+        selection={selection}
+        catalog={modelCatalog}
         open={currentPopover === "selector"}
         onOpenChange={(open) => setPopoverOpen("selector", open)}
         onSelectAgent={onSelectAgent}
-        onSelectModel={onSelectModel}
-        onSelectVariant={onSelectVariant}
+        onSetModel={onSetModel}
+        onRefreshModels={onRefreshModels}
       />
       <button
         type="button"
@@ -310,29 +309,29 @@ export function formatUpdated(updatedAt: number) {
 }
 
 function SelectorMenu({
-  agent,
-  model,
-  variant,
+  selection,
+  catalog,
   open,
   onOpenChange,
   onSelectAgent,
-  onSelectModel,
-  onSelectVariant,
+  onSetModel,
+  onRefreshModels,
 }: {
-  agent: string
-  model: string
-  variant?: string
+  selection: Selection
+  catalog?: ModelCatalogInfo
   open: boolean
   onOpenChange: (open: boolean) => void
   onSelectAgent: () => void
-  onSelectModel: () => void
-  onSelectVariant: () => void
+  onSetModel: (providerID?: string, modelID?: string, variant?: string) => void
+  onRefreshModels: () => void
 }) {
   const { toggle, close, ref } = useDismissableMenu({ open, onOpenChange })
 
+  const agent = selection.agent ?? "default"
+  const model = selection.model ?? "default"
+  const variant = selection.modelVariant
   const prettyModel = formatModel(model)
   const prettyAgent = formatAgent(agent)
-  const prettyVariant = variant ?? "default"
   const triggerTitle = `Model: ${model}${variant ? ` (effort: ${variant})` : ""}\nAgent: ${agent}`
 
   return (
@@ -354,47 +353,16 @@ function SelectorMenu({
         <span className="selector-secondary">{prettyAgent}</span>
       </button>
       {open && (
-        <div className="selector-popover" role="menu">
-          <button
-            type="button"
-            className="selector-row"
-            role="menuitem"
-            onClick={() => {
-              onSelectModel()
-              close()
-            }}
-          >
-            <span className="selector-row-label">Model</span>
-            <span className="selector-row-value" title={model}>{prettyModel}</span>
-            <span className="selector-row-arrow">›</span>
-          </button>
-          <button
-            type="button"
-            className="selector-row"
-            role="menuitem"
-            onClick={() => {
-              onSelectVariant()
-              close()
-            }}
-            title="Change effort / thinking budget for the current model"
-          >
-            <span className="selector-row-label">Effort</span>
-            <span className="selector-row-value" title={variant ?? "default"}>{prettyVariant}</span>
-            <span className="selector-row-arrow">›</span>
-          </button>
-          <button
-            type="button"
-            className="selector-row"
-            role="menuitem"
-            onClick={() => {
-              onSelectAgent()
-              close()
-            }}
-          >
-            <span className="selector-row-label">Agent</span>
-            <span className="selector-row-value" title={agent}>{prettyAgent}</span>
-            <span className="selector-row-arrow">›</span>
-          </button>
+        <div className="model-picker-popover" role="dialog" aria-label="Select model and effort">
+          <ModelPicker
+            catalog={catalog}
+            selection={selection}
+            agentLabel={prettyAgent}
+            onSetModel={onSetModel}
+            onSelectAgent={onSelectAgent}
+            onRefresh={onRefreshModels}
+            onClose={close}
+          />
         </div>
       )}
     </div>

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -14,6 +14,7 @@ import type {
   EditorContextRef,
   FileSearchHit,
   IndexStatusInfo,
+  ModelCatalogInfo,
   Outbound,
   QuestionInfo,
   ReviewChange,
@@ -58,6 +59,12 @@ export type ChatState = {
   continuationPending: boolean
   error?: string
   selection: Selection
+  /**
+   * Host-pushed model list backing the in-panel picker. Arrives on connect
+   * and after every preference change; workspace-scoped like `commands`, so
+   * it survives conversation resets.
+   */
+  modelCatalog?: ModelCatalogInfo
   conversations: ConversationSummary[]
   conversationID?: string
   contextUsage?: ContextUsage
@@ -177,13 +184,15 @@ export function reducer(state: ChatState, action: Action): ChatState {
     case "reset":
       // idleNonce is monotonic for the webview's lifetime — resetting it to 0
       // would desync the flush hook's last-seen ref.
-      return { ...initial, selection: state.selection, context: state.context, connected: state.connected, commands: state.commands, idleNonce: state.idleNonce }
+      return { ...initial, selection: state.selection, modelCatalog: state.modelCatalog, context: state.context, connected: state.connected, commands: state.commands, idleNonce: state.idleNonce }
     case "ready":
       return { ...state, connected: action.connected, selection: action.selection }
     case "connected":
       return { ...state, connected: action.connected, error: action.error }
     case "selection":
       return { ...state, selection: action.selection }
+    case "modelCatalog":
+      return { ...state, modelCatalog: action.catalog }
     case "contextUsage":
       return { ...state, contextUsage: action.usage }
     case "commands":
@@ -434,7 +443,7 @@ export function reducer(state: ChatState, action: Action): ChatState {
     case "unqueueMessage":
       return { ...state, queued: state.queued.filter((q) => q.id !== action.id) }
     case "clear":
-      return { ...initial, selection: state.selection, context: state.context, connected: state.connected, commands: state.commands, idleNonce: state.idleNonce }
+      return { ...initial, selection: state.selection, modelCatalog: state.modelCatalog, context: state.context, connected: state.connected, commands: state.commands, idleNonce: state.idleNonce }
     default:
       return state
   }
@@ -573,11 +582,11 @@ export function useChatState() {
     selectAgent() {
       vscode.post({ type: "selectAgent" })
     },
-    selectModel() {
-      vscode.post({ type: "selectModel" })
+    setModel(providerID?: string, modelID?: string, variant?: string) {
+      vscode.post({ type: "setModel", providerID, modelID, variant })
     },
-    selectVariant() {
-      vscode.post({ type: "selectVariant" })
+    refreshModels() {
+      vscode.post({ type: "refreshModels" })
     },
     replyPermission(id: string, response: "once" | "always" | "reject") {
       vscode.post({ type: "permissionReply", id, response })

--- a/webview/src/protocol.ts
+++ b/webview/src/protocol.ts
@@ -192,6 +192,31 @@ export type Selection = {
   modelVariant?: string
 }
 
+/**
+ * One selectable model in the in-panel picker. Pushed by the host as part of
+ * `modelCatalog` so the popover renders instantly instead of fetching
+ * providers on open.
+ */
+export type ModelCatalogEntry = {
+  providerID: string
+  modelID: string
+  providerName?: string
+  /** Effort/thinking variant keys in the provider's declared order. */
+  variants: string[]
+  /**
+   * Last variant the user picked for this model (per-model memory, held in
+   * host preferences). Re-selecting the model restores it, so a model
+   * switch never silently drops the effort tuning.
+   */
+  lastVariant?: string
+}
+
+export type ModelCatalogInfo = {
+  models: ModelCatalogEntry[]
+  /** `providerID/modelID` keys, most recently used first. */
+  recents: string[]
+}
+
 export type EditorContextRef = {
   path?: string
   label?: string
@@ -411,6 +436,7 @@ export type Outbound =
   | { type: "ready"; connected: boolean; selection: Selection }
   | { type: "connected"; connected: boolean; error?: string }
   | { type: "selection"; selection: Selection }
+  | { type: "modelCatalog"; catalog: ModelCatalogInfo }
   | { type: "contextUsage"; usage?: ContextUsage }
   | { type: "commands"; commands: CommandInfo[] }
   | { type: "conversations"; conversations: ConversationSummary[]; activeID?: string }
@@ -483,8 +509,14 @@ export type Inbound =
   | { type: "openReviewChange"; change: ReviewChange }
   | { type: "reviewAllInChange"; source: string; path: string; action: ReviewHunkState }
   | { type: "selectAgent" }
-  | { type: "selectModel" }
-  | { type: "selectVariant" }
+  /**
+   * Direct model/effort selection from the in-panel picker. All-undefined
+   * means "reset to the opencode default model". The host validates
+   * `variant` against the model's live variant list before persisting.
+   */
+  | { type: "setModel"; providerID?: string; modelID?: string; variant?: string }
+  /** Re-fetch the provider list and re-push `modelCatalog` (picker opened). */
+  | { type: "refreshModels" }
   | { type: "fileSearch"; requestID: number; query: string }
   | { type: "listDir"; requestID: number; path: string }
   | { type: "attachFile"; requestID: number }

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -438,7 +438,9 @@ button:focus-visible {
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.selector-popover {
+/* In-panel model picker (#512): the selector trigger opens this instead of
+   handing off to a native QuickPick at the top of the window. */
+.model-picker-popover {
   position: absolute;
   /* `top: 100%` is the bottom of .statusbar; the +2px is a small visual
      gap. `right: 10px` matches .statusbar's right padding so the popover's
@@ -447,14 +449,142 @@ button:focus-visible {
   top: calc(100% + 2px);
   right: 10px;
   z-index: var(--z-popover);
-  width: min(300px, calc(100vw - 20px));
+  width: min(340px, calc(100vw - 20px));
+  max-height: min(440px, calc(100vh - 70px));
   display: flex;
   flex-direction: column;
-  padding: 4px;
+  padding: 8px;
   border: 1px solid var(--vscode-dropdown-border, var(--vscode-panel-border));
   border-radius: var(--radius);
   background: var(--vscode-dropdown-background, var(--vscode-sideBar-background));
   box-shadow: var(--shadow-popover);
+}
+.model-picker {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+.model-picker-search {
+  width: 100%;
+  height: 26px;
+  padding: 3px 8px;
+  border: 1px solid var(--vscode-input-border, transparent);
+  border-radius: var(--radius-sm);
+  background: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  font-family: inherit;
+  font-size: 12px;
+  outline: none;
+}
+.model-picker-search:focus {
+  border-color: var(--vscode-focusBorder);
+}
+.model-picker-effort {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding: 8px 4px 2px;
+}
+.model-picker-effort-label {
+  color: var(--vscode-descriptionForeground);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.model-picker-chips {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+.model-picker-chip {
+  padding: 2px 8px;
+  border: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: inherit;
+  font-size: 11px;
+  line-height: 1.5;
+  cursor: pointer;
+}
+.model-picker-chip:hover {
+  background: var(--hover-bg-pill);
+}
+.model-picker-chip.is-active {
+  border-color: transparent;
+  background: var(--vscode-button-background);
+  color: var(--vscode-button-foreground);
+}
+.model-picker-list {
+  margin-top: 6px;
+  min-height: 0;
+  overflow-y: auto;
+}
+.model-picker-section {
+  padding: 6px 8px 2px;
+  color: var(--vscode-descriptionForeground);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  cursor: default;
+}
+.model-picker-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  width: 100%;
+  padding: 4px 8px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: inherit;
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+/* Hover moves the active index (via hoverMove), so `.active` is the single
+   highlight — a separate :hover rule would double-highlight during
+   keyboard navigation with a resting cursor. */
+.model-picker-row.active {
+  background: var(--vscode-list-activeSelectionBackground);
+  color: var(--vscode-list-activeSelectionForeground);
+}
+.model-picker-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: 500;
+}
+.model-picker-last-variant,
+.model-picker-provider {
+  flex: 0 0 auto;
+  color: var(--vscode-descriptionForeground);
+  font-size: 11px;
+}
+.model-picker-row.active .model-picker-last-variant,
+.model-picker-row.active .model-picker-provider {
+  color: var(--vscode-list-activeSelectionForeground);
+  opacity: 0.8;
+}
+.model-picker-row .codicon-check {
+  flex: 0 0 auto;
+  align-self: center;
+  font-size: 13px;
+}
+.model-picker-empty {
+  padding: 10px 8px;
+  color: var(--vscode-descriptionForeground);
+  font-size: 12px;
+}
+/* Agent footer keeps the old selector-row look, separated from the list. */
+.model-picker-agent {
+  margin-top: 6px;
+  border-top: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
+  border-radius: 0 0 var(--radius-sm) var(--radius-sm);
 }
 .selector-row {
   display: grid;


### PR DESCRIPTION
Closes #512

## Summary

- **In-panel picker replaces the QuickPick handoff.** The status-bar selector trigger now opens a popover in the sidebar itself (`ModelPicker.tsx`): filter input, a **Recent** section (most-recent-first, capped at 6, persisted in global state), per-provider groups, an **opencode default** reset row, and an Agent footer row that still routes to the agent QuickPick.
- **No fetch before UI.** The host caches `config.providers()` and pushes a `modelCatalog` message on webview mount and on every preference change; the picker also posts `refreshModels` on open (stale-while-revalidate, coalesced host-side onto one in-flight fetch). Opening the picker never blocks on HTTP.
- **Effort is inline and remembered.** The current model's variants render as chips in the same popover (`default · low · high · …`) — changing effort is trigger → chip. Each model remembers the last variant it was used with (`opencui.model.variantMemory`); re-selecting a model restores it, validated against the live variant list so a changed opencode config can never mint an invalid combo. `opencui.selectModel` (command palette) gains the same restore instead of always resetting.
- **Keyboard/hover conventions match the composer pickers**: ArrowUp/Down + Enter with wrap, active index starts on the current model, IME composition guard, Escape consumed by the shared dismissable-menu hook, and both hover guards (arrow keys suppress hover until real pointer movement; hover never triggers scrollIntoView).
- Model rows show the **raw model id** (the picker is where date-suffix/point-release differences matter); the trigger keeps the prettified label.
- Dead `selectModel` / `selectVariant` webview→host protocol variants removed; `setModel` / `refreshModels` added.

## Test plan

- [x] `bun run test` — 1341 passed (32 new: preferences recents/variant-memory, `validVariant`/`buildModelCatalog`, harness catalog push + `setModel` validation via a new mock-server `setProviders`, ModelPicker component incl. keyboard nav, IME guard, hover guards, reducer catalog-survives-reset)
- [x] `bun run check-types` and `cd webview && bunx tsc --noEmit` — both clean
- [x] `bun run compile` — production build clean
- [ ] Extension Development Host hand-check: open picker against a live opencode with multiple providers; verify recents ordering, chip behavior, and variant restore end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)