### PR TITLE
feat(picker): keep the picker open on effort change, slide the active chip

### DIFF
--- a/test/webview/model-picker.test.tsx
+++ b/test/webview/model-picker.test.tsx
@@ -114,7 +114,7 @@ describe("ModelPicker", () => {
     expect(rows[0]!.getAttribute("aria-selected")).toBe("true")
   })
 
-  it("renders effort chips for the current model; a chip click re-picks with that variant", async () => {
+  it("a chip click re-picks with that variant, stays open, and moves the active chip optimistically", async () => {
     const user = userEvent.setup()
     const onSetModel = vi.fn()
     const onClose = vi.fn()
@@ -130,21 +130,53 @@ describe("ModelPicker", () => {
     expect(high.className).toContain("is-active")
     await user.click(screen.getByRole("button", { name: "medium" }))
     expect(onSetModel).toHaveBeenCalledWith("openai", "gpt-5.5", "medium")
-    expect(onClose).toHaveBeenCalledOnce()
+    // Effort tuning is iterative — the popover must survive the click, and
+    // the active chip must not wait for the host's selection echo.
+    expect(onClose).not.toHaveBeenCalled()
+    expect(screen.getByRole("button", { name: "medium" }).className).toContain("is-active")
+    expect(high.className).not.toContain("is-active")
+    // Focus returns to the search input so keyboard flow continues.
+    expect(screen.getByRole("textbox", { name: "Search models" })).toHaveFocus()
   })
 
-  it("the default chip clears the variant for the current model", async () => {
+  it("the host's selection echo wins over the optimistic chip if they disagree", () => {
+    const { rerender } = render(
+      <ModelPicker {...baseProps} selection={{ model: "openai/gpt-5.5", modelVariant: "high" }} />,
+    )
+    fireEvent.click(screen.getByRole("button", { name: "medium" }))
+    expect(screen.getByRole("button", { name: "medium" }).className).toContain("is-active")
+    rerender(
+      <ModelPicker {...baseProps} selection={{ model: "openai/gpt-5.5", modelVariant: "low" }} />,
+    )
+    expect(screen.getByRole("button", { name: "low" }).className).toContain("is-active")
+    expect(screen.getByRole("button", { name: "medium" }).className).not.toContain("is-active")
+  })
+
+  it("the default chip clears the variant for the current model without closing", async () => {
     const user = userEvent.setup()
     const onSetModel = vi.fn()
+    const onClose = vi.fn()
     render(
       <ModelPicker
         {...baseProps}
         selection={{ model: "openai/gpt-5.5", modelVariant: "high" }}
         onSetModel={onSetModel}
+        onClose={onClose}
       />,
     )
     await user.click(screen.getByRole("button", { name: "default" }))
     expect(onSetModel).toHaveBeenCalledWith("openai", "gpt-5.5", undefined)
+    expect(onClose).not.toHaveBeenCalled()
+    expect(screen.getByRole("button", { name: "default" }).className).toContain("is-active")
+  })
+
+  it("renders the sliding thumb behind the chips (decorative, hidden from a11y)", () => {
+    const { container } = render(
+      <ModelPicker {...baseProps} selection={{ model: "openai/gpt-5.5" }} />,
+    )
+    const thumb = container.querySelector(".model-picker-chip-thumb")
+    expect(thumb).not.toBeNull()
+    expect(thumb!.getAttribute("aria-hidden")).toBe("true")
   })
 
   it("hides the effort chips when the current model has no variants", () => {

--- a/webview/src/components/ModelPicker.tsx
+++ b/webview/src/components/ModelPicker.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useMemo, useRef, useState } from "react"
+import { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import type { ModelCatalogEntry, ModelCatalogInfo, Selection } from "../protocol"
 
 /**
@@ -145,10 +145,43 @@ export function ModelPicker({
     onClose()
   }
 
+  // Effort tuning is iterative — try a level, glance at the result, adjust —
+  // so unlike a model pick (the terminal action) a chip click leaves the
+  // popover open. The active chip moves optimistically; the host's selection
+  // echo then confirms it, and wins if it ever disagrees.
+  const [pendingVariant, setPendingVariant] = useState<{ variant?: string } | null>(null)
+  useEffect(() => {
+    setPendingVariant(null)
+  }, [selection.modelVariant, selection.model])
+  const activeVariant = pendingVariant ? pendingVariant.variant : selection.modelVariant
+
+  const searchRef = useRef<HTMLInputElement | null>(null)
+  const chipsRef = useRef<HTMLDivElement | null>(null)
+  const [thumb, setThumb] = useState<{ x: number; y: number; w: number; h: number } | null>(null)
+  // Segment widths vary with their labels, so the sliding thumb is measured
+  // off the active chip instead of derived from an index. Layout effect so
+  // the thumb lands before paint — opening the picker must not animate.
+  useLayoutEffect(() => {
+    const active = chipsRef.current?.querySelector<HTMLElement>(".model-picker-chip.is-active")
+    if (!active) {
+      setThumb(null)
+      return
+    }
+    setThumb({
+      x: active.offsetLeft,
+      y: active.offsetTop,
+      w: active.offsetWidth,
+      h: active.offsetHeight,
+    })
+  }, [activeVariant, currentKey, catalog])
+
   const pickVariant = (variant?: string) => {
     if (!current) return
+    setPendingVariant({ variant })
     onSetModel(current.providerID, current.modelID, variant)
-    onClose()
+    // The click parked focus on the chip; hand it back so arrows and typing
+    // keep working without another click.
+    searchRef.current?.focus()
   }
 
   const onKeyDown = (e: React.KeyboardEvent) => {
@@ -176,6 +209,7 @@ export function ModelPicker({
       <div className="model-picker-search-wrap">
         <span className="codicon codicon-search" aria-hidden="true" />
         <input
+          ref={searchRef}
           className="model-picker-search"
           type="text"
           placeholder="Search models…"
@@ -189,10 +223,21 @@ export function ModelPicker({
       {current && current.variants.length > 0 && (
         <div className="model-picker-effort">
           <span className="model-picker-effort-label">Effort</span>
-          <div className="model-picker-chips">
+          <div className="model-picker-chips" ref={chipsRef}>
+            {thumb && (
+              <span
+                className="model-picker-chip-thumb"
+                style={{
+                  transform: `translate(${thumb.x}px, ${thumb.y}px)`,
+                  width: thumb.w,
+                  height: thumb.h,
+                }}
+                aria-hidden="true"
+              />
+            )}
             <button
               type="button"
-              className={`model-picker-chip ${selection.modelVariant ? "" : "is-active"}`}
+              className={`model-picker-chip ${activeVariant ? "" : "is-active"}`}
               title="Use the model's default effort"
               onClick={() => pickVariant(undefined)}
             >
@@ -202,7 +247,7 @@ export function ModelPicker({
               <button
                 key={v}
                 type="button"
-                className={`model-picker-chip ${selection.modelVariant === v ? "is-active" : ""}`}
+                className={`model-picker-chip ${activeVariant === v ? "is-active" : ""}`}
                 onClick={() => pickVariant(v)}
               >
                 {v}

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -509,8 +509,10 @@ button:focus-visible {
 }
 /* Segmented control: recessed track, raised active segment. NOT
    --radius-pill — that token is 50% (circles) and turns wide chips into
-   ovals. */
+   ovals. `position: relative` makes the track the offsetParent the sliding
+   thumb is measured against. */
 .model-picker-chips {
+  position: relative;
   display: inline-flex;
   flex-wrap: wrap;
   gap: 2px;
@@ -519,6 +521,9 @@ button:focus-visible {
   background: color-mix(in srgb, var(--vscode-foreground) 8%, transparent);
 }
 .model-picker-chip {
+  position: relative;
+  /* Labels paint above the sliding thumb. */
+  z-index: 1;
   padding: 2px 9px;
   border: 0;
   border-radius: 5px;
@@ -527,15 +532,33 @@ button:focus-visible {
   font-size: 11px;
   line-height: 1.5;
   cursor: pointer;
+  transition: color 0.15s ease;
 }
-.model-picker-chip:hover {
-  color: var(--vscode-foreground);
-}
+.model-picker-chip:hover,
 .model-picker-chip.is-active {
-  background: var(--vscode-dropdown-background, var(--vscode-sideBar-background));
+  /* The raised-segment look lives on the thumb; the active chip only
+     brightens. No font-weight change — bolding reflows the neighboring
+     chips mid-slide. */
   color: var(--vscode-foreground);
-  font-weight: 600;
+}
+/* One floating segment that translates to the active chip (#516). Mounted
+   already at its target (measured in a layout effect), so opening the
+   picker never animates — only an effort change does. */
+.model-picker-chip-thumb {
+  position: absolute;
+  top: 0;
+  left: 0;
+  border-radius: 5px;
+  background: var(--vscode-dropdown-background, var(--vscode-sideBar-background));
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+  pointer-events: none;
+  transition: transform 0.18s ease, width 0.18s ease, height 0.18s ease;
+}
+@media (prefers-reduced-motion: reduce) {
+  .model-picker-chip,
+  .model-picker-chip-thumb {
+    transition: none;
+  }
 }
 .model-picker-list {
   min-height: 0;


### PR DESCRIPTION
Closes #516

## Summary

- **Effort chip clicks no longer close the popover.** Effort tuning is iterative; the close forced a reopen per adjustment. Selecting a model row still closes — that is the terminal action.
- **Optimistic active state.** The clicked chip becomes active immediately via local pending state instead of waiting for the host's `selection` echo; the echo confirms it (and wins if it ever disagrees, e.g. the round-trip normalizes the variant).
- **Sliding-thumb animation.** One floating segment (`.model-picker-chip-thumb`) translates to the newly active chip. Segment widths vary with their labels, so the thumb is measured off the active chip in a layout effect rather than derived from an index. It mounts already at its target, so opening the picker never animates — only an effort change does. The active chip no longer bolds (a weight change reflows the neighboring chips mid-slide, so it only brightens); `prefers-reduced-motion` disables the transitions.
- **Focus returns to the search input** after a chip click so arrows and typing keep working without another click.

## Test plan

- [x] `bun run test` — 1343 passed (updated chip tests: stays open, optimistic move, echo-wins-on-disagreement, default chip, thumb presence + `aria-hidden`, focus restore)
- [x] `bun run check-types` and `cd webview && bunx tsc --noEmit` — clean
- [x] `bun run compile` — clean
- [x] Preview harness (real styles + a click-driven thumb simulation) verified in Chrome: resting state renders identically to #515; clicking a chip slides the raised segment to the new label
- [ ] Extension Development Host spot-check: rapid chip switching against a live opencode, confirm the popover stays open and the selection echo never fights the optimistic state

🤖 Generated with [Claude Code](https://claude.com/claude-code)