### PR TITLE
fix(stream): route permission.asked and requestID-keyed replies from opencode 1.18+

### DIFF
--- a/src/chat/stream.ts
+++ b/src/chat/stream.ts
@@ -327,7 +327,11 @@ export function subscribeSession(
         onPartDelta(props)
         markActivity(props?.sessionID)
         return
+      // opencode <=1.17 emitted `permission.updated`; >=1.18 emits
+      // `permission.asked` for the same request (#520). The name already
+      // flipped once (#492 went the other way), so route both forever.
       case "permission.updated":
+      case "permission.asked":
         onPermissionUpdated(props)
         markActivity(props?.sessionID)
         return
@@ -770,10 +774,10 @@ export function subscribeSession(
 
   function onPermissionResolved(p: any) {
     if (!p || p.sessionID !== sessionID) return
-    // `permission.updated` carries a full Permission (keyed `id`) while
-    // `permission.replied` carries only `{sessionID, permissionID, response}`,
-    // so the two events name the same permission differently.
-    const id = p.permissionID ?? p.id
+    // The ask event carries a full request (keyed `id`) while the reply event
+    // names the same permission `permissionID` (opencode <=1.17) or
+    // `requestID` (>=1.18) — each shape carries exactly one of these keys.
+    const id = p.permissionID ?? p.requestID ?? p.id
     if (!id) return
     handlers.onPermissionResolved?.(id)
   }

--- a/test/host/chatview-harness.test.ts
+++ b/test/host/chatview-harness.test.ts
@@ -888,6 +888,31 @@ describe("ChatView harness: waiting-for-input Main status", () => {
     expect(lastMainStatus()).toBe("waiting")
     expect(harness.posted.some((m) => m.type === "permissionResolved")).toBe(false)
   })
+
+  it("routes the opencode >=1.18 shapes: permission.asked and a requestID-keyed reply", async () => {
+    await harness.send({ type: "mounted" })
+    await harness.send({ type: "send", text: "guarded edit" })
+
+    // 1.18 renamed the ask event and dropped `title`; the request carries
+    // `permission` + `patterns` instead (#520).
+    server.push({
+      type: "permission.asked",
+      id: "perm_v2",
+      sessionID: SESSION_ID,
+      permission: "external_directory",
+      patterns: ["/outside/*"],
+      always: ["/outside/*"],
+      tool: { messageID: "msg_1", callID: "call_1" },
+    })
+    await until(() => lastMainStatus() === "waiting")
+    const dialog = harness.posted.find((m) => m.type === "permission" && m.id === "perm_v2")
+    expect(dialog && "title" in dialog ? dialog.title : "").toContain("external_directory")
+
+    // 1.18 replies key the permission `requestID` and the answer `reply`.
+    server.push({ type: "permission.replied", sessionID: SESSION_ID, requestID: "perm_v2", reply: "once" })
+    await until(() => lastMainStatus() === "running")
+    await until(() => harness.posted.some((m) => m.type === "permissionResolved" && m.id === "perm_v2"))
+  })
 })
 
 describe("ChatView harness: errored Main task clears on next turn", () => {


### PR DESCRIPTION
Refs #520 (left open intentionally so the reporter can confirm the fix against their setup).

## Summary

opencode >= 1.18 renamed the permission ask event from `permission.updated` to `permission.asked`, and `permission.replied` now carries `requestID`/`reply` instead of `permissionID`/`response`. The panel routed only the old names, so permission confirmations (e.g. external directory access) never appeared and guarded turns hung on "Working…" until aborted, with unanswered permissions accumulating server-side.

Verified against the opencode source: the current event manifest defines only `permission.asked`/`permission.replied` (`packages/schema/src/v1/permission.ts`), the legacy translation that produced `permission.updated` on `/global/event` is gone, and even the newest `@opencode-ai/sdk` (1.18.18) still ships the stale type names — so an SDK bump cannot fix this; defensive dual routing is the correct shape. The event name already flipped once before (#492 switched in the other direction), hence routing both names permanently.

Two changes in `src/chat/stream.ts`:
- Route `permission.asked` into the same handler as `permission.updated`. The new payload already fits: the handler falls back through `pattern ?? patterns`, `permission ?? type`, and synthesizes the missing `title`.
- Accept the reply's new key: `permissionID ?? requestID ?? id` (each server generation sends exactly one of these).

No change needed on the reply POST: `POST /session/{id}/permissions/{permissionID}` with `{response}` still exists on 1.18.x servers with an unchanged reply enum. All other event names routed by `stream.ts` were checked against the current manifest and still match — only the permission pair flipped.

## Test plan

- [x] New E2E test pushes the 1.18 shapes through the mock server: `permission.asked` (no `title`, with `permission`/`patterns`/`tool`) surfaces the dialog and flips the Main row to waiting; a `requestID`/`reply`-keyed `permission.replied` releases it and posts `permissionResolved`.
- [x] Existing 1.17-shape tests unchanged and passing (both spellings routed).
- [x] `bun run test` — 1344 tests green.
- [x] `bun run check-types` + webview `tsc --noEmit` — both trees clean.
- [x] `bun run compile` — production build green.
- [ ] Live confirmation against a real opencode 1.18.x server is pending — the reporter offered to verify, which is why #520 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
