### PR TITLE
chore(release): 1.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.11.2] - 2026-08-14
+
+### Added
+- Agent selection moved into the model picker as a segmented chip row, working exactly like the effort control: `default` plus one chip per selectable agent, a pick applies immediately and keeps the popover open, and the active segment slides over (skipped under reduced motion). This replaces the picker's Agent footer row, which closed the popover into a native QuickPick at the top-center of the window after a blocking fetch. The agent list arrives with the model catalog — rendered instantly, sorted alphabetically, with subagents and opencode's internal agents filtered out — and the command-palette "Select Agent" command is unchanged (#524, #525).
+
+### Changed
+- Inactive chips in the picker's segmented controls (Effort and Agent) now carry a faint fill so each segment reads as a discrete unit. Multi-word agent names have internal spaces, and fully transparent chips made adjacent labels blur into one continuous run of text (#524, #525).
+
 ## [1.11.1] - 2026-08-13
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
Closes #526

## Summary

- Bump `package.json` to 1.11.2
- Add the `## [1.11.2]` CHANGELOG entry: in-panel agent chips in the model picker (#524, #525) and the chip-fill legibility change

## Test plan

- [x] Full checks ran on the feature PR #525 at the same tree (1349/1349 tests, both tsc trees clean, build green); this PR only bumps the version and CHANGELOG
- [ ] Publish workflow green after tagging `v1.11.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)