### PR TITLE
fix(provider): refresh the server's cached instance after credential changes

### DIFF
--- a/src/provider/manage.ts
+++ b/src/provider/manage.ts
@@ -4,6 +4,7 @@ import type { Preferences } from "../preferences"
 import { log } from "../output"
 import {
   connectableProviders,
+  refreshInstance,
   removableProviders,
   removeProviderAuth,
   UNSUPPORTED_HINT,
@@ -183,10 +184,27 @@ export class ProviderManager {
         return
       }
       vscode.window.showInformationMessage(`OpenCode Panel: connected "${choice.name}".`)
+      await this.refreshBackend(backend)
     } catch (e) {
       log("auth.set failed", e)
       vscode.window.showErrorMessage(`OpenCode Panel: ${(e as Error).message}`)
     }
+  }
+
+  /**
+   * Make a just-changed credential visible to the running server. Stored
+   * credentials don't invalidate opencode's lazily-cached provider config,
+   * so without this the new provider's models only appear after a full
+   * server restart (#571) — which is exactly what the fallback offers when
+   * the dispose route is missing (older opencode).
+   */
+  private async refreshBackend(backend: Backend) {
+    if (await refreshInstance(backend.url, backend.directory)) return
+    const choice = await vscode.window.showInformationMessage(
+      "OpenCode Panel: restart the opencode server to apply the provider change.",
+      "Restart server",
+    )
+    if (choice === "Restart server") await vscode.commands.executeCommand("opencui.server.restart")
   }
 
   private async connectOAuth(backend: Backend, choice: ConnectableProvider, methodIndex: number) {
@@ -249,6 +267,7 @@ export class ProviderManager {
           return
         }
         vscode.window.showInformationMessage(`OpenCode Panel: connected "${choice.name}".`)
+        await this.refreshBackend(backend)
         return
       }
 
@@ -270,6 +289,7 @@ export class ProviderManager {
         return
       }
       vscode.window.showInformationMessage(`OpenCode Panel: connected "${choice.name}".`)
+      await this.refreshBackend(backend)
     } catch (e) {
       log("provider oauth failed", e)
       vscode.window.showErrorMessage(`OpenCode Panel: ${(e as Error).message}`)
@@ -292,6 +312,9 @@ export class ProviderManager {
     const result = await removeProviderAuth(backend.url, row.id)
     if (result.kind === "ok") {
       vscode.window.showInformationMessage(`OpenCode Panel: removed credentials for "${row.name}".`)
+      // Same staleness in the other direction: without the refresh the
+      // removed provider's models linger until a restart (#571).
+      await this.refreshBackend(backend)
       await this.warnIfActiveModel(row)
       return
     }

--- a/src/provider/provider-format.ts
+++ b/src/provider/provider-format.ts
@@ -109,6 +109,37 @@ export function authDeletePath(id: string): string {
   return `/auth/${encodeURIComponent(id)}`
 }
 
+/** The opencode route that disposes the cached per-directory instance state. */
+export function instanceDisposePath(directory: string): string {
+  return `/instance/dispose?directory=${encodeURIComponent(directory)}`
+}
+
+/**
+ * Drop the server's cached instance state so the next `config.providers`
+ * read is rebuilt from disk. opencode builds provider config lazily on
+ * first access and caches it; `auth.set` / credential removal do NOT
+ * invalidate that cache, so a freshly connected provider's models stay
+ * invisible (and a removed one lingers) until the cache is dropped (#571).
+ * The published SDK doesn't expose the route — untyped POST, same pattern
+ * as `removeProviderAuth`. Returns false on any failure (network error, or
+ * an older opencode without the route) so the caller can fall back to
+ * offering a server restart. Verified live: the global SSE stream survives
+ * a dispose, so a running chat is not disturbed.
+ */
+export async function refreshInstance(
+  baseUrl: string,
+  directory: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<boolean> {
+  const url = baseUrl.replace(/\/+$/, "") + instanceDisposePath(directory)
+  try {
+    const res = await fetchImpl(url, { method: "POST" })
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
 /**
  * Remove a provider's stored credentials.
  *

--- a/test/host/provider-format.test.ts
+++ b/test/host/provider-format.test.ts
@@ -4,6 +4,7 @@ import {
   removeProviderAuth,
   authDeletePath,
   connectableProviders,
+  refreshInstance,
 } from "../../src/provider/provider-format"
 
 describe("removableProviders", () => {
@@ -145,5 +146,27 @@ describe("removeProviderAuth", () => {
     const fetchImpl = vi.fn().mockResolvedValue(resp(200))
     await removeProviderAuth("http://h///", "x", fetchImpl as never)
     expect(fetchImpl).toHaveBeenCalledWith("http://h/auth/x", { method: "DELETE" })
+  })
+})
+
+describe("refreshInstance", () => {
+  const resp = (status: number) => ({ ok: status >= 200 && status < 300, status })
+
+  it("POSTs the dispose route with the encoded directory and returns true on 2xx", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(resp(200))
+    expect(await refreshInstance("http://127.0.0.1:9/", "/my ws", fetchImpl as never)).toBe(true)
+    expect(fetchImpl).toHaveBeenCalledWith("http://127.0.0.1:9/instance/dispose?directory=%2Fmy%20ws", {
+      method: "POST",
+    })
+  })
+
+  it("returns false on non-2xx (route missing on older opencode)", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(resp(404))
+    expect(await refreshInstance("http://h", "/ws", fetchImpl as never)).toBe(false)
+  })
+
+  it("returns false when the fetch throws", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("boom"))
+    expect(await refreshInstance("http://h", "/ws", fetchImpl as never)).toBe(false)
   })
 })

--- a/test/host/provider-manage.test.ts
+++ b/test/host/provider-manage.test.ts
@@ -272,3 +272,57 @@ describe("ProviderManager.run — connect", () => {
     expect(win.showInformationMessage).toHaveBeenCalledWith(expect.stringContaining("no providers available"))
   })
 })
+
+describe("ProviderManager — instance refresh after credential changes (#571)", () => {
+  const DISPOSE_URL = "http://127.0.0.1:1234/instance/dispose?directory=%2Fws"
+
+  const connectDeepseek = (backend: unknown) => {
+    win.showQuickPick
+      .mockResolvedValueOnce({ connect: true })
+      .mockResolvedValueOnce({ choice: choice("deepseek", "DeepSeek", [{ type: "api", label: "API key" }]) })
+      .mockResolvedValueOnce(undefined)
+    win.showInputBox.mockResolvedValueOnce("sk-test-123")
+    return makeManager(backend).run()
+  }
+
+  it("disposes the cached instance after an API-key connect so models appear without a restart", async () => {
+    const backend = makeBackend({ all: [{ id: "deepseek", name: "DeepSeek" }] })
+    fetchMock.mockResolvedValue({ ok: true, status: 200 })
+    await connectDeepseek(backend)
+    expect(fetchMock).toHaveBeenCalledWith(DISPOSE_URL, { method: "POST" })
+    // Dispose succeeded — no restart nudge rides along.
+    expect(win.showInformationMessage).not.toHaveBeenCalledWith(
+      expect.stringContaining("restart"),
+      expect.anything(),
+    )
+  })
+
+  it("offers a server restart when the dispose route is missing (older opencode)", async () => {
+    const backend = makeBackend({ all: [{ id: "deepseek", name: "DeepSeek" }] })
+    fetchMock.mockResolvedValue({ ok: false, status: 404 })
+    win.showInformationMessage
+      .mockResolvedValueOnce(undefined) // the "connected" toast
+      .mockResolvedValueOnce("Restart server") // the fallback offer, accepted
+    await connectDeepseek(backend)
+    expect(win.showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining("restart the opencode server"),
+      "Restart server",
+    )
+    expect(exec).toHaveBeenCalledWith("opencui.server.restart")
+  })
+
+  it("disposes the cached instance after a disconnect too", async () => {
+    const backend = makeBackend({
+      connected: ["deepseek"],
+      providers: [{ id: "deepseek", name: "DeepSeek", source: "config" }],
+    })
+    win.showQuickPick
+      .mockResolvedValueOnce({ row: row("deepseek", "DeepSeek", "config", true) })
+      .mockResolvedValueOnce(undefined)
+    win.showWarningMessage.mockResolvedValueOnce("Remove")
+    fetchMock.mockResolvedValue({ ok: true, status: 200 })
+    await makeManager(backend).run()
+    expect(fetchMock).toHaveBeenCalledWith("http://127.0.0.1:1234/auth/deepseek", { method: "DELETE" })
+    expect(fetchMock).toHaveBeenCalledWith(DISPOSE_URL, { method: "POST" })
+  })
+})


### PR DESCRIPTION
Closes #571

## Summary

- After connecting a provider (API key or either OAuth flow) or disconnecting one, the extension now POSTs opencode's `/instance/dispose` so the server rebuilds its lazily-cached provider config on the next read — the new provider's models appear in the model picker immediately, no server restart.
- Root cause: `auth.set` stores the credential but never invalidates opencode's provider-config cache, and the extension primes that cache early (model picker, context usage), so a freshly connected provider was invisible — and a removed one lingered — until restart.
- `refreshInstance` is an untyped POST in `provider-format.ts` (same pattern as `removeProviderAuth`; the published SDK doesn't expose the route), with the `directory` scoped to the backend. If it fails (older opencode without the route), a notification offers **Restart server**, wired to `opencui.server.restart`.
- Verified against a live server: `config.providers` is stale after `auth.set` with a primed cache, fresh after dispose, and the global SSE stream survives the dispose — a running chat is not disturbed.

## Test plan

- [x] `bun run test` — 1421/1421 (6 new: `refreshInstance` unit tests for encoded URL/2xx, non-2xx, and thrown fetch; manage-level tests for dispose-after-connect with no restart nudge, restart fallback wired to the command, and dispose-after-disconnect)
- [x] `bun run check-types` + `cd webview && bunx tsc --noEmit` — both trees clean
- [x] `bun run compile` — builds
- [x] Live-server verification of the stale→dispose→fresh sequence and SSE survival
- [ ] Visual check: `/provider` → connect DeepSeek → open model picker → models present without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)