### PR TITLE
chore(release): 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-08-20
+
+### Added
+- The chat history popover now lists opencode sessions started outside the panel — from the TUI, the web UI, or another client working in the same project — in an "Also in this project" section below the panel's own conversations. Opening one adopts it as a regular saved conversation: the transcript is rebuilt from the server (text, reasoning, finished tool calls, and file patches, with paths rewritten relative to the workspace), edit and rewind work on the imported turns, and aborted turns keep their Stopped badge. A session already bound to a panel conversation is opened rather than duplicated, and the list refreshes each time the popover opens, showing the newest fifty (#534, #535).
+- The panel now asks for attention when it needs input while hidden. A permission request or agent question arriving with the sidebar collapsed or another view in front shows the pending count as a badge on the panel's activity-bar icon, plus one notification per hidden stretch with an "Open Panel" button. The badge tracks replies made from anywhere — including another opencode client — and clears on reveal, abort, or turn end; a visible panel behaves exactly as before (#536, #537).
+
 ## [1.11.3] - 2026-08-17
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.11.3",
+  "version": "1.12.0",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
Closes #538

## Summary

Release v1.12.0: bumps `package.json` to 1.12.0 and adds the CHANGELOG entry covering the two features merged since v1.11.3 — session interop (#534, #535) and hidden-panel attention (#536, #537).

## Test plan

- [x] `bun run test` — 1375/1375 passing
- [x] `bun run check-types` — clean
- [x] `cd webview && bunx tsc --noEmit` — clean
- [x] `bun run compile` — builds
- [ ] Publish workflow green after `gh release create v1.12.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)