### PR TITLE
fix(ui): opaque input surfaces for bubbles and composer in translucent-input themes

### DIFF
--- a/test/webview/opaque-surfaces.test.ts
+++ b/test/webview/opaque-surfaces.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const css = readFileSync(path.resolve(__dirname, "../../webview/src/styles.css"), "utf8")
+
+/** Body of the first top-level rule whose selector list is exactly `selector`. */
+function ruleBody(selector: string): string {
+  const open = css.indexOf(`\n${selector} {`)
+  if (open === -1) throw new Error(`rule not found: ${selector}`)
+  const start = open + selector.length + 3
+  const end = css.indexOf("\n}", start)
+  return css.slice(start, end)
+}
+
+function backgroundOf(selector: string): string {
+  const m = ruleBody(selector).match(/(?:^|\n)\s*background:\s*([^;]+);/)
+  if (!m) throw new Error(`no background declaration on ${selector}`)
+  return m[1].replace(/\s+/g, " ").trim()
+}
+
+// `input.background` is not opaque in every theme (#528: a light theme ships
+// it as #0000000D). Anything that floats over the scrolling transcript must
+// paint the composited surface, never the raw token, or the text underneath
+// shows through.
+const FLOATING_SURFACES = [
+  ".msg.role-user",
+  '.msg.role-user.is-editable[data-edit-phase="view"]:hover',
+  '.msg.role-user:not([data-edit-phase="view"])',
+  ".user-edit-layer",
+  ".review-panel",
+  ".promptbox--bottom",
+  ".context-usage-ring::after",
+]
+
+describe("opaque input surfaces (#528)", () => {
+  it("--surface-input layers the input color over the opaque panel ground", () => {
+    const m = css.match(/--surface-input:\s*([^;]+);/)
+    expect(m).not.toBeNull()
+    const value = m![1].replace(/\s+/g, " ").trim()
+    expect(value).toBe(
+      "linear-gradient(0deg, var(--color-bg-input), var(--color-bg-input)), var(--color-bg-panel)",
+    )
+  })
+
+  it.each(FLOATING_SURFACES)("%s paints --surface-input, not the raw input token", (selector) => {
+    const background = backgroundOf(selector)
+    expect(background).toContain("var(--surface-input)")
+    // The surface must be the bottom layer: anything after it would be painted
+    // beneath, and a bare token there would defeat the composite.
+    expect(background.endsWith("var(--surface-input)")).toBe(true)
+    const body = ruleBody(selector)
+    expect(body).not.toMatch(/var\(--color-bg-input\)|var\(--vscode-input-background\)/)
+    expect(body).not.toMatch(/background-color:/)
+  })
+})

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -42,6 +42,7 @@
   --color-fg-muted:     var(--vscode-descriptionForeground);
   --color-bg-input:     var(--vscode-input-background);
   --color-bg-panel:     var(--vscode-sideBar-background);
+  --surface-input:      linear-gradient(0deg, var(--color-bg-input), var(--color-bg-input)), var(--color-bg-panel);
   --color-border:       var(--vscode-input-border, transparent);
   --color-border-focus: var(--vscode-foreground); /* intentional: text colour, not focusBorder blue */
   --color-accent:       var(--vscode-focusBorder);
@@ -1086,10 +1087,9 @@ button:focus-visible {
   top: 0;
   z-index: var(--z-bubble-sticky);
   padding: var(--bubble-padding);
-  /* Solid opaque background so scrolling content underneath never bleeds
-     through, even when a hover/list color is layered on top. */
-  background: var(--color-bg-input);
-  background-color: var(--color-bg-input);
+  /* Opaque surface so scrolling content underneath never bleeds through, even
+     when a hover/list color is layered on top. */
+  background: var(--surface-input);
   border: var(--bubble-border-width) solid var(--color-border);
   border-radius: var(--radius);
   word-break: break-word;
@@ -1244,7 +1244,7 @@ button:focus-visible {
 }
 .msg.role-user.is-editable[data-edit-phase="view"]:hover {
   /* Layer the (possibly semi-transparent) hover color on TOP of the opaque
-     input-background so scrolling text behind the pinned bubble never shows
+     input surface so scrolling text behind the pinned bubble never shows
      through during hover. Without this, on themes where
      --vscode-list-hoverBackground is rgba(...) with low alpha, hover would
      reveal the chat content scrolling beneath the sticky message.
@@ -1252,7 +1252,7 @@ button:focus-visible {
      to the focus/white border while focused. */
   background:
     linear-gradient(0deg, var(--vscode-list-hoverBackground), var(--vscode-list-hoverBackground)),
-    var(--vscode-input-background);
+    var(--surface-input);
   border-color: var(--color-border);
 }
 .msg.role-user.is-editable[data-edit-phase="view"]:focus-visible {
@@ -1271,7 +1271,7 @@ button:focus-visible {
      normal border through `currentColor` for a frame after the overlay closes,
      which reads as a second white-to-gray flash. */
   border: var(--bubble-border-width) solid var(--color-border);
-  background: var(--color-bg-input);
+  background: var(--surface-input);
   box-shadow: none;
   overflow: visible;
   transition: none;
@@ -1293,7 +1293,7 @@ button:focus-visible {
   padding: var(--bubble-padding);
   border: var(--bubble-border-width) solid var(--color-border-focus);
   border-radius: var(--radius);
-  background: var(--color-bg-input);
+  background: var(--surface-input);
   animation: user-edit-border-in 0.18s ease both;
 }
 @keyframes user-edit-border-in {
@@ -1981,7 +1981,7 @@ button:focus-visible {
   padding: 4px 6px;
   border: var(--bubble-border-width) solid var(--vscode-panel-border);
   border-radius: var(--radius);
-  background: var(--color-bg-input);
+  background: var(--surface-input);
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.22);
 }
 .review-panel::after {
@@ -2360,7 +2360,7 @@ button:focus-visible {
   margin: 0;
   border: var(--bubble-border-width) solid var(--color-border);
   border-radius: var(--radius);
-  background: var(--color-bg-input);
+  background: var(--surface-input);
 }
 .promptbox--top {
   margin: 0;
@@ -2560,7 +2560,7 @@ button:focus-visible {
   position: absolute;
   inset: 3px;
   border-radius: var(--radius-pill);
-  background: var(--color-bg-input);
+  background: var(--surface-input);
 }
 
 .context-usage.is-empty .context-usage-ring {


### PR DESCRIPTION
Refs #528 (left open for the reporter to confirm on their theme).

## Summary

- Some light themes define `input.background` with an alpha channel (the reporter's ships `#0000000D`, about 5% black), meant to composite over whatever the field sits on. Stock VS Code themes use opaque values, which is why this never showed up in default setups.
- The sticky user bubble, the docked composer, the review card, the in-place edit overlay, and the context-usage ring painted that token alone. On such a theme the transcript scrolled straight through the pinned question and the composer text was hard to read.
- Adds `--surface-input`: the input color layered over the sideBar ground via a two-layer `background`, and routes every surface that floats over the transcript through it. Opaque themes render identically (the composite of an opaque color over anything is that color).
- Inputs nested inside already-opaque cards (`.history-search`, `.question-custom`, the empty-state composer field, image thumbs) keep the raw token, matching how VS Code renders its own inputs.
- New `test/webview/opaque-surfaces.test.ts` pins the invariant: each floating surface's `background` ends in `var(--surface-input)` and never references the raw input token, and the token itself is layered over `--color-bg-panel`. It fails against the pre-fix stylesheet.

## Repro

Any light theme plus `"workbench.colorCustomizations": { "input.background": "#0000000d" }`, or in the webview devtools:

```js
document.documentElement.style.setProperty("--vscode-input-background", "#0000000d")
```

## Test plan

- [x] `bun run test` (1357/1357, including the 8 new invariant tests)
- [x] `bun run check-types`
- [x] `cd webview && bunx tsc --noEmit`
- [x] `bun run compile`
- [x] New test fails on `main`'s stylesheet, passes on this branch
- [ ] Reporter confirms on their theme (issue stays open until then)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
