### PR TITLE
perf(webview): memoize the streaming Markdown element on its sample

### DIFF
--- a/test/webview/streaming-renders.test.tsx
+++ b/test/webview/streaming-renders.test.tsx
@@ -5,6 +5,22 @@ import { Markdown } from "../../webview/src/components/Markdown"
 import { useThrottledValue } from "../../webview/src/hooks/useThrottledValue"
 import type { Message } from "../../webview/src/hooks/useChatState"
 
+// react-markdown is installed only under webview/, so the spy is registered
+// by file path: a bare specifier would resolve from the root and never match
+// the component's import. `Markdown` is hook-free, so wrapping the call
+// counts parses exactly.
+const parses = vi.hoisted(() => ({ count: 0 }))
+vi.mock(new URL("../../webview/node_modules/react-markdown/index.js", import.meta.url).pathname, async (importOriginal) => {
+  const mod = await importOriginal<{ default: (options: object) => unknown }>()
+  return {
+    ...mod,
+    default: (options: object) => {
+      parses.count++
+      return mod.default(options)
+    },
+  }
+})
+
 afterEach(() => {
   cleanup()
   vi.useRealTimers()
@@ -47,6 +63,23 @@ describe("Markdown streaming throttle", () => {
       vi.advanceTimersByTime(60)
     })
     expect(container.textContent).toContain("world")
+  })
+
+  it("parses the sample once per throttle window, not once per frame (#597)", () => {
+    vi.useFakeTimers()
+    parses.count = 0
+    const { rerender } = render(<Markdown text="hello" streaming />)
+    expect(parses.count).toBe(1)
+    for (const text of ["hello w", "hello wo", "hello wor", "hello world"]) {
+      rerender(<Markdown text={text} streaming />)
+    }
+    // Four frames inside one window leave the sample unchanged, and the
+    // memoized element keeps React from re-rendering react-markdown.
+    expect(parses.count).toBe(1)
+    act(() => {
+      vi.advanceTimersByTime(60)
+    })
+    expect(parses.count).toBe(2)
   })
 
   it("renders settled (non-streaming) text updates immediately", () => {

--- a/webview/src/components/Markdown.tsx
+++ b/webview/src/components/Markdown.tsx
@@ -1,5 +1,5 @@
 import { isValidElement, memo, useMemo, type ReactNode } from "react"
-import ReactMarkdown, { type Components } from "react-markdown"
+import ReactMarkdown, { type Components, type Options } from "react-markdown"
 import remarkGfm from "remark-gfm"
 import remarkBreaks from "remark-breaks"
 import remarkMath from "remark-math"
@@ -223,20 +223,30 @@ function flattenChildren(node: ReactNode): string {
 // as faint red text and keeps going.
 const katexOptions = { strict: "ignore", throwOnError: false } as const
 
+const PROSE_REMARK: NonNullable<Options["remarkPlugins"]> = [remarkGfm, remarkBreaks]
+const MATH_REMARK: NonNullable<Options["remarkPlugins"]> = [remarkGfm, remarkBreaks, remarkMath]
+const MATH_REHYPE: NonNullable<Options["rehypePlugins"]> = [[rehypeKatex, katexOptions]]
+const NO_REHYPE: NonNullable<Options["rehypePlugins"]> = []
+
 function MarkdownImpl({ text, streaming = false }: Props) {
   const sampled = useThrottledValue(text, streaming ? STREAM_PARSE_MS : 0)
-  const { source, hasMath } = useMemo(() => prepareMarkdown(sampled), [sampled])
-  return (
-    <div className="md">
+  // react-markdown parses inside render, and this component re-renders on
+  // every frame the growing `text` prop arrives on. Memoizing the element,
+  // not just the pre-parse, is what lets React skip that render while the
+  // sample is unchanged; a fresh element re-parsed on every frame (#597).
+  const body = useMemo(() => {
+    const { source, hasMath } = prepareMarkdown(sampled)
+    return (
       <ReactMarkdown
-        remarkPlugins={hasMath ? [remarkGfm, remarkBreaks, remarkMath] : [remarkGfm, remarkBreaks]}
-        rehypePlugins={hasMath ? [[rehypeKatex, katexOptions]] : []}
+        remarkPlugins={hasMath ? MATH_REMARK : PROSE_REMARK}
+        rehypePlugins={hasMath ? MATH_REHYPE : NO_REHYPE}
         components={components}
       >
         {source}
       </ReactMarkdown>
-    </div>
-  )
+    )
+  }, [sampled])
+  return <div className="md">{body}</div>
 }
 
 // Memoized on `text` (its only prop): every settled segment above the one


### PR DESCRIPTION
Closes #597

## Summary

- `Markdown` now memoizes the `<ReactMarkdown>` element on the throttled sample, so frames that arrive inside a window no longer re-render (and re-parse) react-markdown. The pre-parse and the element are produced in one `useMemo`.
- The remark/rehype plugin arrays are module constants instead of inline literals rebuilt on each render.

## Test plan

- [x] New test spies on react-markdown's default export (registered by file path, since the package is installed only under `webview/`) and counts parses across four streamed frames in one 50 ms window: 1 parse for the leading sample, 1 for the trailing sample. The previous component parses 5 times for the same sequence.
- [x] `bun run test`: 97 files, 1448 passed
- [x] `bun run check-types` and `cd webview && bunx tsc --noEmit` clean
- [x] `bun run compile` builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xUfpVFpQuGJodPFqLfB1C
