### PR TITLE
fix(server): launch opencode installed via npm on Windows

### DIFF
--- a/src/server-registry.ts
+++ b/src/server-registry.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs"
 import * as os from "os"
 import * as path from "path"
-import { execFile } from "child_process"
+import { execFile, spawn } from "child_process"
 import { promisify } from "util"
 
 const execFileAsync = promisify(execFile)
@@ -82,6 +82,14 @@ export function defaultProcessOps(): ProcessOps {
       }
     },
     terminate(pid) {
+      if (os.platform() === "win32") {
+        // The recorded pid may be the cmd.exe wrapper around npm's .cmd
+        // shim (#548); TerminateProcess on it alone would orphan the
+        // server it launched. Fire-and-forget is fine — the record is kept
+        // until a later pass observes the pid dead.
+        spawn("taskkill", ["/pid", String(pid), "/t", "/f"], { stdio: "ignore" }).unref()
+        return
+      }
       process.kill(pid)
     },
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode"
 import * as path from "path"
+import * as fs from "fs"
 import { spawn, type ChildProcessWithoutNullStreams } from "child_process"
 import { createOpencodeClient, type OpencodeClient } from "@opencode-ai/sdk"
 import { log } from "./output"
@@ -206,6 +207,48 @@ function bundledBinaryPath(extensionPath: string): string | undefined {
   }
 }
 
+export type SpawnTarget = {
+  command: string
+  /** Route through cmd.exe — required for the .cmd/.bat shims npm installs. */
+  shell: boolean
+}
+
+/**
+ * What to actually hand `spawn`. On Windows, CreateProcess resolves a bare
+ * "opencode" only to an .exe, and a .cmd/.bat shim cannot be spawned
+ * directly at all (EINVAL since the CVE-2024-27980 hardening) — yet
+ * `npm install -g opencode-ai` ships exactly such a shim (#548). Walk PATH
+ * ourselves: the first entry with a match wins (what cmd.exe would run),
+ * a real .exe inside it beats the shim (clean pid, clean kill), and a shim
+ * runs through the shell, quoted against spaces in the path.
+ */
+export function resolveSpawnTarget(
+  binaryPath: string,
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+  fileExists: (candidate: string) => boolean = (candidate) => {
+    try {
+      return fs.statSync(candidate).isFile()
+    } catch {
+      return false
+    }
+  },
+): SpawnTarget {
+  if (platform !== "win32") return { command: binaryPath, shell: false }
+  if (/\.(cmd|bat)$/i.test(binaryPath)) return { command: `"${binaryPath}"`, shell: true }
+  // Explicit path to anything else (.exe, extensionless) → spawn directly.
+  if (path.win32.basename(binaryPath) !== binaryPath) return { command: binaryPath, shell: false }
+  for (const dir of (env.PATH ?? env.Path ?? "").split(";").filter(Boolean)) {
+    const exe = path.win32.join(dir, `${binaryPath}.exe`)
+    if (fileExists(exe)) return { command: exe, shell: false }
+    for (const ext of [".cmd", ".bat"]) {
+      const shim = path.win32.join(dir, binaryPath + ext)
+      if (fileExists(shim)) return { command: `"${shim}"`, shell: true }
+    }
+  }
+  return { command: binaryPath, shell: false }
+}
+
 export function startOpencodeServer(
   binaryPath: string,
   options: {
@@ -229,9 +272,11 @@ export function startOpencodeServer(
   } else {
     delete env.OPENCODE_CONFIG_CONTENT
   }
-  const proc = spawn(binaryPath, ["serve", `--hostname=${options.hostname}`, `--port=${options.port}`], {
+  const target = resolveSpawnTarget(binaryPath)
+  const proc = spawn(target.command, ["serve", `--hostname=${options.hostname}`, `--port=${options.port}`], {
     cwd: options.cwd,
     env,
+    shell: target.shell,
   })
   if (proc.pid !== undefined) options.onSpawn?.(proc.pid)
 
@@ -307,6 +352,16 @@ function stripAnsi(value: string) {
 
 function closeProcess(proc: ChildProcessWithoutNullStreams) {
   if (proc.killed || proc.exitCode !== null) return
+  if (process.platform === "win32" && proc.pid !== undefined) {
+    // No ladder on Windows: proc.kill() is already a hard TerminateProcess,
+    // and when the spawn went through cmd.exe (npm's .cmd shim, #548) it
+    // would kill only the shell and orphan the server — taskkill takes the
+    // whole tree down.
+    const killer = spawn("taskkill", ["/pid", String(proc.pid), "/t", "/f"], { stdio: "ignore" })
+    killer.once("error", () => proc.kill())
+    killer.unref()
+    return
+  }
   // MCP-style shutdown ladder: stdin EOF first (so an opencode that learns
   // the convention exits cleanly), SIGTERM now, SIGKILL only if it lingers.
   try {

--- a/test/host/spawn-target.test.ts
+++ b/test/host/spawn-target.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest"
+import { resolveSpawnTarget } from "../../src/server"
+
+const NPM_DIR = "C:\\Users\\X\\AppData\\Roaming\\npm"
+const SYS_DIR = "C:\\Windows\\System32"
+const PATH = `${NPM_DIR};${SYS_DIR}`
+
+function existsIn(files: string[]) {
+  return (candidate: string) => files.includes(candidate)
+}
+
+describe("resolveSpawnTarget", () => {
+  it("passes through untouched off Windows", () => {
+    expect(resolveSpawnTarget("opencode", "darwin", {}, () => true)).toEqual({
+      command: "opencode",
+      shell: false,
+    })
+  })
+
+  it("routes an explicit .cmd path through the shell, quoted against spaces", () => {
+    expect(resolveSpawnTarget("C:\\name with spaces\\opencode.CMD", "win32", {}, () => false)).toEqual({
+      command: '"C:\\name with spaces\\opencode.CMD"',
+      shell: true,
+    })
+  })
+
+  it("spawns an explicit .exe path directly", () => {
+    expect(resolveSpawnTarget("C:\\tools\\opencode.exe", "win32", {}, () => false)).toEqual({
+      command: "C:\\tools\\opencode.exe",
+      shell: false,
+    })
+  })
+
+  it("resolves a bare name to an .exe on PATH and spawns it directly", () => {
+    const target = resolveSpawnTarget(
+      "opencode",
+      "win32",
+      { PATH },
+      existsIn([`${SYS_DIR}\\opencode.exe`]),
+    )
+    expect(target).toEqual({ command: `${SYS_DIR}\\opencode.exe`, shell: false })
+  })
+
+  it("falls back to the npm .cmd shim through cmd.exe when no .exe exists", () => {
+    // The #548 layout: npm installs only an extensionless sh script (never
+    // probed — Windows cannot execute it) and the .cmd shim.
+    const target = resolveSpawnTarget(
+      "opencode",
+      "win32",
+      { PATH },
+      existsIn([`${NPM_DIR}\\opencode.cmd`]),
+    )
+    expect(target).toEqual({ command: `"${NPM_DIR}\\opencode.cmd"`, shell: true })
+  })
+
+  it("within one directory a real .exe beats the shim", () => {
+    const target = resolveSpawnTarget(
+      "opencode",
+      "win32",
+      { PATH: NPM_DIR },
+      existsIn([`${NPM_DIR}\\opencode.cmd`, `${NPM_DIR}\\opencode.exe`]),
+    )
+    expect(target).toEqual({ command: `${NPM_DIR}\\opencode.exe`, shell: false })
+  })
+
+  it("the first PATH entry with a match wins, matching what the shell would run", () => {
+    const target = resolveSpawnTarget(
+      "opencode",
+      "win32",
+      { PATH },
+      existsIn([`${NPM_DIR}\\opencode.cmd`, `${SYS_DIR}\\opencode.exe`]),
+    )
+    expect(target).toEqual({ command: `"${NPM_DIR}\\opencode.cmd"`, shell: true })
+  })
+
+  it("leaves a bare name alone when PATH has no match, keeping spawn's ENOENT", () => {
+    expect(resolveSpawnTarget("opencode", "win32", { PATH }, () => false)).toEqual({
+      command: "opencode",
+      shell: false,
+    })
+  })
+})


### PR DESCRIPTION
Part of #548 — deliberately not closing it: the issue stays open until the reporter confirms the released build.

## Summary

On Windows with `npm install -g opencode-ai`, the panel failed with `spawn opencode ENOENT` and no configuration could fix it. npm installs only an extensionless sh script and an `opencode.cmd` batch shim — no `.exe`. Node's shell-less `spawn` resolves a bare name through `CreateProcess`, which never considers `.cmd`, so the bare-name launch died with ENOENT; pointing `opencui.binaryPath` at the shim died with EINVAL instead (Node refuses to spawn `.cmd`/`.bat` without a shell since the CVE-2024-27980 hardening).

- `resolveSpawnTarget` (new, exported from `src/server.ts`): on win32, walks PATH the way cmd.exe would — the first entry with a match wins; a real `.exe` inside it spawns directly (clean pid, clean kill); a `.cmd`/`.bat` shim routes through `shell: true` with the path quoted against spaces. An explicit `.cmd`/`.bat` in `opencui.binaryPath` also routes through the shell. Non-Windows behavior is byte-identical.
- Both kill sites tree-kill on win32 via `taskkill /pid <pid> /T /F`: `closeProcess` (dispose/failure paths) and the orphan reaper's `defaultProcessOps.terminate`. With a shell spawn the recorded pid is cmd.exe, and killing it alone would orphan the actual server — recreating the #542 leak on Windows. `proc.kill()` on Windows is already a hard TerminateProcess with no graceful tier, so replacing the POSIX ladder there loses nothing.
- The registry's PID-reuse guard still holds: the cmd.exe wrapper's command line contains `opencode.cmd serve …`, matching the existing `opencode` + `serve` verification.

## Test plan

- [x] `bun run test` — 1406/1406 (8 new `resolveSpawnTarget` tests: non-Windows passthrough; explicit `.cmd` quoted through shell; explicit `.exe` direct; bare name → `.exe` on PATH; the #548 npm layout falling back to the shim; `.exe` beating the shim within one dir; first PATH entry winning across dirs; no-match keeping spawn's ENOENT)
- [x] `bun run check-types` + `cd webview && bunx tsc --noEmit` — both trees clean
- [x] `bun run compile` — build succeeds
- [ ] Real-Windows verification is pending the reporter on #548 (no Windows machine here); the taskkill paths are exercised only on win32

🤖 Generated with [Claude Code](https://claude.com/claude-code)