### PR TITLE
fix(chat): exclude collapsed panel bodies from selection copy

### DIFF
--- a/test/webview/collapsed-copy.test.ts
+++ b/test/webview/collapsed-copy.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const css = readFileSync(path.resolve(__dirname, "../../webview/src/styles.css"), "utf8")
+
+/** Body of the first top-level rule whose selector list is exactly `selector`. */
+function ruleBody(selector: string): string {
+  const open = css.indexOf(`\n${selector} {`)
+  if (open === -1) throw new Error(`rule not found: ${selector}`)
+  const start = open + selector.length + 3
+  const end = css.indexOf("\n}", start)
+  return css.slice(start, end)
+}
+
+// Collapsed clip containers keep their body mounted (the fold animation needs
+// content to clip), and clipped-but-mounted text still rides along in a
+// select-copy of the transcript — a reasoning model's full thinking leaked
+// into the clipboard, glued to the answer (#575). Only `visibility: hidden`
+// excludes text from selection (opacity: 0 does not); the delayed flip keeps
+// the content visible while the fold animation plays.
+describe("collapsed panels are excluded from selection copy (#575)", () => {
+  it("collapsed process bodies are visibility-hidden, delayed past the fold", () => {
+    const collapsed = ruleBody(".process-body-clip")
+    expect(collapsed).toMatch(/visibility:\s*hidden/)
+    expect(collapsed).toMatch(/visibility 0s 0\.18s/)
+  })
+
+  it("open process bodies reveal instantly", () => {
+    const open = ruleBody(".process.is-open .process-body-clip")
+    expect(open).toMatch(/visibility:\s*visible/)
+    expect(open).toMatch(/visibility 0s(?!\s+0)/)
+  })
+
+  it("the review panel's collapsed body gets the same guard", () => {
+    const collapsed = ruleBody(".review-panel.is-collapsed .review-body-clip")
+    expect(collapsed).toMatch(/visibility:\s*hidden/)
+    expect(collapsed).toMatch(/visibility 0s 0\.2s/)
+    const open = ruleBody(".review-body-clip")
+    expect(open).toMatch(/visibility:\s*visible/)
+  })
+})

--- a/webview/src/styles.css
+++ b/webview/src/styles.css
@@ -1547,13 +1547,26 @@ button:focus-visible {
      blocks then scroll horizontally on their own. Mirrors `.review-body`. */
   grid-template-columns: minmax(0, 1fr);
   overflow: hidden;
+  /* The body stays mounted after collapsing (the fold animation needs content
+     to clip), and clipped-but-mounted text still rides along in a select-copy
+     of the transcript — a reasoning model's full thinking leaked into the
+     clipboard, glued to the answer (#575). `visibility: hidden` excludes it
+     from selection; the delay keeps the text visible while the fold plays. */
+  visibility: hidden;
   transition:
     grid-template-rows 0.18s ease,
-    margin-top 0.18s ease;
+    margin-top 0.18s ease,
+    visibility 0s 0.18s;
 }
 .process.is-open .process-body-clip {
   grid-template-rows: 1fr;
   margin-top: 8px;
+  visibility: visible;
+  /* Reveal instantly on expand — only the collapse delays visibility. */
+  transition:
+    grid-template-rows 0.18s ease,
+    margin-top 0.18s ease,
+    visibility 0s;
 }
 .process-body {
   min-height: 0;
@@ -2245,16 +2258,27 @@ button:focus-visible {
   margin-top: 4px;
   overflow: hidden;
   opacity: 1;
+  visibility: visible;
   transition:
     grid-template-rows 0.2s ease,
     margin-top 0.2s ease,
-    opacity 0.16s ease;
+    opacity 0.16s ease,
+    visibility 0s;
 }
 .review-panel.is-collapsed .review-body-clip {
   grid-template-rows: 0fr;
   margin-top: 0;
   opacity: 0;
   pointer-events: none;
+  /* Same copy-leak guard as .process-body-clip (#575): opacity 0 fades the
+     collapsed body but its text still lands in a select-copy — only
+     visibility excludes it. Delayed so the fold animation keeps its content. */
+  visibility: hidden;
+  transition:
+    grid-template-rows 0.2s ease,
+    margin-top 0.2s ease,
+    opacity 0.16s ease,
+    visibility 0s 0.2s;
 }
 .review-body {
   display: grid;


### PR DESCRIPTION
Closes #575

## Summary

- Collapsed process/compaction panel bodies (and the review panel's collapsed body) are now `visibility: hidden`, so selecting and copying the transcript no longer sweeps invisible text — most visibly a reasoning model's full thinking — into the clipboard.
- The bodies stay mounted by design (the 0fr grid fold needs content to clip), and `opacity: 0` doesn't exclude text from selection — only `visibility: hidden` does. The flip is delayed (`visibility 0s 0.18s` process / `0.2s` review) so the fold animation keeps its content while collapsing; expanding reveals instantly (`visibility 0s`).
- Diagnosis verified end-to-end first: opencode delivers `reasoning` as a separate part (confirmed live with DeepSeek v4-flash, including under a custom agent), and the finished bubble renders it collapsed — the leak was clipboard-only, which also explains the glued "thinking.Answer" seam reported (the clipped div boundary contributes no line break).

## Test plan

- [x] `bun run test` — 1424/1424 (3 new in `test/webview/collapsed-copy.test.ts` pinning the visibility rules and their delays on both clip containers)
- [x] `bun run check-types` + `cd webview && bunx tsc --noEmit` — both trees clean
- [x] `bun run compile` — builds
- [ ] Visual check: collapse animation still shows content while folding; select-all copy of a DeepSeek turn contains only the visible answer

🤖 Generated with [Claude Code](https://claude.com/claude-code)