### PR TITLE
chore(release): 1.13.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.13.6] - 2026-08-31
+
+### Fixed
+- Clicking Stop just as a response finishes no longer freezes the conversation at "Stopping…". When the click raced the turn's own completion, the extension aborted an already-idle session — which never emits the idle event that clears the stopping state — leaving the composer stuck until you switched conversations. A settled turn now answers a late Stop by confirming idle instead of entering the unclearable stopping state (#579, #580).
+- "Restart Server" issued while the server is still starting up now actually restarts it. Previously the restart silently returned the old in-flight startup with the old settings — so fixing `opencui.binaryPath` or the config mode precisely because startup was hanging appeared to do nothing until the 60-second timeout. The in-flight startup is now cancelled (its process killed) and a fresh one boots from the current settings; closing the window mid-startup also cleans up the spawning process instead of leaking it (#581, #582).
+
 ## [1.13.5] - 2026-08-28
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.13.5",
+  "version": "1.13.6",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
Closes #583

## Summary

Patch release: two abort/lifecycle fixes from the proactive bug audit.

- Stop racing the turn's own completion no longer wedges the composer at "Stopping…" (#579, #580).
- Restart Server during the startup window cancels the in-flight start and boots from freshly-read settings instead of silently no-op'ing (#581, #582).

## Test plan

- [x] Full suite: 1431/1431
- [x] `bun run check-types` + webview `tsc --noEmit` clean
- [x] CHANGELOG entry inserted under Unreleased; `package.json` 1.13.5 → 1.13.6
- [ ] Release workflow (type-check, test, build, package, publish) runs on `gh release create v1.13.6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)