### PR TITLE
feat(history): list and adopt opencode sessions from the TUI/web in this project

### DIFF
--- a/src/chat/conversation-manager.ts
+++ b/src/chat/conversation-manager.ts
@@ -116,6 +116,18 @@ export class ConversationManager {
     return this.conversations.find((c) => c.id === id)?.title
   }
 
+  /** Backend session IDs already bound to a saved conversation. */
+  boundSessionIDs(): Set<string> {
+    const ids = new Set<string>()
+    for (const c of this.conversations) if (c.sessionID) ids.add(c.sessionID)
+    return ids
+  }
+
+  /** The saved conversation bound to a backend session, if any. */
+  findBySessionID(sessionID: string): string | undefined {
+    return this.conversations.find((c) => c.sessionID === sessionID)?.id
+  }
+
   summaries(): ConversationSummary[] {
     return this.conversations
       .map((c) => ({ id: c.id, title: c.title, updatedAt: c.updatedAt }))

--- a/src/chat/import-session.ts
+++ b/src/chat/import-session.ts
@@ -1,0 +1,161 @@
+import type { ChatBlock, ChatMessage, ExternalSessionSummary } from "../protocol"
+import { relativeToCwd } from "./paths"
+import { toWire } from "./wire-format"
+import type { ToolUpdate } from "./stream"
+
+/** The slice of the SDK's Session shape this module consumes. */
+export type SessionInfo = {
+  id: string
+  parentID?: string
+  title?: string
+  time?: { created?: number; updated?: number }
+}
+
+/** The slice of a `session.messages()` item this module consumes. */
+export type ServerMessageItem = {
+  info?: {
+    id?: string
+    role?: string
+    summary?: boolean | { title?: string }
+    error?: { name?: string; data?: { message?: string } }
+  }
+  parts?: ServerPart[]
+}
+
+type ServerPart = {
+  type?: string
+  text?: string
+  synthetic?: boolean
+  ignored?: boolean
+  callID?: string
+  tool?: string
+  state?: {
+    status?: string
+    title?: string
+    input?: Record<string, unknown>
+    metadata?: Record<string, unknown>
+    output?: string
+    error?: string
+  }
+  files?: unknown[]
+}
+
+const MAX_EXTERNAL_SESSIONS = 50
+
+/**
+ * Sessions worth offering in the history popover: top-level (subagent child
+ * sessions carry a `parentID`) and not already bound to a saved conversation.
+ * Newest first, capped so a long-lived project doesn't flood the popover.
+ */
+export function externalSessionSummaries(
+  sessions: SessionInfo[],
+  boundSessionIDs: ReadonlySet<string>,
+): ExternalSessionSummary[] {
+  return sessions
+    .filter((s) => s.id && !s.parentID && !boundSessionIDs.has(s.id))
+    .map((s) => ({
+      id: s.id,
+      title: s.title?.trim() || "Untitled session",
+      updatedAt: s.time?.updated ?? s.time?.created ?? 0,
+    }))
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+    .slice(0, MAX_EXTERNAL_SESSIONS)
+}
+
+/**
+ * Rebuild a webview transcript from a server session's message list. The live
+ * flow never does this (it accumulates ChatMessages from SSE deltas and
+ * persists them), so importing a TUI/web session is the one place server
+ * parts are converted wholesale. `id` and `backendID` are both the server
+ * message id — backendID is what the edit/rewind flow keys `session.revert`
+ * on, mirroring how `/fork` re-stamps copied messages.
+ */
+export function importedMessages(items: ServerMessageItem[], cwd: string): ChatMessage[] {
+  const messages: ChatMessage[] = []
+  for (const item of items) {
+    const info = item.info
+    if (!info?.id) continue
+    if (info.role === "user") {
+      const text = textOf(item.parts)
+      if (!text) continue
+      messages.push({
+        id: info.id,
+        role: "user",
+        backendID: info.id,
+        blocks: [{ type: "text", text }],
+      })
+      continue
+    }
+    if (info.role !== "assistant") continue
+    const blocks = assistantBlocks(item.parts ?? [], cwd)
+    const aborted = info.error?.name === "MessageAbortedError"
+    const error = info.error && !aborted
+      ? info.error.data?.message ?? info.error.name ?? "unknown error"
+      : undefined
+    if (!blocks.length && !error) continue
+    messages.push({
+      id: info.id,
+      role: "assistant",
+      backendID: info.id,
+      blocks,
+      ...(info.summary ? { summary: true } : {}),
+      ...(aborted ? { stopped: true } : {}),
+      ...(error ? { error } : {}),
+    })
+  }
+  return messages
+}
+
+function textOf(parts: ServerPart[] | undefined): string {
+  return (parts ?? [])
+    .filter((p) => p.type === "text" && !p.synthetic && !p.ignored && typeof p.text === "string")
+    .map((p) => p.text!)
+    .join("\n\n")
+    .trim()
+}
+
+function assistantBlocks(parts: ServerPart[], cwd: string): ChatBlock[] {
+  const blocks: ChatBlock[] = []
+  for (const part of parts) {
+    switch (part.type) {
+      case "text": {
+        if (part.synthetic || part.ignored || !part.text) break
+        blocks.push({ type: "text", text: part.text })
+        break
+      }
+      case "reasoning": {
+        if (part.text) blocks.push({ type: "reasoning", text: part.text })
+        break
+      }
+      case "tool": {
+        const state = part.state
+        // Only settled states import. A session abandoned mid-turn can carry
+        // pending/running parts, and nothing will ever close them here — a
+        // perpetually-"running" block is exactly what the abort flow's
+        // terminal-closure rule exists to prevent.
+        if (!part.callID || !part.tool || !state) break
+        if (state.status !== "completed" && state.status !== "error") break
+        const update: ToolUpdate = {
+          callID: part.callID,
+          tool: part.tool,
+          status: state.status,
+          title: state.title,
+          input: state.input,
+          metadata: state.metadata,
+          output: state.output,
+          error: state.error,
+        }
+        blocks.push({ type: "tool", update: toWire(update, cwd) })
+        break
+      }
+      case "patch": {
+        const files = (part.files ?? []).filter((f): f is string => typeof f === "string")
+        if (files.length) blocks.push({ type: "patch", files: files.map((f) => relativeToCwd(cwd, f)) })
+        break
+      }
+      default:
+        break
+    }
+  }
+  return blocks
+}

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -24,6 +24,7 @@ import type {
   ChatMessage,
   CommandInfo,
   ConversationMention,
+  ExternalSessionSummary,
   Inbound,
   Outbound,
   ToolUpdate as WireToolUpdate,
@@ -36,6 +37,7 @@ import { BUILTIN_COMMAND_NAMES, withBuiltinCommands } from "./builtin-commands"
 import { BuiltinRunners } from "./builtin-runners"
 import { readContextUsage } from "./context-usage"
 import { adoptStorageIDs, migrateConversationsToWorkspace } from "./conversation-store"
+import { externalSessionSummaries, importedMessages, type SessionInfo } from "./import-session"
 import { ConversationManager } from "./conversation-manager"
 import { ContinuationState, isContinuationToast } from "./continuation-state"
 import { sweepAbortTree, drainAbortTree } from "./abort-tree"
@@ -75,6 +77,12 @@ export class ChatView implements vscode.WebviewViewProvider {
   private sessionID?: string
   private subscription?: Subscription
   private activePermissions = new Map<string, PermissionRequest>()
+  /**
+   * Raw top-level sessions from the last `session.list` fetch. Kept unfiltered
+   * so binding a session locally (import, fork) removes it from the popover's
+   * external section on the next post without a refetch.
+   */
+  private serverSessions: SessionInfo[] = []
   private activeQuestions = new Map<string, QuestionRequest>()
   /**
    * Last (text + variant) pair we surfaced as a toast plus its timestamp.
@@ -434,6 +442,7 @@ export class ChatView implements vscode.WebviewViewProvider {
       type: "conversations",
       conversations: this.manager.summaries(),
       activeID: this.manager.getActiveID(),
+      external: this.externalSummaries(),
     })
     this.post({
       type: "restore",
@@ -448,7 +457,79 @@ export class ChatView implements vscode.WebviewViewProvider {
       type: "conversations",
       conversations: this.manager.summaries(),
       activeID: this.manager.getActiveID(),
+      external: this.externalSummaries(),
     })
+  }
+
+  private externalSummaries(): ExternalSessionSummary[] {
+    return externalSessionSummaries(this.serverSessions, this.manager.boundSessionIDs())
+  }
+
+  /**
+   * Sessions on the opencode server for this project that the panel doesn't
+   * know about — created by the TUI, the web UI, or another client. The panel
+   * is the only surface that can't see them: its conversations live in
+   * workspaceState, not on the server, so without this fetch the asymmetry
+   * reads as lost data to anyone running the TUI alongside.
+   */
+  private async refreshExternalSessions(backend?: Backend) {
+    try {
+      const activeBackend = backend ?? (await this.servers.ensure())
+      const res = await activeBackend.client.session.list({ query: { directory: activeBackend.directory } })
+      if (res.error || !res.data) {
+        log("session list failed", res.error)
+        return
+      }
+      this.serverSessions = res.data as SessionInfo[]
+      this.postConversationsList()
+    } catch (e) {
+      log("session list threw", e)
+    }
+  }
+
+  /**
+   * Adopt a server session into a saved conversation and open it. Mirrors the
+   * `/fork` adoption flow, but the transcript is rebuilt from the server's
+   * message list instead of copied from local state.
+   */
+  private async importSession(sessionID: string) {
+    // Double-click / stale-popover race: if something already bound this
+    // session (an earlier import, a fork), open that conversation instead of
+    // minting a duplicate.
+    const existing = this.manager.findBySessionID(sessionID)
+    if (existing) {
+      await this.selectConversation(existing)
+      return
+    }
+    try {
+      const backend = await this.servers.ensure()
+      const res = await backend.client.session.messages({
+        path: { id: sessionID },
+        query: { directory: backend.directory },
+      })
+      if (res.error || !res.data) {
+        log("import session: messages fetch failed", res.error)
+        void vscode.window.showErrorMessage("Failed to load the opencode session.")
+        return
+      }
+      const messages = importedMessages(res.data as Parameters<typeof importedMessages>[0], backend.directory)
+      const title =
+        this.serverSessions.find((sess) => sess.id === sessionID)?.title?.trim() || "Imported session"
+
+      this.resetSessionState()
+      const conversation = this.manager.add(title.slice(0, 80))
+      this.manager.setActiveID(conversation.id)
+      this.manager.updateActive((c) => ({ ...c, sessionID, messages }))
+      this.applyActiveSnapshot()
+      await this.manager.flushPersist()
+      this.sendConversationState()
+      this.post({ type: "contextUsage", usage: undefined })
+      void this.refreshContextUsage(backend)
+      this.reconcileOnConversationEntry()
+    } catch (e) {
+      log("import session threw", e)
+      void vscode.window.showErrorMessage("Failed to load the opencode session.")
+    }
   }
 
   /**
@@ -978,6 +1059,7 @@ export class ChatView implements vscode.WebviewViewProvider {
           this.post({ type: "connected", connected: true })
           void this.refreshCommands(backend)
           void this.refreshModelCatalog(backend)
+          void this.refreshExternalSessions(backend)
           if (this.sessionID) void this.refreshContextUsage(backend)
         } catch (e) {
           this.post({ type: "connected", connected: false, error: (e as Error).message })
@@ -1038,6 +1120,12 @@ export class ChatView implements vscode.WebviewViewProvider {
         return
       case "openConversation":
         await this.selectConversation(msg.id)
+        return
+      case "importSession":
+        await this.importSession(msg.sessionID)
+        return
+      case "refreshSessions":
+        void this.refreshExternalSessions()
         return
       case "renameConversation":
         await this.renameConversation(msg.id, msg.title)

--- a/test/host/chatview-harness.test.ts
+++ b/test/host/chatview-harness.test.ts
@@ -1101,3 +1101,86 @@ describe("ChatView harness: model catalog", () => {
     expect(setAgent).toHaveBeenLastCalledWith(undefined)
   })
 })
+
+describe("ChatView harness: external session interop", () => {
+  it("lists top-level unbound server sessions and adopts one on importSession", async () => {
+    server.setSessions([
+      { id: "ses_tui", title: "TUI refactor", time: { created: 1, updated: 2000 } },
+      { id: "ses_kid", parentID: "ses_tui", title: "subagent", time: { updated: 3000 } },
+    ])
+    server.setSessionMessages("ses_tui", [
+      { info: { id: "msg_u1", role: "user", sessionID: "ses_tui" }, parts: [{ type: "text", text: "refactor this" }] },
+      {
+        info: { id: "msg_a1", role: "assistant", sessionID: "ses_tui" },
+        parts: [
+          {
+            type: "tool",
+            callID: "call_1",
+            tool: "edit",
+            state: { status: "completed", title: "edit", input: { filePath: "/ws/a.ts" }, output: "ok" },
+          },
+          { type: "text", text: "done" },
+        ],
+      },
+    ])
+    await harness.send({ type: "mounted" })
+
+    // The mounted handshake fetches the session list; the child session and
+    // (later) bound sessions never reach the wire.
+    await until(() =>
+      harness.posted.some(
+        (m) => m.type === "conversations" && (m.external ?? []).some((s) => s.id === "ses_tui"),
+      ),
+    )
+    const withExternal = harness.posted.filter((m) => m.type === "conversations" && m.external?.length)
+    const external = withExternal.at(-1)!.type === "conversations" ? withExternal.at(-1)!.external : undefined
+    expect(external).toEqual([{ id: "ses_tui", title: "TUI refactor", updatedAt: 2000 }])
+
+    await harness.send({ type: "importSession", sessionID: "ses_tui" })
+
+    // Adopted: a saved conversation bound to the session, transcript rebuilt.
+    const adopted = savedConversations().find((c) => c.sessionID === "ses_tui")
+    expect(adopted).toBeDefined()
+    expect(adopted!.title).toBe("TUI refactor")
+    expect(adopted!.messages.map((m) => m.id)).toEqual(["msg_u1", "msg_a1"])
+    expect(adopted!.messages[1]!.blocks.map((b) => b.type)).toEqual(["tool", "text"])
+    expect(harness.chatView.activeConversationID()).toBe(adopted!.id)
+
+    // The restore post carries the rebuilt transcript to the webview.
+    const restore = harness.posted.filter((m) => m.type === "restore").at(-1)!
+    expect(restore.type === "restore" && restore.messages.map((m) => m.id)).toEqual(["msg_u1", "msg_a1"])
+
+    // Once bound, the session drops out of the external section.
+    const lastConversations = harness.posted.filter((m) => m.type === "conversations").at(-1)!
+    expect(lastConversations.type === "conversations" && lastConversations.external).toEqual([])
+  })
+
+  it("importSession for an already-bound session opens the existing conversation", async () => {
+    server.setSessions([{ id: "ses_tui", title: "TUI chat", time: { updated: 10 } }])
+    server.setSessionMessages("ses_tui", [
+      { info: { id: "msg_u1", role: "user", sessionID: "ses_tui" }, parts: [{ type: "text", text: "hi" }] },
+    ])
+    await harness.send({ type: "mounted" })
+    await harness.send({ type: "importSession", sessionID: "ses_tui" })
+    const first = savedConversations().filter((c) => c.sessionID === "ses_tui")
+    expect(first).toHaveLength(1)
+
+    // Switch away, then import the same session again — no duplicate.
+    await harness.send({ type: "createConversation" })
+    await harness.send({ type: "importSession", sessionID: "ses_tui" })
+    const again = savedConversations().filter((c) => c.sessionID === "ses_tui")
+    expect(again).toHaveLength(1)
+    expect(harness.chatView.activeConversationID()).toBe(again[0]!.id)
+  })
+
+  it("refreshSessions re-fetches the list on demand", async () => {
+    await harness.send({ type: "mounted" })
+    server.setSessions([{ id: "ses_late", title: "Started after mount", time: { updated: 99 } }])
+    await harness.send({ type: "refreshSessions" })
+    await until(() =>
+      harness.posted.some(
+        (m) => m.type === "conversations" && (m.external ?? []).some((s) => s.id === "ses_late"),
+      ),
+    )
+  })
+})

--- a/test/host/import-session.test.ts
+++ b/test/host/import-session.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest"
+import { externalSessionSummaries, importedMessages } from "../../src/chat/import-session"
+
+describe("externalSessionSummaries", () => {
+  const bound = new Set(["ses_bound"])
+  it("filters child sessions and already-bound sessions, sorts newest first", () => {
+    const out = externalSessionSummaries(
+      [
+        { id: "ses_old", title: "Old chat", time: { created: 100, updated: 200 } },
+        { id: "ses_child", parentID: "ses_old", title: "subagent", time: { updated: 999 } },
+        { id: "ses_bound", title: "Panel chat", time: { updated: 900 } },
+        { id: "ses_new", title: "Fresh TUI chat", time: { updated: 500 } },
+      ],
+      bound,
+    )
+    expect(out).toEqual([
+      { id: "ses_new", title: "Fresh TUI chat", updatedAt: 500 },
+      { id: "ses_old", title: "Old chat", updatedAt: 200 },
+    ])
+  })
+
+  it("falls back to created time and an Untitled label", () => {
+    const out = externalSessionSummaries([{ id: "ses_x", title: "  ", time: { created: 42 } }], new Set())
+    expect(out).toEqual([{ id: "ses_x", title: "Untitled session", updatedAt: 42 }])
+  })
+
+  it("caps the list", () => {
+    const many = Array.from({ length: 80 }, (_, i) => ({
+      id: `ses_${i}`,
+      title: `chat ${i}`,
+      time: { updated: i },
+    }))
+    expect(externalSessionSummaries(many, new Set())).toHaveLength(50)
+  })
+})
+
+describe("importedMessages", () => {
+  it("rebuilds user and assistant messages with server ids as both id and backendID", () => {
+    const out = importedMessages(
+      [
+        {
+          info: { id: "msg_u1", role: "user" },
+          parts: [
+            { type: "text", text: "fix the bug" },
+            { type: "text", text: "injected context", synthetic: true },
+          ],
+        },
+        {
+          info: { id: "msg_a1", role: "assistant" },
+          parts: [
+            { type: "reasoning", text: "thinking" },
+            { type: "step-start" },
+            {
+              type: "tool",
+              callID: "call_1",
+              tool: "read",
+              state: { status: "completed", title: "read file", input: { filePath: "/ws/a.ts" }, output: "ok" },
+            },
+            { type: "text", text: "done" },
+          ],
+        },
+      ],
+      "/ws",
+    )
+    expect(out).toHaveLength(2)
+    expect(out[0]).toMatchObject({
+      id: "msg_u1",
+      backendID: "msg_u1",
+      role: "user",
+      blocks: [{ type: "text", text: "fix the bug" }],
+    })
+    expect(out[1]!.blocks.map((b) => b.type)).toEqual(["reasoning", "tool", "text"])
+    const tool = out[1]!.blocks[1]
+    expect(tool.type === "tool" && tool.update.input?.filePath).toBe("a.ts")
+  })
+
+  it("drops unsettled tool parts from an interrupted session", () => {
+    const out = importedMessages(
+      [
+        {
+          info: { id: "msg_a", role: "assistant" },
+          parts: [
+            { type: "tool", callID: "c1", tool: "bash", state: { status: "running", input: {} } },
+            { type: "tool", callID: "c2", tool: "bash", state: { status: "error", input: {}, error: "boom" } },
+          ],
+        },
+      ],
+      "/ws",
+    )
+    expect(out[0]!.blocks).toHaveLength(1)
+    const block = out[0]!.blocks[0]
+    expect(block.type === "tool" && block.update.status).toBe("error")
+  })
+
+  it("maps MessageAbortedError to the Stopped badge, real errors to error text", () => {
+    const out = importedMessages(
+      [
+        {
+          info: { id: "msg_stop", role: "assistant", error: { name: "MessageAbortedError" } },
+          parts: [{ type: "text", text: "partial" }],
+        },
+        {
+          info: { id: "msg_err", role: "assistant", error: { name: "ApiError", data: { message: "rate limit" } } },
+          parts: [{ type: "text", text: "partial" }],
+        },
+      ],
+      "/ws",
+    )
+    expect(out[0]).toMatchObject({ stopped: true })
+    expect(out[0]!.error).toBeUndefined()
+    expect(out[1]).toMatchObject({ error: "rate limit" })
+  })
+
+  it("keeps the compaction summary flag and skips empty messages", () => {
+    const out = importedMessages(
+      [
+        { info: { id: "msg_sum", role: "assistant", summary: true }, parts: [{ type: "text", text: "recap" }] },
+        { info: { id: "msg_empty", role: "assistant" }, parts: [{ type: "step-start" }] },
+        { info: { id: "msg_ctx", role: "user" }, parts: [{ type: "text", text: "ctx", synthetic: true }] },
+      ],
+      "/ws",
+    )
+    expect(out).toHaveLength(1)
+    expect(out[0]).toMatchObject({ id: "msg_sum", summary: true })
+  })
+
+  it("relativizes patch part files against the backend directory", () => {
+    const out = importedMessages(
+      [
+        {
+          info: { id: "msg_p", role: "assistant" },
+          parts: [{ type: "patch", files: ["/ws/src/a.ts", "/ws/b.ts"] }],
+        },
+      ],
+      "/ws",
+    )
+    expect(out[0]!.blocks[0]).toEqual({ type: "patch", files: ["src/a.ts", "b.ts"] })
+  })
+})

--- a/test/host/mock-opencode-server.ts
+++ b/test/host/mock-opencode-server.ts
@@ -79,6 +79,10 @@ export type MockOpencodeServer = {
   setProviders: (providers: Array<Record<string, unknown>>) => void
   /** Configure what GET /agent returns (default: one primary agent). */
   setAgents: (agents: Array<Record<string, unknown>>) => void
+  /** Configure what GET /session (session.list) returns (default: none). */
+  setSessions: (sessions: Array<Record<string, unknown>>) => void
+  /** Configure what GET /session/{id}/message (session.messages) returns for one session. */
+  setSessionMessages: (sessionID: string, items: Array<Record<string, unknown>>) => void
   /**
    * Configure what GET /session/status returns. Pass `undefined` to clear
    * the entry. Tests use this to drive the watchdog's recovery path.
@@ -124,6 +128,8 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
   const commandCalls: Array<{ sessionID: string; body: unknown }> = []
   let commands: Array<Record<string, unknown>> = []
   let providers: Array<Record<string, unknown>> = []
+  let sessions: Array<Record<string, unknown>> = []
+  const sessionMessages = new Map<string, Array<Record<string, unknown>>>()
   let agents: Array<Record<string, unknown>> = [
     {
       name: "default",
@@ -211,6 +217,19 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
     // Custom command list
     if (path === "/command" && req.method === "GET") {
       reply(res, 200, commands)
+      return
+    }
+
+    // Session list (session.list)
+    if (path === "/session" && req.method === "GET") {
+      reply(res, 200, sessions)
+      return
+    }
+
+    // Session transcript (session.messages)
+    const messagesMatch = path.match(/^\/session\/([^/]+)\/message$/)
+    if (messagesMatch && req.method === "GET") {
+      reply(res, 200, sessionMessages.get(messagesMatch[1]!) ?? [])
       return
     }
 
@@ -472,6 +491,12 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
     },
     setAgents(next) {
       agents = next
+    },
+    setSessions(next) {
+      sessions = next
+    },
+    setSessionMessages(sessionID, items) {
+      sessionMessages.set(sessionID, items)
     },
     setSessionStatus(sessionID, status) {
       if (status) sessionStatuses.set(sessionID, status)

--- a/test/webview/statusbar.test.tsx
+++ b/test/webview/statusbar.test.tsx
@@ -694,3 +694,97 @@ describe("AgentActivity", () => {
     expect(screen.getByText(/error · boom · 12s/)).toBeInTheDocument()
   })
 })
+
+describe("StatusBar: external sessions in the history popover", () => {
+  const conversations = [{ id: "c1", title: "Panel chat", updatedAt: Date.now() }]
+  const external = [
+    { id: "ses_tui", title: "TUI refactor", updatedAt: Date.now() - 60_000 },
+    { id: "ses_web", title: "Web session", updatedAt: Date.now() - 120_000 },
+  ]
+
+  it("renders the section with import rows and no rename/delete actions", async () => {
+    const user = userEvent.setup()
+    const onImportSession = vi.fn()
+    render(
+      <StatusBar
+        {...baseProps}
+        conversations={conversations}
+        externalSessions={external}
+        onImportSession={onImportSession}
+        onRefreshSessions={vi.fn()}
+      />,
+    )
+    await user.click(screen.getByRole("button", { name: /chat history/i }))
+    expect(screen.getByText("Also in this project")).toBeInTheDocument()
+    const row = screen.getByText("TUI refactor").closest("button")!
+    expect(row.closest(".history-item")?.querySelector(".history-action")).toBeNull()
+
+    await user.click(row)
+    expect(onImportSession).toHaveBeenCalledWith("ses_tui")
+    // Importing closes the popover, like opening a local conversation does.
+    expect(screen.queryByText("Also in this project")).not.toBeInTheDocument()
+  })
+
+  it("re-fetches the session list when the popover opens", async () => {
+    const user = userEvent.setup()
+    const onRefreshSessions = vi.fn()
+    render(
+      <StatusBar
+        {...baseProps}
+        conversations={conversations}
+        externalSessions={external}
+        onImportSession={vi.fn()}
+        onRefreshSessions={onRefreshSessions}
+      />,
+    )
+    expect(onRefreshSessions).not.toHaveBeenCalled()
+    await user.click(screen.getByRole("button", { name: /chat history/i }))
+    expect(onRefreshSessions).toHaveBeenCalledTimes(1)
+  })
+
+  it("search filters external rows too, and the section hides when nothing matches", async () => {
+    const user = userEvent.setup()
+    const manyLocal = [
+      { id: "c1", title: "Panel chat one", updatedAt: Date.now() },
+      { id: "c2", title: "Panel chat two", updatedAt: Date.now() },
+      { id: "c3", title: "Panel chat three", updatedAt: Date.now() },
+    ]
+    render(
+      <StatusBar
+        {...baseProps}
+        conversations={manyLocal}
+        externalSessions={external}
+        onImportSession={vi.fn()}
+        onRefreshSessions={vi.fn()}
+      />,
+    )
+    await user.click(screen.getByRole("button", { name: /chat history/i }))
+    // The search box keys off the combined local + external count.
+    const search = screen.getByPlaceholderText("Search chats…")
+
+    await user.type(search, "TUI")
+    expect(screen.getByText("TUI refactor")).toBeInTheDocument()
+    expect(screen.queryByText("Web session")).not.toBeInTheDocument()
+    expect(screen.queryByText("Panel chat one")).not.toBeInTheDocument()
+
+    await user.clear(search)
+    await user.type(search, "Panel")
+    expect(screen.queryByText("Also in this project")).not.toBeInTheDocument()
+    expect(screen.getByText("Panel chat one")).toBeInTheDocument()
+  })
+
+  it("hides the section when there are no external sessions", async () => {
+    const user = userEvent.setup()
+    render(
+      <StatusBar
+        {...baseProps}
+        conversations={conversations}
+        externalSessions={[]}
+        onImportSession={vi.fn()}
+        onRefreshSessions={vi.fn()}
+      />,
+    )
+    await user.click(screen.getByRole("button", { name: /chat history/i }))
+    expect(screen.queryByText("Also in this project")).not.toBeInTheDocument()
+  })
+})

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -24,6 +24,8 @@ export default function App() {
     abort,
     newSession,
     openConversation,
+    importSession,
+    refreshSessions,
     renameConversation,
     deleteConversation,
     setAgent,
@@ -247,6 +249,7 @@ export default function App() {
         selection={state.selection}
         modelCatalog={state.modelCatalog}
         conversations={state.conversations}
+        externalSessions={state.externalSessions}
         activeConversationID={state.conversationID}
         activePopover={activeHeaderPopover}
         onActivePopoverChange={setActiveHeaderPopover}
@@ -255,6 +258,8 @@ export default function App() {
         onRefreshModels={refreshModels}
         onCreateConversation={newSession}
         onOpenConversation={openConversation}
+        onImportSession={importSession}
+        onRefreshSessions={refreshSessions}
         onRenameConversation={renameConversation}
         onDeleteConversation={deleteConversation}
       />

--- a/webview/src/components/StatusBar.tsx
+++ b/webview/src/components/StatusBar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type Dispatch, type SetStateAction } from "react"
-import type { ConversationSummary, ModelCatalogInfo, Selection } from "../protocol"
+import type { ConversationSummary, ExternalSessionSummary, ModelCatalogInfo, Selection } from "../protocol"
 import { useDismissableMenu } from "../hooks/useDismissableMenu"
 import { StatusIndicator, type StatusIndicatorKind } from "./StatusIndicator"
 import { ModelPicker } from "./ModelPicker"
@@ -14,6 +14,7 @@ type Props = {
   selection: Selection
   modelCatalog?: ModelCatalogInfo
   conversations: ConversationSummary[]
+  externalSessions?: ExternalSessionSummary[]
   activeConversationID?: string
   activePopover?: HeaderPopoverID | null
   onActivePopoverChange?: HeaderPopoverSetter
@@ -22,6 +23,8 @@ type Props = {
   onRefreshModels: () => void
   onCreateConversation: () => void
   onOpenConversation: (id: string) => void
+  onImportSession?: (sessionID: string) => void
+  onRefreshSessions?: () => void
   onRenameConversation: (id: string, title: string) => void
   onDeleteConversation: (id: string) => void
 }
@@ -33,6 +36,7 @@ export function StatusBar({
   selection,
   modelCatalog,
   conversations,
+  externalSessions,
   activeConversationID,
   activePopover,
   onActivePopoverChange,
@@ -41,6 +45,8 @@ export function StatusBar({
   onRefreshModels,
   onCreateConversation,
   onOpenConversation,
+  onImportSession,
+  onRefreshSessions,
   onRenameConversation,
   onDeleteConversation,
 }: Props) {
@@ -90,12 +96,15 @@ export function StatusBar({
       </button>
       <ChatHistoryMenu
         conversations={conversations}
+        external={externalSessions ?? []}
         activeID={activeConversationID}
         activeTitle={active?.title}
         open={currentPopover === "history"}
         onOpenChange={(open) => setPopoverOpen("history", open)}
         onCreate={onCreateConversation}
         onOpen={onOpenConversation}
+        onImport={onImportSession}
+        onRefreshExternal={onRefreshSessions}
         onRename={onRenameConversation}
         onDelete={onDeleteConversation}
       />
@@ -105,22 +114,28 @@ export function StatusBar({
 
 function ChatHistoryMenu({
   conversations,
+  external,
   activeID,
   activeTitle,
   open,
   onOpenChange,
   onCreate,
   onOpen,
+  onImport,
+  onRefreshExternal,
   onRename,
   onDelete,
 }: {
   conversations: ConversationSummary[]
+  external: ExternalSessionSummary[]
   activeID?: string
   activeTitle?: string
   open: boolean
   onOpenChange: (open: boolean) => void
   onCreate: () => void
   onOpen: (id: string) => void
+  onImport?: (sessionID: string) => void
+  onRefreshExternal?: () => void
   onRename: (id: string, title: string) => void
   onDelete: (id: string) => void
 }) {
@@ -134,7 +149,12 @@ function ChatHistoryMenu({
     if (!open) {
       setQuery("")
       setConfirmDeleteID(undefined)
+      return
     }
+    // Stale-while-revalidate: the last known external list renders instantly,
+    // and opening the popover re-fetches so TUI sessions started since the
+    // panel mounted show up.
+    onRefreshExternal?.()
   }, [open])
 
   useEffect(() => {
@@ -170,7 +190,10 @@ function ChatHistoryMenu({
   const filtered = query.trim()
     ? conversations.filter((c) => c.title.toLowerCase().includes(query.trim().toLowerCase()))
     : conversations
-  const showSearch = conversations.length >= 5
+  const filteredExternal = query.trim()
+    ? external.filter((s) => s.title.toLowerCase().includes(query.trim().toLowerCase()))
+    : external
+  const showSearch = conversations.length + external.length >= 5
 
   return (
     <div className="history-menu" ref={ref}>
@@ -274,6 +297,31 @@ function ChatHistoryMenu({
                 </div>
               )
             })}
+            {filteredExternal.length > 0 && onImport && (
+              <>
+                <div
+                  className="history-section-label"
+                  title="opencode sessions in this project from the TUI, web UI, or another client. Opening one saves it as a conversation here."
+                >
+                  Also in this project
+                </div>
+                {filteredExternal.map((session) => (
+                  <div className="history-item is-external" key={session.id}>
+                    <button
+                      className="history-open"
+                      onClick={() => {
+                        close()
+                        onImport(session.id)
+                      }}
+                      title={session.title}
+                    >
+                      <span className="history-title">{session.title}</span>
+                      <span className="history-date">{formatUpdated(session.updatedAt)}</span>
+                    </button>
+                  </div>
+                ))}
+              </>
+            )}
           </div>
         </div>
       )}

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -10,6 +10,7 @@ import type {
   ContextUsage,
   ConversationMention,
   ConversationSummary,
+  ExternalSessionSummary,
   DirEntry,
   EditorContextRef,
   FileSearchHit,
@@ -66,6 +67,7 @@ export type ChatState = {
    */
   modelCatalog?: ModelCatalogInfo
   conversations: ConversationSummary[]
+  externalSessions: ExternalSessionSummary[]
   conversationID?: string
   contextUsage?: ContextUsage
   /** Workspace opencode commands for the `/` picker (pushed by the host). */
@@ -110,6 +112,7 @@ const initial: ChatState = {
   continuationPending: false,
   selection: {},
   conversations: [],
+  externalSessions: [],
   commands: [],
   messages: [],
   reviewHunks: {},
@@ -200,7 +203,14 @@ export function reducer(state: ChatState, action: Action): ChatState {
     case "setComposerText":
       return { ...state, injectedText: { text: action.text, nonce: (state.injectedText?.nonce ?? 0) + 1 } }
     case "conversations":
-      return { ...state, conversations: action.conversations, conversationID: action.activeID }
+      return {
+        ...state,
+        conversations: action.conversations,
+        conversationID: action.activeID,
+        // Posts that predate a session-list fetch omit `external` — keep the
+        // last known list rather than flashing the section empty.
+        externalSessions: action.external ?? state.externalSessions,
+      }
     case "restore":
       // Clear any pending composer inject — a conversation switch invalidates it.
       // `/undo` posts `restore` then `setComposerText`, so its restore re-sets it.
@@ -560,6 +570,12 @@ export function useChatState() {
     },
     openConversation(id: string) {
       vscode.post({ type: "openConversation", id })
+    },
+    importSession(sessionID: string) {
+      vscode.post({ type: "importSession", sessionID })
+    },
+    refreshSessions() {
+      vscode.post({ type: "refreshSessions" })
     },
     renameConversation(id: string, title: string) {
       vscode.post({ type: "renameConversation", id, title })

--- a/webview/src/protocol.ts
+++ b/webview/src/protocol.ts
@@ -140,6 +140,17 @@ export type ConversationSummary = {
 }
 
 /**
+ * An opencode session that exists on the server for this project directory
+ * but has no saved conversation in the panel (created by the opencode TUI,
+ * web UI, or another client). `id` is the backend session ID.
+ */
+export type ExternalSessionSummary = {
+  id: string
+  title: string
+  updatedAt: number
+}
+
+/**
  * A past-conversation @-mention: the chip label exactly as it appears in the
  * message text, bound to the conversation it references. Carried as a pair
  * end to end so the edit flow restores label→id bindings by lookup —
@@ -452,7 +463,7 @@ export type Outbound =
   | { type: "modelCatalog"; catalog: ModelCatalogInfo }
   | { type: "contextUsage"; usage?: ContextUsage }
   | { type: "commands"; commands: CommandInfo[] }
-  | { type: "conversations"; conversations: ConversationSummary[]; activeID?: string }
+  | { type: "conversations"; conversations: ConversationSummary[]; activeID?: string; external?: ExternalSessionSummary[] }
   | { type: "restore"; conversationID: string; messages: ChatMessage[]; reviewHunks?: Record<string, ReviewHunkState> }
   | { type: "context"; ref: EditorContextRef }
   | { type: "userMessage"; id: string; text: string; ref?: EditorContextRef; backendID?: string; attachments?: Attachment[]; mentions?: string[]; conversationMentions?: ConversationMention[]; context?: PromptContextManifest }
@@ -514,6 +525,10 @@ export type Inbound =
   | { type: "abort" }
   | { type: "createConversation" }
   | { type: "openConversation"; id: string }
+  /** Adopt an opencode session (from the TUI/web) into a saved conversation and open it. */
+  | { type: "importSession"; sessionID: string }
+  /** Re-fetch the server's session list (history popover opening). */
+  | { type: "refreshSessions" }
   | { type: "renameConversation"; id: string; title: string }
   | { type: "deleteConversation"; id: string }
   | { type: "apply"; code: string; language?: string }

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -810,6 +810,18 @@ button:focus-visible {
   color: var(--vscode-descriptionForeground);
   font-size: 12px;
 }
+/* Divider heading for the "Also in this project" external-session section,
+   styled like the picker's EFFORT/AGENT group labels. */
+.history-section-label {
+  margin-top: 6px;
+  padding: 8px 7px 2px;
+  border-top: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
+  color: var(--vscode-descriptionForeground);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
 .history-item {
   position: relative;
   display: grid;


### PR DESCRIPTION
Closes #534

## Summary

- **Host**: `refreshExternalSessions` fetches `session.list` for the backend directory (mounted handshake + a new `refreshSessions` inbound fired when the history popover opens). The raw list is kept unfiltered on `ChatView`; `externalSessionSummaries` (new pure module `src/chat/import-session.ts`) filters out subagent children (`parentID`) and sessions bound to a saved conversation at post time, so an import removes the row without a refetch. Newest first, capped at 50.
- **Import**: `importSession` rebuilds the transcript from `session.messages` via `importedMessages` — text (synthetic/ignored parts skipped), reasoning, settled tool calls through the existing `toWire` path-rewrite, patch files relativized. Server message ids become both `id` and `backendID` (mirroring `/fork`'s re-stamp) so edit/rewind works on imported turns. Unsettled tool parts are dropped (a session abandoned mid-turn must not import perpetually-"running" blocks); `MessageAbortedError` maps to the Stopped badge, real errors keep their message. Double-import races open the existing bound conversation instead of duplicating.
- **Webview**: the history popover renders an "Also in this project" section below the local list — import-only rows (no rename/delete), the search box filters both lists, and opening the popover re-fetches stale-while-revalidate style.
- **Protocol**: `conversations` gains optional `external`; new inbound `importSession` / `refreshSessions`. Posts that omit `external` keep the last known list instead of flashing the section empty.
- **Mock server**: `setSessions` / `setSessionMessages` scripting hooks + `GET /session` and `GET /session/{id}/message` routes.

## Test plan

- [x] `bun run test` — 1372/1372 (15 new: 8 converter, 3 harness end-to-end incl. adopt + no-duplicate + on-demand refresh, 4 popover)
- [x] `bun run check-types` and `cd webview && bunx tsc --noEmit`
- [x] `bun run compile`
- [ ] Visual pass against a real TUI session (start `opencode` in a project, open the panel's history popover, import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
