### PR TITLE
feat(picker): search results start unfolded, with transient mid-search folding

### DIFF
--- a/test/webview/model-picker.test.tsx
+++ b/test/webview/model-picker.test.tsx
@@ -119,7 +119,7 @@ describe("buildPickerItems", () => {
     expect(sections.filter((s) => s.collapsed)).toHaveLength(1)
   })
 
-  it("filtering respects folds: matches collapse behind the folded header (#557)", () => {
+  it("sections fold by whatever set the caller passes; the search view hands over its transient folds (#565)", () => {
     // The rows leave the keyboard list, but the section survives with its
     // matches — the header is what proves the folded provider has any.
     const items = buildPickerItems(catalog, "haiku", new Set(["anthropic"]))
@@ -377,7 +377,7 @@ describe("ModelPicker provider folding", () => {
     expect(screen.getByRole("button", { name: "Google" }).getAttribute("aria-expanded")).toBe("false")
   })
 
-  it("a folded provider's matches sit behind its header while searching; one click reveals them", () => {
+  it("a provider folded in the browse view starts revealed while searching (#565)", () => {
     const onSetProviderCollapsed = vi.fn()
     render(
       <ModelPicker
@@ -388,17 +388,16 @@ describe("ModelPicker provider folding", () => {
     )
     const input = screen.getByRole("textbox", { name: "Search models" })
     fireEvent.change(input, { target: { value: "haiku" } })
-    expect(screen.queryAllByRole("option")).toHaveLength(0)
-    // Hidden matches are still matches — no empty state over the header.
-    expect(screen.queryByText(/No models match/)).toBeNull()
-    const header = screen.getByRole("button", { name: "Anthropic" })
-    expect(header.getAttribute("aria-expanded")).toBe("false")
-    fireEvent.click(header)
+    // The user typed a name to SEE it — the browse fold must not hide it.
     expect(rowNames()).toEqual(["claude-haiku-4-5"])
-    expect(onSetProviderCollapsed).toHaveBeenCalledWith("anthropic", false)
+    expect(screen.getByRole("button", { name: "Anthropic" }).getAttribute("aria-expanded")).toBe("true")
+    // Clearing the query returns to the browse view with its fold intact.
+    fireEvent.change(input, { target: { value: "" } })
+    expect(screen.getByRole("button", { name: "Anthropic" }).getAttribute("aria-expanded")).toBe("false")
+    expect(onSetProviderCollapsed).not.toHaveBeenCalled()
   })
 
-  it("search headers are the same fold toggles; collapsing a noisy provider persists", () => {
+  it("folding mid-search is transient: local to the session, never persisted (#565)", () => {
     const onSetProviderCollapsed = vi.fn()
     render(<ModelPicker {...baseProps} onSetProviderCollapsed={onSetProviderCollapsed} />)
     const input = screen.getByRole("textbox", { name: "Search models" })
@@ -408,10 +407,22 @@ describe("ModelPicker provider folding", () => {
     expect(google.getAttribute("aria-expanded")).toBe("true")
     fireEvent.click(google)
     expect(rowNames()).toEqual(["gpt-5.5"])
-    expect(onSetProviderCollapsed).toHaveBeenCalledWith("google", true)
+    expect(onSetProviderCollapsed).not.toHaveBeenCalled()
+    // The fold survives refining the query within the same session; hidden
+    // matches are still matches, so no empty state over the folded header.
+    fireEvent.change(input, { target: { value: "gem" } })
+    expect(screen.queryAllByRole("option")).toHaveLength(0)
+    expect(screen.queryByText(/No models match/)).toBeNull()
     // A query with no matches at all still gets the empty state.
     fireEvent.change(input, { target: { value: "zzz" } })
     expect(screen.getByText(/No models match/)).toBeInTheDocument()
+    // Leaving search discards the session fold: the browse view is untouched
+    // and the next search starts fully revealed again.
+    fireEvent.change(input, { target: { value: "" } })
+    expect(screen.getByRole("button", { name: "Google" }).getAttribute("aria-expanded")).toBe("true")
+    fireEvent.change(input, { target: { value: "g" } })
+    expect(rowNames()).toEqual(["gpt-5.5", "gemini-3-pro"])
+    expect(onSetProviderCollapsed).not.toHaveBeenCalled()
   })
 
   it("folding the tail group clamps the active index instead of stranding it", async () => {

--- a/webview/src/components/ModelPicker.tsx
+++ b/webview/src/components/ModelPicker.tsx
@@ -32,13 +32,14 @@ export type PickerSection = {
 /**
  * Ordered section list for rendering. Unfiltered: Recent (host-pushed
  * order) → per-provider groups → the default-reset row. Filtered: the
- * matches keep their provider grouping AND their folds (#557 — a provider
- * with many matches can be tucked away; its header proves it has matches
- * and one click reveals them). Every whitespace-separated token must
- * appear in `providerID/modelID providerName`, so "openai mini" or "5.2"
- * both narrow the way you'd expect. A folded provider keeps its section
- * (the header stays clickable) but contributes nothing to the flat item
- * list.
+ * matches keep their provider grouping, folded by whatever set the caller
+ * passes — the picker passes its transient search folds there, NOT the
+ * persisted browse-view folds, so every search session starts with all
+ * matching groups revealed and mid-search folding stays local to the
+ * session (#565). Every whitespace-separated token must appear in
+ * `providerID/modelID providerName`, so "openai mini" or "5.2" both
+ * narrow the way you'd expect. A folded provider keeps its section (the
+ * header stays clickable) but contributes nothing to the flat item list.
  */
 export function buildPickerSections(
   catalog: ModelCatalogInfo | undefined,
@@ -216,7 +217,22 @@ export function ModelPicker({
   const seededFolds = useMemo(() => new Set(catalog?.collapsedProviders ?? []), [catalog])
   const [localFolds, setLocalFolds] = useState<ReadonlySet<string> | null>(null)
   const folds = localFolds ?? seededFolds
-  const sections = useMemo(() => buildPickerSections(catalog, query, folds), [catalog, query, folds])
+  const inSearch = query.trim().length > 0
+  // Transient folds for the search view (#565): a search always starts with
+  // every matching group revealed — the user typed a name to SEE it, so the
+  // browse view's persisted folds must not hide it. Folding mid-search only
+  // touches this set; it survives query refinement within the session and is
+  // discarded when the query clears.
+  const [searchFolds, setSearchFolds] = useState<ReadonlySet<string>>(() => new Set())
+  useEffect(() => {
+    // Functional update returning the same ref when already empty, so
+    // leaving search doesn't trigger a redundant render.
+    if (!inSearch) setSearchFolds((prev) => (prev.size ? new Set() : prev))
+  }, [inSearch])
+  const sections = useMemo(
+    () => buildPickerSections(catalog, query, inSearch ? searchFolds : folds),
+    [catalog, query, inSearch, searchFolds, folds],
+  )
   const items = useMemo(() => sections.flatMap((s) => (s.collapsed ? [] : s.rows)), [sections])
   const indexOfItem = useMemo(() => new Map(items.map((item, i) => [item, i])), [items])
   const currentKey = selection.model
@@ -321,6 +337,18 @@ export function ModelPicker({
     searchRef.current?.focus()
   }
   const toggleProvider = (providerID: string) => {
+    if (inSearch) {
+      // Transient act on a transient view: never written through to the
+      // persisted browse-view folds (#565).
+      setSearchFolds((prev) => {
+        const next = new Set(prev)
+        if (next.has(providerID)) next.delete(providerID)
+        else next.add(providerID)
+        return next
+      })
+      searchRef.current?.focus()
+      return
+    }
     const next = new Set(folds)
     const fold = !next.has(providerID)
     if (fold) next.add(providerID)


### PR DESCRIPTION
Closes #565

## Summary

- Searching in the model picker now starts with every matching group **unfolded**, regardless of the browse view's persisted folds — the user typed a model name precisely to see it (partially reverses the #557 decision to carry folds into search).
- Headers remain fold toggles mid-search, but the fold is **transient**: it lives in a session-local set, survives query refinement, is never written through `onSetProviderCollapsed`, and is discarded when the query clears. Leaving search returns to the browse view exactly as it was; the next search starts fully revealed again.
- `buildPickerSections` is mechanically unchanged — it folds by whatever set the caller passes; the component now passes the transient search set in query mode and the persisted set in browse mode. Keyboard nav and the sections-keyed empty state keep working unchanged.

## Test plan

- [x] `bun run test` — 1412/1412. Rewrote the two #557 RTL tests for the new semantics (folded-in-browse provider starts revealed in search + query-clear restores browse; mid-search fold is session-local, survives refinement, suppresses/permits the empty state correctly, never persists, resets on a fresh search) and retitled the pure `buildPickerSections` test.
- [x] `bun run check-types` + `cd webview && bunx tsc --noEmit` — both trees clean
- [x] `bun run compile` — builds
- [ ] Visual check in the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)