### PR TITLE
perf(webview): keep one tree shape across the answer boundary

### DIFF
--- a/test/webview/streaming-renders.test.tsx
+++ b/test/webview/streaming-renders.test.tsx
@@ -3,7 +3,7 @@ import { render, renderHook, screen, cleanup, fireEvent, act } from "@testing-li
 import { MessageView } from "../../webview/src/components/MessageView"
 import { Markdown } from "../../webview/src/components/Markdown"
 import { useThrottledValue } from "../../webview/src/hooks/useThrottledValue"
-import type { Message } from "../../webview/src/hooks/useChatState"
+import type { Block, Message } from "../../webview/src/hooks/useChatState"
 
 // react-markdown is installed only under webview/, so the spy is registered
 // by file path: a bare specifier would resolve from the root and never match
@@ -117,5 +117,60 @@ describe("ProcessPanel lazy body", () => {
     fireEvent.click(head)
     expect(container.querySelector(".process")!.classList.contains("is-open")).toBe(false)
     expect(body.childNodes.length).toBeGreaterThan(0)
+  })
+})
+
+// The answer boundary moves on every tool call; the bubble must keep one
+// tree shape across it or React remounts the panel and everything rendered
+// inside it (#601).
+describe("assistant bubble keeps its process panel across answer boundaries", () => {
+  const tool = (callID: string): Block => ({
+    type: "tool",
+    update: { callID, tool: "read", status: "completed", input: { filePath: "src/foo.ts" } },
+  } as Block)
+  const text = (t: string): Block => ({ type: "text", text: t })
+  const message = (blocks: Block[]): Message => ({ id: "a1", role: "assistant", blocks, pending: true } as Message)
+  // A first-person line so textTitle() leaves it as a paragraph, not a title.
+  const thinking = text("I need to read the file first.")
+
+  it("the panel node and a paragraph inside it survive text, tool, text, tool", () => {
+    const { container, rerender } = render(
+      <MessageView message={message([thinking, tool("c1")])} processOpen processOnly={false} />,
+    )
+    const panel = container.querySelector(".process")!
+    expect(panel.classList.contains("is-open")).toBe(true)
+    const paragraph = panel.querySelector(".process-body p")!
+    expect(paragraph.textContent).toBe("I need to read the file first.")
+
+    // Answer text after the tool: the same panel, now the collapsed final one.
+    rerender(
+      <MessageView message={message([thinking, tool("c1"), text("Found it.")])} processOpen processOnly={false} />,
+    )
+    expect(container.querySelector(".process")).toBe(panel)
+    expect(panel.querySelector(".process-body p")).toBe(paragraph)
+    expect(panel.classList.contains("is-open")).toBe(false)
+    expect(screen.getByText("Found it.")).toBeInTheDocument()
+
+    // The next tool folds that text back into the live process: same panel,
+    // open again, and the answer slot is empty.
+    rerender(
+      <MessageView
+        message={message([thinking, tool("c1"), text("Found it."), tool("c2")])}
+        processOpen
+        processOnly={false}
+      />,
+    )
+    expect(container.querySelector(".process")).toBe(panel)
+    expect(panel.querySelector(".process-body p")).toBe(paragraph)
+    expect(panel.classList.contains("is-open")).toBe(true)
+    expect(container.querySelectorAll(".process")).toHaveLength(1)
+  })
+
+  it("a text-only reply still renders no panel", () => {
+    const { container } = render(
+      <MessageView message={message([text("Just an answer.")])} processOpen processOnly={false} />,
+    )
+    expect(container.querySelector(".process")).toBeNull()
+    expect(screen.getByText("Just an answer.")).toBeInTheDocument()
   })
 })

--- a/webview/src/components/MessageView.tsx
+++ b/webview/src/components/MessageView.tsx
@@ -470,17 +470,27 @@ function renderMessageBlocks(message: Message, processOpen: boolean, processOnly
   const answer = message.blocks.slice(start)
   const answerHasText = answer.some((b) => b.type === "text" && b.text.trim().length > 0)
 
-  if (!answerHasText) {
-    // Ends on activity/reasoning (or is empty) — no distinct answer to surface.
-    if (!hasProcessBlocks(message.blocks)) return renderBlocks(message.blocks, false, onReviewFile, pending)
-    return <ProcessPanel blocks={message.blocks} pending={pending} openKey={`process-${message.id}-${message.blocks.length}`} defaultOpen={processOpen} onReviewFile={onReviewFile} />
+  // One shape for every phase of the turn: the panel slot, then the answer
+  // slot. The boundary moves on every tool call, and alternating between a
+  // bare panel and a fragment at this slot made React remount the panel
+  // (and re-parse and re-highlight everything open inside it) at each flip.
+  // A null panel keeps the slot, so a text-only reply still has none (#601).
+  let panel: ReactNode = null
+  let answerBlocks = answer
+  if (answerHasText) {
+    if (hasProcessBlocks(process)) {
+      panel = <ProcessPanel blocks={process} pending={false} openKey={`final-${message.id}-${start}`} defaultOpen={false} onReviewFile={onReviewFile} />
+    }
+  } else if (hasProcessBlocks(message.blocks)) {
+    // Ends on activity/reasoning — no distinct answer to surface yet, so the
+    // whole message is the live process.
+    panel = <ProcessPanel blocks={message.blocks} pending={pending} openKey={`process-${message.id}-${message.blocks.length}`} defaultOpen={processOpen} onReviewFile={onReviewFile} />
+    answerBlocks = []
   }
-
-  if (!hasProcessBlocks(process)) return renderBlocks(answer, false, onReviewFile, pending)
   return (
     <>
-      <ProcessPanel blocks={process} pending={false} openKey={`final-${message.id}-${start}`} defaultOpen={false} onReviewFile={onReviewFile} />
-      {renderBlocks(answer, false, onReviewFile, pending)}
+      {panel}
+      {renderBlocks(answerBlocks, false, onReviewFile, pending)}
     </>
   )
 }


### PR DESCRIPTION
Closes #601

## Summary

- `renderMessageBlocks` now renders one shape for every phase of an assistant turn: a panel slot holding a `ProcessPanel` or null, followed by the answer slot. Before, the message ending on activity produced a bare panel and answer text after it produced a fragment, in the same child slot, and React remounted the panel at every flip, which happens twice per tool call during an agentic turn. With the panel open that redid every Markdown parse and shiki highlight inside it.
- Visible behaviour is unchanged: a text-only reply shows no panel, the live panel follows the process-open preference while the message ends on activity, and the panel collapses once answer text follows. One side effect is that the collapse and reopen at the boundary now animate through the existing fold transition instead of snapping, since the element persists.
- Not in scope: the panel's `openKey` including the block count, which re-applies the default open state on every new block (the review's lower-priority item).

## Test plan

- [x] New test streams an assistant message through text, tool, text, tool and asserts the panel's DOM node and a paragraph rendered inside it are the same nodes throughout, with the open state flipping as before; fails on the previous render at the first boundary. A second test pins that a text-only reply still renders no panel.
- [x] `bun run test`: 97 files, 1455 passed. One earlier full run had `stream-watchdog.test.ts > discards a stale status poll answered after new activity` fail at 3.2 s; it is a real-timer race in host code this branch does not touch, and it passed three consecutive isolated runs and the full re-run.
- [x] `bun run check-types` and `cd webview && bunx tsc --noEmit` clean
- [x] `bun run compile` builds
- [ ] Manual: run an agentic turn with the process panel open and confirm the panel's expanded content does not flicker or re-highlight when the reply alternates between text and tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xUfpVFpQuGJodPFqLfB1C
