### PR TITLE
perf(chat): persist only the workspaceState keys that changed

### DIFF
--- a/src/chat/conversation-manager.ts
+++ b/src/chat/conversation-manager.ts
@@ -23,8 +23,13 @@ export type ActiveSnapshot = {
   reviewHunks: Record<string, ReviewHunkState>
 }
 
-/** Debounce window for the streaming hot path's disk writes. */
-const PERSIST_DEBOUNCE_MS = 300
+/**
+ * Debounce window for the streaming hot path's memento writes. Turn end and
+ * every conversation boundary flush explicitly, so this only bounds what a
+ * hard crash mid-stream loses; each write reserializes the whole extension
+ * memento, so the window is kept coarse (#599).
+ */
+const PERSIST_DEBOUNCE_MS = 1000
 
 /**
  * Workspace-state-backed list of saved conversations. Owns the
@@ -37,12 +42,21 @@ const PERSIST_DEBOUNCE_MS = 300
 export class ConversationManager {
   private conversations: SavedConversation[]
   private activeID: string
+  /**
+   * What workspaceState last read or wrote for each key. Every mutation
+   * replaces `conversations`, so reference equality is its dirty check.
+   */
+  private persistedConversations: SavedConversation[] | undefined
+  private persistedActiveID: string
   private pendingPersist?: ReturnType<typeof setTimeout>
   private disposed = false
 
   constructor(private context: vscode.ExtensionContext) {
-    this.conversations = context.workspaceState.get<SavedConversation[]>(CONVERSATIONS_KEY) ?? []
+    const stored = context.workspaceState.get<SavedConversation[]>(CONVERSATIONS_KEY)
+    this.conversations = stored ?? []
+    this.persistedConversations = stored
     this.activeID = context.workspaceState.get<string>(ACTIVE_CONVERSATION_KEY) ?? ""
+    this.persistedActiveID = this.activeID
     if (!this.conversations.length) this.add("New conversation")
     if (!this.conversations.some((c) => c.id === this.activeID)) {
       this.activeID = this.conversations[0]!.id
@@ -214,15 +228,31 @@ export class ConversationManager {
     return true
   }
 
+  /**
+   * Every workspaceState.update reserializes the extension's whole memento,
+   * every key included, so a key is written only when its value changed
+   * since it was last read or written. A stream then costs one write per
+   * tick instead of two, and a flush with nothing new writes nothing. The
+   * marker moves only after the write resolved, so a rejected write is
+   * retried by the next persist (#599).
+   */
   async persist(): Promise<void> {
-    // Store-backed attachments persist as a storageID reference only; the
-    // inline base64 stays in memory for previews but never reaches
-    // workspaceState (it's what made streaming persists cost ~100 ms+).
-    await this.context.workspaceState.update(
-      CONVERSATIONS_KEY,
-      stripAttachmentDataForPersist(this.conversations),
-    )
-    await this.context.workspaceState.update(ACTIVE_CONVERSATION_KEY, this.activeID)
+    const conversations = this.conversations
+    if (conversations !== this.persistedConversations) {
+      // Store-backed attachments persist as a storageID reference only; the
+      // inline base64 stays in memory for previews but never reaches
+      // workspaceState (it's what made streaming persists cost ~100 ms+).
+      await this.context.workspaceState.update(
+        CONVERSATIONS_KEY,
+        stripAttachmentDataForPersist(conversations),
+      )
+      this.persistedConversations = conversations
+    }
+    const activeID = this.activeID
+    if (activeID !== this.persistedActiveID) {
+      await this.context.workspaceState.update(ACTIVE_CONVERSATION_KEY, activeID)
+      this.persistedActiveID = activeID
+    }
   }
 
   /**

--- a/test/host/conversation-manager-persist.test.ts
+++ b/test/host/conversation-manager-persist.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { ConversationManager } from "../../src/chat/conversation-manager"
-import { CONVERSATIONS_KEY } from "../../src/chat/conversation-store"
+import { ACTIVE_CONVERSATION_KEY, CONVERSATIONS_KEY } from "../../src/chat/conversation-store"
 
 type Store = Map<string, unknown>
 
@@ -58,9 +58,10 @@ describe("ConversationManager debounced persistence", () => {
     // Nothing hits disk until the debounce window elapses.
     expect(update).not.toHaveBeenCalled()
 
-    await vi.advanceTimersByTimeAsync(300)
+    await vi.advanceTimersByTimeAsync(1000)
 
-    // One persist == two workspaceState.update calls (conversations + active id).
+    // The first persist writes both keys: construction added a conversation
+    // and made it active, so both changed since they were read.
     expect(update).toHaveBeenCalledTimes(2)
     // The single coalesced write holds the latest state, not a stale prefix.
     const messages = activeMessages(store)
@@ -93,18 +94,18 @@ describe("ConversationManager debounced persistence", () => {
     expect(update).not.toHaveBeenCalled()
   })
 
-  it("a re-schedule mid-window does not push the 300ms deadline out", async () => {
+  it("a re-schedule mid-window does not push the 1 s deadline out", async () => {
     const { context, update } = fakeContext()
     const manager = new ConversationManager(context)
 
     manager.saveActiveSnapshot(snap(1))
     manager.schedulePersist()
-    await vi.advanceTimersByTimeAsync(200)
+    await vi.advanceTimersByTimeAsync(700)
     manager.saveActiveSnapshot(snap(2))
     manager.schedulePersist() // non-resetting: must not delay the original deadline
     expect(update).not.toHaveBeenCalled()
 
-    await vi.advanceTimersByTimeAsync(100) // now 300ms after the first schedule
+    await vi.advanceTimersByTimeAsync(300) // now 1 s after the first schedule
     expect(update).toHaveBeenCalledTimes(2)
   })
 
@@ -123,5 +124,86 @@ describe("ConversationManager debounced persistence", () => {
     const restored = reloaded.loadActiveSnapshot()
     expect(restored.messages.map((m) => m.id)).toEqual(["m0", "m1", "m2", "m3", "m4"])
     expect(restored.messages.every((m) => m.pending === false)).toBe(true)
+  })
+})
+
+// Every workspaceState.update reserializes the whole memento, so persist()
+// writes a key only when its value changed since it was last read or written
+// (#599).
+describe("ConversationManager persist writes only changed keys", () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  function conversation(id: string) {
+    return { id, title: id, createdAt: 1, updatedAt: 1, messages: [], reviewHunks: {} }
+  }
+
+  function writtenKeys(update: ReturnType<typeof fakeContext>["update"]) {
+    return update.mock.calls.map((c) => c[0])
+  }
+
+  it("a stream costs one write per tick once the active id is on disk", async () => {
+    const { context, update } = fakeContext()
+    const manager = new ConversationManager(context)
+    await manager.flushPersist()
+    update.mockClear()
+
+    for (let i = 1; i <= 10; i++) {
+      manager.saveActiveSnapshot(snap(i))
+      manager.schedulePersist()
+    }
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(writtenKeys(update)).toEqual([CONVERSATIONS_KEY])
+  })
+
+  it("a flush with nothing changed writes nothing", async () => {
+    const { context, update } = fakeContext()
+    const manager = new ConversationManager(context)
+    await manager.flushPersist()
+    update.mockClear()
+
+    await manager.flushPersist()
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  it("constructing over an intact store makes the first persist a no-op", async () => {
+    const { context, store, update } = fakeContext()
+    store.set(CONVERSATIONS_KEY, [conversation("c1"), conversation("c2")])
+    store.set(ACTIVE_CONVERSATION_KEY, "c1")
+    const manager = new ConversationManager(context)
+
+    await manager.persist()
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  it("only the active id is written when only it changed", async () => {
+    const { context, store, update } = fakeContext()
+    store.set(CONVERSATIONS_KEY, [conversation("c1"), conversation("c2")])
+    store.set(ACTIVE_CONVERSATION_KEY, "c1")
+    const manager = new ConversationManager(context)
+
+    manager.setActiveID("c2")
+    await manager.flushPersist()
+    expect(update.mock.calls).toEqual([[ACTIVE_CONVERSATION_KEY, "c2"]])
+
+    // A stale stored id is corrected on the first persist the same way.
+    const other = fakeContext()
+    other.store.set(CONVERSATIONS_KEY, [conversation("c1")])
+    other.store.set(ACTIVE_CONVERSATION_KEY, "gone")
+    await new ConversationManager(other.context).persist()
+    expect(other.update.mock.calls).toEqual([[ACTIVE_CONVERSATION_KEY, "c1"]])
+  })
+
+  it("a rejected write is retried by the next persist", async () => {
+    const { context, store, update } = fakeContext()
+    const manager = new ConversationManager(context)
+    update.mockRejectedValueOnce(new Error("disk"))
+
+    await expect(manager.persist()).rejects.toThrow("disk")
+    expect(store.has(CONVERSATIONS_KEY)).toBe(false)
+
+    await manager.persist()
+    expect(store.has(CONVERSATIONS_KEY)).toBe(true)
+    expect(store.get(ACTIVE_CONVERSATION_KEY)).toBe(manager.getActiveID())
   })
 })


### PR DESCRIPTION
Closes #599

## Summary

- `ConversationManager.persist()` now writes a workspaceState key only when its value changed since it was last read from or written to the memento: the conversations array by reference (every mutation replaces it), the active id by value. A stream costs one `update` per tick instead of two, a flush with nothing new writes nothing, and constructing over an intact store no longer rewrites it. The marker moves only after the write resolved, so a rejected write is retried by the next persist.
- The streaming debounce is 1 s instead of 300 ms. Turn end, conversation boundaries and shutdown still flush explicitly, so the window only bounds what a hard crash mid-stream loses.
- Left for a follow-up: per-conversation files, so a write no longer scales with every conversation in the workspace.

## Test plan

- [x] Five new manager tests: one write per stream tick once the active id is on disk, no writes when nothing changed, no-op first persist over an intact store, active id written alone when only it changed (including correcting a stale stored id), rejected write retried. Four of them and the retimed window test fail on the previous manager.
- [x] `bun run test`: 97 files, 1453 passed
- [x] `bun run check-types` and `cd webview && bunx tsc --noEmit` clean
- [x] `bun run compile` builds
- [ ] Manual: stream a long reply in a workspace with a large memento and confirm the extension host stays responsive; reload mid-stream and confirm the transcript up to the last flush survives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xUfpVFpQuGJodPFqLfB1C
