### PR TITLE
feat(trace): show elapsed time on long-running tool rows

### DIFF
--- a/test/webview/tool-row-elapsed.test.tsx
+++ b/test/webview/tool-row-elapsed.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { act, render, screen, cleanup } from "@testing-library/react"
+import { ToolTrace } from "../../webview/src/components/ToolCard"
+import type { ToolUpdate } from "../../webview/src/protocol"
+
+function bash(status: ToolUpdate["status"]): ToolUpdate {
+  return { callID: "c1", tool: "bash", status, input: { command: "bun run test" } }
+}
+
+function edit(status: ToolUpdate["status"]): ToolUpdate {
+  return {
+    callID: "c2",
+    tool: "edit",
+    status,
+    input: { filePath: "src/server.ts", oldString: "a", newString: "b" },
+  }
+}
+
+beforeEach(() => {
+  cleanup()
+  vi.useFakeTimers()
+})
+afterEach(() => {
+  vi.useRealTimers()
+  cleanup()
+})
+
+const advance = (ms: number) => act(() => vi.advanceTimersByTime(ms))
+
+describe("running tool row elapsed time (#561)", () => {
+  it("shows plain 'running' inside the grace period", () => {
+    render(<ToolTrace updates={[bash("running")]} />)
+    advance(1000)
+    expect(screen.getByText("running")).toBeTruthy()
+    expect(screen.queryByText(/·/)).toBeNull()
+  })
+
+  it("ticks an elapsed suffix past the grace period", () => {
+    render(<ToolTrace updates={[bash("running")]} />)
+    advance(3000)
+    expect(screen.getByText("running · 3s")).toBeTruthy()
+    advance(1000)
+    expect(screen.getByText("running · 4s")).toBeTruthy()
+  })
+
+  it("formats long runs through formatElapsed", () => {
+    render(<ToolTrace updates={[bash("running")]} />)
+    advance(75_000)
+    expect(screen.getByText("running · 1m")).toBeTruthy()
+  })
+
+  it("drops the marker entirely when the tool completes", () => {
+    const { rerender } = render(<ToolTrace updates={[bash("running")]} />)
+    advance(5000)
+    expect(screen.getByText("running · 5s")).toBeTruthy()
+    rerender(<ToolTrace updates={[bash("completed")]} />)
+    expect(screen.queryByText(/running/)).toBeNull()
+  })
+
+  it("does not count pending time toward the clock", () => {
+    // A tool can sit `pending` (e.g. awaiting a permission decision) long
+    // before it starts; the clock must measure running time only.
+    const { rerender } = render(<ToolTrace updates={[bash("pending")]} />)
+    advance(10_000)
+    rerender(<ToolTrace updates={[bash("running")]} />)
+    advance(2000)
+    expect(screen.getByText("running · 2s")).toBeTruthy()
+  })
+
+  it("applies the same treatment to a running edit row", () => {
+    render(<ToolTrace updates={[edit("running")]} />)
+    advance(1000)
+    expect(screen.getByText("running")).toBeTruthy()
+    advance(4000)
+    expect(screen.getByText("running · 5s")).toBeTruthy()
+  })
+})

--- a/webview/src/components/ToolCard.tsx
+++ b/webview/src/components/ToolCard.tsx
@@ -1,6 +1,40 @@
+import { useEffect, useState } from "react"
 import type { Todo, ToolStatus, ToolUpdate } from "../protocol"
 import { basename, isRecord, patchKind } from "../review-extract"
 import { vscode } from "../vscode"
+import { formatElapsed } from "./AgentActivity"
+
+/**
+ * Grace period before a running row starts showing elapsed time. Most tools
+ * finish well under this; ticking a counter on every quick read/edit would
+ * add churn without information. Past it, the counter is what distinguishes
+ * a slow tool from a hung one (#561).
+ */
+const ELAPSED_GRACE_MS = 2000
+
+/**
+ * Live elapsed time for a running tool row, or null while the row is not
+ * running or still inside the grace period. The wire ToolUpdate carries no
+ * timing, so the clock starts when the row is first observed in `running`
+ * status — the SSE update lands as the tool starts, so this tracks the real
+ * start closely. `pending` (e.g. awaiting a permission decision) deliberately
+ * does not count as running time.
+ */
+function useRunningElapsed(running: boolean): string | null {
+  const [elapsedMs, setElapsedMs] = useState<number | null>(null)
+  useEffect(() => {
+    if (!running) {
+      setElapsedMs(null)
+      return
+    }
+    const started = Date.now()
+    setElapsedMs(0)
+    const handle = window.setInterval(() => setElapsedMs(Date.now() - started), 1000)
+    return () => window.clearInterval(handle)
+  }, [running])
+  if (elapsedMs === null || elapsedMs < ELAPSED_GRACE_MS) return null
+  return formatElapsed(elapsedMs)
+}
 
 type FileAction = "read" | "created" | "updated" | "deleted" | "moved"
 
@@ -89,6 +123,7 @@ function statusLabel(status: Todo["status"]): string {
 }
 
 function EditCard({ op, onReviewFile }: { op: FileOp; onReviewFile?: (path: string) => void }) {
+  const elapsed = useRunningElapsed(op.status === "running")
   const click = () => {
     if (onReviewFile && op.reviewable) onReviewFile(op.path)
     else vscode.post({ type: "openFile", path: op.path })
@@ -98,7 +133,7 @@ function EditCard({ op, onReviewFile }: { op: FileOp; onReviewFile?: (path: stri
       <span className="edit-name">{basename(op.path)}</span>
       {typeof op.additions === "number" && op.additions > 0 && <span className="edit-add">+{op.additions}</span>}
       {typeof op.deletions === "number" && op.deletions > 0 && <span className="edit-del">−{op.deletions}</span>}
-      {op.status === "running" && <span className="edit-running">running</span>}
+      {op.status === "running" && <span className="edit-running">running{elapsed ? ` · ${elapsed}` : ""}</span>}
       {op.errorText && <span className="edit-error">{op.errorText}</span>}
     </button>
   )
@@ -128,11 +163,12 @@ function ReadsLine({ reads }: { reads: FileOp[] }) {
 }
 
 function OtherRow({ op }: { op: OtherOp }) {
+  const elapsed = useRunningElapsed(op.status === "running")
   return (
     <div className={`other-row status-${op.status}`} title={op.title}>
       <span className="other-action">{op.action}</span>
       {op.detail && <span className="other-detail">{op.detail}</span>}
-      {op.status === "running" && <span className="other-meta">running</span>}
+      {op.status === "running" && <span className="other-meta">running{elapsed ? ` · ${elapsed}` : ""}</span>}
       {op.errorText && <span className="other-error">{op.errorText}</span>}
     </div>
   )

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -1767,6 +1767,9 @@ button:focus-visible {
   opacity: 0.65;
   font-style: italic;
   font-size: 11px;
+  /* The elapsed counter ticks every second; fixed-width digits keep the row
+     from jiggling on each tick (#561). */
+  font-variant-numeric: tabular-nums;
 }
 .edit-error {
   grid-column: 1 / -1;
@@ -1862,6 +1865,8 @@ button:focus-visible {
   flex: 0 0 auto;
   opacity: 0.75;
   font-style: italic;
+  /* Same tabular-nums rationale as .edit-running (#561). */
+  font-variant-numeric: tabular-nums;
 }
 .other-error {
   min-width: 0;


### PR DESCRIPTION
Closes #561

## Summary

- Running tool rows in the trace now show a live elapsed suffix — `running · 12s` — after a 2-second grace period, on both `OtherRow` (bash / grep / task / webfetch) and `EditCard` (write/edit). A slow tool is now visibly distinct from a hung one.
- New `useRunningElapsed` hook in `ToolCard.tsx`: the wire `ToolUpdate` carries no timing, so the clock starts when the row is first observed in `running` status (the SSE update lands as the tool starts). `pending` time — e.g. a tool waiting on a permission decision — deliberately does not count; the clock resets on the pending→running transition.
- Reuses `formatElapsed` from `AgentActivity.tsx` (`12s`, `2m`, `1h 5m`); the suffix disappears with the running marker on terminal status.
- `font-variant-numeric: tabular-nums` on `.edit-running` / `.other-meta` so the ticking digits don't jiggle the row width.

## Test plan

- [x] `bun run test` — 1412/1412 (6 new in `test/webview/tool-row-elapsed.test.tsx`: grace period, ticking, `formatElapsed` formatting past 60s, marker dropped on completion, pending time excluded, edit-row parity)
- [x] `bun run check-types` + `cd webview && bunx tsc --noEmit` — both trees clean
- [x] `bun run compile` — builds
- [ ] Visual check in the sidebar against a long-running bash command

🤖 Generated with [Claude Code](https://claude.com/claude-code)