### PR TITLE
feat(picker): move the Effort row below the model list, above Agent

### DIFF
--- a/test/webview/model-picker.test.tsx
+++ b/test/webview/model-picker.test.tsx
@@ -238,6 +238,15 @@ describe("ModelPicker", () => {
     expect(screen.queryByText("Effort")).not.toBeInTheDocument()
   })
 
+  it("renders the chip rows as a footer: list first, then Effort, then Agent", () => {
+    render(<ModelPicker {...baseProps} selection={{ model: "openai/gpt-5.5" }} />)
+    const list = screen.getByRole("listbox", { name: "Models" })
+    const effort = screen.getByRole("group", { name: "Effort" })
+    const agent = screen.getByRole("group", { name: "Agent" })
+    expect(list.compareDocumentPosition(effort) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(effort.compareDocumentPosition(agent) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
   it("typing filters the list; Enter picks the active match", () => {
     const onSetModel = vi.fn()
     render(<ModelPicker {...baseProps} onSetModel={onSetModel} />)

--- a/webview/src/components/ModelPicker.tsx
+++ b/webview/src/components/ModelPicker.tsx
@@ -365,18 +365,6 @@ export function ModelPicker({
           onKeyDown={onKeyDown}
         />
       </div>
-      {current && current.variants.length > 0 && (
-        <div className="model-picker-effort">
-          <span className="model-picker-chip-label">Effort</span>
-          <ChipGroup
-            groupLabel="Effort"
-            options={current.variants.map((v) => ({ key: v, label: v }))}
-            activeKey={activeVariant}
-            defaultTitle="Use the model's default effort"
-            onPick={pickVariant}
-          />
-        </div>
-      )}
       <div
         className="model-picker-list"
         ref={listRef}
@@ -468,6 +456,18 @@ export function ModelPicker({
           </Fragment>
         ))}
       </div>
+      {current && current.variants.length > 0 && (
+        <div className="model-picker-effort">
+          <span className="model-picker-chip-label">Effort</span>
+          <ChipGroup
+            groupLabel="Effort"
+            options={current.variants.map((v) => ({ key: v, label: v }))}
+            activeKey={activeVariant}
+            defaultTitle="Use the model's default effort"
+            onPick={pickVariant}
+          />
+        </div>
+      )}
       {agents.length > 0 && (
         <div className="model-picker-agents">
           <span className="model-picker-chip-label">Agent</span>

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -493,20 +493,22 @@ button:focus-visible {
 .model-picker-search::placeholder {
   color: var(--vscode-input-placeholderForeground, var(--vscode-descriptionForeground));
 }
+/* Both chip rows sit below the list as a divider-anchored footer (the agent
+   row replaced the old footer handoff into the native QuickPick; effort
+   joined it in #551). One divider opens the footer; the rows inside share
+   it rather than each drawing their own. */
 .model-picker-effort,
 .model-picker-agents {
   display: flex;
   align-items: center;
   gap: var(--space-3);
   flex-wrap: wrap;
-  padding: var(--space-3) 12px 2px;
-}
-/* The agent chips replace the old footer handoff row — same divider-anchored
-   position at the bottom of the popover, but picking in place (like effort)
-   instead of closing into the native QuickPick. */
-.model-picker-agents {
   padding: 8px 12px;
   border-top: 1px solid var(--vscode-widget-border, var(--vscode-panel-border));
+}
+.model-picker-effort + .model-picker-agents {
+  border-top: 0;
+  padding-top: 0;
 }
 .model-picker-chip-label {
   color: var(--vscode-descriptionForeground);


### PR DESCRIPTION
Closes #551

## Summary

The Effort chip row moved from the top of the picker popover (between the search line and the model list) into the footer, directly above the Agent row. The popover now reads: search line, model list, Effort, Agent.

- JSX-only reorder of the Effort block; its render condition (current model has variants) and behavior (pick applies immediately, popover stays open, focus returns to search) are unchanged.
- CSS: both chip rows now share the divider-anchored footer style the Agent row already had. One divider opens the footer; `.model-picker-effort + .model-picker-agents` drops its own border and top padding so the seam never doubles when both rows render. When only one row renders (model without variants, or no agents), it still gets the divider.

## Test plan

- [x] `bun run test` — 1398/1398 (1 new: document-order pin that Effort follows the listbox and precedes Agent)
- [x] `bun run check-types` + `cd webview && bunx tsc --noEmit` — both trees clean
- [x] `bun run compile` — build succeeds
- [ ] Visual pass across the four presence combinations: variants+agents, variants only, agents only, neither

🤖 Generated with [Claude Code](https://claude.com/claude-code)