### PR TITLE
fix(picker): reserve the scrollbar gutter and respect folds while searching

### DIFF
--- a/test/webview/model-picker.test.tsx
+++ b/test/webview/model-picker.test.tsx
@@ -119,15 +119,16 @@ describe("buildPickerItems", () => {
     expect(sections.filter((s) => s.collapsed)).toHaveLength(1)
   })
 
-  it("filtering ignores folds so search always reaches every model", () => {
+  it("filtering respects folds: matches collapse behind the folded header (#557)", () => {
+    // The rows leave the keyboard list, but the section survives with its
+    // matches — the header is what proves the folded provider has any.
     const items = buildPickerItems(catalog, "haiku", new Set(["anthropic"]))
-    expect(items).toHaveLength(1)
-    expect(items[0]!.kind === "model" && items[0]!.entry.modelID).toBe("claude-haiku-4-5")
-    // The match's section renders expanded even though its provider is folded.
+    expect(items).toEqual([])
     const sections = buildPickerSections(catalog, "haiku", new Set(["anthropic"]))
     expect(sections).toHaveLength(1)
-    expect(sections[0]!.collapsed).toBe(false)
+    expect(sections[0]!.collapsed).toBe(true)
     expect(sections[0]!.title).toBe("Anthropic")
+    expect(sections[0]!.rows).toHaveLength(1)
   })
 })
 
@@ -376,24 +377,41 @@ describe("ModelPicker provider folding", () => {
     expect(screen.getByRole("button", { name: "Google" }).getAttribute("aria-expanded")).toBe("false")
   })
 
-  it("typing a query reaches models inside a folded group", () => {
-    render(<ModelPicker {...baseProps} catalog={{ ...catalog, collapsedProviders: ["anthropic"] }} />)
+  it("a folded provider's matches sit behind its header while searching; one click reveals them", () => {
+    const onSetProviderCollapsed = vi.fn()
+    render(
+      <ModelPicker
+        {...baseProps}
+        onSetProviderCollapsed={onSetProviderCollapsed}
+        catalog={{ ...catalog, collapsedProviders: ["anthropic"] }}
+      />,
+    )
     const input = screen.getByRole("textbox", { name: "Search models" })
     fireEvent.change(input, { target: { value: "haiku" } })
+    expect(screen.queryAllByRole("option")).toHaveLength(0)
+    // Hidden matches are still matches — no empty state over the header.
+    expect(screen.queryByText(/No models match/)).toBeNull()
+    const header = screen.getByRole("button", { name: "Anthropic" })
+    expect(header.getAttribute("aria-expanded")).toBe("false")
+    fireEvent.click(header)
     expect(rowNames()).toEqual(["claude-haiku-4-5"])
+    expect(onSetProviderCollapsed).toHaveBeenCalledWith("anthropic", false)
   })
 
-  it("search results keep provider headers, rendered as labels rather than fold toggles", () => {
+  it("search headers are the same fold toggles; collapsing a noisy provider persists", () => {
     const onSetProviderCollapsed = vi.fn()
-    const { container } = render(<ModelPicker {...baseProps} onSetProviderCollapsed={onSetProviderCollapsed} />)
+    render(<ModelPicker {...baseProps} onSetProviderCollapsed={onSetProviderCollapsed} />)
     const input = screen.getByRole("textbox", { name: "Search models" })
     fireEvent.change(input, { target: { value: "g" } })
     expect(rowNames()).toEqual(["gpt-5.5", "gemini-3-pro"])
-    const headers = Array.from(container.querySelectorAll(".model-picker-section")).map((h) => h.textContent)
-    expect(headers).toEqual(["OpenAI", "Google"])
-    expect(screen.queryByRole("button", { name: "OpenAI" })).toBeNull()
-    expect(screen.queryByRole("button", { name: "Google" })).toBeNull()
-    expect(onSetProviderCollapsed).not.toHaveBeenCalled()
+    const google = screen.getByRole("button", { name: "Google" })
+    expect(google.getAttribute("aria-expanded")).toBe("true")
+    fireEvent.click(google)
+    expect(rowNames()).toEqual(["gpt-5.5"])
+    expect(onSetProviderCollapsed).toHaveBeenCalledWith("google", true)
+    // A query with no matches at all still gets the empty state.
+    fireEvent.change(input, { target: { value: "zzz" } })
+    expect(screen.getByText(/No models match/)).toBeInTheDocument()
   })
 
   it("folding the tail group clamps the active index instead of stranding it", async () => {

--- a/webview/src/components/ModelPicker.tsx
+++ b/webview/src/components/ModelPicker.tsx
@@ -32,12 +32,13 @@ export type PickerSection = {
 /**
  * Ordered section list for rendering. Unfiltered: Recent (host-pushed
  * order) → per-provider groups → the default-reset row. Filtered: the
- * matches keep their provider grouping but folds are ignored and the
- * sections never collapse — a query must always reach every model; every
- * whitespace-separated token must appear in
- * `providerID/modelID providerName`, so "openai mini" or "5.2" both narrow
- * the way you'd expect. A folded provider keeps its section (the header
- * stays clickable) but contributes nothing to the flat item list.
+ * matches keep their provider grouping AND their folds (#557 — a provider
+ * with many matches can be tucked away; its header proves it has matches
+ * and one click reveals them). Every whitespace-separated token must
+ * appear in `providerID/modelID providerName`, so "openai mini" or "5.2"
+ * both narrow the way you'd expect. A folded provider keeps its section
+ * (the header stays clickable) but contributes nothing to the flat item
+ * list.
  */
 export function buildPickerSections(
   catalog: ModelCatalogInfo | undefined,
@@ -57,7 +58,7 @@ export function buildPickerSections(
         sections.push({
           title: entry.providerName ?? entry.providerID,
           providerID: entry.providerID,
-          collapsed: false,
+          collapsed: collapsedProviders.has(entry.providerID),
           rows: [],
         })
       }
@@ -373,17 +374,16 @@ export function ModelPicker({
         onMouseMove={onListMouseMove}
       >
         {!catalog && <div className="model-picker-empty">Waiting for the model list…</div>}
-        {catalog && items.length === 0 && (
+        {/* Keyed off sections, not items: matches hidden behind a collapsed
+            header are still matches, not an empty result. */}
+        {catalog && sections.length === 0 && (
           <div className="model-picker-empty">
             {query ? `No models match “${query.trim()}”` : "No models reported by opencode"}
           </div>
         )}
         {sections.map((section) => (
           <Fragment key={section.providerID ? `provider:${section.providerID}` : `section:${section.title}`}>
-            {/* While filtering, provider headers are labels, not fold toggles:
-                a query must reach every model regardless of fold state, and
-                browsing results must not mutate the persisted folds. */}
-            {section.providerID && !query.trim() ? (
+            {section.providerID ? (
               <button
                 type="button"
                 className="model-picker-section model-picker-section-toggle"

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -581,6 +581,9 @@ button:focus-visible {
 .model-picker-list {
   min-height: 0;
   overflow-y: auto;
+  /* Reserve the gutter even while the list fits: expanding a group would
+     otherwise summon the scrollbar and shift every row's text left (#556). */
+  scrollbar-gutter: stable;
   padding: var(--space-1) var(--space-2) var(--space-2);
   /* Same fade-in-on-hover scrollbar as .mention-popover — a permanently
      visible thumb reads as chrome, not content. */


### PR DESCRIPTION
Closes #556
Closes #557

## Summary

Two model-picker refinements from user feedback:

- **Scrollbar gutter (#556)**: `scrollbar-gutter: stable` on `.model-picker-list`. Expanding a provider group used to summon the classic scrollbar, which took its 8px out of the content width and shifted every row's text left. The gutter is now reserved whether or not the list overflows (same treatment the transcript container already uses).
- **Folds apply while searching (#557)**: search sections seed their collapsed state from the same fold set as the unfiltered view, and their headers are the same chevron toggles — so a provider with many matching models can be tucked away mid-search, and a persisted fold carries into the search view. This deliberately reverses #550's headers-as-labels decision. A folded provider's header still renders whenever it has matches (that's how you know it has any), one click reveals them, and folding from search persists exactly like folding from the list. The keyboard item list already skips collapsed rows, so navigation can never land on a hidden match. The "no models match" empty state now keys off sections rather than visible rows — matches behind a collapsed header are still matches.

## Test plan

- [x] `bun run test` — 1406/1406 (rewrote the three tests pinning always-expanded search: builder respects folds; folded matches sit behind the header and one click + `setProviderCollapsed(false)` reveals them; search headers toggle and persist, with the empty state still appearing for true no-match queries)
- [x] `bun run check-types` + `cd webview && bunx tsc --noEmit` — both trees clean
- [x] `bun run compile` — build succeeds
- [ ] Visual pass: expand a tall provider and confirm rows no longer shift when the scrollbar appears; search with a folded provider and confirm the collapsed header + reveal

🤖 Generated with [Claude Code](https://claude.com/claude-code)