### PR TITLE
fix(server): restart during startup cancels the in-flight start

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -37,6 +37,8 @@ export class ServerManager {
   private server: ServerHandle | undefined
   private client: OpencodeClient | undefined
   private starting: Promise<Backend> | undefined
+  /** Cancels the in-flight start attempt so restart/dispose mid-startup is not a no-op (#581). */
+  private startAbort: AbortController | undefined
   /** Workspace root captured at start time so subsequent `ensure()` calls return a stable Backend. */
   private workspace: WorkspaceRoot | undefined
   private configMode: OpencodeConfigMode = "isolated"
@@ -48,13 +50,21 @@ export class ServerManager {
       return this.toBackend(this.server, this.client)
     }
     if (this.starting) return this.starting
-    this.starting = this.startInternal().finally(() => {
-      this.starting = undefined
+    const abort = new AbortController()
+    const attempt = this.startInternal(abort.signal).finally(() => {
+      // dispose() may have already detached this attempt and a successor may
+      // be starting — only clear the slots that still belong to it.
+      if (this.starting === attempt) {
+        this.starting = undefined
+        this.startAbort = undefined
+      }
     })
-    return this.starting
+    this.starting = attempt
+    this.startAbort = abort
+    return attempt
   }
 
-  private async startInternal(): Promise<Backend> {
+  private async startInternal(signal: AbortSignal): Promise<Backend> {
     const config = vscode.workspace.getConfiguration("opencui")
     const port = config.get<number>("serverPort") ?? 0
     const configuredBinaryPath = config.get<string>("binaryPath") || "opencode"
@@ -78,6 +88,7 @@ export class ServerManager {
         timeout: SERVER_START_TIMEOUT_MS,
         cwd: workspace?.fsPath,
         configMode,
+        signal,
         // Registered at spawn, not at ready: an extension host killed during
         // the 60s startup window must still leave a reapable record.
         onSpawn: (pid) => {
@@ -123,6 +134,20 @@ export class ServerManager {
   }
 
   async dispose() {
+    const starting = this.starting
+    if (starting) {
+      // A start is still in flight: abort it (killing the spawned child via
+      // the startOpencodeServer fail path) and wait for it to settle. If it
+      // wins the photo-finish and installs itself instead, the settle
+      // happens-before the block below, which tears it down normally.
+      // Without this, restart() mid-startup returned the OLD in-flight
+      // attempt with the old settings (#581).
+      log("cancelling in-flight opencode server start")
+      this.startAbort?.abort()
+      this.starting = undefined
+      this.startAbort = undefined
+      await starting.catch(() => {})
+    }
     if (this.server) {
       log("stopping opencode server")
       this.server.close()
@@ -260,8 +285,13 @@ export function startOpencodeServer(
     configMode: OpencodeConfigMode
     /** Fired with the child pid immediately after spawn. */
     onSpawn?: (pid: number) => void
+    /** Aborting rejects the startup promise and kills the spawned child. */
+    signal?: AbortSignal
   },
 ): Promise<ServerHandle> {
+  if (options.signal?.aborted) {
+    return Promise.reject(new Error("opencode server start cancelled"))
+  }
   // `isolated` keeps the historical behavior: hand opencode an empty config so
   // the user's `~/.config/opencode` and any local config/plugins are ignored —
   // gives the extension predictable defaults. `user` opts back in to the
@@ -299,6 +329,12 @@ export function startOpencodeServer(
       closeProcess(proc)
       reject(error)
     }
+
+    options.signal?.addEventListener(
+      "abort",
+      () => fail(new Error("opencode server start cancelled")),
+      { once: true },
+    )
 
     proc.stdout.on("data", (chunk) => {
       if (settled) return

--- a/test/host/server-handle.test.ts
+++ b/test/host/server-handle.test.ts
@@ -44,4 +44,52 @@ describe("startOpencodeServer exit notification", () => {
       }),
     ).rejects.toThrow(/exited with code 7/)
   })
+
+  it("aborting the signal mid-startup rejects AND kills the spawned process (#581)", async () => {
+    // `exec` so the sh pid IS the sleep pid — the kill check below targets
+    // the process the handle actually manages.
+    const bin = fakeBinary("exec sleep 30")
+    const abort = new AbortController()
+    let pid: number | undefined
+    const attempt = startOpencodeServer(bin, {
+      hostname: "127.0.0.1",
+      port: 43212,
+      timeout: 5000,
+      configMode: "isolated",
+      onSpawn: (p) => (pid = p),
+      signal: abort.signal,
+    })
+    abort.abort()
+    await expect(attempt).rejects.toThrow(/cancelled/)
+    expect(pid).toBeDefined()
+    const gone = async () => {
+      for (let i = 0; i < 30; i++) {
+        try {
+          process.kill(pid!, 0)
+        } catch {
+          return true
+        }
+        await new Promise((r) => setTimeout(r, 100))
+      }
+      return false
+    }
+    expect(await gone()).toBe(true)
+  })
+
+  it("an already-aborted signal rejects without spawning at all", async () => {
+    const abort = new AbortController()
+    abort.abort()
+    let spawned = false
+    await expect(
+      startOpencodeServer("/nonexistent/opencode", {
+        hostname: "127.0.0.1",
+        port: 43213,
+        timeout: 5000,
+        configMode: "isolated",
+        onSpawn: () => (spawned = true),
+        signal: abort.signal,
+      }),
+    ).rejects.toThrow(/cancelled/)
+    expect(spawned).toBe(false)
+  })
 })

--- a/test/host/server-manager.test.ts
+++ b/test/host/server-manager.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import * as vscode from "vscode"
+import { mkdtempSync, writeFileSync, chmodSync } from "fs"
+import { tmpdir } from "os"
+import { join } from "path"
+import { ServerManager } from "../../src/server"
+
+// Real fake-binary spawns (same pattern as server-handle.test.ts) so the
+// restart contract is pinned through the actual child-process lifecycle,
+// not a stubbed startOpencodeServer.
+function fakeBinary(script: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "opencui-fake-opencode-"))
+  const file = join(dir, "opencode")
+  writeFileSync(file, `#!/bin/sh\n${script}\n`)
+  chmodSync(file, 0o755)
+  return file
+}
+
+// Announces like the real server, then stays alive so onExit doesn't clear
+// the cached backend mid-assertion.
+function announcing(port: number): string {
+  return fakeBinary(`echo "opencode server listening on http://127.0.0.1:${port}"\nexec sleep 10`)
+}
+
+const settings: Record<string, unknown> = {}
+let manager: ServerManager
+let savedFolders: unknown
+
+beforeEach(() => {
+  for (const key of Object.keys(settings)) delete settings[key]
+  vi.mocked(vscode.workspace.getConfiguration).mockImplementation(
+    () => ({ get: (key: string) => settings[key] }) as never,
+  )
+  // No workspace folder: the mock's "/workspace" doesn't exist on disk and
+  // spawn(cwd) would ENOENT before the lifecycle under test even begins.
+  savedFolders = vscode.workspace.workspaceFolders
+  ;(vscode.workspace as { workspaceFolders: unknown }).workspaceFolders = undefined
+  manager = new ServerManager({ extensionPath: "/nonexistent" } as never)
+})
+
+afterEach(async () => {
+  await manager.dispose()
+  ;(vscode.workspace as { workspaceFolders: unknown }).workspaceFolders = savedFolders
+})
+
+describe("ServerManager.restart", () => {
+  it("restart during a hung startup abandons it and boots with freshly-read settings (#581)", async () => {
+    // The user's actual scenario: startup hangs (bad binary / never
+    // announces), they fix the setting and hit Restart while the 60s
+    // window is still open.
+    settings.binaryPath = fakeBinary("exec sleep 30")
+    const first = manager.ensure()
+    first.catch(() => {}) // observed via rejects.toThrow below
+    await new Promise((r) => setTimeout(r, 100))
+
+    settings.binaryPath = announcing(43298)
+    const backend = await manager.restart()
+
+    // Pre-fix, dispose() no-op'd and ensure() returned the old in-flight
+    // attempt — this await would hang on the 30s sleep until timeout.
+    expect(backend.url).toBe("http://127.0.0.1:43298")
+    await expect(first).rejects.toThrow(/cancelled/)
+    expect(manager.currentBackend()?.url).toBe("http://127.0.0.1:43298")
+  })
+
+  it("restart after a completed start also re-reads settings", async () => {
+    settings.binaryPath = announcing(43297)
+    expect((await manager.ensure()).url).toBe("http://127.0.0.1:43297")
+
+    settings.binaryPath = announcing(43296)
+    expect((await manager.restart()).url).toBe("http://127.0.0.1:43296")
+  })
+
+  it("dispose during startup settles the attempt (deactivation must not leak the spawning child)", async () => {
+    settings.binaryPath = fakeBinary("exec sleep 30")
+    const first = manager.ensure()
+    first.catch(() => {})
+    await new Promise((r) => setTimeout(r, 100))
+
+    await manager.dispose()
+
+    await expect(first).rejects.toThrow(/cancelled/)
+    expect(manager.currentBackend()).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Closes #581

## Summary

`restart()` issued during the 60s startup window was a silent no-op: `dispose()` only acted on a completed start, and `ensure()` returned the old in-flight attempt with the old settings. The most likely trigger was also the worst one — the user changes `binaryPath`/`opencodeConfigMode` *because* startup is hanging, hits Restart, and gets the same hung attempt back. Deactivation mid-startup also leaked the spawning child.

- `startOpencodeServer` accepts an optional `AbortSignal`; abort settles startup via the existing `fail` path, which kills the child through `closeProcess` (Windows tree-kill included). An already-aborted signal rejects before spawning.
- `ensure()` mints an `AbortController` per attempt; its `finally` only clears the `starting`/`startAbort` slots if they still belong to that attempt, so a successor started after `dispose()` detached it is never clobbered.
- `dispose()` aborts and awaits any in-flight attempt before the completed-server teardown. If the attempt wins the photo-finish and installs itself, the awaited settle happens-before the `this.server` block, which tears it down normally. Registry records release through the existing paths (startInternal's catch / dispose's release).
- Abandoned `ensure()` awaiters get a rejection ("cancelled") instead of a backend that no longer reflects current settings.

## Test plan

- [x] New: abort mid-startup rejects AND the spawned process dies (polled `kill -0`); already-aborted signal rejects without spawning (`server-handle.test.ts`)
- [x] New `server-manager.test.ts` (first ServerManager lifecycle coverage, real fake-binary spawns): restart during a hung startup abandons it and boots from freshly-read settings; restart after a completed start re-reads settings; dispose during startup settles the attempt
- [x] Verified all 4 new tests fail (hang to timeout) against pre-fix `src/server.ts`
- [x] Full suite: 1431/1431
- [x] `bun run check-types` + webview `tsc --noEmit` clean
- [x] `bun run compile` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)