### PR TITLE
feat(chat): badge and notify when a permission or question arrives while hidden

### DIFF
--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -235,6 +235,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     // turn's Main row on `waiting` (syncAgentWaitState counts these maps).
     this.activePermissions.clear()
     this.activeQuestions.clear()
+    this.syncAttention()
     this.subagentDispatch.clearMainTaskID()
     this.post({ type: "sessionIdle" })
     void this.manager.flushPersist()
@@ -260,6 +261,44 @@ export class ChatView implements vscode.WebviewViewProvider {
   private syncAgentWaitState() {
     const pending = this.activePermissions.size + this.activeQuestions.size
     void this.subagentDispatch.setMainWaiting(pending > 0)
+    this.syncAttention()
+  }
+
+  /**
+   * A permission/question raised while the panel is hidden blocks the turn
+   * with nothing on screen to answer it — opencode just waits. Mirror the
+   * pending count onto the view container's badge so the activity bar shows
+   * something is stuck on the user. Cleared the moment the view is visible
+   * (the dialog itself is the affordance then) or the count drops to zero.
+   */
+  private syncAttention() {
+    const view = this.view
+    if (!view) return
+    const pending = this.activePermissions.size + this.activeQuestions.size
+    if (pending > 0 && !view.visible) {
+      view.badge = {
+        value: pending,
+        tooltip: pending === 1 ? "1 request is waiting for your input" : `${pending} requests are waiting for your input`,
+      }
+      return
+    }
+    view.badge = undefined
+    if (view.visible) this.attentionToastShown = false
+  }
+
+  /**
+   * One toast per hidden stretch (reset when the view becomes visible), so a
+   * permission storm doesn't stack notifications. The badge carries the count.
+   */
+  private attentionToastShown = false
+
+  private maybeNotifyHidden(message: string) {
+    const view = this.view
+    if (!view || view.visible || this.attentionToastShown) return
+    this.attentionToastShown = true
+    void Promise.resolve(vscode.window.showInformationMessage(message, "Open Panel")).then((choice) => {
+      if (choice === "Open Panel") this.focus()
+    })
   }
 
   async resolveWebviewView(view: vscode.WebviewView) {
@@ -283,6 +322,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     }
     view.webview.onDidReceiveMessage((msg: Inbound) => this.onMessage(msg))
     view.onDidDispose(() => this.dispose())
+    view.onDidChangeVisibility(() => this.syncAttention())
 
     vscode.window.onDidChangeActiveTextEditor(() => {
       this.pushContext()
@@ -561,6 +601,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.redoStack = []
     this.activePermissions.clear()
     this.activeQuestions.clear()
+    this.syncAttention()
   }
 
   private async selectConversation(id: string) {
@@ -1324,6 +1365,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     // turn's waiting computation in syncAgentWaitState.
     this.activePermissions.clear()
     this.activeQuestions.clear()
+    this.syncAttention()
     void this.subagentDispatch.recordMainTaskFinish("cancelled")
 
     // Tear down the tracker's local view of the subagent tree first.
@@ -1979,6 +2021,7 @@ export class ChatView implements vscode.WebviewViewProvider {
         if (this.aborting) return
         this.activePermissions.set(perm.id, perm)
         this.syncAgentWaitState()
+        this.maybeNotifyHidden(`OpenCode Panel is waiting for permission: ${perm.title}`)
         this.post({
           type: "permission",
           id: perm.id,
@@ -1997,6 +2040,7 @@ export class ChatView implements vscode.WebviewViewProvider {
         if (this.aborting) return
         this.activeQuestions.set(q.id, q)
         this.syncAgentWaitState()
+        this.maybeNotifyHidden("OpenCode Panel is waiting for you to answer a question.")
         this.post({
           type: "question",
           id: q.id,

--- a/test/host/chatview-harness.test.ts
+++ b/test/host/chatview-harness.test.ts
@@ -66,10 +66,15 @@ function makeFakeWebviewView() {
       disposeCb = cb
       return { dispose: vi.fn() }
     },
-    onDidChangeVisibility: () => ({ dispose: vi.fn() }),
+    onDidChangeVisibility: (cb: () => void) => {
+      visibilityCb = cb
+      return { dispose: vi.fn() }
+    },
     visible: true,
+    badge: undefined as { value: number; tooltip: string } | undefined,
     show: vi.fn(),
   }
+  let visibilityCb: (() => void) | undefined
   return {
     view: view as unknown as vscode.WebviewView,
     posted,
@@ -77,6 +82,11 @@ function makeFakeWebviewView() {
     // promise, so awaiting this awaits the full host-side handling.
     send: (msg: Inbound) => Promise.resolve(receive?.(msg)),
     disposeView: () => disposeCb?.(),
+    setVisible: (visible: boolean) => {
+      view.visible = visible
+      visibilityCb?.()
+    },
+    badge: () => view.badge,
   }
 }
 
@@ -94,6 +104,8 @@ let harness: {
   posted: Outbound[]
   send: (msg: Inbound) => Promise<unknown>
   disposeView: () => void
+  setVisible: (visible: boolean) => void
+  badge: () => { value: number; tooltip: string } | undefined
   workspaceState: Memento
   servers: ServerManager
   taskStore: AgentTaskStore
@@ -143,7 +155,7 @@ beforeEach(async () => {
   )
   const fake = makeFakeWebviewView()
   await chatView.resolveWebviewView(fake.view)
-  harness = { chatView, posted: fake.posted, send: fake.send, disposeView: fake.disposeView, workspaceState, servers, taskStore, prefs }
+  harness = { chatView, posted: fake.posted, send: fake.send, disposeView: fake.disposeView, setVisible: fake.setVisible, badge: fake.badge, workspaceState, servers, taskStore, prefs }
 })
 
 afterEach(async () => {
@@ -1182,5 +1194,70 @@ describe("ChatView harness: external session interop", () => {
         (m) => m.type === "conversations" && (m.external ?? []).some((s) => s.id === "ses_late"),
       ),
     )
+  })
+})
+
+describe("ChatView harness: hidden-panel attention", () => {
+  it("a permission arriving while hidden badges the container and toasts once", async () => {
+    const toast = vi.mocked(vscode.window.showInformationMessage)
+    toast.mockClear()
+    await harness.send({ type: "mounted" })
+    await harness.send({ type: "send", text: "guarded edit" })
+    harness.setVisible(false)
+
+    server.push({ type: "permission.updated", id: "perm_1", sessionID: SESSION_ID, title: "Edit file" })
+    await until(() => harness.badge()?.value === 1)
+    expect(toast).toHaveBeenCalledTimes(1)
+    expect(toast).toHaveBeenCalledWith(expect.stringContaining("Edit file"), "Open Panel")
+
+    // A second pending request bumps the badge but does not stack toasts.
+    server.push({ type: "permission.updated", id: "perm_2", sessionID: SESSION_ID, title: "Run command" })
+    await until(() => harness.badge()?.value === 2)
+    expect(toast).toHaveBeenCalledTimes(1)
+
+    // Answering one outside the panel drops the count.
+    server.push({ type: "permission.replied", sessionID: SESSION_ID, permissionID: "perm_1", response: "once" })
+    await until(() => harness.badge()?.value === 1)
+
+    // Revealing the panel clears the badge — the dialog is the affordance now.
+    harness.setVisible(true)
+    expect(harness.badge()).toBeUndefined()
+
+    // Hidden again: a fresh hidden stretch may toast again.
+    harness.setVisible(false)
+    server.push({ type: "permission.updated", id: "perm_3", sessionID: SESSION_ID, title: "Third ask" })
+    await until(() => toast.mock.calls.length === 2)
+  })
+
+  it("no badge or toast while the panel is visible", async () => {
+    const toast = vi.mocked(vscode.window.showInformationMessage)
+    toast.mockClear()
+    await harness.send({ type: "mounted" })
+    await harness.send({ type: "send", text: "guarded edit" })
+
+    server.push({ type: "permission.updated", id: "perm_v", sessionID: SESSION_ID, title: "Edit file" })
+    await until(() => harness.posted.some((m) => m.type === "permission" && m.id === "perm_v"))
+    expect(harness.badge()).toBeUndefined()
+    expect(toast).not.toHaveBeenCalled()
+  })
+
+  it("a question arriving while hidden badges too, and abort clears it", async () => {
+    const toast = vi.mocked(vscode.window.showInformationMessage)
+    toast.mockClear()
+    await harness.send({ type: "mounted" })
+    await harness.send({ type: "send", text: "do the thing" })
+    harness.setVisible(false)
+
+    server.push({
+      type: "question.asked",
+      id: "q_1",
+      sessionID: SESSION_ID,
+      questions: [{ question: "Which flavor?", options: [{ label: "a" }, { label: "b" }] }],
+    })
+    await until(() => harness.badge()?.value === 1)
+    expect(toast).toHaveBeenCalledTimes(1)
+
+    await harness.send({ type: "abort" })
+    expect(harness.badge()).toBeUndefined()
   })
 })


### PR DESCRIPTION
Closes #536

## Summary

- `syncAttention()` mirrors `activePermissions.size + activeQuestions.size` onto `WebviewView.badge` whenever the view is hidden. It rides `syncAgentWaitState()` — already called after every mutation of both maps — plus the three clear sites that bypass it (`settleSessionIdle`, `resetSessionState`, the abort path), and a new `onDidChangeVisibility` listener clears the badge on reveal (the in-panel dialog is the affordance once visible).
- `maybeNotifyHidden()` shows one `showInformationMessage` toast per hidden stretch — first pending request only, with an "Open Panel" action wired to the existing `focus()` — reset when the view becomes visible, so a permission storm bumps the badge instead of stacking notifications.
- The toast return is wrapped in `Promise.resolve` because mocked environments return `undefined` from `showInformationMessage`; real VS Code returns a thenable either way.
- Test harness: the fake `WebviewView` gains a drivable `visible` flag (fires the registered visibility callback) and a `badge()` accessor.

## Test plan

- [x] `bun run test` — 1375/1375 (3 new harness tests: hidden permission → badge + single toast + count tracking through an external reply and re-hide; visible → no badge/toast; hidden question → badge, abort clears)
- [x] `bun run check-types` and `cd webview && bunx tsc --noEmit`
- [x] `bun run compile`
- [ ] Visual pass: collapse the sidebar mid-turn with a permission-gated tool and check the activity-bar badge + toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)
