### PR TITLE
fix(webview): stop rewriting the body of a code fence that is still streaming

### DIFF
--- a/test/webview/markdown.test.tsx
+++ b/test/webview/markdown.test.tsx
@@ -4,9 +4,46 @@ import {
   Markdown,
   normalizeMath,
   normalizeAgentEnvelopes,
+  prepareMarkdown,
 } from "../../webview/src/components/Markdown"
 
 afterEach(cleanup)
+
+describe("unclosed fence (a code block still streaming in, #587)", () => {
+  it("normalizeMath leaves the body of an unclosed fence alone but still rewrites the prose before it", () => {
+    const out = normalizeMath("Price \\(p\\)\n\n```bash\necho $1 \\(x\\)")
+    expect(out).toMatch(/\$p\$/)
+    expect(out).toContain("echo $1 \\(x\\)")
+  })
+
+  it("normalizeAgentEnvelopes leaves envelope tags inside an unclosed fence alone", () => {
+    const out = normalizeAgentEnvelopes("<answer>done</answer>\n\n```xml\n<analysis>raw</analysis>")
+    expect(out).toContain("**Answer**")
+    expect(out).toContain("<analysis>raw</analysis>")
+    expect(out).not.toContain("**Analysis**")
+  })
+
+  it("a closed fence followed by an unclosed one skips both", () => {
+    const out = normalizeMath("```\n$1\n```\ntext \\(a\\)\n```\n$2")
+    expect(out).toContain("$1\n```")
+    expect(out).toMatch(/\$a\$/)
+    expect(out.endsWith("```\n$2")).toBe(true)
+    expect(out).not.toContain("\\$")
+  })
+
+  it("prepareMarkdown counts math in prose only, whether the fence is closed or not", () => {
+    expect(prepareMarkdown("```sh\necho $HOME\n```").hasMath).toBe(false)
+    expect(prepareMarkdown("```sh\necho $HOME").hasMath).toBe(false)
+    expect(prepareMarkdown("cost $x$ here").hasMath).toBe(true)
+    expect(prepareMarkdown("<answer>\\(a\\)</answer>").source).toMatch(/\$a\$/)
+  })
+
+  it("renders a streaming code block's `$1` literally while the fence is still open", () => {
+    const { container } = render(<Markdown text={"```bash\nkill $1"} streaming />)
+    expect(container.textContent).toContain("kill $1")
+    expect(container.textContent).not.toContain("\\$1")
+  })
+})
 
 describe("normalizeMath", () => {
   it("rewrites display math \\[ ... \\] to $$ ... $$", () => {

--- a/webview/src/components/Markdown.tsx
+++ b/webview/src/components/Markdown.tsx
@@ -52,18 +52,36 @@ const ENVELOPE_LABELS: Record<string, string> = {
   next_steps: "Next steps",
 }
 
-export function normalizeAgentEnvelopes(input: string): string {
-  const out: string[] = []
-  const fence = /```[\s\S]*?```|~~~[\s\S]*?~~~/g
+// An unclosed fence runs to the end of input, matching CommonMark and what
+// remark will do with the same text. Mid-stream the block is still being
+// typed; treating its body as prose rewrote `$1`, `\(…\)`, and envelope tags
+// inside code until the closer arrived (#587).
+const FENCE = /```[\s\S]*?(?:```|$)|~~~[\s\S]*?(?:~~~|$)/g
+
+type Segment = { code: boolean; text: string }
+
+function splitFences(input: string): Segment[] {
+  const out: Segment[] = []
+  const fence = new RegExp(FENCE.source, "g")
   let last = 0
   let m: RegExpExecArray | null
   while ((m = fence.exec(input)) !== null) {
-    out.push(rewriteEnvelopesOutsideCode(input.slice(last, m.index)))
-    out.push(m[0])
+    if (m.index > last) out.push({ code: false, text: input.slice(last, m.index) })
+    out.push({ code: true, text: m[0] })
     last = m.index + m[0].length
   }
-  out.push(rewriteEnvelopesOutsideCode(input.slice(last)))
-  return out.join("")
+  out.push({ code: false, text: input.slice(last) })
+  return out
+}
+
+function mapProse(input: string, fn: (prose: string) => string): string {
+  return splitFences(input)
+    .map((s) => (s.code ? s.text : fn(s.text)))
+    .join("")
+}
+
+export function normalizeAgentEnvelopes(input: string): string {
+  return mapProse(input, rewriteEnvelopesOutsideCode)
 }
 
 function rewriteEnvelopesOutsideCode(s: string): string {
@@ -105,17 +123,36 @@ function rewriteEnvelopesOutsideCode(s: string): string {
  * variables and `\(…\)`, not bare numeric kernels.
  */
 export function normalizeMath(input: string): string {
-  const out: string[] = []
-  const fence = /```[\s\S]*?```|~~~[\s\S]*?~~~/g
-  let last = 0
-  let m: RegExpExecArray | null
-  while ((m = fence.exec(input)) !== null) {
-    out.push(rewriteOutsideCode(input.slice(last, m.index)))
-    out.push(m[0])
-    last = m.index + m[0].length
-  }
-  out.push(rewriteOutsideCode(input.slice(last)))
-  return out.join("")
+  return mapProse(input, rewriteOutsideCode)
+}
+
+// Math is comparatively expensive: normalizeMath's regex passes, the
+// remark-math tokenizer, and the rehype-katex tree walk all re-run on every
+// render of a streaming message. Most chat messages contain no math, so detect
+// the delimiters once and skip the whole math pipeline when there are none.
+// Covers `$…$` / `$$…$$` plus the `\(…\)` / `\[…\]` forms normalizeMath would
+// convert into dollar math. Currency like `$5` trips this too — intentional:
+// the pipeline then escapes it correctly, exactly as before.
+const MATH_HINT = /\$|\\\(|\\\[/
+
+/**
+ * The component's single pre-parse pass: envelope rewrite, math detection,
+ * and math rewrite, each restricted to prose. `hasMath` reflects prose only —
+ * a `$` inside a code block (a shell variable, say) used to switch on
+ * remark-math + katex for the whole segment.
+ */
+export function prepareMarkdown(input: string): { source: string; hasMath: boolean } {
+  let hasMath = false
+  const source = splitFences(input)
+    .map((s) => {
+      if (s.code) return s.text
+      const prose = rewriteEnvelopesOutsideCode(s.text)
+      if (!MATH_HINT.test(prose)) return prose
+      hasMath = true
+      return rewriteOutsideCode(prose)
+    })
+    .join("")
+  return { source, hasMath }
 }
 
 function rewriteOutsideCode(s: string): string {
@@ -186,22 +223,9 @@ function flattenChildren(node: ReactNode): string {
 // as faint red text and keeps going.
 const katexOptions = { strict: "ignore", throwOnError: false } as const
 
-// Math is comparatively expensive: normalizeMath's regex passes, the
-// remark-math tokenizer, and the rehype-katex tree walk all re-run on every
-// render of a streaming message. Most chat messages contain no math, so detect
-// the delimiters once and skip the whole math pipeline when there are none.
-// Covers `$…$` / `$$…$$` plus the `\(…\)` / `\[…\]` forms normalizeMath would
-// convert into dollar math. Currency like `$5` trips this too — intentional:
-// the pipeline then escapes it correctly, exactly as before.
-const MATH_HINT = /\$|\\\(|\\\[/
-
 function MarkdownImpl({ text, streaming = false }: Props) {
   const sampled = useThrottledValue(text, streaming ? STREAM_PARSE_MS : 0)
-  const { source, hasMath } = useMemo(() => {
-    const enveloped = normalizeAgentEnvelopes(sampled)
-    const math = MATH_HINT.test(enveloped)
-    return { source: math ? normalizeMath(enveloped) : enveloped, hasMath: math }
-  }, [sampled])
+  const { source, hasMath } = useMemo(() => prepareMarkdown(sampled), [sampled])
   return (
     <div className="md">
       <ReactMarkdown


### PR DESCRIPTION
Closes #587

## Summary

While a fenced code block streamed in, both Markdown pre-processors treated its body as prose because their fence regexes required a closing fence: `$1` became `\$1`, `\(x\)` became `$x$`, and envelope tags inside code were rewritten into bold sections, until the closer landed and the block snapped back. remark already treats an unclosed fence as running to end of input (CommonMark), so the pre-processors now agree with the parser they feed.

- One `splitFences` helper (fence ends at a closer **or end of input**) shared by `normalizeAgentEnvelopes` and `normalizeMath`.
- The component's pre-parse pass is a single `prepareMarkdown` that restricts the envelope rewrite, math detection, and math rewrite to prose runs. `hasMath` now reflects prose only, so a `$` inside any code block (closed or not) no longer enables remark-math + rehype-katex for the whole segment.

## Test plan

- [x] Five new cases in `markdown.test.tsx`: unclosed-fence bodies untouched by the math and envelope rewrites while the prose before them is still normalized; closed-then-unclosed fences both skipped; `hasMath` false for code-only `$` (closed and unclosed), true for prose math; a streaming block renders `kill $1` literally
- [x] All five fail against the pre-fix `Markdown.tsx`
- [x] Full suite 1442/1442; `bun run check-types` + webview `tsc --noEmit` clean; `bun run compile` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xUfpVFpQuGJodPFqLfB1C