### PR TITLE
feat(picker): foldable provider groups in the model picker

### DIFF
--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -949,6 +949,7 @@ export class ChatView implements vscode.WebviewViewProvider {
       this.prefs.recentModels(),
       (providerID, modelID) => this.prefs.variantFor(providerID, modelID),
       this.modelCatalogAgents ?? [],
+      this.prefs.collapsedProviders(),
     )
     this.post({ type: "modelCatalog", catalog })
   }
@@ -1212,6 +1213,11 @@ export class ChatView implements vscode.WebviewViewProvider {
       }
       case "refreshModels":
         void this.refreshModelCatalog()
+        return
+      case "setProviderCollapsed":
+        // No catalog re-push: the picker folds optimistically, and an echo
+        // would reset its keyboard position mid-interaction.
+        await this.prefs.setProviderCollapsed(msg.providerID, msg.collapsed)
         return
       case "permissionReply": {
         this.activePermissions.delete(msg.id)

--- a/src/picker.ts
+++ b/src/picker.ts
@@ -256,8 +256,9 @@ export function validVariant(
 }
 
 /**
- * Wire catalog for the in-panel picker. Recents are filtered to models that
- * still exist (an opencode config change must not leave dead rows), and each
+ * Wire catalog for the in-panel picker. Recents and folded provider groups
+ * are filtered to entries that still exist (an opencode config change must
+ * not leave dead rows or dead fold state), and each
  * entry carries the validated per-model variant memory so the webview can
  * restore effort on selection without a round-trip.
  */
@@ -266,8 +267,10 @@ export function buildModelCatalog(
   recents: string[],
   variantFor: (providerID: string, modelID: string) => string | undefined,
   agents: AgentCatalogEntry[],
+  collapsedProviders: string[],
 ): ModelCatalogInfo {
   const keys = new Set(models.map((m) => `${m.providerID}/${m.modelID}`))
+  const providerIDs = new Set(models.map((m) => m.providerID))
   return {
     models: models.map((m) => ({
       providerID: m.providerID,
@@ -277,6 +280,7 @@ export function buildModelCatalog(
       lastVariant: validVariant(m, variantFor(m.providerID, m.modelID)),
     })),
     recents: recents.filter((key) => keys.has(key)),
+    collapsedProviders: collapsedProviders.filter((id) => providerIDs.has(id)),
     agents,
   }
 }

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -4,6 +4,7 @@ const KEY_AGENT = "opencui.agent"
 const KEY_MODEL = "opencui.model"
 const KEY_MODEL_RECENTS = "opencui.model.recents"
 const KEY_MODEL_VARIANT_MEMORY = "opencui.model.variantMemory"
+const KEY_MODEL_COLLAPSED_PROVIDERS = "opencui.model.collapsedProviders"
 
 /**
  * Enough to cover a "testing new LLM releases across 4-5 providers" rotation
@@ -50,6 +51,18 @@ export class Preferences {
   /** Last variant the user picked for this model; undefined = its default. */
   variantFor(providerID: string, modelID: string): string | undefined {
     return this.variantMemory()[`${providerID}/${modelID}`]
+  }
+
+  /** Provider IDs whose model-picker group the user folded. */
+  collapsedProviders(): string[] {
+    const raw = this.state.get<unknown>(KEY_MODEL_COLLAPSED_PROVIDERS)
+    if (!Array.isArray(raw)) return []
+    return raw.filter((v): v is string => typeof v === "string")
+  }
+
+  async setProviderCollapsed(providerID: string, collapsed: boolean) {
+    const rest = this.collapsedProviders().filter((id) => id !== providerID)
+    await this.state.update(KEY_MODEL_COLLAPSED_PROVIDERS, collapsed ? [...rest, providerID] : rest)
   }
 
   async setAgent(agent: string | undefined) {

--- a/test/host/chatview-harness.test.ts
+++ b/test/host/chatview-harness.test.ts
@@ -121,6 +121,7 @@ beforeEach(async () => {
     currentWorkspace: vi.fn(() => undefined),
     currentBackend: vi.fn(() => backend),
   } as unknown as ServerManager
+  const foldedProviders: string[] = []
   const prefs = {
     get: () => ({}),
     onChange: vi.fn(() => ({ dispose: vi.fn() })),
@@ -128,6 +129,12 @@ beforeEach(async () => {
     variantFor: () => undefined,
     setModel: vi.fn(async () => {}),
     setAgent: vi.fn(async () => {}),
+    collapsedProviders: () => [...foldedProviders],
+    setProviderCollapsed: vi.fn(async (id: string, collapsed: boolean) => {
+      const idx = foldedProviders.indexOf(id)
+      if (collapsed && idx < 0) foldedProviders.push(id)
+      if (!collapsed && idx >= 0) foldedProviders.splice(idx, 1)
+    }),
   } as unknown as Preferences
   const indexManager = {
     onStatusChange: vi.fn(() => ({ dispose: vi.fn() })),
@@ -1049,6 +1056,7 @@ describe("ChatView harness: model catalog", () => {
         },
       ],
       recents: [],
+      collapsedProviders: [],
       agents: [{ name: "default" }],
     })
   })
@@ -1063,6 +1071,19 @@ describe("ChatView harness: model catalog", () => {
         (m) => m.type === "modelCatalog" && m.catalog.models.some((e) => e.modelID === "gpt-5.5"),
       ),
     )
+  })
+
+  it("setProviderCollapsed persists without an echo and rides the next catalog push", async () => {
+    server.setProviders([GPT_PROVIDER])
+    await harness.send({ type: "mounted" })
+    await until(() => catalogs().length > 0)
+    const before = catalogs().length
+    await harness.send({ type: "setProviderCollapsed", providerID: "openai", collapsed: true })
+    expect(catalogs().length).toBe(before)
+    await harness.send({ type: "refreshModels" })
+    await until(() => catalogs().length > before)
+    const last = catalogs()[catalogs().length - 1]!
+    expect(last.type === "modelCatalog" && last.catalog.collapsedProviders).toEqual(["openai"])
   })
 
   it("setModel persists via prefs; the variant is validated against the live catalog", async () => {

--- a/test/host/picker.test.ts
+++ b/test/host/picker.test.ts
@@ -125,7 +125,7 @@ describe("buildModelCatalog", () => {
       "anthropic/sonnet": "max",
       "openai/gpt-5.5": "xhigh", // no longer declared — must not survive
     }
-    const catalog = buildModelCatalog(models, [], (p, m) => memory[`${p}/${m}`], [])
+    const catalog = buildModelCatalog(models, [], (p, m) => memory[`${p}/${m}`], [], [])
     expect(catalog.models.map((m) => m.lastVariant)).toEqual(["max", undefined])
   })
 
@@ -135,12 +135,18 @@ describe("buildModelCatalog", () => {
       ["openai/gpt-5.5", "meta/removed-model", "anthropic/sonnet"],
       () => undefined,
       [],
+      [],
     )
     expect(catalog.recents).toEqual(["openai/gpt-5.5", "anthropic/sonnet"])
   })
 
   it("passes the agent entries through for the picker's Agent chips", () => {
     const agents = [{ name: "build", description: "makes changes" }, { name: "plan" }]
-    expect(buildModelCatalog(models, [], () => undefined, agents).agents).toEqual(agents)
+    expect(buildModelCatalog(models, [], () => undefined, agents, []).agents).toEqual(agents)
+  })
+
+  it("filters folded providers to ones that still exist", () => {
+    const catalog = buildModelCatalog(models, [], () => undefined, [], ["openai", "meta"])
+    expect(catalog.collapsedProviders).toEqual(["openai"])
   })
 })

--- a/test/host/preferences.test.ts
+++ b/test/host/preferences.test.ts
@@ -69,6 +69,7 @@ describe("Preferences per-model variant memory", () => {
     const store = new Map<string, unknown>([
       ["opencui.model.recents", "not-an-array"],
       ["opencui.model.variantMemory", [1, 2, 3]],
+      ["opencui.model.collapsedProviders", "not-an-array"],
     ])
     const memento = {
       keys: () => [...store.keys()],
@@ -78,5 +79,18 @@ describe("Preferences per-model variant memory", () => {
     const prefs = new Preferences(memento as unknown as vscode.Memento)
     expect(prefs.recentModels()).toEqual([])
     expect(prefs.variantFor("a", "b")).toBeUndefined()
+    expect(prefs.collapsedProviders()).toEqual([])
+  })
+})
+
+describe("Preferences folded picker providers", () => {
+  it("folds and unfolds a provider, deduping repeat folds", async () => {
+    const prefs = makePrefs()
+    await prefs.setProviderCollapsed("openai", true)
+    await prefs.setProviderCollapsed("anthropic", true)
+    await prefs.setProviderCollapsed("openai", true)
+    expect(prefs.collapsedProviders()).toEqual(["anthropic", "openai"])
+    await prefs.setProviderCollapsed("openai", false)
+    expect(prefs.collapsedProviders()).toEqual(["anthropic"])
   })
 })

--- a/test/webview/model-picker.test.tsx
+++ b/test/webview/model-picker.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { fireEvent, render, screen, cleanup, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-import { ModelPicker, buildPickerItems } from "../../webview/src/components/ModelPicker"
+import { ModelPicker, buildPickerItems, buildPickerSections } from "../../webview/src/components/ModelPicker"
 import { reducer, initialChatState } from "../../webview/src/hooks/useChatState"
 import type { ModelCatalogInfo } from "../../webview/src/protocol"
 
@@ -37,9 +37,12 @@ const baseProps = {
   selection: {},
   onSetModel: vi.fn(),
   onSetAgent: vi.fn(),
+  onSetProviderCollapsed: vi.fn(),
   onRefresh: vi.fn(),
   onClose: vi.fn(),
 }
+
+const noFolds: ReadonlySet<string> = new Set()
 
 function effortChips() {
   return within(screen.getByRole("group", { name: "Effort" }))
@@ -54,7 +57,7 @@ function rowNames(): string[] {
 
 describe("buildPickerItems", () => {
   it("orders recents first (host order), then provider groups, then the default row", () => {
-    const items = buildPickerItems(catalog, "")
+    const items = buildPickerItems(catalog, "", noFolds)
     expect(items.map((i) => (i.kind === "model" ? `${i.section}:${i.entry.modelID}` : i.kind))).toEqual([
       "Recent:gpt-5.5",
       "Recent:claude-sonnet-4-6",
@@ -67,21 +70,46 @@ describe("buildPickerItems", () => {
   })
 
   it("skips recents whose model is no longer in the catalog", () => {
-    const items = buildPickerItems({ ...catalog, recents: ["openai/gone", "google/gemini-3-pro"] }, "")
+    const items = buildPickerItems({ ...catalog, recents: ["openai/gone", "google/gemini-3-pro"] }, "", noFolds)
     const recent = items.filter((i) => i.section === "Recent")
     expect(recent).toHaveLength(1)
   })
 
   it("filters with every whitespace token matched against provider/model/name", () => {
-    const items = buildPickerItems(catalog, "anthropic sonnet")
+    const items = buildPickerItems(catalog, "anthropic sonnet", noFolds)
     expect(items).toHaveLength(1)
     expect(items[0]!.kind === "model" && items[0]!.entry.modelID).toBe("claude-sonnet-4-6")
     // Filtered mode drops sections and the default row.
-    expect(buildPickerItems(catalog, "gpt").some((i) => i.kind === "default")).toBe(false)
+    expect(buildPickerItems(catalog, "gpt", noFolds).some((i) => i.kind === "default")).toBe(false)
   })
 
   it("returns nothing while the catalog has not arrived", () => {
-    expect(buildPickerItems(undefined, "")).toEqual([])
+    expect(buildPickerItems(undefined, "", noFolds)).toEqual([])
+  })
+
+  it("a folded provider's rows leave the flat list; Recent and Default stay", () => {
+    const items = buildPickerItems(catalog, "", new Set(["anthropic"]))
+    expect(items.map((i) => (i.kind === "model" ? `${i.section}:${i.entry.modelID}` : i.kind))).toEqual([
+      "Recent:gpt-5.5",
+      "Recent:claude-sonnet-4-6",
+      "OpenAI:gpt-5.5",
+      "Google:gemini-3-pro",
+      "default",
+    ])
+  })
+
+  it("a folded provider keeps its section so the header stays clickable", () => {
+    const sections = buildPickerSections(catalog, "", new Set(["anthropic"]))
+    const anthropic = sections.find((s) => s.providerID === "anthropic")!
+    expect(anthropic.collapsed).toBe(true)
+    expect(anthropic.rows).toHaveLength(2)
+    expect(sections.filter((s) => s.collapsed)).toHaveLength(1)
+  })
+
+  it("filtering ignores folds so search always reaches every model", () => {
+    const items = buildPickerItems(catalog, "haiku", new Set(["anthropic"]))
+    expect(items).toHaveLength(1)
+    expect(items[0]!.kind === "model" && items[0]!.entry.modelID).toBe("claude-haiku-4-5")
   })
 })
 
@@ -293,6 +321,50 @@ describe("ModelPicker", () => {
   it("hides the agent chips when the catalog reports no agents", () => {
     render(<ModelPicker {...baseProps} catalog={{ ...catalog, agents: [] }} />)
     expect(screen.queryByRole("group", { name: "Agent" })).not.toBeInTheDocument()
+  })
+})
+
+describe("ModelPicker provider folding", () => {
+  it("clicking a provider header folds its rows and reports the fold to the host", async () => {
+    const user = userEvent.setup()
+    const onSetProviderCollapsed = vi.fn()
+    render(<ModelPicker {...baseProps} onSetProviderCollapsed={onSetProviderCollapsed} />)
+    const header = screen.getByRole("button", { name: "Anthropic" })
+    expect(header.getAttribute("aria-expanded")).toBe("true")
+    await user.click(header)
+    expect(onSetProviderCollapsed).toHaveBeenCalledWith("anthropic", true)
+    expect(header.getAttribute("aria-expanded")).toBe("false")
+    // Provider rows gone; the Recent copy of sonnet stays.
+    expect(rowNames()).toEqual(["gpt-5.5", "claude-sonnet-4-6", "gpt-5.5", "gemini-3-pro", "opencode default"])
+    // Focus handed back to the search line so arrows keep working (chip pattern).
+    expect(screen.getByRole("textbox", { name: "Search models" })).toHaveFocus()
+    await user.click(header)
+    expect(onSetProviderCollapsed).toHaveBeenLastCalledWith("anthropic", false)
+    expect(rowNames()).toContain("claude-haiku-4-5")
+  })
+
+  it("a catalog arriving with folded providers renders them folded", () => {
+    render(<ModelPicker {...baseProps} catalog={{ ...catalog, collapsedProviders: ["google"] }} />)
+    expect(rowNames()).not.toContain("gemini-3-pro")
+    expect(screen.getByRole("button", { name: "Google" }).getAttribute("aria-expanded")).toBe("false")
+  })
+
+  it("typing a query reaches models inside a folded group", () => {
+    render(<ModelPicker {...baseProps} catalog={{ ...catalog, collapsedProviders: ["anthropic"] }} />)
+    const input = screen.getByRole("textbox", { name: "Search models" })
+    fireEvent.change(input, { target: { value: "haiku" } })
+    expect(rowNames()).toEqual(["claude-haiku-4-5"])
+  })
+
+  it("folding the tail group clamps the active index instead of stranding it", async () => {
+    const user = userEvent.setup()
+    const onSetModel = vi.fn()
+    render(<ModelPicker {...baseProps} onSetModel={onSetModel} />)
+    const input = screen.getByRole("textbox", { name: "Search models" })
+    fireEvent.keyDown(input, { key: "ArrowUp" }) // wrap to the last row (default)
+    await user.click(screen.getByRole("button", { name: "Google" }))
+    fireEvent.keyDown(input, { key: "Enter" })
+    expect(onSetModel).toHaveBeenCalledWith(undefined, undefined, undefined)
   })
 })
 

--- a/test/webview/statusbar.test.tsx
+++ b/test/webview/statusbar.test.tsx
@@ -16,6 +16,7 @@ const baseProps = {
   activeConversationID: undefined as string | undefined,
   onSetAgent: vi.fn(),
   onSetModel: vi.fn(),
+  onSetProviderCollapsed: vi.fn(),
   onRefreshModels: vi.fn(),
   onCreateConversation: vi.fn(),
   onOpenConversation: vi.fn(),

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -30,6 +30,7 @@ export default function App() {
     deleteConversation,
     setAgent,
     setModel,
+    setProviderCollapsed,
     refreshModels,
     replyPermission,
     replyQuestion,
@@ -255,6 +256,7 @@ export default function App() {
         onActivePopoverChange={setActiveHeaderPopover}
         onSetAgent={setAgent}
         onSetModel={setModel}
+        onSetProviderCollapsed={setProviderCollapsed}
         onRefreshModels={refreshModels}
         onCreateConversation={newSession}
         onOpenConversation={openConversation}

--- a/webview/src/components/ModelPicker.tsx
+++ b/webview/src/components/ModelPicker.tsx
@@ -21,40 +21,83 @@ export function modelKey(entry: ModelCatalogEntry): string {
   return `${entry.providerID}/${entry.modelID}`
 }
 
+export type PickerSection = {
+  /** "" while filtering — the flat match list renders headerless. */
+  title: string
+  /** Folding identity; set only on provider groups. Recent/Default never fold. */
+  providerID?: string
+  collapsed: boolean
+  rows: PickerItem[]
+}
+
 /**
- * Flat, ordered row list for rendering AND keyboard navigation — one array
- * so the active index can never point at a row the list isn't showing.
- * Unfiltered: Recent (host-pushed order) → per-provider groups → the
- * default-reset row. Filtered: a flat match list; every whitespace-separated
- * token must appear in `providerID/modelID providerName`, so "openai mini"
- * or "5.2" both narrow the way you'd expect.
+ * Ordered section list for rendering. Unfiltered: Recent (host-pushed
+ * order) → per-provider groups → the default-reset row. Filtered: one flat
+ * headerless section ignoring folds — a query must always reach every
+ * model; every whitespace-separated token must appear in
+ * `providerID/modelID providerName`, so "openai mini" or "5.2" both narrow
+ * the way you'd expect. A folded provider keeps its section (the header
+ * stays clickable) but contributes nothing to the flat item list.
  */
-export function buildPickerItems(
+export function buildPickerSections(
   catalog: ModelCatalogInfo | undefined,
   query: string,
-): PickerItem[] {
+  collapsedProviders: ReadonlySet<string>,
+): PickerSection[] {
   if (!catalog) return []
   const q = query.trim().toLowerCase()
   if (q) {
     const tokens = q.split(/\s+/)
-    return catalog.models
+    const rows = catalog.models
       .filter((m) => {
         const hay = `${modelKey(m)} ${m.providerName ?? ""}`.toLowerCase()
         return tokens.every((t) => hay.includes(t))
       })
       .map((entry): PickerItem => ({ kind: "model", entry, section: "" }))
+    return rows.length ? [{ title: "", collapsed: false, rows }] : []
   }
   const byKey = new Map(catalog.models.map((m) => [modelKey(m), m]))
-  const items: PickerItem[] = []
+  const sections: PickerSection[] = []
+  const recent: PickerItem[] = []
   for (const key of catalog.recents) {
     const entry = byKey.get(key)
-    if (entry) items.push({ kind: "model", entry, section: "Recent" })
+    if (entry) recent.push({ kind: "model", entry, section: "Recent" })
   }
+  if (recent.length) sections.push({ title: "Recent", collapsed: false, rows: recent })
   for (const entry of catalog.models) {
-    items.push({ kind: "model", entry, section: entry.providerName ?? entry.providerID })
+    const tail = sections[sections.length - 1]
+    if (!tail || tail.providerID !== entry.providerID) {
+      sections.push({
+        title: entry.providerName ?? entry.providerID,
+        providerID: entry.providerID,
+        collapsed: collapsedProviders.has(entry.providerID),
+        rows: [],
+      })
+    }
+    sections[sections.length - 1]!.rows.push({
+      kind: "model",
+      entry,
+      section: entry.providerName ?? entry.providerID,
+    })
   }
-  if (catalog.models.length > 0) items.push({ kind: "default", section: "Default" })
-  return items
+  if (catalog.models.length > 0) {
+    sections.push({ title: "Default", collapsed: false, rows: [{ kind: "default", section: "Default" }] })
+  }
+  return sections
+}
+
+/**
+ * Flat row list for keyboard navigation — folded groups contribute no rows,
+ * so the active index can never point at a row the list isn't showing.
+ */
+export function buildPickerItems(
+  catalog: ModelCatalogInfo | undefined,
+  query: string,
+  collapsedProviders: ReadonlySet<string>,
+): PickerItem[] {
+  return buildPickerSections(catalog, query, collapsedProviders).flatMap((s) =>
+    s.collapsed ? [] : s.rows,
+  )
 }
 
 type ChipOption = { key: string; label: string; title?: string }
@@ -137,6 +180,7 @@ type Props = {
   selection: Selection
   onSetModel: (providerID?: string, modelID?: string, variant?: string) => void
   onSetAgent: (name?: string) => void
+  onSetProviderCollapsed: (providerID: string, collapsed: boolean) => void
   /** Posted on mount so a freshly opened picker re-syncs the catalog. */
   onRefresh: () => void
   onClose: () => void
@@ -147,11 +191,20 @@ export function ModelPicker({
   selection,
   onSetModel,
   onSetAgent,
+  onSetProviderCollapsed,
   onRefresh,
   onClose,
 }: Props) {
   const [query, setQuery] = useState("")
-  const items = useMemo(() => buildPickerItems(catalog, query), [catalog, query])
+  // Fold state: the host-pushed catalog seeds it; after the first toggle the
+  // local set wins (the host persists without echoing, so a later catalog
+  // push carries the same folds and can never fight this).
+  const seededFolds = useMemo(() => new Set(catalog?.collapsedProviders ?? []), [catalog])
+  const [localFolds, setLocalFolds] = useState<ReadonlySet<string> | null>(null)
+  const folds = localFolds ?? seededFolds
+  const sections = useMemo(() => buildPickerSections(catalog, query, folds), [catalog, query, folds])
+  const items = useMemo(() => sections.flatMap((s) => (s.collapsed ? [] : s.rows)), [sections])
+  const indexOfItem = useMemo(() => new Map(items.map((item, i) => [item, i])), [items])
   const currentKey = selection.model
   const current = useMemo(
     () => (currentKey ? catalog?.models.find((m) => modelKey(m) === currentKey) : undefined),
@@ -217,6 +270,11 @@ export function ModelPicker({
     onClose()
   }
 
+  // Folding the tail group can strand the active index past the new end.
+  useEffect(() => {
+    setActiveIndex((i) => Math.min(i, Math.max(0, items.length - 1)))
+  }, [items.length])
+
   // Effort and agent are iterative tweaks — try one, glance at the result,
   // adjust — so unlike a model pick (the terminal action) a chip click leaves
   // the popover open. The active chip moves optimistically; the host's
@@ -246,6 +304,15 @@ export function ModelPicker({
   const pickAgent = (name?: string) => {
     setPendingAgent({ name })
     onSetAgent(name)
+    searchRef.current?.focus()
+  }
+  const toggleProvider = (providerID: string) => {
+    const next = new Set(folds)
+    const fold = !next.has(providerID)
+    if (fold) next.add(providerID)
+    else next.delete(providerID)
+    setLocalFolds(next)
+    onSetProviderCollapsed(providerID, fold)
     searchRef.current?.focus()
   }
 
@@ -310,64 +377,81 @@ export function ModelPicker({
             {query ? `No models match “${query.trim()}”` : "No models reported by opencode"}
           </div>
         )}
-        {items.map((item, i) => {
-          const showHeader =
-            item.section !== "" && (i === 0 || items[i - 1]!.section !== item.section)
-          if (item.kind === "default") {
-            return (
-              <Fragment key={`${item.section}:__default`}>
-                {showHeader && <div className="model-picker-section">{item.section}</div>}
+        {sections.map((section) => (
+          <Fragment key={section.providerID ? `provider:${section.providerID}` : `section:${section.title}`}>
+            {section.title !== "" &&
+              (section.providerID ? (
                 <button
                   type="button"
-                  role="option"
-                  aria-selected={i === activeIndex}
-                  className={`model-picker-row ${i === activeIndex ? "active" : ""} ${currentKey ? "" : "is-current"}`}
-                  onMouseEnter={() => hoverMove(() => setActiveIndex(i))}
-                  onClick={() => selectItem(item)}
-                  title="Use opencode's configured default model"
+                  className="model-picker-section model-picker-section-toggle"
+                  aria-expanded={!section.collapsed}
+                  onClick={() => toggleProvider(section.providerID!)}
                 >
-                  <span className="model-picker-name">opencode default</span>
-                  {!currentKey && <span className="codicon codicon-check" aria-hidden="true" />}
+                  <span
+                    className={`codicon codicon-chevron-${section.collapsed ? "right" : "down"}`}
+                    aria-hidden="true"
+                  />
+                  {section.title}
                 </button>
-              </Fragment>
-            )
-          }
-          const entry = item.entry
-          const key = modelKey(entry)
-          const isCurrent = key === currentKey
-          const tooltip = entry.lastVariant ? `${key} · ${entry.lastVariant}` : key
-          // Inside a provider group the header already names the provider;
-          // repeating it per row is noise. Recent rows and filtered results
-          // mix providers, so there the label disambiguates.
-          const showProvider = item.section === "Recent" || item.section === ""
-          return (
-            <Fragment key={`${item.section}:${key}`}>
-              {showHeader && <div className="model-picker-section">{item.section}</div>}
-              <button
-                type="button"
-                role="option"
-                aria-selected={i === activeIndex}
-                className={`model-picker-row ${i === activeIndex ? "active" : ""} ${isCurrent ? "is-current" : ""}`}
-                onMouseEnter={() => hoverMove(() => setActiveIndex(i))}
-                onClick={() => selectItem(item)}
-                title={tooltip}
-              >
-                {/* Raw model id, not the prettified label: the picker is where
-                    date-suffix and point-release differences matter. */}
-                <span className="model-picker-name">{entry.modelID}</span>
-                {entry.lastVariant && (
-                  <span className="model-picker-last-variant">{entry.lastVariant}</span>
-                )}
-                {showProvider && (
-                  <span className="model-picker-provider">
-                    {entry.providerName ?? entry.providerID}
-                  </span>
-                )}
-                {isCurrent && <span className="codicon codicon-check" aria-hidden="true" />}
-              </button>
-            </Fragment>
-          )
-        })}
+              ) : (
+                <div className="model-picker-section">{section.title}</div>
+              ))}
+            {!section.collapsed &&
+              section.rows.map((item) => {
+                const i = indexOfItem.get(item)!
+                if (item.kind === "default") {
+                  return (
+                    <button
+                      key={`${item.section}:__default`}
+                      type="button"
+                      role="option"
+                      aria-selected={i === activeIndex}
+                      className={`model-picker-row ${i === activeIndex ? "active" : ""} ${currentKey ? "" : "is-current"}`}
+                      onMouseEnter={() => hoverMove(() => setActiveIndex(i))}
+                      onClick={() => selectItem(item)}
+                      title="Use opencode's configured default model"
+                    >
+                      <span className="model-picker-name">opencode default</span>
+                      {!currentKey && <span className="codicon codicon-check" aria-hidden="true" />}
+                    </button>
+                  )
+                }
+                const entry = item.entry
+                const key = modelKey(entry)
+                const isCurrent = key === currentKey
+                const tooltip = entry.lastVariant ? `${key} · ${entry.lastVariant}` : key
+                // Inside a provider group the header already names the provider;
+                // repeating it per row is noise. Recent rows and filtered results
+                // mix providers, so there the label disambiguates.
+                const showProvider = item.section === "Recent" || item.section === ""
+                return (
+                  <button
+                    key={`${item.section}:${key}`}
+                    type="button"
+                    role="option"
+                    aria-selected={i === activeIndex}
+                    className={`model-picker-row ${i === activeIndex ? "active" : ""} ${isCurrent ? "is-current" : ""}`}
+                    onMouseEnter={() => hoverMove(() => setActiveIndex(i))}
+                    onClick={() => selectItem(item)}
+                    title={tooltip}
+                  >
+                    {/* Raw model id, not the prettified label: the picker is where
+                        date-suffix and point-release differences matter. */}
+                    <span className="model-picker-name">{entry.modelID}</span>
+                    {entry.lastVariant && (
+                      <span className="model-picker-last-variant">{entry.lastVariant}</span>
+                    )}
+                    {showProvider && (
+                      <span className="model-picker-provider">
+                        {entry.providerName ?? entry.providerID}
+                      </span>
+                    )}
+                    {isCurrent && <span className="codicon codicon-check" aria-hidden="true" />}
+                  </button>
+                )
+              })}
+          </Fragment>
+        ))}
       </div>
       {agents.length > 0 && (
         <div className="model-picker-agents">

--- a/webview/src/components/StatusBar.tsx
+++ b/webview/src/components/StatusBar.tsx
@@ -20,6 +20,7 @@ type Props = {
   onActivePopoverChange?: HeaderPopoverSetter
   onSetAgent: (name?: string) => void
   onSetModel: (providerID?: string, modelID?: string, variant?: string) => void
+  onSetProviderCollapsed: (providerID: string, collapsed: boolean) => void
   onRefreshModels: () => void
   onCreateConversation: () => void
   onOpenConversation: (id: string) => void
@@ -42,6 +43,7 @@ export function StatusBar({
   onActivePopoverChange,
   onSetAgent,
   onSetModel,
+  onSetProviderCollapsed,
   onRefreshModels,
   onCreateConversation,
   onOpenConversation,
@@ -83,6 +85,7 @@ export function StatusBar({
         onOpenChange={(open) => setPopoverOpen("selector", open)}
         onSetAgent={onSetAgent}
         onSetModel={onSetModel}
+        onSetProviderCollapsed={onSetProviderCollapsed}
         onRefreshModels={onRefreshModels}
       />
       <button
@@ -363,6 +366,7 @@ function SelectorMenu({
   onOpenChange,
   onSetAgent,
   onSetModel,
+  onSetProviderCollapsed,
   onRefreshModels,
 }: {
   selection: Selection
@@ -371,6 +375,7 @@ function SelectorMenu({
   onOpenChange: (open: boolean) => void
   onSetAgent: (name?: string) => void
   onSetModel: (providerID?: string, modelID?: string, variant?: string) => void
+  onSetProviderCollapsed: (providerID: string, collapsed: boolean) => void
   onRefreshModels: () => void
 }) {
   const { toggle, close, ref } = useDismissableMenu({ open, onOpenChange })
@@ -407,6 +412,7 @@ function SelectorMenu({
             selection={selection}
             onSetModel={onSetModel}
             onSetAgent={onSetAgent}
+            onSetProviderCollapsed={onSetProviderCollapsed}
             onRefresh={onRefreshModels}
             onClose={close}
           />

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -604,6 +604,9 @@ export function useChatState() {
     refreshModels() {
       vscode.post({ type: "refreshModels" })
     },
+    setProviderCollapsed(providerID: string, collapsed: boolean) {
+      vscode.post({ type: "setProviderCollapsed", providerID, collapsed })
+    },
     replyPermission(id: string, response: "once" | "always" | "reject") {
       vscode.post({ type: "permissionReply", id, response })
       dispatch({ type: "clearPermission", id })

--- a/webview/src/protocol.ts
+++ b/webview/src/protocol.ts
@@ -234,6 +234,11 @@ export type ModelCatalogInfo = {
   /** `providerID/modelID` keys, most recently used first. */
   recents: string[]
   /**
+   * Provider IDs whose picker group the user folded. Persisted host-side
+   * and rides the catalog push like `recents`.
+   */
+  collapsedProviders?: string[]
+  /**
    * User-selectable agents (subagents and opencode's internal agents are
    * filtered host-side). Rides on the catalog message so the picker's Agent
    * chips share the models' stale-while-revalidate refresh cycle.
@@ -549,6 +554,8 @@ export type Inbound =
   | { type: "setModel"; providerID?: string; modelID?: string; variant?: string }
   /** Re-fetch the provider list and re-push `modelCatalog` (picker opened). */
   | { type: "refreshModels" }
+  /** Fold/unfold a provider group in the model picker (persisted host-side). */
+  | { type: "setProviderCollapsed"; providerID: string; collapsed: boolean }
   | { type: "fileSearch"; requestID: number; query: string }
   | { type: "listDir"; requestID: number; path: string }
   | { type: "attachFile"; requestID: number }

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -616,6 +616,23 @@ button:focus-visible {
   letter-spacing: 0.05em;
   cursor: default;
 }
+.model-picker-section-toggle {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.model-picker-section-toggle:hover {
+  color: var(--vscode-foreground);
+}
+.model-picker-section-toggle .codicon {
+  font-size: 11px;
+}
 .model-picker-row {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Closes #540

## Summary

The model picker's per-provider sections can now fold and unfold:

- Provider headers are chevron toggles (`aria-expanded` kept in sync); Recent and Default stay always open.
- Fold state is a host preference (`opencui.model.collapsedProviders` in globalState) and rides the catalog push like `recents`, so it survives popover close and window reload. Folded ids whose provider vanished from the opencode config are filtered out, same as dead recents.
- The picker folds optimistically and the host persists without re-pushing the catalog — an echo would reset the keyboard position mid-interaction.
- Search ignores folds: a query always reaches every model, including those in folded groups.
- Keyboard navigation runs over the flat visible-row list, so arrows never land on a hidden row; folding the tail group clamps the active index instead of stranding it past the end.

Implementation: `buildPickerItems` became `buildPickerSections` (sections keep their header row while folded, contribute no rows to the flat list) plus a flat wrapper for navigation. New inbound protocol variant `setProviderCollapsed`; `buildModelCatalog` gains the `collapsedProviders` parameter.

## Test plan

- [x] `bun run test` — 1385/1385 passing (10 new: 4 section/flat-list builder, 4 component fold interactions, 1 preferences round-trip, 1 harness persist-and-ride-catalog)
- [x] `bun run check-types` — clean
- [x] `cd webview && bunx tsc --noEmit` — clean
- [x] `bun run compile` — builds
- [ ] Visual pass: fold a provider, close/reopen the popover and reload the window, confirm the fold sticks and the chevron/hover affordance reads well

🤖 Generated with [Claude Code](https://claude.com/claude-code)