### PR TITLE
perf(webview): extract review changes only when the review set changes

### DIFF
--- a/test/webview/review-attribution-render.test.tsx
+++ b/test/webview/review-attribution-render.test.tsx
@@ -46,7 +46,7 @@ describe("ReviewPanel: subagent attribution stays on the tooltip", () => {
         }),
       ]),
     ]
-    const { container } = render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
+    const { container } = render(<ReviewPanel reviewRevision={0} messages={messages} reviewedHunks={{}} />)
     // No `.review-file-actor` element — the old badge is gone.
     expect(container.querySelector(".review-file-actor")).toBeNull()
     // The row title tooltip still carries the attribution so power users can hover.
@@ -64,7 +64,7 @@ describe("ReviewPanel: subagent attribution stays on the tooltip", () => {
         }),
       ]),
     ]
-    const { container } = render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
+    const { container } = render(<ReviewPanel reviewRevision={0} messages={messages} reviewedHunks={{}} />)
     expect(container.querySelector(".review-file-actor")).toBeNull()
     const head = container.querySelector(".review-head") as HTMLElement
     expect(head.title).toBe("src/foo.ts")
@@ -87,7 +87,7 @@ describe("ReviewPanel: subagent attribution stays on the tooltip", () => {
         }),
       ]),
     ]
-    const { container } = render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
+    const { container } = render(<ReviewPanel reviewRevision={0} messages={messages} reviewedHunks={{}} />)
     const head = container.querySelector(".review-head") as HTMLElement
     expect(head.title).toContain("explore")
     expect(head.title).toContain("hephaestus")
@@ -110,7 +110,7 @@ describe("ReviewPanel: subagent attribution stays on the tooltip", () => {
         }),
       ]),
     ]
-    const { container } = render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
+    const { container } = render(<ReviewPanel reviewRevision={0} messages={messages} reviewedHunks={{}} />)
     expect(container.querySelectorAll(".review-head")).toHaveLength(1)
     expect(container.querySelector(".review-file-actor")).toBeNull()
     const head = container.querySelector(".review-head") as HTMLElement

--- a/test/webview/review-panel-extract.test.tsx
+++ b/test/webview/review-panel-extract.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { render, cleanup } from "@testing-library/react"
+import { ReviewPanel } from "../../webview/src/components/ReviewPanel"
+import type { Message } from "../../webview/src/hooks/useChatState"
+
+// Counts how often the panel re-extracts changes from the transcript. A
+// streamed delta hands the panel a new messages array on every frame, and
+// extraction walks every block of every message, so it must run only when
+// the reducer says the review set may have changed (#603).
+const extracts = vi.hoisted(() => ({ count: 0 }))
+vi.mock("../../webview/src/review-extract", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("../../webview/src/review-extract")>()
+  return {
+    ...mod,
+    turnChanges: (messages: Message[]) => {
+      extracts.count++
+      return mod.turnChanges(messages)
+    },
+  }
+})
+
+afterEach(() => {
+  cleanup()
+  extracts.count = 0
+})
+
+function editMessage(id: string, filePath: string): Message {
+  return {
+    id,
+    role: "assistant",
+    blocks: [
+      {
+        type: "tool",
+        update: {
+          callID: `c-${id}`,
+          tool: "edit",
+          status: "completed",
+          input: { filePath },
+          metadata: { filediff: { patch: "@@ -1 +1 @@\n-a\n+b\n", additions: 1, deletions: 1 } },
+        },
+      },
+    ],
+  } as unknown as Message
+}
+
+function withText(message: Message, text: string): Message {
+  return { ...message, blocks: [...message.blocks, { type: "text", text }] }
+}
+
+describe("ReviewPanel extraction keys on reviewRevision", () => {
+  it("does not re-extract for a new messages array at the same revision, and does when it bumps", () => {
+    const first = editMessage("a1", "src/foo.ts")
+    const { rerender, container } = render(
+      <ReviewPanel messages={[first]} reviewRevision={1} reviewedHunks={{}} />,
+    )
+    expect(extracts.count).toBe(1)
+    expect(container.textContent).toContain("foo.ts")
+
+    // Four streamed frames: each replaces the array and grows the text block.
+    let streamed = first
+    for (let i = 0; i < 4; i++) {
+      streamed = withText(streamed, `token ${i}`)
+      rerender(<ReviewPanel messages={[streamed]} reviewRevision={1} reviewedHunks={{}} />)
+    }
+    expect(extracts.count).toBe(1)
+    expect(container.textContent).toContain("foo.ts")
+
+    rerender(
+      <ReviewPanel messages={[streamed, editMessage("a2", "src/bar.ts")]} reviewRevision={2} reviewedHunks={{}} />,
+    )
+    expect(extracts.count).toBe(2)
+    expect(container.textContent).toContain("foo.ts")
+    expect(container.textContent).toContain("bar.ts")
+  })
+
+  it("a hunk state change recomputes pending rows without re-extracting", () => {
+    const first = editMessage("a1", "src/foo.ts")
+    const { rerender, container } = render(
+      <ReviewPanel messages={[first]} reviewRevision={1} reviewedHunks={{}} />,
+    )
+    expect(container.firstChild).not.toBeNull()
+    // reviewKey is source:path:hunkID, and splitDiff ids a hunk by its
+    // index and header.
+    rerender(
+      <ReviewPanel
+        messages={[first]}
+        reviewRevision={1}
+        reviewedHunks={{ "c-a1:src/foo.ts:0-@@ -1 +1 @@": "accepted" }}
+      />,
+    )
+    expect(container.firstChild).toBeNull()
+    expect(extracts.count).toBe(1)
+  })
+})

--- a/test/webview/review-panel.test.tsx
+++ b/test/webview/review-panel.test.tsx
@@ -55,7 +55,7 @@ function createMessage(id: string, opts: { filePath: string; content: string }):
 describe("ReviewPanel", () => {
   it("renders nothing when there are no pending changes", () => {
     const { container } = render(
-      <ReviewPanel messages={[]} reviewedHunks={{}} />,
+      <ReviewPanel reviewRevision={0} messages={[]} reviewedHunks={{}} />,
     )
     expect(container.firstChild).toBeNull()
   })
@@ -69,7 +69,7 @@ describe("ReviewPanel", () => {
         deletions: 1,
       }),
     ]
-    const { container } = render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
+    const { container } = render(<ReviewPanel reviewRevision={0} messages={messages} reviewedHunks={{}} />)
     expect(screen.getByText("Review")).toBeInTheDocument()
     // The single-file card is one row: the filename shows once (no duplicate
     // body row), with inline Keep/Undo in the header.
@@ -84,7 +84,7 @@ describe("ReviewPanel", () => {
       editMessage("m2", { filePath: "b.ts", patch: "@@ -1 +1 @@\n+b", additions: 1, deletions: 0 }),
       editMessage("m3", { filePath: "c.ts", patch: "@@ -1 +1 @@\n+c", additions: 1, deletions: 0 }),
     ]
-    render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
+    render(<ReviewPanel reviewRevision={0} messages={messages} reviewedHunks={{}} />)
     expect(screen.getByText(/Review changes/)).toBeInTheDocument()
     expect(screen.getByText(/3 files/)).toBeInTheDocument()
   })
@@ -94,7 +94,7 @@ describe("ReviewPanel", () => {
       editMessage("m1", { filePath: "foo.ts", patch: "@@\n+a\n+b\n+c", additions: 3, deletions: 0, callID: "edit-1" }),
       editMessage("m2", { filePath: "foo.ts", patch: "@@\n+d\n-e", additions: 1, deletions: 1, callID: "edit-2" }),
     ]
-    const { container } = render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
+    const { container } = render(<ReviewPanel reviewRevision={0} messages={messages} reviewedHunks={{}} />)
     // Single row (path collapsed) but stats aggregated across the two records
     expect(screen.getAllByRole("button", { name: /Keep changes in foo.ts/ })).toHaveLength(1)
     // Header shows combined stats
@@ -104,7 +104,7 @@ describe("ReviewPanel", () => {
 
   it("applies the kind-created class for a new file", () => {
     const messages = [createMessage("m1", { filePath: "new.ts", content: "line1\nline2\nline3" })]
-    const { container } = render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
+    const { container } = render(<ReviewPanel reviewRevision={0} messages={messages} reviewedHunks={{}} />)
     expect(container.querySelector(".kind-created")).not.toBeNull()
   })
 
@@ -113,7 +113,7 @@ describe("ReviewPanel", () => {
       editMessage("m1", { filePath: "views/index.ts", patch: "@@\n+a", additions: 1, deletions: 0 }),
       editMessage("m2", { filePath: "admin/index.ts", patch: "@@\n+b", additions: 1, deletions: 0 }),
     ]
-    render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
+    render(<ReviewPanel reviewRevision={0} messages={messages} reviewedHunks={{}} />)
     expect(screen.getByText("views/index.ts")).toBeInTheDocument()
     expect(screen.getByText("admin/index.ts")).toBeInTheDocument()
   })
@@ -126,6 +126,7 @@ describe("ReviewPanel", () => {
     ]
     render(
       <ReviewPanel
+        reviewRevision={0}
         messages={messages}
         reviewedHunks={{}}
         onReviewAllInChange={onReviewAllInChange}
@@ -144,6 +145,7 @@ describe("ReviewPanel", () => {
     ]
     render(
       <ReviewPanel
+        reviewRevision={0}
         messages={messages}
         reviewedHunks={{}}
         onReviewAllInChange={onReviewAllInChange}
@@ -162,6 +164,7 @@ describe("ReviewPanel", () => {
     ]
     const { container } = render(
       <ReviewPanel
+        reviewRevision={0}
         messages={messages}
         reviewedHunks={{}}
         onSelectPath={onSelectPath}
@@ -182,7 +185,7 @@ describe("ReviewPanel", () => {
     // splitDiff produces hunk id = "0-@@ -1,1 +1,1 @@"
     const reviewedHunks = { "c-m1:foo.ts:0-@@ -1,1 +1,1 @@": "accepted" as const }
     const { container } = render(
-      <ReviewPanel messages={messages} reviewedHunks={reviewedHunks} />,
+      <ReviewPanel reviewRevision={0} messages={messages} reviewedHunks={reviewedHunks} />,
     )
     // No pending → panel returns null
     expect(container.firstChild).toBeNull()
@@ -194,7 +197,7 @@ describe("ReviewPanel", () => {
       editMessage("m1", { filePath: "a.ts", patch: "@@\n+a", additions: 1, deletions: 0 }),
       editMessage("m2", { filePath: "b.ts", patch: "@@\n+b", additions: 1, deletions: 0 }),
     ]
-    const { container } = render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
+    const { container } = render(<ReviewPanel reviewRevision={0} messages={messages} reviewedHunks={{}} />)
     const header = container.querySelector(".review-head") as HTMLButtonElement
     expect(header.getAttribute("aria-expanded")).toBe("true")
     await user.click(header)
@@ -206,7 +209,7 @@ describe("ReviewPanel", () => {
       editMessage("m1", { filePath: "a.ts", patch: "@@\n+a", additions: 1, deletions: 0 }),
       editMessage("m2", { filePath: "b.ts", patch: "@@\n+b", additions: 1, deletions: 0 }),
     ]
-    render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
+    render(<ReviewPanel reviewRevision={0} messages={messages} reviewedHunks={{}} />)
     expect(screen.getByRole("button", { name: /Keep all/i })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: /Undo all/i })).toBeInTheDocument()
   })
@@ -219,7 +222,7 @@ describe("ReviewPanel", () => {
       editMessage("m1", { filePath: "a.ts", patch: "@@\n+a", additions: 1, deletions: 0 }),
       editMessage("m2", { filePath: "b.ts", patch: "@@\n+b", additions: 1, deletions: 0 }),
     ]
-    const { container } = render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
+    const { container } = render(<ReviewPanel reviewRevision={0} messages={messages} reviewedHunks={{}} />)
     expect([...container.querySelectorAll(".review-bulk-label")].map((n) => n.textContent)).toEqual([
       "Keep all",
       "Undo all",
@@ -234,7 +237,7 @@ describe("ReviewPanel", () => {
     const messages = [
       editMessage("m1", { filePath: "only.ts", patch: "@@\n+a", additions: 1, deletions: 0 }),
     ]
-    render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
+    render(<ReviewPanel reviewRevision={0} messages={messages} reviewedHunks={{}} />)
     expect(screen.queryByRole("button", { name: /Keep all/i })).toBeNull()
     expect(screen.queryByRole("button", { name: /Undo all/i })).toBeNull()
   })
@@ -248,6 +251,7 @@ describe("ReviewPanel", () => {
     ]
     render(
       <ReviewPanel
+        reviewRevision={0}
         messages={messages}
         reviewedHunks={{}}
         onReviewAllInChange={onReviewAllInChange}
@@ -268,6 +272,7 @@ describe("ReviewPanel", () => {
     ]
     render(
       <ReviewPanel
+        reviewRevision={0}
         messages={messages}
         reviewedHunks={{}}
         onReviewAllInChange={onReviewAllInChange}
@@ -285,7 +290,7 @@ describe("ReviewPanel", () => {
       editMessage("m2", { filePath: "b.ts", patch: "@@\n+b", additions: 1, deletions: 0 }),
     ]
     const { container } = render(
-      <ReviewPanel messages={messages} reviewedHunks={{}} onReviewAllInChange={vi.fn()} />,
+      <ReviewPanel reviewRevision={0} messages={messages} reviewedHunks={{}} onReviewAllInChange={vi.fn()} />,
     )
     const header = container.querySelector(".review-head") as HTMLButtonElement
     expect(header.getAttribute("aria-expanded")).toBe("true")
@@ -298,7 +303,7 @@ describe("ReviewPanel", () => {
       createMessage("m1", { filePath: "new.ts", content: "line1\nline2" }),
       editMessage("m2", { filePath: "new.ts", patch: "@@\n+x", additions: 1, deletions: 0 }),
     ]
-    const { container } = render(<ReviewPanel messages={messages} reviewedHunks={{}} />)
+    const { container } = render(<ReviewPanel reviewRevision={0} messages={messages} reviewedHunks={{}} />)
     expect(container.querySelector(".kind-created")).not.toBeNull()
     expect(container.querySelector(".kind-updated")).toBeNull()
   })

--- a/test/webview/review-revision.test.ts
+++ b/test/webview/review-revision.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest"
+import { reducer, initialChatState, type ChatState } from "../../webview/src/hooks/useChatState"
+import type { ToolUpdate } from "../../webview/src/protocol"
+
+// The Review panel keys its diff extraction on `reviewRevision` instead of
+// the messages array, so the counter must move exactly when the review set
+// can change and never move backwards (#603).
+
+function withAssistant(id = "a1"): ChatState {
+  return reducer({ ...initialChatState, busy: true }, { type: "assistantStart", id })
+}
+
+function edit(status: ToolUpdate["status"], callID = "c1"): ToolUpdate {
+  return {
+    callID,
+    tool: "edit",
+    status,
+    input: { filePath: "src/foo.ts" },
+    metadata: { filediff: { patch: "@@ -1 +1 @@\n-a\n+b\n", additions: 1, deletions: 1 } },
+  }
+}
+
+describe("reducer reviewRevision", () => {
+  it("starts at 0 and ignores events that cannot change the review set", () => {
+    let state = withAssistant()
+    expect(state.reviewRevision).toBe(0)
+    state = reducer(state, { type: "textDelta", id: "a1", delta: "hello" })
+    state = reducer(state, { type: "reasoningDelta", id: "a1", delta: "hmm" })
+    state = reducer(state, { type: "tool", id: "a1", update: edit("running") })
+    state = reducer(state, { type: "tool", id: "a1", update: edit("pending") })
+    state = reducer(state, { type: "reviewHunkState", key: "tool:src/foo.ts:h1", state: "kept" })
+    state = reducer(state, { type: "userMessage", id: "u2", text: "next" })
+    state = reducer(state, { type: "assistantStart", id: "a2" })
+    state = reducer(state, { type: "assistantDone", id: "a2" })
+    expect(state.reviewRevision).toBe(0)
+  })
+
+  it("bumps once per completed tool, patch, restore, and real removal", () => {
+    let state = withAssistant()
+    state = reducer(state, { type: "tool", id: "a1", update: edit("running") })
+    state = reducer(state, { type: "tool", id: "a1", update: edit("completed") })
+    expect(state.reviewRevision).toBe(1)
+    state = reducer(state, { type: "patch", id: "a1", files: ["src/bar.ts"], diff: "diff --git a/src/bar.ts b/src/bar.ts\n" })
+    expect(state.reviewRevision).toBe(2)
+    state = reducer(state, { type: "messageRemoved", id: "nope" })
+    expect(state.reviewRevision).toBe(2)
+    state = reducer(state, { type: "messageRemoved", id: "a1" })
+    expect(state.reviewRevision).toBe(3)
+    state = reducer(state, { type: "restore", conversationID: "c2", messages: [] })
+    expect(state.reviewRevision).toBe(4)
+  })
+
+  it("clear and reset keep it monotonic instead of returning to 0", () => {
+    let state = withAssistant()
+    state = reducer(state, { type: "tool", id: "a1", update: edit("completed") })
+    expect(state.reviewRevision).toBe(1)
+    const cleared = reducer(state, { type: "clear" })
+    expect(cleared.messages).toEqual([])
+    expect(cleared.reviewRevision).toBe(2)
+    const reset = reducer(cleared, { type: "reset" })
+    expect(reset.reviewRevision).toBe(3)
+  })
+})

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -383,6 +383,7 @@ export default function App() {
         )}
         <ReviewPanel
           messages={state.messages}
+          reviewRevision={state.reviewRevision}
           selectedPath={reviewRequest?.path}
           selectedKey={reviewRequest?.key}
           reviewedHunks={state.reviewHunks}

--- a/webview/src/components/ReviewPanel.tsx
+++ b/webview/src/components/ReviewPanel.tsx
@@ -15,6 +15,7 @@ type DiffHunk = {
 
 export function ReviewPanel({
   messages,
+  reviewRevision,
   selectedPath,
   selectedKey,
   reviewedHunks,
@@ -23,6 +24,7 @@ export function ReviewPanel({
   onReviewAllInChange,
 }: {
   messages: Message[]
+  reviewRevision: number
   selectedPath?: string
   selectedKey?: number
   reviewedHunks: Record<string, ReviewHunkState>
@@ -30,7 +32,11 @@ export function ReviewPanel({
   onOpenReviewChange?: (change: ReviewChange) => void
   onReviewAllInChange?: (source: string, path: string, action: ReviewHunkState) => void
 }) {
-  const changes = useMemo(() => turnChanges(messages), [messages])
+  // `messages` is a new array on every streamed delta, and extraction walks
+  // every block of every message and splits every patch. Only the reducer
+  // arms that can change the review set bump `reviewRevision`, so the memo
+  // keys on that and reads `messages` as of the bump (#603).
+  const changes = useMemo(() => turnChanges(messages), [reviewRevision])
   const pendingChanges = useMemo(
     () => changes.map((change) => ({ change, diff: splitDiff(change.patch) }))
       .filter(({ change, diff }) => (

--- a/webview/src/hooks/useChatState.ts
+++ b/webview/src/hooks/useChatState.ts
@@ -75,6 +75,14 @@ export type ChatState = {
   context?: EditorContextRef
   messages: Message[]
   reviewHunks: Record<string, ReviewHunkState>
+  /**
+   * Bumped only by the arms that can change what the Review panel extracts
+   * from `messages`: completed tools, patches, restore, removal, clear.
+   * Streamed deltas replace `messages` on every frame, so the panel keys its
+   * extraction on this instead (#603). Monotonic across clear/reset for the
+   * same reason as `idleNonce`.
+   */
+  reviewRevision: number
   pendingPermission?: { id: string; title: string; pattern?: string | string[] }
   pendingQuestion?: { id: string; questions: QuestionInfo[] }
   indexStatus?: IndexStatusInfo
@@ -116,6 +124,7 @@ const initial: ChatState = {
   commands: [],
   messages: [],
   reviewHunks: {},
+  reviewRevision: 0,
   queued: [],
   idleNonce: 0,
 }
@@ -187,7 +196,7 @@ export function reducer(state: ChatState, action: Action): ChatState {
     case "reset":
       // idleNonce is monotonic for the webview's lifetime — resetting it to 0
       // would desync the flush hook's last-seen ref.
-      return { ...initial, selection: state.selection, modelCatalog: state.modelCatalog, context: state.context, connected: state.connected, commands: state.commands, idleNonce: state.idleNonce }
+      return { ...initial, selection: state.selection, modelCatalog: state.modelCatalog, context: state.context, connected: state.connected, commands: state.commands, idleNonce: state.idleNonce, reviewRevision: state.reviewRevision + 1 }
     case "ready":
       return { ...state, connected: action.connected, selection: action.selection }
     case "connected":
@@ -228,6 +237,7 @@ export function reducer(state: ChatState, action: Action): ChatState {
         conversationID: action.conversationID,
         messages: action.messages,
         reviewHunks: action.reviewHunks ?? {},
+        reviewRevision: state.reviewRevision + 1,
         pendingPermission: undefined,
         // The host drops the old session's activeQuestions without posting
         // questionResolved on switch, so a question left open here would
@@ -328,12 +338,19 @@ export function reducer(state: ChatState, action: Action): ChatState {
       ) {
         return state
       }
-      return { ...state, messages: upsertTool(state.messages, action.id, action.update, action.actor) }
+      return {
+        ...state,
+        messages: upsertTool(state.messages, action.id, action.update, action.actor),
+        // Extraction reads only completed tool blocks, so running/pending
+        // churn (streamed bash output) leaves the review set unchanged.
+        reviewRevision: action.update.status === "completed" ? state.reviewRevision + 1 : state.reviewRevision,
+      }
     case "patch":
       // Patches describe disk mutations that already happened; hiding them
       // while aborting only desyncs the Review panel from reality.
       return {
         ...state,
+        reviewRevision: state.reviewRevision + 1,
         messages: state.messages.map((m) =>
           m.id === action.id
             ? { ...m, blocks: [...m.blocks, { type: "patch", files: action.files, diff: action.diff, actor: action.actor }] }
@@ -457,14 +474,14 @@ export function reducer(state: ChatState, action: Action): ChatState {
       const next = state.messages.filter((m) => m.id !== action.id)
       if (next.length === state.messages.length) return state
       const anyPending = next.some((m) => m.pending)
-      return { ...state, messages: next, busy: state.busy && anyPending }
+      return { ...state, messages: next, busy: state.busy && anyPending, reviewRevision: state.reviewRevision + 1 }
     }
     case "queueMessage":
       return { ...state, queued: [...state.queued, action.message] }
     case "unqueueMessage":
       return { ...state, queued: state.queued.filter((q) => q.id !== action.id) }
     case "clear":
-      return { ...initial, selection: state.selection, modelCatalog: state.modelCatalog, context: state.context, connected: state.connected, commands: state.commands, idleNonce: state.idleNonce }
+      return { ...initial, selection: state.selection, modelCatalog: state.modelCatalog, context: state.context, connected: state.connected, commands: state.commands, idleNonce: state.idleNonce, reviewRevision: state.reviewRevision + 1 }
     default:
       return state
   }


### PR DESCRIPTION
Closes #603

## Summary

- `ReviewPanel` memoized `turnChanges(messages)` on the messages array, which every streamed delta replaces, so the panel re-walked every block of every message and re-split every patch once per frame while text streamed. The cost grows with the diffs of all prior turns.
- The reducer now carries `reviewRevision`, bumped only by the arms that can change the extraction result: a `tool` update with `status: "completed"`, `patch`, `restore`, a `messageRemoved` that actually removed a message, `clear`, and `reset`. Running and pending tool churn (streamed bash output) does not bump it because extraction reads only completed tool blocks.
- The counter is monotonic across `clear` and `reset`, like `idleNonce`, so a reset never hands the memo a value it has already seen.
- `ReviewPanel` takes `reviewRevision` and keys its extraction memo on it. `pendingChanges` still keys on the extracted changes and `reviewedHunks`, so hunk state changes recompute pending rows without re-extracting.

## Test plan

- [x] New `test/webview/review-panel-extract.test.tsx` counts `turnChanges` calls through a partial module mock: four streamed re-renders at the same revision cost no extra extraction, a revision bump costs one, and a hunk state change hides the panel without re-extracting. On the pre-fix panel the same test sees 5 and 2 extractions.
- [x] New `test/webview/review-revision.test.ts` pins the reducer: deltas, `assistantStart`, running and pending tool updates, `reviewHunkState`, `userMessage`, and `assistantDone` leave the counter alone; completed tool, patch, real removal, and restore bump it once each; `clear` and `reset` keep it climbing.
- [x] Existing `review-panel` and `review-attribution-render` tests pass a constant revision and are unchanged otherwise.
- [x] `bun run test`: 1460 passed.
- [x] `bun run check-types` and `cd webview && bunx tsc --noEmit`: clean.
- [x] `bun run compile`: OK.
- [ ] Visual: a long agentic conversation with many edits streams text without the Review panel rows flickering or lagging, and a new edit still appears in the panel as soon as its tool completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017oUXZHzx2WRrAo9UTspAT6
