### PR TITLE
fix(chat): flush host-coalesced deltas in arrival order

### DIFF
--- a/src/chat/view.ts
+++ b/src/chat/view.ts
@@ -464,21 +464,26 @@ export class ChatView implements vscode.WebviewViewProvider {
 
   /**
    * Host-side token coalescing: streamed text/reasoning deltas buffer here
-   * for up to DELTA_FLUSH_MS and go out as one post per (kind, message)
-   * pair. Every delta used to cost its own webview IPC message plus an
-   * applyLocal pass (message-array rebuild + conversation snapshot); at fast
-   * token rates that work now happens ~40×/s instead of per token. The
-   * webview's own per-frame coalescer sits downstream, unchanged.
+   * for up to DELTA_FLUSH_MS and go out as one post per run of same-kind
+   * deltas to one message, in arrival order. Every delta used to cost its
+   * own webview IPC message plus an applyLocal pass (message-array rebuild +
+   * conversation snapshot); at fast token rates that work now happens
+   * ~40×/s instead of per token. The webview's own per-frame coalescer sits
+   * downstream, unchanged.
+   *
+   * An ordered run list, not a (kind, message) map: the map merged a
+   * reasoning/text/reasoning interleave into one reasoning post ahead of
+   * the text, and both block builders append by kind, so the second
+   * thinking block landed before the answer it followed (#595).
    */
-  private pendingDeltas = new Map<string, { type: "textDelta" | "reasoningDelta"; id: string; delta: string }>()
+  private pendingDeltas: { type: "textDelta" | "reasoningDelta"; id: string; delta: string }[] = []
   private deltaFlushTimer?: ReturnType<typeof setTimeout>
   private static readonly DELTA_FLUSH_MS = 25
 
   private queueDelta(type: "textDelta" | "reasoningDelta", id: string, delta: string) {
-    const key = `${type}:${id}`
-    const pending = this.pendingDeltas.get(key)
-    if (pending) pending.delta += delta
-    else this.pendingDeltas.set(key, { type, id, delta })
+    const last = this.pendingDeltas[this.pendingDeltas.length - 1]
+    if (last && last.type === type && last.id === id) last.delta += delta
+    else this.pendingDeltas.push({ type, id, delta })
     this.deltaFlushTimer ??= setTimeout(() => this.flushDeltas(), ChatView.DELTA_FLUSH_MS)
   }
 
@@ -487,9 +492,9 @@ export class ChatView implements vscode.WebviewViewProvider {
       clearTimeout(this.deltaFlushTimer)
       this.deltaFlushTimer = undefined
     }
-    if (!this.pendingDeltas.size) return
-    const batch = [...this.pendingDeltas.values()]
-    this.pendingDeltas.clear()
+    if (!this.pendingDeltas.length) return
+    const batch = this.pendingDeltas
+    this.pendingDeltas = []
     for (const d of batch) this.post({ type: d.type, id: d.id, delta: d.delta })
   }
 
@@ -500,7 +505,7 @@ export class ChatView implements vscode.WebviewViewProvider {
       clearTimeout(this.deltaFlushTimer)
       this.deltaFlushTimer = undefined
     }
-    this.pendingDeltas.clear()
+    this.pendingDeltas = []
   }
 
   private sendConversationState() {

--- a/test/host/chatview-harness.test.ts
+++ b/test/host/chatview-harness.test.ts
@@ -803,6 +803,54 @@ describe("ChatView harness: host-side delta coalescing", () => {
     expect(assistant.blocks).toContainEqual({ type: "reasoning", text: "R" })
   })
 
+  it("keeps a reasoning/text/reasoning interleave in arrival order inside one flush window (#595)", async () => {
+    await harness.send({ type: "mounted" })
+    await harness.send({ type: "send", text: "interleave" })
+    server.push({ type: "message.updated", info: { id: "usr_1", role: "user", sessionID: SESSION_ID } })
+    server.push({ type: "message.updated", info: { id: "msg_a", role: "assistant", sessionID: SESSION_ID } })
+    const part = (id: string, type: "text" | "reasoning", text: string) => ({
+      type: "message.part.updated",
+      part: { id, messageID: "msg_a", sessionID: SESSION_ID, type, text },
+    })
+    const delta = (partID: string, delta: string) => ({
+      type: "message.part.delta",
+      sessionID: SESSION_ID,
+      messageID: "msg_a",
+      partID,
+      field: "text",
+      delta,
+    })
+    // Part announcements and end-of-part snapshots post nothing, so the
+    // three deltas share one buffer window with no flush between them.
+    server.push(part("p_r1", "reasoning", ""))
+    server.push(delta("p_r1", "a"))
+    server.push(part("p_r1", "reasoning", "a"))
+    server.push(part("p_t", "text", ""))
+    server.push(delta("p_t", "b"))
+    server.push(part("p_t", "text", "b"))
+    server.push(part("p_r2", "reasoning", ""))
+    server.push(delta("p_r2", "c"))
+    server.push({ type: "session.idle", sessionID: SESSION_ID })
+    await until(() => harness.posted.some((m) => m.type === "sessionIdle"))
+
+    const deltas = harness.posted
+      .filter((m) => m.type === "textDelta" || m.type === "reasoningDelta")
+      .map((m) => [m.type, "delta" in m ? m.delta : ""])
+    expect(deltas).toEqual([
+      ["reasoningDelta", "a"],
+      ["textDelta", "b"],
+      ["reasoningDelta", "c"],
+    ])
+
+    await harness.chatView.flushPersist()
+    const [active] = savedConversations()
+    expect(active!.messages[1]!.blocks).toEqual([
+      { type: "reasoning", text: "a" },
+      { type: "text", text: "b" },
+      { type: "reasoning", text: "c" },
+    ])
+  })
+
   it("no longer logs a line per token delta", async () => {
     const appendLine = getOutputChannel().appendLine as unknown as ReturnType<typeof vi.fn>
     await harness.send({ type: "mounted" })


### PR DESCRIPTION
Closes #595

## Summary

- `ChatView.pendingDeltas` is now an ordered run list instead of a `(kind, message)` map. Consecutive deltas of the same kind for the same message still merge into one post; anything else starts a new run, and runs flush in arrival order. This mirrors the webview's per-frame coalescer.
- A reasoning/text/reasoning interleave inside one 25 ms window used to flush as one reasoning post ahead of the text, and both block builders append by kind, so the second thinking block was persisted before the answer it followed.

## Test plan

- [x] New harness test streams two reasoning parts around a short text part in one window and asserts the posted delta order and the persisted block order; fails on the previous map-based buffer (`reasoningDelta "ac"` then `textDelta "b"`), passes on this branch
- [x] `bun run test`: 97 files, 1447 passed
- [x] `bun run check-types` and `cd webview && bunx tsc --noEmit` clean
- [x] `bun run compile` builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xUfpVFpQuGJodPFqLfB1C
