### PR TITLE
fix(provider): offer the full catalog in Connect a provider

### DIFF
--- a/src/provider/provider-format.ts
+++ b/src/provider/provider-format.ts
@@ -61,12 +61,23 @@ export type ConnectableProvider = {
 }
 
 /**
- * Build the "connect a provider" list from `provider.auth()` (providerID ->
- * login methods), the id->name map (from `provider.list().all` /
- * `config.providers()`), and the connected ids. Providers with no methods are
- * dropped; already-connected providers stay (so they can re-auth) and are
- * flagged. Sorted by name. Method order is preserved because the OAuth
- * `method` field is an index into it.
+ * Fallback login method for catalog providers with no declared flow.
+ * opencode's `auth.set` accepts a plain API key for ANY provider id — the
+ * TUI's `auth login` offers the whole catalog this way — so a missing
+ * `provider.auth()` entry means "API key", not "not connectable" (#567).
+ */
+const API_KEY_METHOD: AuthMethod = { type: "api", label: "API key" }
+
+/**
+ * Build the "connect a provider" list by merging `provider.auth()`
+ * (providerID -> declared login methods: OAuth flows, device logins, …)
+ * with the full catalog behind the id->name map (from `provider.list().all`
+ * / `config.providers()`). Catalog providers without declared methods get
+ * the synthetic API-key method; declared methods always win, and their
+ * order is preserved because the OAuth `method` field is an index into it.
+ * An id with an empty declared list and no catalog presence stays dropped.
+ * Already-connected providers stay (so they can re-auth) and are flagged.
+ * Sorted by name.
  */
 export function connectableProviders(
   methodsByProvider: Readonly<Record<string, ReadonlyArray<AuthMethod>>>,
@@ -74,14 +85,22 @@ export function connectableProviders(
   connected: ReadonlyArray<string>,
 ): ConnectableProvider[] {
   const connectedSet = new Set(connected)
-  return Object.entries(methodsByProvider)
-    .filter(([, methods]) => methods.length > 0)
-    .map(([id, methods]): ConnectableProvider => ({
-      id,
-      name: names.get(id)?.trim() || id,
-      connected: connectedSet.has(id),
-      methods: methods.map((m) => ({ type: m.type, label: m.label })),
-    }))
+  const ids = new Set(names.keys())
+  for (const [id, methods] of Object.entries(methodsByProvider)) {
+    if (methods.length > 0) ids.add(id)
+  }
+  return [...ids]
+    .map((id): ConnectableProvider => {
+      const declared = methodsByProvider[id] ?? []
+      return {
+        id,
+        name: names.get(id)?.trim() || id,
+        connected: connectedSet.has(id),
+        methods: declared.length > 0
+          ? declared.map((m) => ({ type: m.type, label: m.label }))
+          : [{ ...API_KEY_METHOD }],
+      }
+    })
     .sort((a, b) => a.name.localeCompare(b.name))
 }
 

--- a/test/host/provider-format.test.ts
+++ b/test/host/provider-format.test.ts
@@ -80,6 +80,34 @@ describe("connectableProviders", () => {
     expect(out.map((p) => p.id)).toEqual(["bar"])
     expect(out[0]!.name).toBe("bar")
   })
+
+  it("catalog providers without a declared login flow get the API-key method (#567)", () => {
+    // The #567 shape: deepseek is in the /provider catalog but has no
+    // /provider/auth entry — it must still be connectable via auth.set.
+    const out = connectableProviders(
+      { openai: [{ type: "oauth", label: "Login with OpenAI" }] },
+      new Map([
+        ["deepseek", "DeepSeek"],
+        ["openai", "OpenAI"],
+      ]),
+      [],
+    )
+    expect(out.map((p) => p.id)).toEqual(["deepseek", "openai"])
+    expect(out[0]!.methods).toEqual([{ type: "api", label: "API key" }])
+    // Declared methods always win over the synthetic fallback.
+    expect(out[1]!.methods).toEqual([{ type: "oauth", label: "Login with OpenAI" }])
+  })
+
+  it("a declared-but-empty method list falls back to API key when the catalog knows the id", () => {
+    const out = connectableProviders({ deepseek: [] }, new Map([["deepseek", "DeepSeek"]]), [])
+    expect(out).toHaveLength(1)
+    expect(out[0]!.methods).toEqual([{ type: "api", label: "API key" }])
+  })
+
+  it("flags connected catalog-only providers so they read as reconnect", () => {
+    const out = connectableProviders({}, new Map([["deepseek", "DeepSeek"]]), ["deepseek"])
+    expect(out[0]!.connected).toBe(true)
+  })
 })
 
 describe("removeProviderAuth", () => {


### PR DESCRIPTION
Closes #567

## Summary

- "Connect a provider" now offers the full opencode catalog (~207 providers, DeepSeek included) instead of only the 9 providers with declared special login flows.
- Root cause: the list was built exclusively from `GET /provider/auth` (OAuth/device/gateway registrations). `connectableProviders` now unions that with the id→name catalog map `fetchState` already builds from `provider.list().all`, synthesizing a `{ type: "api", label: "API key" }` method for providers without a declared flow — opencode's `auth.set` accepts a plain API key for any provider id, which is exactly how the TUI's `auth login` offers the whole catalog.
- Declared methods always win and keep their order (the OAuth `method` field is an index into them); an id with an empty declared list and no catalog presence stays dropped; connected catalog-only providers are flagged "connected — reconnect". No changes needed in `manage.ts` — single-method providers already skip the method picker and `type: "api"` already routes to the key input box.

## Test plan

- [x] `bun run test` — 1415/1415 (3 new: catalog provider without declared flow gets the API-key method with declared methods winning; declared-but-empty list falls back when the catalog knows the id; connected flag on catalog-only providers). Both pre-existing `connectableProviders` tests pass unchanged.
- [x] `bun run check-types` + `cd webview && bunx tsc --noEmit` — both trees clean
- [x] `bun run compile` — builds
- [x] Verified against a live `opencode serve`: `/provider/auth` returns exactly the 9 previously-shown ids; `/provider` `all` has 207 entries including `deepseek`
- [ ] Visual check: `/provider` → Connect → type "deepseek" → paste key → DeepSeek models appear in the model picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)