### PR TITLE
chore(release): 1.13.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.13.5] - 2026-08-28
+
+### Fixed
+- Copying the transcript no longer includes text hidden inside collapsed panels. A process panel's body stays mounted after it collapses (the fold animation needs content to clip), and that clipped-but-invisible text rode along in a select-copy — most visibly a reasoning model's full thinking, glued to the answer with no separator. Collapsed process, compaction, and review-panel bodies are now excluded from selection; the fold animation still shows its content while collapsing (#575, #576).
+
 ## [1.13.4] - 2026-08-28
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.13.4",
+  "version": "1.13.5",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
Closes #577

## Summary

- Bump `package.json` to 1.13.5.
- Add the `## [1.13.5] - 2026-08-28` CHANGELOG entry:
  - **Fixed** — transcript copies no longer include hidden collapsed-panel text (#575, #576).

## Test plan

- [x] `bun run test` — 1424/1424
- [x] `bun run check-types` + `cd webview && bunx tsc --noEmit` — both trees clean
- [x] `bun run compile` — builds
- [ ] After merge: tag `v1.13.5`, publish the GitHub Release, watch `release.yml` publish to Marketplace + Open VSX

🤖 Generated with [Claude Code](https://claude.com/claude-code)