### PR TITLE
chore(release): 1.13.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.13.4] - 2026-08-28
+
+### Fixed
+- Connecting a provider now takes effect immediately. opencode caches its provider configuration lazily and storing a credential does not invalidate that cache, so a freshly connected provider's models stayed invisible — and a removed provider lingered — until the server was restarted. After every successful credential change (API-key connect, both OAuth flows, disconnect) the extension now asks the server to drop its cached instance state, and the model picker shows the change on next open. On an older opencode without the dispose route, a notification offers a one-click server restart instead of failing silently (#571, #572).
+
 ## [1.13.3] - 2026-08-28
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
Closes #573

## Summary

- Bump `package.json` to 1.13.4.
- Add the `## [1.13.4] - 2026-08-28` CHANGELOG entry:
  - **Fixed** — provider credential changes take effect immediately; no server restart needed (#571, #572).

## Test plan

- [x] `bun run test` — 1421/1421
- [x] `bun run check-types` + `cd webview && bunx tsc --noEmit` — both trees clean
- [x] `bun run compile` — builds
- [ ] After merge: tag `v1.13.4`, publish the GitHub Release, watch `release.yml` publish to Marketplace + Open VSX

🤖 Generated with [Claude Code](https://claude.com/claude-code)