### PR TITLE
fix(chat): SSE re-attach resumes the in-flight message instead of duplicating it

### DIFF
--- a/src/chat/stream.ts
+++ b/src/chat/stream.ts
@@ -196,6 +196,66 @@ export type SubscriptionOptions = {
    * Defaults to 30 s; tests pass shorter values.
    */
   watchdogMs?: number
+  /**
+   * Dedup/offset state for the session, owned by the caller so a re-attach
+   * after stream loss resumes where the dead subscription left off. A fresh
+   * subscription with empty state treats the in-flight assistant message as
+   * new (duplicate `onAssistantStart`) and re-emits the full text of any
+   * part opencode re-delivers (#585). Omit for a one-shot subscription.
+   */
+  state?: SessionStreamState
+}
+
+/**
+ * Everything `subscribeSession` remembers about a session in order to turn
+ * opencode's at-least-once, full-snapshot events into exactly-once deltas.
+ * Keyed by ids that are unique across sessions, so sharing one object across
+ * re-subscriptions of the same session is safe; sharing across sessions is
+ * merely wasteful.
+ */
+export type SessionStreamState = {
+  sessionID: string
+  /** partID → characters already emitted as deltas. */
+  seenLen: Map<string, number>
+  seenAssistantMessages: Set<string>
+  summaryFlagged: Set<string>
+  seenUserMessages: Set<string>
+  assistantFinished: Set<string>
+  seenPatches: Set<string>
+  /**
+   * messageID → tool part IDs still pending/running. Defers per-message
+   * `assistantEnd` until every tool call terminates: some providers return
+   * `finish: "stop"` while the message still has running tool parts, so the
+   * finish reason alone isn't sufficient.
+   */
+  activeToolParts: Map<string, Set<string>>
+  /** messageID → payload waiting on tool-part completion before assistantEnd fires. */
+  pendingFinish: Map<string, { finish: string; usage?: MessageUsage }>
+  /**
+   * Sessions we additionally route lifecycle events for (subagent
+   * children). Distinct from the parent `sessionID` because parent routing
+   * has rich per-message handlers; child routing only needs the small
+   * `ChildSessionEvent` surface.
+   */
+  childSessions: Set<string>
+  /** assistantEnd dedup for child sessions (parent has its own set). */
+  childAssistantFinished: Set<string>
+}
+
+export function createSessionStreamState(sessionID: string): SessionStreamState {
+  return {
+    sessionID,
+    seenLen: new Map(),
+    seenAssistantMessages: new Set(),
+    summaryFlagged: new Set(),
+    seenUserMessages: new Set(),
+    assistantFinished: new Set(),
+    seenPatches: new Set(),
+    activeToolParts: new Map(),
+    pendingFinish: new Map(),
+    childSessions: new Set(),
+    childAssistantFinished: new Set(),
+  }
 }
 
 const DEFAULT_WATCHDOG_MS = 30_000
@@ -222,30 +282,18 @@ export function subscribeSession(
   const controller = new AbortController()
   const watchdogMs = options.watchdogMs ?? DEFAULT_WATCHDOG_MS
 
-  const seenLen = new Map<string, number>()
-  const seenAssistantMessages = new Set<string>()
-  const summaryFlagged = new Set<string>()
-  const seenUserMessages = new Set<string>()
-  const assistantFinished = new Set<string>()
-  const toolStatus = new Map<string, string>()
-  const seenPatches = new Set<string>()
-  /**
-   * Sessions we additionally route lifecycle events for (subagent
-   * children). Distinct from the parent `sessionID` because parent
-   * routing has rich per-message handlers; child routing only needs
-   * the small `ChildSessionEvent` surface.
-   */
-  const childSessions = new Set<string>()
-  /** assistantEnd dedup for child sessions (parent has its own set). */
-  const childAssistantFinished = new Set<string>()
-
-  // messageID → set of tool part IDs that are still pending/running.
-  // Used to defer per-message `assistantEnd` until all tool calls terminate:
-  // some providers return `finish: "stop"` while the message still has
-  // running tool parts, so the finish reason alone isn't sufficient.
-  const activeToolParts = new Map<string, Set<string>>()
-  // messageID → payload waiting on tool-part completion before assistantEnd fires.
-  const pendingFinish = new Map<string, { finish: string; usage?: MessageUsage }>()
+  const {
+    seenLen,
+    seenAssistantMessages,
+    summaryFlagged,
+    seenUserMessages,
+    assistantFinished,
+    seenPatches,
+    activeToolParts,
+    pendingFinish,
+    childSessions,
+    childAssistantFinished,
+  } = options.state ?? createSessionStreamState(sessionID)
 
   let watchdogTimer: ReturnType<typeof setTimeout> | null = null
   let busyTracked = false
@@ -697,7 +745,6 @@ export function subscribeSession(
     if (part.type === "tool" && part.callID && part.tool && part.state) {
       const key = part.callID as string
       const curr = part.state.status as ToolUpdate["status"]
-      toolStatus.set(key, curr)
       // Track unfinished tool parts per message; flush a deferred
       // assistantEnd once everything settles.
       const partKey = (part.id as string | undefined) ?? key

--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -9,6 +9,8 @@ import {
   type Subscription,
   type Toast,
   type ToolUpdate,
+  createSessionStreamState,
+  type SessionStreamState,
 } from "./stream"
 import { getEditorContext, formatContextHeader } from "../context"
 import { searchWorkspaceFiles, listWorkspaceDir } from "../file-search"
@@ -105,6 +107,8 @@ export class ChatView implements vscode.WebviewViewProvider {
   private continuationState: ContinuationState
   /** opencode messageID → webview-side id used in UI */
   private messageMap = new Map<string, string>()
+  /** Stream dedup/offset state, shared across re-attaches of the same session (#585). */
+  private streamState?: SessionStreamState
   /**
    * Tails removed by `/undo`, newest last, so `/redo` can re-append them. Purely
    * in-memory: it does not survive a reload, and any new turn or conversation
@@ -621,6 +625,7 @@ export class ChatView implements vscode.WebviewViewProvider {
     this.sessionID = undefined
     this.clearPendingDeltas()
     this.messageMap.clear()
+    this.streamState = undefined
     this.redoStack = []
     this.activePermissions.clear()
     this.activeQuestions.clear()
@@ -885,6 +890,10 @@ export class ChatView implements vscode.WebviewViewProvider {
         this.saveActive()
         return
       case "assistantStart":
+        // The stream can re-announce a message the transcript already holds
+        // (re-attach, trailing bookkeeping after a reload); a second row with
+        // the same id is never right (#585).
+        if (this.messages.some((m) => m.id === msg.id)) return
         this.messages = [...this.messages, { id: msg.id, role: "assistant", blocks: [], pending: true }]
         this.saveActive()
         return
@@ -1972,6 +1981,10 @@ export class ChatView implements vscode.WebviewViewProvider {
 
   private async attachSubscription(backend: Backend, sessionID: string) {
     this.subscription?.abort()
+    // A re-attach after stream loss must resume at the dead stream's offsets:
+    // fresh state re-announces the in-flight message and re-emits the full
+    // text of any part opencode re-delivers (#585).
+    if (this.streamState?.sessionID !== sessionID) this.streamState = createSessionStreamState(sessionID)
     const subscription = subscribeSession(backend, sessionID, {
       onUserMessage: (mid) => {
         // A user message on the stream means a turn is running, whichever
@@ -2208,7 +2221,7 @@ export class ChatView implements vscode.WebviewViewProvider {
         this.postIdle()
         void this.reattachAfterStreamLoss()
       },
-    })
+    }, { state: this.streamState })
     this.subscription = subscription
     if (this.taskStore) {
       this.subagentTracker = new SubagentTracker({

--- a/test/host/chatview-harness.test.ts
+++ b/test/host/chatview-harness.test.ts
@@ -266,6 +266,46 @@ describe("ChatView harness: send round-trip", () => {
   })
 })
 
+describe("ChatView harness: SSE re-attach mid-turn", () => {
+  it("resumes the in-flight message in place: one row, text once, and that is what persists (#585)", async () => {
+    await harness.send({ type: "mounted" })
+    await harness.send({ type: "send", text: "hello there" })
+
+    server.push({ type: "message.updated", info: { id: "usr_1", role: "user", sessionID: SESSION_ID } })
+    server.push({ type: "message.updated", info: { id: "msg_a", role: "assistant", sessionID: SESSION_ID } })
+    server.push({
+      type: "message.part.updated",
+      part: { id: "part_1", messageID: "msg_a", sessionID: SESSION_ID, type: "text", text: "Hi" },
+    })
+    await until(() => harness.posted.some((m) => m.type === "textDelta"))
+
+    // Transport drop: the view unsticks the composer and re-attaches to the
+    // same (still running) session.
+    server.dropClients()
+    await until(() => harness.posted.some((m) => m.type === "sessionIdle"))
+    await server.awaitClient()
+
+    // opencode's end-of-part snapshot re-delivers the whole text; before
+    // #585 the fresh subscription re-announced msg_a (second row, same id)
+    // and re-emitted "Hi there" in full into both rows.
+    server.push({
+      type: "message.part.updated",
+      part: { id: "part_1", messageID: "msg_a", sessionID: SESSION_ID, type: "text", text: "Hi there" },
+    })
+    server.push({ type: "message.updated", info: { id: "msg_a", role: "assistant", sessionID: SESSION_ID, finish: "stop" } })
+    await until(() => harness.posted.some((m) => m.type === "assistantDone" && m.id === "a_msg_a"))
+
+    expect(harness.posted.filter((m) => m.type === "assistantStart" && m.id === "a_msg_a")).toHaveLength(1)
+    const deltas = harness.posted.flatMap((m) => (m.type === "textDelta" ? [m.delta] : []))
+    expect(deltas.join("")).toBe("Hi there")
+
+    await harness.chatView.flushPersist()
+    const assistants = savedConversations()[0]!.messages.filter((m) => m.role === "assistant")
+    expect(assistants).toHaveLength(1)
+    expect(assistants[0]!.blocks).toEqual([{ type: "text", text: "Hi there" }])
+  })
+})
+
 describe("ChatView harness: Stop mid-stream", () => {
   it("posts aborted, aborts the session subtree, drops late deltas, and persists the Stopped state", async () => {
     await harness.send({ type: "mounted" })

--- a/test/host/mock-opencode-server.ts
+++ b/test/host/mock-opencode-server.ts
@@ -31,6 +31,8 @@ export type MockOpencodeServer = {
   push: (event: ScriptedEvent) => void
   /** Resolves once at least one SSE client connects. */
   awaitClient: () => Promise<void>
+  /** End every open SSE response (a transport drop) while the server stays up. */
+  dropClients: () => void
   /** Records of every prompt the SDK pushed to the server. */
   prompts: Array<{ sessionID: string; body: unknown }>
   /** Records of every revert call. */
@@ -458,6 +460,11 @@ export async function startMockOpencode(): Promise<MockOpencodeServer> {
       return new Promise<void>((resolve) => {
         clientResolver = resolve
       })
+    },
+    dropClients() {
+      // Splice first so a push racing the client's own close never writes to
+      // an ended response.
+      for (const c of sseClients.splice(0)) c.end()
     },
     prompts,
     reverts,

--- a/test/host/stream-reattach.test.ts
+++ b/test/host/stream-reattach.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest"
+import { createOpencodeClient } from "@opencode-ai/sdk"
+import { startMockOpencode, type MockOpencodeServer } from "./mock-opencode-server"
+import { createSessionStreamState, subscribeSession, type StreamHandlers } from "../../src/chat/stream"
+
+// A re-subscription after stream loss must continue the dead subscription's
+// dedup/offset bookkeeping. opencode's events are full snapshots delivered
+// at-least-once (the end-of-part `message.part.updated` carries the whole
+// text), so a subscription that starts from empty state re-announces the
+// in-flight message and re-emits everything already shown (#585).
+
+let server: MockOpencodeServer
+
+beforeEach(async () => {
+  server = await startMockOpencode()
+})
+
+afterEach(async () => {
+  await server.close()
+})
+
+const SESSION = "ses_test"
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+function backend() {
+  const client = createOpencodeClient({ baseUrl: server.url })
+  return { url: server.url, client, directory: "/tmp" }
+}
+
+type Log = { starts: string[]; deltas: string[]; ends: string[] }
+
+function recorder(): { log: Log; handlers: StreamHandlers } {
+  const log: Log = { starts: [], deltas: [], ends: [] }
+  return {
+    log,
+    handlers: {
+      onAssistantStart: (mid) => log.starts.push(mid),
+      onTextDelta: (_mid, delta) => log.deltas.push(delta),
+      onAssistantEnd: (mid) => log.ends.push(mid),
+    },
+  }
+}
+
+async function subscribe(handlers: StreamHandlers, state?: ReturnType<typeof createSessionStreamState>) {
+  const subscription = subscribeSession(backend(), SESSION, handlers, { watchdogMs: 10_000, state })
+  await subscription.ready
+  await server.awaitClient()
+  return subscription
+}
+
+function textPart(text: string) {
+  return {
+    type: "message.part.updated",
+    part: { id: "part_1", messageID: "msg_a", sessionID: SESSION, type: "text", text },
+  }
+}
+
+describe("subscribeSession re-attach with shared SessionStreamState", () => {
+  it("resumes at the dead stream's offsets: no second assistantStart, only the unseen tail of a re-delivered part", async () => {
+    const state = createSessionStreamState(SESSION)
+    const { log, handlers } = recorder()
+
+    await subscribe(handlers, state)
+    server.push({ type: "message.updated", info: { id: "msg_a", role: "assistant", sessionID: SESSION } })
+    server.push(textPart("Hi"))
+    await wait(30)
+    expect(log.starts).toEqual(["msg_a"])
+    expect(log.deltas).toEqual(["Hi"])
+
+    // Transport drop, then the owner re-subscribes with the same state.
+    server.dropClients()
+    await wait(30)
+    const second = await subscribe(handlers, state)
+    server.push(textPart("Hi there"))
+    server.push({
+      type: "message.part.delta",
+      sessionID: SESSION,
+      messageID: "msg_a",
+      partID: "part_1",
+      field: "text",
+      delta: "!",
+    })
+    await wait(30)
+    second.abort()
+
+    expect(log.starts).toEqual(["msg_a"])
+    expect(log.deltas).toEqual(["Hi", " there", "!"])
+  })
+
+  it("without shared state the re-subscription re-announces the message and re-emits its full text", async () => {
+    // Pins WHY the state is caller-owned: this is the pre-#585 behavior a
+    // fresh subscription still exhibits by construction.
+    const { log, handlers } = recorder()
+    await subscribe(handlers)
+    server.push({ type: "message.updated", info: { id: "msg_a", role: "assistant", sessionID: SESSION } })
+    server.push(textPart("Hi"))
+    await wait(30)
+    server.dropClients()
+    await wait(30)
+    const second = await subscribe(handlers)
+    server.push(textPart("Hi there"))
+    await wait(30)
+    second.abort()
+
+    expect(log.starts).toEqual(["msg_a", "msg_a"])
+    expect(log.deltas).toEqual(["Hi", "Hi there"])
+  })
+
+  it("a tool that started before the drop still defers assistantEnd after the re-attach", async () => {
+    const state = createSessionStreamState(SESSION)
+    const { log, handlers } = recorder()
+
+    await subscribe(handlers, state)
+    server.push({ type: "message.updated", info: { id: "msg_a", role: "assistant", sessionID: SESSION } })
+    server.push({
+      type: "message.part.updated",
+      part: {
+        id: "part_t", messageID: "msg_a", sessionID: SESSION, type: "tool",
+        callID: "call_1", tool: "bash", state: { status: "running" },
+      },
+    })
+    await wait(30)
+    server.dropClients()
+    await wait(30)
+
+    const second = await subscribe(handlers, state)
+    // finish=stop while the tool part is still running: with fresh state the
+    // running part would be unknown and assistantEnd would fire here.
+    server.push({ type: "message.updated", info: { id: "msg_a", role: "assistant", sessionID: SESSION, finish: "stop" } })
+    await wait(30)
+    expect(log.ends).toEqual([])
+
+    server.push({
+      type: "message.part.updated",
+      part: {
+        id: "part_t", messageID: "msg_a", sessionID: SESSION, type: "tool",
+        callID: "call_1", tool: "bash", state: { status: "completed", output: "ok" },
+      },
+    })
+    await wait(30)
+    second.abort()
+    expect(log.ends).toEqual(["msg_a"])
+  })
+})

--- a/test/webview/stream-dedup.test.ts
+++ b/test/webview/stream-dedup.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest"
+import { reducer, initialChatState } from "../../webview/src/hooks/useChatState"
+
+describe("reducer — re-announced assistant message", () => {
+  it("assistantStart for an id already in the transcript is a no-op by reference", () => {
+    // An SSE re-attach mid-turn (or trailing bookkeeping after a reload) can
+    // announce a message the transcript already holds; a second row with the
+    // same id duplicated the bubble and every later delta (#585).
+    let state = reducer(initialChatState, { type: "assistantStart", id: "a_1" })
+    state = reducer(state, { type: "textDelta", id: "a_1", delta: "Hi" })
+    state = reducer(state, { type: "sessionIdle" })
+
+    const again = reducer(state, { type: "assistantStart", id: "a_1" })
+
+    expect(again).toBe(state)
+    expect(again.messages).toHaveLength(1)
+  })
+
+  it("a delta after the re-announcement lands in the single existing row", () => {
+    let state = reducer(initialChatState, { type: "assistantStart", id: "a_1" })
+    state = reducer(state, { type: "textDelta", id: "a_1", delta: "Hi" })
+    state = reducer(state, { type: "assistantStart", id: "a_1" })
+    state = reducer(state, { type: "textDelta", id: "a_1", delta: " there" })
+
+    expect(state.messages).toHaveLength(1)
+    expect(state.messages[0]!.blocks).toEqual([{ type: "text", text: "Hi there" }])
+  })
+})

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -293,6 +293,9 @@ export function reducer(state: ChatState, action: Action): ChatState {
       // after Stop must not append a fresh pending assistant bubble (it would
       // render with no Stopped badge once sessionIdle clears its pending flag).
       if (state.aborting) return state
+      // A re-announced id (SSE re-attach mid-turn, trailing bookkeeping after
+      // a reload) must not mint a second row with the same id (#585).
+      if (state.messages.some((m) => m.id === action.id)) return state
       return {
         ...state,
         busy: true,


### PR DESCRIPTION
Closes #585

## Summary

A mid-turn SSE drop re-attached with a fresh `subscribeSession` whose dedup state started empty while ChatView kept its message map and transcript. The next event for the in-flight assistant message re-fired `onAssistantStart`, the host's `applyLocal` and the webview reducer each appended a second row with the same id, and opencode's end-of-part snapshot re-emitted the full text into both rows. The corruption was persisted.

- `subscribeSession` accepts a caller-owned `SessionStreamState` (`createSessionStreamState(sessionID)`) carrying the seen-message sets, per-part emitted offsets, finish/patch dedup, active tool parts and child-session routing. `ChatView` keeps one per session and passes the same object to every re-attach, minting a fresh one only when the session id changes; `resetSessionState` clears it.
- Side benefits of the shared state: a tool that started before the drop still defers `assistantEnd` after the re-attach, the phantom-bubble guard keeps working, and a running subagent's edits keep routing to the review card without waiting for reconcile.
- `assistantStart` for an id already in the transcript is a no-op on both the host and the reducer. This also covers a window reload followed by trailing `message.updated` bookkeeping for a persisted message, which previously minted a duplicate row too.
- The write-only `toolStatus` map is removed.
- Mock server gains `dropClients()` (end every SSE response while the server stays up) so tests can model a transport drop.

## Test plan

- [x] New `stream-reattach.test.ts`: shared state across a drop yields no second `assistantStart` and only the unseen tail of a re-delivered part; the no-shared-state control pins the pre-fix behavior; a tool running before the drop still defers `assistantEnd`
- [x] New ChatView harness test: send, partial reply, `dropClients()`, re-attach, full-text snapshot + finish; asserts one `assistantStart`, deltas join to the text once, and the persisted conversation holds one assistant row
- [x] New `stream-dedup.test.ts`: reducer no-op by reference for a re-announced id; a following delta lands in the single row
- [x] Verified the harness and reducer tests fail against the pre-fix source
- [x] Full suite 1437/1437; `bun run check-types` + webview `tsc --noEmit` clean; `bun run compile` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xUfpVFpQuGJodPFqLfB1C