### PR TITLE
chore(release): 1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.13.1] - 2026-08-26
+
+### Changed
+- Provider folds now apply while searching in the model picker. Search result headers are the same chevron toggles as the unfiltered view instead of static labels, so a provider with many matching models can be collapsed mid-search, and an already-folded provider stays folded in results — its header still appears whenever it has matches, and one click reveals them. Folding from the search view persists exactly like folding from the list, keyboard navigation never lands on a hidden match, and the "no models match" message stays away when matches exist behind a collapsed header (#557, #558).
+
+### Fixed
+- Expanding a provider group in the model picker no longer shifts every row's text to the left. When the list grew past its height, the appearing scrollbar took its width out of the content and reflowed the rows; the scrollbar gutter is now reserved whether or not the list overflows (#556, #558).
+
 ## [1.13.0] - 2026-08-26
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
Closes #559

## Summary

Bump version to 1.13.1 and add the CHANGELOG entry covering the change on main since v1.13.0:

- **Changed**: provider folds apply while searching in the model picker (#557, #558)
- **Fixed**: model picker rows no longer shift left when the scrollbar appears (#556, #558)

## Test plan

- [x] `bun run test` — 1406/1406 passing
- [x] `bun run check-types` + `cd webview && bunx tsc --noEmit` — both trees clean
- [x] `bun run compile` — build succeeds
- [ ] Publish workflow green after tagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)