### PR TITLE
fix(chat): Stop racing turn-completion no longer wedges the composer

### DIFF
--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -135,6 +135,17 @@ export class ChatView implements vscode.WebviewViewProvider {
    * mutate the already-stopped message with leftover content.
    */
   private aborting = false
+  /**
+   * True while a turn is in flight from the webview's point of view: set when
+   * a turn starts (send / builtin / SSE user-assistant-busy events), cleared
+   * exactly where `sessionIdle` is posted (postIdle). A continuation defer
+   * keeps it true — the webview is still busy and Stop must reach the abort
+   * path. Guards `abortCurrent` against the Stop-races-turn-completion
+   * deadlock (#579): aborting an already-idle session emits no new
+   * session.idle, so entering the aborting state then would wedge both sides
+   * forever.
+   */
+  private turnActive = false
   private taskStoreUnsub?: vscode.Disposable
   /**
    * Owns the per-turn main-task lifecycle in the AgentTaskStore and
@@ -237,8 +248,18 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.activeQuestions.clear()
     this.syncAttention()
     this.subagentDispatch.clearMainTaskID()
-    this.post({ type: "sessionIdle" })
+    this.postIdle()
     void this.manager.flushPersist()
+  }
+
+  /**
+   * The ONLY way to tell the webview the session is idle. Clearing
+   * `turnActive` and posting `sessionIdle` must never diverge — a post
+   * without the clear re-opens the #579 late-Stop deadlock.
+   */
+  private postIdle() {
+    this.turnActive = false
+    this.post({ type: "sessionIdle" })
   }
 
   private postAgentsStatus(tasks: AgentTask[]) {
@@ -403,6 +424,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.subscription?.abort()
     this.subscription = undefined
     this.aborting = false
+    this.turnActive = false
     this.clearPendingDeltas()
     if (this.reviewSyncTimer) {
       clearTimeout(this.reviewSyncTimer)
@@ -595,6 +617,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.subscription?.abort()
     this.subscription = undefined
     this.aborting = false
+    this.turnActive = false
     this.sessionID = undefined
     this.clearPendingDeltas()
     this.messageMap.clear()
@@ -1362,6 +1385,15 @@ export class ChatView implements vscode.WebviewViewProvider {
 
   private async abortCurrent() {
     if (!this.sessionID) return
+    if (!this.turnActive) {
+      // Late Stop: the click raced the turn's own completion — sessionIdle
+      // was already posted, there is nothing to abort, and an already-idle
+      // session emits no new session.idle to ever clear an aborting state.
+      // The webview showed a clickable Stop, so it holds a stale busy
+      // belief; settle it instead of wedging both sides (#579).
+      this.postIdle()
+      return
+    }
     const sessionID = this.sessionID
     this.aborting = true
     this.pendingUserBackendID = undefined
@@ -1450,6 +1482,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     // A new turn supersedes any in-flight abort drain from a prior Stop so it
     // can't abort the session tree the new turn is about to (re)use.
     this.abortGen++
+    this.turnActive = true
     this.redoStack = [] // a new turn diverges the history; nothing to redo
     const ctx = getEditorContext()
     const label = formatContextHeader(ctx)
@@ -1690,7 +1723,7 @@ export class ChatView implements vscode.WebviewViewProvider {
   private failTurnUnstick(message: string, toastTitle: string) {
     const classified = classifyTerminal(message)
     void this.subagentDispatch.recordMainTaskFinish(classified.status, classified.error)
-    this.post({ type: "sessionIdle" })
+    this.postIdle()
     if (classified.status === "error") {
       this.surfaceToast({ variant: "error", title: toastTitle, message })
     }
@@ -1734,6 +1767,7 @@ export class ChatView implements vscode.WebviewViewProvider {
       await this.handleBuiltinCommand(command)
       return
     }
+    this.turnActive = true
     this.redoStack = [] // a custom-command turn diverges the history
     const ctx = getEditorContext()
     const label = formatContextHeader(ctx)
@@ -1849,6 +1883,7 @@ export class ChatView implements vscode.WebviewViewProvider {
 
   /** Post the typed-invocation bubble and key the Agents popover for a built-in turn. */
   private async beginBuiltinTurn(display: string) {
+    this.turnActive = true
     this.redoStack = [] // a /compact or /init turn diverges the history
     const ctx = getEditorContext()
     const userMessageID = "u_" + Date.now()
@@ -1939,6 +1974,10 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.subscription?.abort()
     const subscription = subscribeSession(backend, sessionID, {
       onUserMessage: (mid) => {
+        // A user message on the stream means a turn is running, whichever
+        // client started it (this panel, the TUI on a shared session, a
+        // reattach replay).
+        this.turnActive = true
         const targetID = this.pendingUserBackendID
         if (!targetID) return
         const target = this.messages.find((m) => m.id === targetID)
@@ -1947,6 +1986,7 @@ export class ChatView implements vscode.WebviewViewProvider {
         this.post({ type: "userMessageBackendID", id: targetID, backendID: mid })
       },
       onAssistantStart: (mid) => {
+        this.turnActive = true
         // A new assistant turn means any deferred idle is moot — clear it
         // so the timer doesn't accidentally fire mid-stream and clear busy.
         this.continuationState.finishPending()
@@ -2086,6 +2126,7 @@ export class ChatView implements vscode.WebviewViewProvider {
         }
       },
       onSessionBusy: () => {
+        this.turnActive = true
         // A new busy state means continuation (if any) took over — cancel
         // any pending idle so we don't accidentally clear busy later.
         this.continuationState.finishPending()
@@ -2111,7 +2152,7 @@ export class ChatView implements vscode.WebviewViewProvider {
             }
           }
           this.subagentDispatch.clearMainTaskID()
-          this.post({ type: "sessionIdle" })
+          this.postIdle()
           void this.manager.flushPersist()
           return
         }
@@ -2164,7 +2205,7 @@ export class ChatView implements vscode.WebviewViewProvider {
         this.subscription = undefined
         this.aborting = false
         this.continuationState.finishPending()
-        this.post({ type: "sessionIdle" })
+        this.postIdle()
         void this.reattachAfterStreamLoss()
       },
     })

--- a/test/host/stop-flow.test.ts
+++ b/test/host/stop-flow.test.ts
@@ -57,6 +57,7 @@ function fakeTaskStore() {
 type ChatViewInternals = {
   sessionID?: string
   aborting: boolean
+  turnActive: boolean
   view: unknown
   subagentTracker?: unknown
   subagentDispatch: { recordMainTaskStart: (text: string) => Promise<void> }
@@ -107,6 +108,7 @@ describe("Stop flow (webview abort → ChatView → opencode HTTP)", () => {
 
     const { chat } = makeChatView(server)
     internals(chat).sessionID = "ses_main"
+    internals(chat).turnActive = true
 
     await stop(chat)
 
@@ -127,6 +129,7 @@ describe("Stop flow (webview abort → ChatView → opencode HTTP)", () => {
 
     const { chat } = makeChatView(server)
     internals(chat).sessionID = "ses_main"
+    internals(chat).turnActive = true
     const cancelForSession = vi.fn(async () => ["ses_orchestrator"])
     internals(chat).subagentTracker = { cancelForSession }
 
@@ -142,6 +145,7 @@ describe("Stop flow (webview abort → ChatView → opencode HTTP)", () => {
     server.setChildren("ses_main", ["ses_sub_a"])
     const { chat, posts } = makeChatView(server)
     internals(chat).sessionID = "ses_main"
+    internals(chat).turnActive = true
 
     const inFlight = stop(chat)
 
@@ -158,6 +162,7 @@ describe("Stop flow (webview abort → ChatView → opencode HTTP)", () => {
     const taskStore = fakeTaskStore()
     const { chat } = makeChatView(server, taskStore)
     internals(chat).sessionID = "ses_main"
+    internals(chat).turnActive = true
 
     // A turn is in flight: the Agents popover has a running Main row.
     await internals(chat).subagentDispatch.recordMainTaskStart("long prompt")
@@ -182,6 +187,7 @@ describe("Stop flow (webview abort → ChatView → opencode HTTP)", () => {
     server.setChildren("ses_main", [])
     const { chat } = makeChatView(server)
     internals(chat).sessionID = "ses_main"
+    internals(chat).turnActive = true
 
     await stop(chat)
     // The user sent another turn in the same session and pressed Stop again.
@@ -196,6 +202,22 @@ describe("Stop flow (webview abort → ChatView → opencode HTTP)", () => {
     await stop(chat)
 
     expect(posts).toEqual([])
+    expect(internals(chat).aborting).toBe(false)
+    expect(server.aborts).toEqual([])
+  })
+
+  it("Stop racing the turn's own completion re-idles the webview instead of wedging (#579)", async () => {
+    // The turn already settled (sessionIdle was posted, turnActive cleared)
+    // but the click landed before the webview rendered it. Aborting an idle
+    // session emits no new session.idle, so entering the aborting state here
+    // would leave the composer at "Stopping…" forever.
+    const { chat, posts } = makeChatView(server)
+    internals(chat).sessionID = "ses_main"
+
+    await stop(chat)
+
+    expect(posts).toContainEqual({ type: "sessionIdle" })
+    expect(posts).not.toContainEqual({ type: "aborted" })
     expect(internals(chat).aborting).toBe(false)
     expect(server.aborts).toEqual([])
   })

--- a/test/webview/abort-flow.test.ts
+++ b/test/webview/abort-flow.test.ts
@@ -23,6 +23,17 @@ describe("reducer abort flow", () => {
     expect(msg.error).toBeUndefined()
   })
 
+  it("aborted after sessionIdle (Stop raced completion) is a no-op — no wedge, no badge (#579)", () => {
+    const idle = reducer(pendingAssistant("a1"), { type: "sessionIdle" })
+    expect(idle.busy).toBe(false)
+    const after = reducer(idle, { type: "aborted" })
+    // Entering aborting here would stick forever: the already-idle session
+    // emits no further sessionIdle to clear it.
+    expect(after).toBe(idle)
+    expect(after.aborting).toBe(false)
+    expect(after.messages.find((m) => m.id === "a1")!.stopped).toBeUndefined()
+  })
+
   it("sessionIdle after aborted: clears both busy and aborting", () => {
     const before = pendingAssistant()
     const aborted = reducer(before, { type: "aborted" })

--- a/test/webview/permission-flow.test.ts
+++ b/test/webview/permission-flow.test.ts
@@ -24,7 +24,8 @@ describe("reducer — permission flow", () => {
   })
 
   it("ignores a permission raised while aborting", () => {
-    const aborting = reducer(initialChatState, { type: "aborted" })
+    // Seed a running turn: `aborted` at idle is a no-op by design (#579).
+    const aborting = reducer({ ...initialChatState, busy: true }, { type: "aborted" })
     const after = reducer(aborting, { type: "permission", id: "perm_1", title: "Edit file" })
     expect(after.pendingPermission).toBeUndefined()
   })

--- a/test/webview/queue-flow.test.tsx
+++ b/test/webview/queue-flow.test.tsx
@@ -39,7 +39,8 @@ describe("reducer queue transitions", () => {
   })
 
   it("aborted clears the queue — Stop must not auto-restart work via a queued follow-up", () => {
-    const state = reducer(initialChatState, { type: "queueMessage", message: q("q1") })
+    // Queueing only happens while busy; `aborted` at idle is a no-op (#579).
+    const state = reducer({ ...initialChatState, busy: true }, { type: "queueMessage", message: q("q1") })
     expect(reducer(state, { type: "aborted" }).queued).toEqual([])
   })
 

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -362,6 +362,14 @@ export function reducer(state: ChatState, action: Action): ChatState {
         messages: upsertMessage(state.messages, action.id, { pending: false, usage: action.usage }),
       }
     case "aborted": {
+      // A Stop can race the turn's own completion: if sessionIdle was already
+      // processed there is no turn left to stop, and no further sessionIdle
+      // will arrive to clear `aborting` — entering the aborting state here
+      // would wedge the composer at "Stopping…" forever (#579). The host
+      // guards this too (turnActive); this is defense in depth.
+      if (!state.busy && !state.messages.some((m) => m.role === "assistant" && m.pending)) {
+        return state
+      }
       // Stay busy (Send button must NOT re-enable yet) and enter aborting mode
       // until opencode sends sessionIdle. One abort = one Stopped badge: a
       // turn can contain multiple assistant messages (subtasks etc.), only the


### PR DESCRIPTION
Closes #579

## Summary

- Fixes the highest-severity finding from the bug-hunt: clicking Stop (or pressing Esc) just as a turn completes permanently wedged the conversation at "Stopping…" — aborting an already-idle session produces no new `session.idle`, the only event that clears the aborting state on either side.
- Host: new `turnActive` flag. Set when a turn starts — `handleSend`, `beginBuiltinTurn`, `handleRunCommand`, and the SSE `onUserMessage`/`onAssistantStart`/`onSessionBusy` handlers (turns started by another client on a shared session count too). Cleared in exactly one place: a new `postIdle()` helper that owns every `sessionIdle` post (settle, wasAborting branch, stream-closed, failed-send unstick), so the flag and the post can never diverge. `abortCurrent` with no active turn now posts `sessionIdle` back — the webview showed a clickable Stop, so it holds a stale busy belief that this settles — instead of entering the aborting state.
- A continuation defer deliberately keeps `turnActive` true: Stop during "Continuing…" still reaches the real abort path unchanged (that flow's own bug is #2 on the hunt list, tracked separately).
- Webview: the `aborted` reducer case no-ops when there is no turn to stop (not busy, no pending assistant) — defense in depth behind the host guard.

## Test plan

- [x] `bun run test` — 1426/1426. New host test (stop-flow harness): Stop with a settled turn re-idles the webview, posts no `aborted`, and hits no abort endpoint; existing stop-flow tests now declare `turnActive = true` (they model a running turn). New reducer test: `sessionIdle` → `aborted` returns the identical state, no wedge, no Stopped badge. Two pre-existing reducer tests seeded `busy: true` — they had applied `aborted` to an unreachable idle shape; the behaviors they pin are unchanged.
- [x] `bun run check-types` + `cd webview && bunx tsc --noEmit` — both trees clean
- [x] `bun run compile` — builds
- [ ] Manual: spam Stop at the end of a short turn — composer must settle to idle every time

🤖 Generated with [Claude Code](https://claude.com/claude-code)