### PR TITLE
chore(release): 1.13.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.13.8] - 2026-09-01
+
+### Fixed
+- A reasoning model's thinking no longer appears inside the final answer. opencode streams reasoning tokens under the same `text` field as answer tokens (the field names the property on the part, not the part's type), so every streamed thought was appended to the answer block and the bubble showed the thinking glued to the reply with no separator. Most visible with DeepSeek, but the same path carried gpt-5 reasoning summaries too. Each part's type is now taken from the announcement opencode sends before its first token, so thinking folds into the collapsed process panel above the answer, and a reconnect mid-turn keeps that routing (#591, #592).
+
 ## [1.13.7] - 2026-08-31
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "opencui",
   "displayName": "OpenCode Panel",
   "description": "OpenCode Panel: opencode-powered AI assistant with a modern React chat UI",
-  "version": "1.13.7",
+  "version": "1.13.8",
   "private": true,
   "publisher": "haoyangzeng",
   "license": "MIT",


### PR DESCRIPTION
Closes #593

## Summary

- Bump `package.json` to 1.13.8 and add the `## [1.13.8]` CHANGELOG entry.
- Ships #592: streamed reasoning is routed by the part type opencode announces, so a reasoning model's thinking folds into the process panel instead of being appended to the answer (#591).

## Test plan

- [x] `bun run test` 1446/1446
- [x] `bun run check-types` and webview `tsc --noEmit` clean
- [ ] After merge: tag `v1.13.8`, create the GitHub Release, confirm `release.yml` publishes to the Marketplace and Open VSX

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xUfpVFpQuGJodPFqLfB1C