### PR TITLE
chore(release): 1.13.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.13.2] - 2026-08-27
+
+### Added
+- Running tool rows in the trace show a live elapsed time. A `bash` command, agent dispatch, or slow file write that runs past two seconds now ticks a "running · 12s" suffix next to its status marker, so a slow tool is visibly distinct from a hung one. Time spent `pending` — for example waiting on a permission decision — does not count; the clock measures running time only and disappears when the tool finishes (#561, #562).
+
 ## [1.13.1] - 2026-08-26
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.13.1",
+  "version": "1.13.2",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
Closes #563

## Summary

- Bump `package.json` to 1.13.2.
- Add the `## [1.13.2] - 2026-08-27` CHANGELOG entry:
  - **Added** — live elapsed time on running tool rows in the trace, after a 2-second grace period; pending time excluded (#561, #562).

## Test plan

- [x] `bun run test` — 1412/1412
- [x] `bun run check-types` + `cd webview && bunx tsc --noEmit` — both trees clean
- [x] `bun run compile` — builds
- [ ] After merge: tag `v1.13.2`, publish the GitHub Release, watch `release.yml` publish to Marketplace + Open VSX

🤖 Generated with [Claude Code](https://claude.com/claude-code)