### PR TITLE
fix(server): reap opencode servers orphaned by killed extension hosts

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import { AgentTaskStore } from "./agents/task-store"
 import { showAgentsQuickPick } from "./agents/quickpick"
 import { getOutputChannel, log } from "./output"
 import { initFileSearch } from "./file-search"
+import { reapOrphanServers, registryPath } from "./server-registry"
 
 let servers: ServerManager | undefined
 let recentEdits: RecentEditsTracker | undefined
@@ -22,6 +23,18 @@ let chatView: ChatView | undefined
 
 export async function activate(context: vscode.ExtensionContext) {
   log("activating OpenCode Panel")
+  // Sweep servers orphaned by killed extension hosts (debugger Stop, host
+  // crash) — those paths never run deactivate, and opencode has no
+  // parent-death watchdog of its own.
+  const storageDir = context.globalStorageUri?.fsPath
+  if (storageDir) {
+    void reapOrphanServers(registryPath(storageDir), process.pid).then(
+      (killed) => {
+        if (killed.length) log("reaped orphaned opencode servers", killed)
+      },
+      (e) => log("orphan server reap failed", e),
+    )
+  }
   servers = new ServerManager(context)
   recentEdits = new RecentEditsTracker()
   const indexSettings = readIndexSettings(vscode.workspace.getConfiguration("opencui"))

--- a/src/server-registry.ts
+++ b/src/server-registry.ts
@@ -1,0 +1,139 @@
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+import { execFile } from "child_process"
+import { promisify } from "util"
+
+const execFileAsync = promisify(execFile)
+
+export type ServerRecord = {
+  pid: number
+  /** Extension-host pid that spawned the server; a dead owner marks it orphaned. */
+  ownerPid: number
+  startedAt: number
+}
+
+export function registryPath(globalStorageDir: string): string {
+  return path.join(globalStorageDir, "opencode-servers.json")
+}
+
+export function readRegistry(file: string): ServerRecord[] {
+  try {
+    const raw: unknown = JSON.parse(fs.readFileSync(file, "utf8"))
+    if (!Array.isArray(raw)) return []
+    return raw.filter(
+      (r): r is ServerRecord =>
+        !!r &&
+        typeof (r as ServerRecord).pid === "number" &&
+        typeof (r as ServerRecord).ownerPid === "number" &&
+        typeof (r as ServerRecord).startedAt === "number",
+    )
+  } catch {
+    return []
+  }
+}
+
+function writeRegistry(file: string, records: ServerRecord[]): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true })
+  fs.writeFileSync(file, JSON.stringify(records))
+}
+
+export function recordServer(file: string, record: ServerRecord): void {
+  const rest = readRegistry(file).filter((r) => r.pid !== record.pid)
+  writeRegistry(file, [...rest, record])
+}
+
+export function releaseServer(file: string, pid: number): void {
+  writeRegistry(file, readRegistry(file).filter((r) => r.pid !== pid))
+}
+
+export type ProcessOps = {
+  isAlive(pid: number): boolean
+  /** Full command line of the process, or undefined when the lookup failed. */
+  commandOf(pid: number): Promise<string | undefined>
+  terminate(pid: number): void
+}
+
+export function defaultProcessOps(): ProcessOps {
+  return {
+    isAlive(pid) {
+      try {
+        process.kill(pid, 0)
+        return true
+      } catch (e) {
+        // EPERM = alive but owned by someone else.
+        return (e as NodeJS.ErrnoException).code === "EPERM"
+      }
+    },
+    async commandOf(pid) {
+      try {
+        if (os.platform() === "win32") {
+          const { stdout } = await execFileAsync("powershell.exe", [
+            "-NoProfile",
+            "-Command",
+            `(Get-CimInstance Win32_Process -Filter "ProcessId=${pid}").CommandLine`,
+          ])
+          return stdout.trim() || undefined
+        }
+        const { stdout } = await execFileAsync("ps", ["-p", String(pid), "-o", "command="])
+        return stdout.trim() || undefined
+      } catch {
+        return undefined
+      }
+    },
+    terminate(pid) {
+      process.kill(pid)
+    },
+  }
+}
+
+/**
+ * Kill servers recorded by extension hosts that no longer exist. A debugger
+ * Stop (or a host crash) skips deactivate, and opencode has no parent-death
+ * watchdog of its own — it ignores stdin EOF — so the orphaned server would
+ * otherwise hold its port forever. Runs at every activation. Returns the
+ * pids terminated.
+ */
+export async function reapOrphanServers(
+  file: string,
+  ownPid: number,
+  ops: ProcessOps = defaultProcessOps(),
+): Promise<number[]> {
+  const records = readRegistry(file)
+  if (!records.length) return []
+  const kept: ServerRecord[] = []
+  const killed: number[] = []
+  for (const record of records) {
+    if (record.ownerPid === ownPid) {
+      kept.push(record)
+      continue
+    }
+    // Server already gone — just drop the stale entry.
+    if (!ops.isAlive(record.pid)) continue
+    // Owner alive: another window's healthy server, leave it alone.
+    if (ops.isAlive(record.ownerPid)) {
+      kept.push(record)
+      continue
+    }
+    const command = await ops.commandOf(record.pid)
+    // Can't verify what the pid is now — keep the record and retry next
+    // activation rather than kill blind.
+    if (command === undefined) {
+      kept.push(record)
+      continue
+    }
+    // Pid reused by an unrelated process — drop the entry, never kill.
+    if (!command.includes("opencode") || !command.includes("serve")) continue
+    try {
+      ops.terminate(record.pid)
+      killed.push(record.pid)
+      // Keep the record: if the server ignored SIGTERM the next activation
+      // retries; if it died, the dead-pid branch drops it then.
+      kept.push(record)
+    } catch {
+      kept.push(record)
+    }
+  }
+  writeRegistry(file, kept)
+  return killed
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import { spawn, type ChildProcessWithoutNullStreams } from "child_process"
 import { createOpencodeClient, type OpencodeClient } from "@opencode-ai/sdk"
 import { log } from "./output"
 import { primaryWorkspaceRoot, type WorkspaceRoot } from "./workspace-root"
+import { recordServer, registryPath, releaseServer } from "./server-registry"
 
 const SERVER_START_TIMEOUT_MS = 60000
 
@@ -11,6 +12,7 @@ export type OpencodeConfigMode = "isolated" | "user"
 
 type ServerHandle = {
   url: string
+  pid?: number
   close(): void
   /** Register a callback fired if the process exits AFTER successful startup. */
   onExit(listener: () => void): void
@@ -66,13 +68,31 @@ export class ServerManager {
       configMode,
       workspace: workspace?.fsPath ?? "(no workspace)",
     })
-    const server = await startOpencodeServer(binaryPath, {
-      hostname: "127.0.0.1",
-      port: port || randomPort(),
-      timeout: SERVER_START_TIMEOUT_MS,
-      cwd: workspace?.fsPath,
-      configMode,
-    })
+    let spawnedPid: number | undefined
+    let server: ServerHandle
+    try {
+      server = await startOpencodeServer(binaryPath, {
+        hostname: "127.0.0.1",
+        port: port || randomPort(),
+        timeout: SERVER_START_TIMEOUT_MS,
+        cwd: workspace?.fsPath,
+        configMode,
+        // Registered at spawn, not at ready: an extension host killed during
+        // the 60s startup window must still leave a reapable record.
+        onSpawn: (pid) => {
+          spawnedPid = pid
+          this.updateRegistry((file) =>
+            recordServer(file, { pid, ownerPid: process.pid, startedAt: Date.now() }),
+          )
+        },
+      })
+    } catch (e) {
+      if (spawnedPid !== undefined) {
+        const pid = spawnedPid
+        this.updateRegistry((file) => releaseServer(file, pid))
+      }
+      throw e
+    }
     log("opencode server ready at", server.url)
     const client = createOpencodeClient({
       baseUrl: server.url,
@@ -88,6 +108,7 @@ export class ServerManager {
       // must not clobber its successor.
       if (this.server !== server) return
       log("opencode server exited unexpectedly; clearing cached backend")
+      if (server.pid !== undefined) this.updateRegistry((file) => releaseServer(file, server.pid!))
       this.server = undefined
       this.client = undefined
       this.workspace = undefined
@@ -104,9 +125,24 @@ export class ServerManager {
     if (this.server) {
       log("stopping opencode server")
       this.server.close()
+      if (this.server.pid !== undefined) {
+        const pid = this.server.pid
+        this.updateRegistry((file) => releaseServer(file, pid))
+      }
       this.server = undefined
       this.client = undefined
       this.workspace = undefined
+    }
+  }
+
+  /** Registry writes are best-effort — a broken storage dir must never take the server down. */
+  private updateRegistry(fn: (file: string) => void): void {
+    const dir = this.context.globalStorageUri?.fsPath
+    if (!dir) return
+    try {
+      fn(registryPath(dir))
+    } catch (e) {
+      log("server registry update failed", e)
     }
   }
 
@@ -179,6 +215,8 @@ export function startOpencodeServer(
     /** Workspace root for the subprocess `cwd`. Undefined means inherit. */
     cwd?: string
     configMode: OpencodeConfigMode
+    /** Fired with the child pid immediately after spawn. */
+    onSpawn?: (pid: number) => void
   },
 ): Promise<ServerHandle> {
   // `isolated` keeps the historical behavior: hand opencode an empty config so
@@ -195,6 +233,7 @@ export function startOpencodeServer(
     cwd: options.cwd,
     env,
   })
+  if (proc.pid !== undefined) options.onSpawn?.(proc.pid)
 
   return new Promise((resolve, reject) => {
     let output = ""
@@ -231,6 +270,7 @@ export function startOpencodeServer(
         clearTimeout(timer)
         resolve({
           url: match[1],
+          pid: proc.pid,
           close: () => closeProcess(proc),
           onExit: (listener) => exitListeners.push(listener),
         })
@@ -266,6 +306,18 @@ function stripAnsi(value: string) {
 }
 
 function closeProcess(proc: ChildProcessWithoutNullStreams) {
-  if (proc.killed) return
+  if (proc.killed || proc.exitCode !== null) return
+  // MCP-style shutdown ladder: stdin EOF first (so an opencode that learns
+  // the convention exits cleanly), SIGTERM now, SIGKILL only if it lingers.
+  try {
+    proc.stdin.end()
+  } catch {
+    // stream already closed
+  }
   proc.kill()
+  const hardKill = setTimeout(() => {
+    if (proc.exitCode === null) proc.kill("SIGKILL")
+  }, 3000)
+  hardKill.unref?.()
+  proc.once("exit", () => clearTimeout(hardKill))
 }

--- a/test/host/server-registry.test.ts
+++ b/test/host/server-registry.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from "vitest"
+import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
+import {
+  readRegistry,
+  recordServer,
+  releaseServer,
+  reapOrphanServers,
+  registryPath,
+  type ProcessOps,
+  type ServerRecord,
+} from "../../src/server-registry"
+
+function tmpRegistry(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "opencui-registry-"))
+  return registryPath(dir)
+}
+
+const OWN_PID = 1000
+
+function record(pid: number, ownerPid: number): ServerRecord {
+  return { pid, ownerPid, startedAt: 123 }
+}
+
+function ops(overrides: Partial<ProcessOps> = {}): ProcessOps {
+  return {
+    isAlive: () => true,
+    commandOf: async () => "/usr/local/bin/opencode serve --hostname=127.0.0.1 --port=1234",
+    terminate: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe("server registry file", () => {
+  it("records, replaces by pid, and releases", () => {
+    const file = tmpRegistry()
+    recordServer(file, record(1, 10))
+    recordServer(file, record(2, 10))
+    recordServer(file, { pid: 1, ownerPid: 99, startedAt: 456 })
+    expect(readRegistry(file)).toEqual([record(2, 10), { pid: 1, ownerPid: 99, startedAt: 456 }])
+    releaseServer(file, 1)
+    expect(readRegistry(file)).toEqual([record(2, 10)])
+  })
+
+  it("tolerates a missing or corrupt file and malformed entries", () => {
+    const file = tmpRegistry()
+    expect(readRegistry(file)).toEqual([])
+    fs.mkdirSync(path.dirname(file), { recursive: true })
+    fs.writeFileSync(file, "not json")
+    expect(readRegistry(file)).toEqual([])
+    fs.writeFileSync(file, JSON.stringify([{ pid: "nope" }, record(3, 30), null]))
+    expect(readRegistry(file)).toEqual([record(3, 30)])
+  })
+})
+
+describe("reapOrphanServers", () => {
+  it("kills a server whose owning extension host is dead", async () => {
+    const file = tmpRegistry()
+    recordServer(file, record(50, 40))
+    const terminate = vi.fn()
+    const killed = await reapOrphanServers(file, OWN_PID, ops({ isAlive: (pid) => pid !== 40, terminate }))
+    expect(killed).toEqual([50])
+    expect(terminate).toHaveBeenCalledWith(50)
+    // Record stays so a SIGTERM-ignorer is retried next activation; the
+    // dead-pid branch drops it once the process is actually gone.
+    expect(readRegistry(file)).toEqual([record(50, 40)])
+  })
+
+  it("leaves another live window's server alone", async () => {
+    const file = tmpRegistry()
+    recordServer(file, record(50, 40))
+    const terminate = vi.fn()
+    const killed = await reapOrphanServers(file, OWN_PID, ops({ terminate }))
+    expect(killed).toEqual([])
+    expect(terminate).not.toHaveBeenCalled()
+    expect(readRegistry(file)).toEqual([record(50, 40)])
+  })
+
+  it("keeps records owned by the current extension host untouched", async () => {
+    const file = tmpRegistry()
+    recordServer(file, record(50, OWN_PID))
+    const terminate = vi.fn()
+    await reapOrphanServers(file, OWN_PID, ops({ isAlive: () => false, terminate }))
+    expect(terminate).not.toHaveBeenCalled()
+    expect(readRegistry(file)).toEqual([record(50, OWN_PID)])
+  })
+
+  it("drops a dead server's entry without killing anything", async () => {
+    const file = tmpRegistry()
+    recordServer(file, record(50, 40))
+    const terminate = vi.fn()
+    const killed = await reapOrphanServers(file, OWN_PID, ops({ isAlive: () => false, terminate }))
+    expect(killed).toEqual([])
+    expect(terminate).not.toHaveBeenCalled()
+    expect(readRegistry(file)).toEqual([])
+  })
+
+  it("never kills a reused pid whose command line is not opencode serve", async () => {
+    const file = tmpRegistry()
+    recordServer(file, record(50, 40))
+    const terminate = vi.fn()
+    const killed = await reapOrphanServers(
+      file,
+      OWN_PID,
+      ops({ isAlive: (pid) => pid !== 40, commandOf: async () => "/usr/bin/vim notes.txt", terminate }),
+    )
+    expect(killed).toEqual([])
+    expect(terminate).not.toHaveBeenCalled()
+    expect(readRegistry(file)).toEqual([])
+  })
+
+  it("keeps the record for retry when the command lookup fails, rather than kill blind", async () => {
+    const file = tmpRegistry()
+    recordServer(file, record(50, 40))
+    const terminate = vi.fn()
+    const killed = await reapOrphanServers(
+      file,
+      OWN_PID,
+      ops({ isAlive: (pid) => pid !== 40, commandOf: async () => undefined, terminate }),
+    )
+    expect(killed).toEqual([])
+    expect(terminate).not.toHaveBeenCalled()
+    expect(readRegistry(file)).toEqual([record(50, 40)])
+  })
+
+  it("keeps the record when terminate throws", async () => {
+    const file = tmpRegistry()
+    recordServer(file, record(50, 40))
+    const killed = await reapOrphanServers(
+      file,
+      OWN_PID,
+      ops({
+        isAlive: (pid) => pid !== 40,
+        terminate: () => {
+          throw new Error("EPERM")
+        },
+      }),
+    )
+    expect(killed).toEqual([])
+    expect(readRegistry(file)).toEqual([record(50, 40)])
+  })
+
+  it("handles a mixed registry in one pass", async () => {
+    const file = tmpRegistry()
+    recordServer(file, record(50, 40)) // orphan → kill
+    recordServer(file, record(60, 41)) // owner alive → keep
+    recordServer(file, record(70, 42)) // server dead → drop
+    const terminate = vi.fn()
+    const killed = await reapOrphanServers(
+      file,
+      OWN_PID,
+      ops({ isAlive: (pid) => pid !== 40 && pid !== 42 && pid !== 70, terminate }),
+    )
+    expect(killed).toEqual([50])
+    expect(terminate).toHaveBeenCalledTimes(1)
+    expect(readRegistry(file)).toEqual([record(50, 40), record(60, 41)])
+  })
+})


### PR DESCRIPTION
Closes #542

## Summary

Stopping a debug session (or any extension-host crash) kills the host without running `deactivate`, so its `opencode serve` child reparented to launchd/init and held a port forever — five multi-day orphans were observed on a dev machine. opencode implements neither the MCP stdin-EOF convention nor a parent-PID watchdog, so the fix is entirely client-side:

- **PID registry** (`src/server-registry.ts`): every spawn records `{pid, ownerPid, startedAt}` in `globalStorageUri/opencode-servers.json` — registered at spawn time, not at ready, so a host killed during the 60s startup window still leaves a reapable record. Records are released on clean dispose, on unexpected server exit, and on startup failure. Registry writes are best-effort and can never take server startup down.
- **Activation-time reaper**: `activate()` sweeps the registry. A recorded server is terminated only when its owning extension host is dead AND its live command line still matches `opencode serve` (guards PID reuse). Records owned by other live windows are untouched; failed command lookups keep the record for retry instead of killing blind; a terminated record is kept until a later pass confirms the pid is dead, so a SIGTERM-ignorer gets retried.
- **Escalating close**: `closeProcess` now follows the MCP shutdown ladder — stdin EOF (future-proofing for an opencode that honors it), SIGTERM, then SIGKILL after 3s if still alive (timer unref'd so shutdown is never delayed).

## Test plan

- [x] `bun run test` — 1395/1395 passing (10 new: registry round-trip/corruption, and reap decisions for orphan/other-window/own/dead/pid-reuse/lookup-failure/terminate-throw/mixed)
- [x] End-to-end with the real (un-mocked) process ops: spawned an actual orphaned `opencode serve`-lookalike with a dead owner pid, ran `reapOrphanServers` — pass 1 terminated it and kept the record, pass 2 dropped the dead entry
- [x] `bun run check-types` + `cd webview && bunx tsc --noEmit` — clean
- [x] `bun run compile` — builds
- [ ] Visual pass: F5 a debug session, Stop it, F5 again — the previous session's server should disappear (check the OpenCode Panel log for "reaped orphaned opencode servers")

🤖 Generated with [Claude Code](https://claude.com/claude-code)