### PR TITLE
fix(chat): route streamed reasoning by the announced part type

### DIFF
--- a/src/chat/stream.ts
+++ b/src/chat/stream.ts
@@ -217,6 +217,13 @@ export type SessionStreamState = {
   sessionID: string
   /** partID → characters already emitted as deltas. */
   seenLen: Map<string, number>
+  /**
+   * partID → part type, recorded from the `message.part.updated` opencode
+   * publishes when it creates the part. A `message.part.delta`'s `field` is
+   * the property name on the part (`"text"` for reasoning parts too), so the
+   * delta alone cannot say whether it is thinking or answer.
+   */
+  partKinds: Map<string, "text" | "reasoning">
   seenAssistantMessages: Set<string>
   summaryFlagged: Set<string>
   seenUserMessages: Set<string>
@@ -246,6 +253,7 @@ export function createSessionStreamState(sessionID: string): SessionStreamState 
   return {
     sessionID,
     seenLen: new Map(),
+    partKinds: new Map(),
     seenAssistantMessages: new Set(),
     summaryFlagged: new Set(),
     seenUserMessages: new Set(),
@@ -284,6 +292,7 @@ export function subscribeSession(
 
   const {
     seenLen,
+    partKinds,
     seenAssistantMessages,
     summaryFlagged,
     seenUserMessages,
@@ -726,18 +735,11 @@ export function subscribeSession(
       handlers.onAssistantStart?.(messageID)
     }
     const partID = part.id as string | undefined
-    if (part.type === "text" && typeof part.text === "string" && partID) {
+    if ((part.type === "text" || part.type === "reasoning") && typeof part.text === "string" && partID) {
+      partKinds.set(partID, part.type)
       const seen = seenLen.get(partID) ?? 0
       if (part.text.length > seen) {
-        handlers.onTextDelta(messageID, part.text.slice(seen))
-        seenLen.set(partID, part.text.length)
-      }
-      return
-    }
-    if (part.type === "reasoning" && typeof part.text === "string" && partID) {
-      const seen = seenLen.get(partID) ?? 0
-      if (part.text.length > seen) {
-        handlers.onReasoningDelta?.(messageID, part.text.slice(seen))
+        emitDelta(messageID, part.type, part.text.slice(seen))
         seenLen.set(partID, part.text.length)
       }
       return
@@ -800,13 +802,16 @@ export function subscribeSession(
     // part.text): a malformed/empty delta would otherwise throw on
     // `p.delta.length`, propagate out of the SSE reader loop, and tear down the
     // live subscription mid-turn.
-    if (p.field === "text" && typeof p.delta === "string") {
-      handlers.onTextDelta(messageID, p.delta)
-      seenLen.set(partID, (seenLen.get(partID) ?? 0) + p.delta.length)
-    } else if (p.field === "reasoning" && typeof p.delta === "string") {
-      handlers.onReasoningDelta?.(messageID, p.delta)
-      seenLen.set(partID, (seenLen.get(partID) ?? 0) + p.delta.length)
-    }
+    if (p.field !== "text" || typeof p.delta !== "string") return
+    // A part whose creation event this subscription never saw (it started
+    // before a reload) can only be assumed to be answer text.
+    emitDelta(messageID, partKinds.get(partID) ?? "text", p.delta)
+    seenLen.set(partID, (seenLen.get(partID) ?? 0) + p.delta.length)
+  }
+
+  function emitDelta(messageID: string, kind: "text" | "reasoning", delta: string) {
+    if (kind === "reasoning") handlers.onReasoningDelta?.(messageID, delta)
+    else handlers.onTextDelta(messageID, delta)
   }
 
   function onPermissionUpdated(p: any) {

--- a/test/host/chatview-harness.test.ts
+++ b/test/host/chatview-harness.test.ts
@@ -778,7 +778,8 @@ describe("ChatView harness: host-side delta coalescing", () => {
     for (const ch of ["a", "b", "c", "d", "e"]) {
       server.push({ type: "message.part.delta", sessionID: SESSION_ID, messageID: "msg_a", partID: "p1", field: "text", delta: ch })
     }
-    server.push({ type: "message.part.delta", sessionID: SESSION_ID, messageID: "msg_a", partID: "p2", field: "reasoning", delta: "R" })
+    server.push({ type: "message.part.updated", part: { id: "p2", messageID: "msg_a", sessionID: SESSION_ID, type: "reasoning", text: "" } })
+    server.push({ type: "message.part.delta", sessionID: SESSION_ID, messageID: "msg_a", partID: "p2", field: "text", delta: "R" })
     server.push({ type: "session.idle", sessionID: SESSION_ID })
     await until(() => harness.posted.some((m) => m.type === "sessionIdle"))
 
@@ -799,6 +800,7 @@ describe("ChatView harness: host-side delta coalescing", () => {
     const [active] = savedConversations()
     const assistant = active!.messages[1]!
     expect(assistant.blocks).toContainEqual({ type: "text", text: "abcde" })
+    expect(assistant.blocks).toContainEqual({ type: "reasoning", text: "R" })
   })
 
   it("no longer logs a line per token delta", async () => {
@@ -1320,5 +1322,49 @@ describe("ChatView harness: hidden-panel attention", () => {
 
     await harness.send({ type: "abort" })
     expect(harness.badge()).toBeUndefined()
+  })
+})
+
+describe("ChatView harness: reasoning parts stay out of the answer (#591)", () => {
+  it("a DeepSeek-shaped turn persists thinking and answer as separate blocks", async () => {
+    await harness.send({ type: "mounted" })
+    await harness.send({ type: "send", text: "think first" })
+    server.push({ type: "message.updated", info: { id: "usr_1", role: "user", sessionID: SESSION_ID } })
+    server.push({ type: "message.updated", info: { id: "msg_a", role: "assistant", sessionID: SESSION_ID } })
+    const part = (id: string, type: "text" | "reasoning", text: string) => ({
+      type: "message.part.updated",
+      part: { id, messageID: "msg_a", sessionID: SESSION_ID, type, text },
+    })
+    const delta = (partID: string, delta: string) => ({
+      type: "message.part.delta",
+      sessionID: SESSION_ID,
+      messageID: "msg_a",
+      partID,
+      field: "text",
+      delta,
+    })
+    server.push(part("p_think", "reasoning", ""))
+    server.push(delta("p_think", "Let me "))
+    server.push(delta("p_think", "think."))
+    server.push(part("p_think", "reasoning", "Let me think."))
+    server.push(part("p_text", "text", ""))
+    server.push(delta("p_text", "Hel"))
+    server.push(delta("p_text", "lo"))
+    server.push(part("p_text", "text", "Hello"))
+    server.push({ type: "message.updated", info: { id: "msg_a", role: "assistant", sessionID: SESSION_ID, finish: "stop" } })
+    server.push({ type: "session.idle", sessionID: SESSION_ID })
+    await until(() => harness.posted.some((m) => m.type === "sessionIdle"))
+
+    const joined = (type: "textDelta" | "reasoningDelta") =>
+      harness.posted.filter((m) => m.type === type).map((d) => ("delta" in d ? d.delta : "")).join("")
+    expect(joined("reasoningDelta")).toBe("Let me think.")
+    expect(joined("textDelta")).toBe("Hello")
+
+    await harness.chatView.flushPersist()
+    const [active] = savedConversations()
+    expect(active!.messages[1]!.blocks).toEqual([
+      { type: "reasoning", text: "Let me think." },
+      { type: "text", text: "Hello" },
+    ])
   })
 })

--- a/test/host/stream-part-delta.test.ts
+++ b/test/host/stream-part-delta.test.ts
@@ -66,3 +66,69 @@ describe("subscribeSession message.part.delta guard", () => {
     expect(textDeltas).toEqual(["hello"])
   })
 })
+
+// opencode publishes a reasoning part's deltas with `field: "text"` (the
+// property name on the ReasoningPart), so the delta alone cannot say whether
+// it is thinking or answer. The part's type is known from the
+// `message.part.updated` opencode sends when it creates the part, before the
+// first delta (#591).
+describe("subscribeSession routes part deltas by the announced part type", () => {
+  const part = (id: string, type: "text" | "reasoning", text: string) => ({
+    type: "message.part.updated",
+    part: { id, messageID: "msg_a", sessionID: "ses_test", type, text },
+  })
+  const delta = (partID: string, delta: string) => ({
+    type: "message.part.delta",
+    sessionID: "ses_test",
+    messageID: "msg_a",
+    partID,
+    field: "text",
+    delta,
+  })
+
+  async function subscribe() {
+    const text: string[] = []
+    const reasoning: string[] = []
+    const subscription = subscribeSession(
+      makeBackend(),
+      "ses_test",
+      {
+        onTextDelta: (_id, d) => text.push(d),
+        onReasoningDelta: (_id, d) => reasoning.push(d),
+      },
+      { watchdogMs: 10_000 },
+    )
+    await subscription.ready
+    await server.awaitClient()
+    return { subscription, text, reasoning }
+  }
+
+  it("a reasoning part's deltas reach onReasoningDelta and the text part's reach onTextDelta", async () => {
+    const { subscription, text, reasoning } = await subscribe()
+
+    server.push(part("p_think", "reasoning", ""))
+    server.push(delta("p_think", "Let me "))
+    server.push(delta("p_think", "think."))
+    // reasoning-end: the full-text snapshot must not re-emit what streamed.
+    server.push(part("p_think", "reasoning", "Let me think."))
+    server.push(part("p_text", "text", ""))
+    server.push(delta("p_text", "Hello"))
+    server.push(part("p_text", "text", "Hello"))
+    await wait(30)
+    subscription.abort()
+
+    expect(reasoning).toEqual(["Let me ", "think."])
+    expect(text).toEqual(["Hello"])
+  })
+
+  it("a delta for a part this subscription never saw announced is treated as answer text", async () => {
+    const { subscription, text, reasoning } = await subscribe()
+
+    server.push(delta("p_unknown", "tail"))
+    await wait(30)
+    subscription.abort()
+
+    expect(text).toEqual(["tail"])
+    expect(reasoning).toEqual([])
+  })
+})

--- a/test/host/stream-reattach.test.ts
+++ b/test/host/stream-reattach.test.ts
@@ -142,3 +142,43 @@ describe("subscribeSession re-attach with shared SessionStreamState", () => {
     expect(log.ends).toEqual(["msg_a"])
   })
 })
+
+describe("subscribeSession re-attach keeps the part-type map", () => {
+  it("deltas of a reasoning part that began before the drop still route as reasoning", async () => {
+    const state = createSessionStreamState(SESSION)
+    const text: string[] = []
+    const reasoning: string[] = []
+    const handlers: StreamHandlers = {
+      onTextDelta: (_mid, d) => text.push(d),
+      onReasoningDelta: (_mid, d) => reasoning.push(d),
+    }
+    const think = (body: string) => ({
+      type: "message.part.updated",
+      part: { id: "part_r", messageID: "msg_a", sessionID: SESSION, type: "reasoning", text: body },
+    })
+    const delta = (d: string) => ({
+      type: "message.part.delta",
+      sessionID: SESSION,
+      messageID: "msg_a",
+      partID: "part_r",
+      field: "text",
+      delta: d,
+    })
+
+    await subscribe(handlers, state)
+    server.push(think(""))
+    server.push(delta("Let me "))
+    await wait(30)
+
+    server.dropClients()
+    await wait(30)
+    const second = await subscribe(handlers, state)
+    server.push(delta("think."))
+    server.push(think("Let me think."))
+    await wait(30)
+    second.abort()
+
+    expect(reasoning).toEqual(["Let me ", "think."])
+    expect(text).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #591

## Summary

- With a reasoning model (seen with DeepSeek v4 pro/flash), the model's thinking was rendered inside the final answer bubble: the persisted message held one `text` block with the reasoning immediately followed by the answer. opencode stores them as separate `reasoning` and `text` parts, so the split was lost in `subscribeSession`.
- Cause: `message.part.delta` was routed by its `field`, but `field` names the property on the part object. opencode publishes reasoning deltas with `field: "text"` too (the `ReasoningPart` text lives in `.text`), so the `"reasoning"` branch never fired. No persisted assistant message on this machine, for any provider, ever received a `reasoning` block.
- Fix: record each part's type from the `message.part.updated` opencode sends when it creates the part (before its first delta) in a `partKinds` map on the shared `SessionStreamState`, and route deltas by that map. A delta for a part this subscription never saw announced (started before a reload) still defaults to answer text. The end-of-part snapshot goes through the same offset dedup as before.
- The harness coalescing test previously modeled reasoning as `field: "reasoning"`, which opencode never sends; it now uses the real shape (announcement, then `field: "text"` deltas).

## Test plan

- [x] New: `stream-part-delta.test.ts` routes an announced reasoning part to `onReasoningDelta` and the text part to `onTextDelta`, with no re-emit from the end-of-part snapshot; an unannounced part defaults to text
- [x] New: `stream-reattach.test.ts` keeps routing a reasoning part as reasoning after a transport drop with shared state
- [x] New: `chatview-harness.test.ts` DeepSeek-shaped turn persists `[reasoning, text]` blocks and posts only the answer as `textDelta`
- [x] Verified the four routing tests fail against the pre-fix `stream.ts`
- [x] `bun run test` 1446/1446, `bun run check-types` and webview `tsc --noEmit` clean, `bun run compile` builds
- [ ] Visual: send a prompt to a DeepSeek model and confirm the thinking folds into the collapsed process panel above the answer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xUfpVFpQuGJodPFqLfB1C