### PR TITLE
feat(picker): group model search results by provider

### DIFF
--- a/test/webview/model-picker.test.tsx
+++ b/test/webview/model-picker.test.tsx
@@ -79,8 +79,21 @@ describe("buildPickerItems", () => {
     const items = buildPickerItems(catalog, "anthropic sonnet", noFolds)
     expect(items).toHaveLength(1)
     expect(items[0]!.kind === "model" && items[0]!.entry.modelID).toBe("claude-sonnet-4-6")
-    // Filtered mode drops sections and the default row.
+    // Filtered mode drops Recent and the default row.
     expect(buildPickerItems(catalog, "gpt", noFolds).some((i) => i.kind === "default")).toBe(false)
+  })
+
+  it("keeps matches grouped by provider while filtering", () => {
+    const sections = buildPickerSections(catalog, "g", noFolds)
+    expect(
+      sections.map((s) => ({
+        title: s.title,
+        rows: s.rows.map((r) => (r.kind === "model" ? `${r.section}:${r.entry.modelID}` : r.kind)),
+      })),
+    ).toEqual([
+      { title: "OpenAI", rows: ["OpenAI:gpt-5.5"] },
+      { title: "Google", rows: ["Google:gemini-3-pro"] },
+    ])
   })
 
   it("returns nothing while the catalog has not arrived", () => {
@@ -110,6 +123,11 @@ describe("buildPickerItems", () => {
     const items = buildPickerItems(catalog, "haiku", new Set(["anthropic"]))
     expect(items).toHaveLength(1)
     expect(items[0]!.kind === "model" && items[0]!.entry.modelID).toBe("claude-haiku-4-5")
+    // The match's section renders expanded even though its provider is folded.
+    const sections = buildPickerSections(catalog, "haiku", new Set(["anthropic"]))
+    expect(sections).toHaveLength(1)
+    expect(sections[0]!.collapsed).toBe(false)
+    expect(sections[0]!.title).toBe("Anthropic")
   })
 })
 
@@ -354,6 +372,19 @@ describe("ModelPicker provider folding", () => {
     const input = screen.getByRole("textbox", { name: "Search models" })
     fireEvent.change(input, { target: { value: "haiku" } })
     expect(rowNames()).toEqual(["claude-haiku-4-5"])
+  })
+
+  it("search results keep provider headers, rendered as labels rather than fold toggles", () => {
+    const onSetProviderCollapsed = vi.fn()
+    const { container } = render(<ModelPicker {...baseProps} onSetProviderCollapsed={onSetProviderCollapsed} />)
+    const input = screen.getByRole("textbox", { name: "Search models" })
+    fireEvent.change(input, { target: { value: "g" } })
+    expect(rowNames()).toEqual(["gpt-5.5", "gemini-3-pro"])
+    const headers = Array.from(container.querySelectorAll(".model-picker-section")).map((h) => h.textContent)
+    expect(headers).toEqual(["OpenAI", "Google"])
+    expect(screen.queryByRole("button", { name: "OpenAI" })).toBeNull()
+    expect(screen.queryByRole("button", { name: "Google" })).toBeNull()
+    expect(onSetProviderCollapsed).not.toHaveBeenCalled()
   })
 
   it("folding the tail group clamps the active index instead of stranding it", async () => {

--- a/webview/src/components/ModelPicker.tsx
+++ b/webview/src/components/ModelPicker.tsx
@@ -22,9 +22,8 @@ export function modelKey(entry: ModelCatalogEntry): string {
 }
 
 export type PickerSection = {
-  /** "" while filtering — the flat match list renders headerless. */
   title: string
-  /** Folding identity; set only on provider groups. Recent/Default never fold. */
+  /** Provider identity; set only on provider groups. Recent/Default never fold. */
   providerID?: string
   collapsed: boolean
   rows: PickerItem[]
@@ -32,9 +31,10 @@ export type PickerSection = {
 
 /**
  * Ordered section list for rendering. Unfiltered: Recent (host-pushed
- * order) → per-provider groups → the default-reset row. Filtered: one flat
- * headerless section ignoring folds — a query must always reach every
- * model; every whitespace-separated token must appear in
+ * order) → per-provider groups → the default-reset row. Filtered: the
+ * matches keep their provider grouping but folds are ignored and the
+ * sections never collapse — a query must always reach every model; every
+ * whitespace-separated token must appear in
  * `providerID/modelID providerName`, so "openai mini" or "5.2" both narrow
  * the way you'd expect. A folded provider keeps its section (the header
  * stays clickable) but contributes nothing to the flat item list.
@@ -48,13 +48,26 @@ export function buildPickerSections(
   const q = query.trim().toLowerCase()
   if (q) {
     const tokens = q.split(/\s+/)
-    const rows = catalog.models
-      .filter((m) => {
-        const hay = `${modelKey(m)} ${m.providerName ?? ""}`.toLowerCase()
-        return tokens.every((t) => hay.includes(t))
+    const sections: PickerSection[] = []
+    for (const entry of catalog.models) {
+      const hay = `${modelKey(entry)} ${entry.providerName ?? ""}`.toLowerCase()
+      if (!tokens.every((t) => hay.includes(t))) continue
+      const tail = sections[sections.length - 1]
+      if (!tail || tail.providerID !== entry.providerID) {
+        sections.push({
+          title: entry.providerName ?? entry.providerID,
+          providerID: entry.providerID,
+          collapsed: false,
+          rows: [],
+        })
+      }
+      sections[sections.length - 1]!.rows.push({
+        kind: "model",
+        entry,
+        section: entry.providerName ?? entry.providerID,
       })
-      .map((entry): PickerItem => ({ kind: "model", entry, section: "" }))
-    return rows.length ? [{ title: "", collapsed: false, rows }] : []
+    }
+    return sections
   }
   const byKey = new Map(catalog.models.map((m) => [modelKey(m), m]))
   const sections: PickerSection[] = []
@@ -379,23 +392,25 @@ export function ModelPicker({
         )}
         {sections.map((section) => (
           <Fragment key={section.providerID ? `provider:${section.providerID}` : `section:${section.title}`}>
-            {section.title !== "" &&
-              (section.providerID ? (
-                <button
-                  type="button"
-                  className="model-picker-section model-picker-section-toggle"
-                  aria-expanded={!section.collapsed}
-                  onClick={() => toggleProvider(section.providerID!)}
-                >
-                  <span
-                    className={`codicon codicon-chevron-${section.collapsed ? "right" : "down"}`}
-                    aria-hidden="true"
-                  />
-                  {section.title}
-                </button>
-              ) : (
-                <div className="model-picker-section">{section.title}</div>
-              ))}
+            {/* While filtering, provider headers are labels, not fold toggles:
+                a query must reach every model regardless of fold state, and
+                browsing results must not mutate the persisted folds. */}
+            {section.providerID && !query.trim() ? (
+              <button
+                type="button"
+                className="model-picker-section model-picker-section-toggle"
+                aria-expanded={!section.collapsed}
+                onClick={() => toggleProvider(section.providerID!)}
+              >
+                <span
+                  className={`codicon codicon-chevron-${section.collapsed ? "right" : "down"}`}
+                  aria-hidden="true"
+                />
+                {section.title}
+              </button>
+            ) : (
+              <div className="model-picker-section">{section.title}</div>
+            )}
             {!section.collapsed &&
               section.rows.map((item) => {
                 const i = indexOfItem.get(item)!
@@ -421,9 +436,9 @@ export function ModelPicker({
                 const isCurrent = key === currentKey
                 const tooltip = entry.lastVariant ? `${key} · ${entry.lastVariant}` : key
                 // Inside a provider group the header already names the provider;
-                // repeating it per row is noise. Recent rows and filtered results
-                // mix providers, so there the label disambiguates.
-                const showProvider = item.section === "Recent" || item.section === ""
+                // repeating it per row is noise. Only Recent mixes providers,
+                // so only there the label disambiguates.
+                const showProvider = item.section === "Recent"
                 return (
                   <button
                     key={`${item.section}:${key}`}


### PR DESCRIPTION
Closes #549

## Summary

Typing in the model picker's search line flattened the matches into a single headerless list. Matches now stay grouped under their provider section headers — the same presentation as the unfiltered view.

- `buildPickerSections` query mode groups consecutive matches by `providerID` (catalog order), one section per provider with `collapsed: false` always.
- Headers during search render as informational labels, not fold-toggle buttons: a query must reach every model regardless of fold state, and browsing search results must not mutate the persisted folds (a toggle click posts `setProviderCollapsed` to the host).
- Rows inside a grouped result no longer repeat the provider name on the right — the header names it, matching the unfiltered provider groups. Only Recent rows (which mix providers) keep the per-row label.
- Recent and Default sections still stay out of filtered results; keyboard navigation walks all matches across groups unchanged.

## Test plan

- [x] `bun run test` — 1397/1397 (2 new: grouped query sections in the builder; component-level pin that search headers are labels, produce no fold posts, and rows render in catalog order)
- [x] Extended the folds-ignored-while-filtering test: a folded provider's matches render in an expanded section
- [x] `bun run check-types` + `cd webview && bunx tsc --noEmit` — both trees clean
- [x] `bun run compile` — build succeeds
- [ ] Visual pass: type a query spanning two providers, confirm headers appear between match groups and chevrons are absent while filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)