### PR TITLE
chore(release): 1.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.11.3] - 2026-08-17
+
+### Fixed
+- The sticky user bubble, the docked composer, the review card, the in-place edit overlay, and the context-usage ring now paint an opaque surface in themes whose `input.background` carries an alpha channel (some light themes ship it as `#0000000D`). On those themes the transcript scrolled straight through the pinned question and the composer text was hard to read; the input color is now layered over the panel ground, which is what VS Code renders for its own fields there and is a no-op for opaque themes (#528, #529).
+
 ## [1.11.2] - 2026-08-14
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
Closes #530

## Summary

- Bumps `package.json` to 1.11.3.
- Adds the `## [1.11.3] - 2026-08-17` CHANGELOG entry covering #529 (opaque input surfaces for translucent-input themes, refs #528).

## Test plan

- [x] Version and CHANGELOG entry match
- [x] `bun run test` / type-checks / build already green on `main` at `9b963e2` (no code changes here)
- [ ] After merge: `gh release create v1.11.3 --target main`, then watch the release workflow publish to the Marketplace and Open VSX

🤖 Generated with [Claude Code](https://claude.com/claude-code)
