### PR TITLE
chore(release): 1.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.13.3] - 2026-08-28
+
+### Changed
+- Model picker search results now start with every matching provider group unfolded, regardless of the browse view's folds — the user typed a model name precisely to see it. Headers remain fold toggles mid-search, but the fold is transient: it survives query refinement, is never written to the persisted fold state, and is discarded when the query clears, so the browse view comes back exactly as it was and the next search starts fully revealed again (#565, #566). Partially reverses the fold-carrying behavior from #557.
+
+### Fixed
+- "Connect a provider" now offers opencode's full provider catalog (about 207 providers, DeepSeek included) instead of only the 9 with declared special login flows. The list was built exclusively from the OAuth/device-login registry; providers without a declared flow now appear with a plain API-key method, matching what `opencode auth login` offers in a terminal (#567, #568).
+
 ## [1.13.2] - 2026-08-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
Closes #569

## Summary

- Bump `package.json` to 1.13.3.
- Add the `## [1.13.3] - 2026-08-28` CHANGELOG entry:
  - **Changed** — model picker search results start unfolded, with transient mid-search folding (#565, #566).
  - **Fixed** — "Connect a provider" offers the full opencode catalog, DeepSeek included (#567, #568).

## Test plan

- [x] `bun run test` — 1415/1415
- [x] `bun run check-types` + `cd webview && bunx tsc --noEmit` — both trees clean
- [x] `bun run compile` — builds
- [ ] After merge: tag `v1.13.3`, publish the GitHub Release, watch `release.yml` publish to Marketplace + Open VSX

🤖 Generated with [Claude Code](https://claude.com/claude-code)