### PR TITLE
chore(release): 1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.11.1] - 2026-08-13
+
+### Fixed
+- Permission dialogs appear again with opencode server 1.18.x. The server renamed its permission events — the ask event `permission.updated` became `permission.asked`, and replies now carry `requestID`/`reply` instead of `permissionID`/`response` — so any tool call needing authorization (for example external directory access) hung on "Working…" with no dialog until aborted, while unanswered permission requests piled up server-side. The panel now routes both spellings of both events, so older 1.17.x servers keep working too. Thanks to @VinciYan for the report with a complete root-cause analysis (#520, #521).
+
 ## [1.11.0] - 2026-08-12
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
Closes #522

## Summary

Patch release v1.11.1: bumps `package.json` and adds the CHANGELOG entry for the opencode 1.18.x permission-event compatibility fix (#520, #521). Issue #520 stays open deliberately until the reporter confirms the published build against their setup.

## Test plan

- [x] `bun run test` — 1344 tests green (one full-suite run flaked on timeouts under machine load; reran clean twice, including the affected files in isolation).
- [x] `bun run check-types` — clean.
- [x] `bun run compile` — production build green (pre-merge on #521; no source changes since).
- [ ] Post-merge: tag v1.11.1, publish the GitHub release, watch the release workflow through Marketplace + Open VSX publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
